### PR TITLE
Provide basic as-you-type compile diagnostics

### DIFF
--- a/crates/rune-languageserver/Cargo.toml
+++ b/crates/rune-languageserver/Cargo.toml
@@ -28,5 +28,6 @@ log = "0.4.11"
 log4rs = "1.0.0-alpha-1"
 ropey = "1.2.0"
 
-rune = {version = "0.6.16", path = "../rune"}
+rune = {version = "0.6.16", path = "../rune", features = ["modules"]}
+rune-macros = {version = "0.6.16", path = "../rune-macros"}
 runestick = {version = "0.6.16", path = "../runestick"}

--- a/crates/rune-languageserver/src/state.rs
+++ b/crates/rune-languageserver/src/state.rs
@@ -1,10 +1,14 @@
+use crate::Output;
 use anyhow::{anyhow, Result};
 use hashbrown::HashMap;
 use lsp::Url;
 use ropey::Rope;
+use runestick::Span;
+use std::collections::BTreeMap;
 use std::fmt;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use tokio::sync::{mpsc, RwLock};
 use tokio::sync::{Mutex, MutexGuard};
 
 /// Shared server state.
@@ -15,9 +19,13 @@ pub struct State {
 
 impl State {
     /// Construct a new state.
-    pub fn new() -> Self {
+    pub fn new(
+        rebuild_tx: mpsc::Sender<()>,
+        context: runestick::Context,
+        options: rune::Options,
+    ) -> Self {
         Self {
-            inner: Arc::new(Inner::new()),
+            inner: Arc::new(Inner::new(rebuild_tx, context, options)),
         }
     }
 
@@ -35,21 +43,130 @@ impl State {
     pub async fn sources(&self) -> MutexGuard<'_, Sources> {
         self.inner.sources.lock().await
     }
+
+    /// Indicate interest in having the project rebuild.
+    ///
+    /// Sources that have been modified will be marked as dirty.
+    pub async fn rebuild_interest(&self) -> Result<()> {
+        self.inner
+            .rebuild_tx
+            .clone()
+            .send(())
+            .await
+            .map_err(|_| anyhow!("failed to send rebuild interest"))
+    }
+
+    /// Rebuild the current project.
+    pub async fn rebuild(&self, output: &Output) -> Result<()> {
+        let mut inner = self.inner.sources.lock().await;
+
+        for (url, source) in &mut inner.sources {
+            if !std::mem::take(&mut source.dirty) {
+                continue;
+            }
+
+            let mut sources = rune::Sources::new();
+            sources.insert_default(runestick::Source::new(url.to_string(), source.to_string()));
+
+            let mut warnings = rune::Warnings::new();
+            let mut diagnostics = Vec::new();
+
+            let error = rune::load_sources(
+                &self.inner.context,
+                &self.inner.options,
+                &mut sources,
+                &mut warnings,
+            );
+
+            if let Err(error) = error {
+                match error.kind() {
+                    rune::LoadErrorKind::ReadFile { error, path } => {
+                        diagnostics.push(source.display_to_error(
+                            Span::empty(),
+                            format!("failed to read file: {}: {}", path.display(), error),
+                        ));
+                    }
+                    // TODO: match source id with the document that has the error.
+                    rune::LoadErrorKind::ParseError { error, .. } => {
+                        diagnostics.push(source.display_to_error(error.span(), error));
+                    }
+                    // TODO: match the source id with the document that has the error.
+                    rune::LoadErrorKind::CompileError { error, .. } => {
+                        diagnostics.push(source.display_to_error(error.span(), error));
+                    }
+                    rune::LoadErrorKind::LinkError { errors } => {
+                        for error in errors {
+                            match error {
+                                rune::LinkerError::MissingFunction { hash, spans } => {
+                                    for (span, _) in spans {
+                                        diagnostics.push(source.display_to_error(
+                                            *span,
+                                            format!("missing function with hash `{}`", hash),
+                                        ));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    rune::LoadErrorKind::Internal { message } => {
+                        diagnostics.push(source.display_to_error(Span::empty(), message));
+                    }
+                }
+
+                log::error!("build error: {:?}", error);
+            }
+
+            for warning in &warnings {
+                diagnostics.push(source.display_to_warning(warning.span(), warning.kind()));
+            }
+
+            let diagnostics = lsp::PublishDiagnosticsParams {
+                uri: url.clone(),
+                diagnostics,
+                version: None,
+            };
+
+            output
+                .notification::<lsp::notification::PublishDiagnostics>(diagnostics)
+                .await?;
+        }
+
+        return Ok(());
+    }
 }
 
 struct Inner {
+    /// The rune context to build for.
+    context: runestick::Context,
+    /// Build options.
+    options: rune::Options,
+    /// Sender to indicate interest in rebuilding the project.
+    /// Can be triggered on modification.
+    rebuild_tx: mpsc::Sender<()>,
     /// Indicate if the server is initialized.
     initialized: AtomicBool,
     /// Sources used in the project.
     sources: Mutex<Sources>,
+    /// Indexes used to answer queries.
+    /// TODO: will be used.
+    #[allow(unused)]
+    indexes: RwLock<Indexes>,
 }
 
 impl Inner {
     /// Construct a new empty inner state.
-    pub fn new() -> Self {
+    pub fn new(
+        rebuild_tx: mpsc::Sender<()>,
+        context: runestick::Context,
+        options: rune::Options,
+    ) -> Self {
         Self {
+            context,
+            options,
+            rebuild_tx,
             initialized: Default::default(),
             sources: Default::default(),
+            indexes: Default::default(),
         }
     }
 }
@@ -64,6 +181,7 @@ impl Sources {
     /// Insert the given source at the given url.
     pub fn insert_text(&mut self, url: Url, text: String) -> Option<Source> {
         let source = Source {
+            dirty: true,
             content: Rope::from(text),
         };
 
@@ -83,6 +201,8 @@ impl Sources {
 
 /// A single open source.
 pub struct Source {
+    /// If the source is dirty and needs to be rebuilt.
+    dirty: bool,
     /// The content of the current source.
     content: Rope,
 }
@@ -98,7 +218,64 @@ impl Source {
             self.content.insert(start, content);
         }
 
+        self.dirty = true;
         Ok(())
+    }
+
+    /// Convert the given span and error into an error diagnostic.
+    fn display_to_error<E>(&self, span: Span, error: E) -> lsp::Diagnostic
+    where
+        E: fmt::Display,
+    {
+        self.display_to_diagnostic(span, error, lsp::DiagnosticSeverity::Error)
+    }
+
+    /// Convert the given span and error into a warning diagnostic.
+    fn display_to_warning<E>(&self, span: Span, error: E) -> lsp::Diagnostic
+    where
+        E: fmt::Display,
+    {
+        self.display_to_diagnostic(span, error, lsp::DiagnosticSeverity::Warning)
+    }
+
+    /// Convert a span and something displayeable into diagnostics.
+    fn display_to_diagnostic<E>(
+        &self,
+        span: Span,
+        error: E,
+        severity: lsp::DiagnosticSeverity,
+    ) -> lsp::Diagnostic
+    where
+        E: fmt::Display,
+    {
+        let start = self.offset_to_lsp_position(span.start);
+        let end = self.offset_to_lsp_position(span.end);
+
+        lsp::Diagnostic {
+            range: lsp::Range::new(start, end),
+            severity: Some(severity),
+            code: None,
+            source: None,
+            message: error.to_string(),
+            related_information: None,
+            tags: None,
+        }
+    }
+
+    /// Offset in the rope to lsp position.
+    fn offset_to_lsp_position(&self, offset: usize) -> lsp::Position {
+        let line = self.content.byte_to_line(offset);
+
+        let col_char = self.content.byte_to_char(offset);
+        let col_char = self.content.char_to_utf16_cu(col_char);
+
+        let line_char = self.content.line_to_char(line);
+        let line_char = self.content.char_to_utf16_cu(line_char);
+
+        let col_char = col_char - line_char;
+
+        // TODO: handle utf-16 conversion.
+        lsp::Position::new(line as u64, col_char as u64)
     }
 
     /// Iterate over the text chunks in the source.
@@ -146,3 +323,24 @@ fn rope_utf16_position(rope: &Rope, position: lsp::Position) -> Result<usize> {
 
     Ok(rope.line_to_char(position.line as usize) + char_offset)
 }
+
+/// All indexes used to answer questions.
+/// TODO: will be used.
+#[allow(unused)]
+#[derive(Default)]
+pub struct Indexes {
+    /// Indexes by url.
+    by_url: HashMap<Url, Index>,
+}
+
+/// TODO: will be used.
+#[allow(unused)]
+pub struct Index {
+    /// Spans mapping to their corresponding definitions.
+    goto_definitions: BTreeMap<Span, Definition>,
+}
+
+/// Definitions that can be jumped to.
+/// TODO: will be used.
+#[allow(unused)]
+pub enum Definition {}

--- a/crates/rune/src/compile_visitor.rs
+++ b/crates/rune/src/compile_visitor.rs
@@ -1,0 +1,19 @@
+use runestick::{CompileMeta, Span};
+
+/// A visitor that will be called for every language item compiled.
+pub trait CompileVisitor {
+    /// Mark that we've encountered a specific compile meta at the given span.
+    fn visit_meta(&mut self, _meta: &CompileMeta, _span: Span) {}
+}
+
+/// A compile visitor that does nothing.
+pub struct NoopCompileVisitor(());
+
+impl NoopCompileVisitor {
+    /// Construct a new noop compile visitor.
+    pub const fn new() -> Self {
+        Self(())
+    }
+}
+
+impl CompileVisitor for NoopCompileVisitor {}

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -168,6 +168,7 @@ mod util_macros;
 mod assembly;
 pub mod ast;
 mod compile;
+mod compile_visitor;
 mod compiler;
 #[cfg(feature = "diagnostics")]
 pub mod diagnostics;
@@ -204,9 +205,10 @@ mod collections {
 }
 
 pub use crate::assembly::Assembly;
+pub use crate::compile_visitor::{CompileVisitor, NoopCompileVisitor};
 pub use crate::error::{CompileError, ParseError};
 pub use crate::lexer::Lexer;
-pub use crate::load::{load_path, load_sources};
+pub use crate::load::{load_path, load_sources, load_sources_with_visitor};
 pub use crate::load_error::{LoadError, LoadErrorKind};
 pub use crate::macro_context::MacroContext;
 pub use crate::options::Options;
@@ -217,7 +219,7 @@ pub use crate::token_stream::{IntoTokens, TokenStream, TokenStreamIter};
 pub use crate::traits::{Parse, Peek, Resolve};
 pub use crate::warning::{Warning, WarningKind, Warnings};
 pub use compiler::compile;
-pub use unit_builder::{ImportEntry, ImportKey, UnitBuilder};
+pub use unit_builder::{ImportEntry, ImportKey, LinkerError, LinkerErrors, UnitBuilder};
 
 #[cfg(feature = "diagnostics")]
 pub use diagnostics::{termcolor, DiagnosticsError, EmitDiagnostics};

--- a/crates/rune/src/warning.rs
+++ b/crates/rune/src/warning.rs
@@ -1,4 +1,5 @@
 use runestick::Span;
+use thiserror::Error;
 
 /// Compilation warning.
 #[derive(Debug, Clone, Copy)]
@@ -9,10 +10,29 @@ pub struct Warning {
     pub kind: WarningKind,
 }
 
+impl Warning {
+    /// Access the kind of the warning.
+    pub fn kind(&self) -> &WarningKind {
+        &self.kind
+    }
+
+    /// Get the span of the warning.
+    pub fn span(&self) -> Span {
+        match &self.kind {
+            WarningKind::NotUsed { span, .. } => *span,
+            WarningKind::LetPatternMightPanic { span, .. } => *span,
+            WarningKind::TemplateWithoutExpansions { span, .. } => *span,
+            WarningKind::RemoveTupleCallParams { span, .. } => *span,
+            WarningKind::UnecessarySemiColon { span, .. } => *span,
+        }
+    }
+}
+
 /// Compilation warning kind.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Error)]
 pub enum WarningKind {
     /// Item identified by the span is not used.
+    #[error("not used")]
     NotUsed {
         /// The span that is not used.
         span: Span,
@@ -21,6 +41,7 @@ pub enum WarningKind {
     },
     /// Warning that an unconditional let pattern will panic if it doesn't
     /// match.
+    #[error("pattern might panic")]
     LetPatternMightPanic {
         /// The span of the pattern.
         span: Span,
@@ -28,6 +49,7 @@ pub enum WarningKind {
         context: Option<Span>,
     },
     /// Encountered a template string without an expansion.
+    #[error("using a template string without expansions, like `Hello World`")]
     TemplateWithoutExpansions {
         /// Span that caused the error.
         span: Span,
@@ -35,6 +57,7 @@ pub enum WarningKind {
         context: Option<Span>,
     },
     /// Suggestion that call parameters could be removed.
+    #[error("call paramters are not needed here")]
     RemoveTupleCallParams {
         /// The span of the call.
         span: Span,
@@ -44,6 +67,7 @@ pub enum WarningKind {
         context: Option<Span>,
     },
     /// An unecessary semi-colon is used.
+    #[error("unnecessary semicolon")]
     UnecessarySemiColon {
         /// Span where the semi-colon is.
         span: Span,

--- a/editors/code/src/main.ts
+++ b/editors/code/src/main.ts
@@ -84,14 +84,28 @@ function detectPlatform(): Platform | undefined {
     let out: string | undefined;
 
     if (process.arch === "x64") {
-        if (process.platform === "win32") {
-            out = "windows";
+        switch (process.platform) {
+        case "win32":
+            out = "windows"
+            break;
+        case "linux":
+            out = "linux"
+            break;
+        case "darwin":
+            out = "mac"
+            break;
+        default:
+            break;
         }
     }
 
     switch (out) {
     case "windows":
         return {ext: ".exe"};
+    case "linux":
+        return {ext: ""};
+    case "mac":
+        return {ext: ""};
     default:
         vscode.window.showErrorMessage(
             `Unfortunately we don't support your platform yet.


### PR DESCRIPTION
This enables all modules (experimental or not).

How exactly to provide diagnostics for third-party native modules will be a challenge, since they're not available at the time the language server is compiled. Maybe some way to provide external definitions?

Relates to #44 

![bMUq0hMs80](https://user-images.githubusercontent.com/111092/92784122-a5342480-f3a6-11ea-976c-b06dbaf70582.gif)
