### PR TITLE
Implement strict testing for semi colons in blocks

### DIFF
--- a/crates/rune/src/ast/expr.rs
+++ b/crates/rune/src/ast/expr.rs
@@ -149,6 +149,21 @@ into_tokens_enum! {
 }
 
 impl Expr {
+    /// Indicates if an expression needs a semicolon or must be last in a block.
+    pub fn needs_semi(&self) -> bool {
+        match self {
+            Expr::ExprWhile(_) => false,
+            Expr::ExprLoop(_) => false,
+            Expr::ExprFor(_) => false,
+            Expr::ExprIf(_) => false,
+            Expr::ExprMatch(_) => false,
+            Expr::ExprBlock(_) => false,
+            Expr::ExprAsync(_) => false,
+            Expr::ExprSelect(_) => false,
+            _ => true,
+        }
+    }
+
     /// Test if the expression implicitly evaluates to nothing.
     pub fn produces_nothing(&self) -> bool {
         match self {

--- a/crates/rune/src/error.rs
+++ b/crates/rune/src/error.rs
@@ -357,6 +357,14 @@ pub enum ParseError {
         /// The delimiter we saw.
         actual: Kind,
     },
+    /// Expected a block semicolon which is needed for the kind of expression.
+    #[error("expected expression to be terminated by a semicolon `;`")]
+    ExpectedBlockSemiColon {
+        /// Span where we expected the semicolon.
+        span: Span,
+        /// The following expression.
+        followed_span: Span,
+    },
 }
 
 impl ParseError {
@@ -410,6 +418,7 @@ impl ParseError {
             Self::UnsupportedAsyncExpr { span, .. } => span,
             Self::ExpectedMacroDelimiter { span, .. } => span,
             Self::ExpectedMacroCloseDelimiter { span, .. } => span,
+            Self::ExpectedBlockSemiColon { span, .. } => span,
         }
     }
 }


### PR DESCRIPTION
This prevents the use of arbitrary sequences of expressions in blocks without terminating them, like these:

```rust
{
    let a = 1
    let b = 2
    a + b
}
```