### PR TITLE
Rewrite `&&` and `||` with conditional logic

### DIFF
--- a/crates/rune/src/assembly.rs
+++ b/crates/rune/src/assembly.rs
@@ -9,6 +9,8 @@ pub enum AssemblyInst {
     Jump { label: Label },
     JumpIf { label: Label },
     JumpIfNot { label: Label },
+    JumpIfOrPop { label: Label },
+    JumpIfNotOrPop { label: Label },
     JumpIfBranch { branch: i64, label: Label },
     PopAndJumpIfNot { count: usize, label: Label },
     Raw { raw: Inst },
@@ -81,6 +83,20 @@ impl Assembly {
     pub(crate) fn jump_if_not(&mut self, label: Label, span: Span) {
         self.instructions
             .push((AssemblyInst::JumpIfNot { label }, span));
+    }
+
+    /// Add a conditional jump to the given label. Only pops the top of the
+    /// stack if the jump is not executed.
+    pub(crate) fn jump_if_or_pop(&mut self, label: Label, span: Span) {
+        self.instructions
+            .push((AssemblyInst::JumpIfOrPop { label }, span));
+    }
+
+    /// Add a conditional jump to the given label. Only pops the top of the
+    /// stack if the jump is not executed.
+    pub(crate) fn jump_if_not_or_pop(&mut self, label: Label, span: Span) {
+        self.instructions
+            .push((AssemblyInst::JumpIfNotOrPop { label }, span));
     }
 
     /// Add a conditional jump-if-branch instruction.

--- a/crates/rune/src/ast/expr_binary.rs
+++ b/crates/rune/src/ast/expr_binary.rs
@@ -117,6 +117,15 @@ impl BinOp {
         }
     }
 
+    /// Test if operator is a condiational operator.
+    pub fn is_conditional(self) -> bool {
+        match self {
+            Self::And => true,
+            Self::Or => true,
+            _ => false,
+        }
+    }
+
     /// Get the precedence for the current operator.
     pub(super) fn precedence(self) -> usize {
         // NB: Rules from: https://doc.rust-lang.org/reference/expressions.html#expression-precedence

--- a/crates/rune/src/compile/expr_binary.rs
+++ b/crates/rune/src/compile/expr_binary.rs
@@ -42,7 +42,7 @@ impl Compile<(&ast::ExprBinary, Needs)> for Compiler<'_> {
                 needs,
             )?;
 
-            return Ok(())
+            return Ok(());
         }
 
         // NB: need to declare these as anonymous local variables so that they
@@ -52,7 +52,7 @@ impl Compile<(&ast::ExprBinary, Needs)> for Compiler<'_> {
 
         self.compile((&*expr_binary.rhs, rhs_needs_of(expr_binary.op)))?;
         self.scopes.decl_anon(span)?;
-      
+
         let inst = match expr_binary.op {
             ast::BinOp::Eq => Inst::Eq,
             ast::BinOp::Neq => Inst::Neq,
@@ -106,14 +106,14 @@ fn rhs_needs_of(op: ast::BinOp) -> Needs {
 }
 
 fn compile_conditional_binop(
-   this: &mut Compiler<'_>,
-   lhs: &ast::Expr,
-   rhs: &ast::Expr,
-   bin_op: ast::BinOp,
-   needs: Needs,
+    this: &mut Compiler<'_>,
+    lhs: &ast::Expr,
+    rhs: &ast::Expr,
+    bin_op: ast::BinOp,
+    needs: Needs,
 ) -> CompileResult<()> {
     let span = lhs.span().join(rhs.span());
-    
+
     let then_label = this.asm.new_label("conditional_then");
     let end_label = this.asm.new_label("conditional_end");
 
@@ -122,7 +122,7 @@ fn compile_conditional_binop(
 
     match bin_op {
         ast::BinOp::And => {
-            this.asm.jump_if_not(then_label, lhs.span()); 
+            this.asm.jump_if_not(then_label, lhs.span());
         }
         ast::BinOp::Or => {
             this.asm.jump_if(then_label, lhs.span());
@@ -133,12 +133,12 @@ fn compile_conditional_binop(
                 CompileErrorKind::UnsupportedBinaryOp { op },
             ));
         }
-    } 
+    }
 
     this.compile((&*rhs, needs))?;
 
     if !needs.value() {
-        this.asm.push(Inst::unit(), span); 
+        this.asm.push(Inst::unit(), span);
     }
 
     this.asm.jump(end_label, span);
@@ -161,7 +161,7 @@ fn compile_conditional_binop(
 
     this.asm.label(end_label)?;
     this.scopes.undecl_anon(1, span)?;
-    
+
     Ok(())
 }
 

--- a/crates/rune/src/compile/expr_binary.rs
+++ b/crates/rune/src/compile/expr_binary.rs
@@ -33,6 +33,18 @@ impl Compile<(&ast::ExprBinary, Needs)> for Compiler<'_> {
             return Ok(());
         }
 
+        if expr_binary.op.is_conditional() {
+            compile_conditional_binop(
+                self,
+                &*expr_binary.lhs,
+                &*expr_binary.rhs,
+                expr_binary.op,
+                needs,
+            )?;
+
+            return Ok(())
+        }
+
         // NB: need to declare these as anonymous local variables so that they
         // get cleaned up in case there is an early break (return, try, ...).
         self.compile((&*expr_binary.lhs, Needs::Value))?;
@@ -40,7 +52,7 @@ impl Compile<(&ast::ExprBinary, Needs)> for Compiler<'_> {
 
         self.compile((&*expr_binary.rhs, rhs_needs_of(expr_binary.op)))?;
         self.scopes.decl_anon(span)?;
-
+      
         let inst = match expr_binary.op {
             ast::BinOp::Eq => Inst::Eq,
             ast::BinOp::Neq => Inst::Neq,
@@ -62,6 +74,7 @@ impl Compile<(&ast::ExprBinary, Needs)> for Compiler<'_> {
             ast::BinOp::BitOr => Inst::Op { op: InstOp::BitOr },
             ast::BinOp::Shl => Inst::Op { op: InstOp::Shl },
             ast::BinOp::Shr => Inst::Op { op: InstOp::Shr },
+
             op => {
                 return Err(CompileError::new(
                     span,
@@ -90,6 +103,66 @@ fn rhs_needs_of(op: ast::BinOp) -> Needs {
         ast::BinOp::Is | ast::BinOp::IsNot => Needs::Type,
         _ => Needs::Value,
     }
+}
+
+fn compile_conditional_binop(
+   this: &mut Compiler<'_>,
+   lhs: &ast::Expr,
+   rhs: &ast::Expr,
+   bin_op: ast::BinOp,
+   needs: Needs,
+) -> CompileResult<()> {
+    let span = lhs.span().join(rhs.span());
+    
+    let then_label = this.asm.new_label("conditional_then");
+    let end_label = this.asm.new_label("conditional_end");
+
+    this.compile((&*lhs, needs))?;
+    this.scopes.decl_anon(span)?;
+
+    match bin_op {
+        ast::BinOp::And => {
+            this.asm.jump_if_not(then_label, lhs.span()); 
+        }
+        ast::BinOp::Or => {
+            this.asm.jump_if(then_label, lhs.span());
+        }
+        op => {
+            return Err(CompileError::new(
+                span,
+                CompileErrorKind::UnsupportedBinaryOp { op },
+            ));
+        }
+    } 
+
+    this.compile((&*rhs, needs))?;
+
+    if !needs.value() {
+        this.asm.push(Inst::unit(), span); 
+    }
+
+    this.asm.jump(end_label, span);
+    this.asm.label(then_label)?;
+
+    match bin_op {
+        ast::BinOp::And => {
+            this.asm.push(Inst::bool(false), span);
+        }
+        ast::BinOp::Or => {
+            this.asm.push(Inst::bool(true), span);
+        }
+        op => {
+            return Err(CompileError::new(
+                span,
+                CompileErrorKind::UnsupportedBinaryOp { op },
+            ));
+        }
+    }
+
+    this.asm.label(end_label)?;
+    this.scopes.undecl_anon(1, span)?;
+    
+    Ok(())
 }
 
 fn compile_assign_binop(

--- a/crates/rune/src/compile/expr_binary.rs
+++ b/crates/rune/src/compile/expr_binary.rs
@@ -120,12 +120,10 @@ fn compile_conditional_binop(
 
     match bin_op {
         ast::BinOp::And => {
-            this.asm.push(Inst::Dup, lhs.span());
-            this.asm.jump_if_not(end_label, lhs.span());
+            this.asm.jump_if_not_or_pop(end_label, lhs.span());
         }
         ast::BinOp::Or => {
-            this.asm.push(Inst::Dup, lhs.span());
-            this.asm.jump_if(end_label, lhs.span());
+            this.asm.jump_if_or_pop(end_label, lhs.span());
         }
         op => {
             return Err(CompileError::new(
@@ -135,7 +133,6 @@ fn compile_conditional_binop(
         }
     }
 
-    this.asm.push(Inst::Pop, span);
     this.compile((&*rhs, Needs::Value))?;
 
     this.asm.label(end_label)?;

--- a/crates/rune/src/compile/expr_if.rs
+++ b/crates/rune/src/compile/expr_if.rs
@@ -35,7 +35,7 @@ impl Compile<(&ast::ExprIf, Needs)> for Compiler<'_> {
         }
 
         self.asm.jump(end_label, span);
-        
+
         self.asm.label(then_label)?;
 
         let expected = self.scopes.push(then_scope);

--- a/crates/rune/src/compile/expr_if.rs
+++ b/crates/rune/src/compile/expr_if.rs
@@ -35,7 +35,7 @@ impl Compile<(&ast::ExprIf, Needs)> for Compiler<'_> {
         }
 
         self.asm.jump(end_label, span);
-
+        
         self.asm.label(then_label)?;
 
         let expected = self.scopes.push(then_scope);

--- a/crates/rune/src/tests/compiler_expr_binary.rs
+++ b/crates/rune/src/tests/compiler_expr_binary.rs
@@ -14,4 +14,5 @@ fn test_binary_exprs() {
     assert_parse!(r#"fn main() { 0 < (10 >= 10) }"#);
     assert_parse!(r#"fn main() { 0 < 10 && 10 > 0 }"#);
     assert_parse!(r#"fn main() { 0 < 10 && 10 > 0 || true }"#);
+    assert_parse!(r#"fn main() { false || return }"#);
 }

--- a/crates/rune/src/tests/mod.rs
+++ b/crates/rune/src/tests/mod.rs
@@ -14,6 +14,7 @@ mod vm_function;
 mod vm_general;
 mod vm_generators;
 mod vm_is;
+mod vm_lazy_and_or;
 mod vm_literals;
 mod vm_match;
 mod vm_option;

--- a/crates/rune/src/tests/vm_lazy_and_or.rs
+++ b/crates/rune/src/tests/vm_lazy_and_or.rs
@@ -1,0 +1,22 @@
+#[test]
+fn test_lazy_and_or() {
+    assert_eq! {
+        rune!(bool => r#"fn main() { true || return false }"#),
+        true,
+    };
+
+    assert_eq! {
+        rune!(bool => r#"fn main() { false && return true }"#),
+        false,
+    };
+
+    assert_eq! {
+        rune!(bool => r#"fn main() { false || false || {return true; false} || false }"#),
+        true,
+    };
+
+    assert_eq! {
+        rune!(bool => r#"fn main() { false && false && {return false; false} || true }"#),
+        true,
+    };
+}

--- a/crates/rune/src/unit_builder.rs
+++ b/crates/rune/src/unit_builder.rs
@@ -803,6 +803,16 @@ impl UnitBuilder {
                     let offset = translate_offset(pos, label, &assembly.labels)?;
                     self.instructions.push(Inst::JumpIfNot { offset });
                 }
+                AssemblyInst::JumpIfOrPop { label } => {
+                    comment = Some(format!("label:{}", label));
+                    let offset = translate_offset(pos, label, &assembly.labels)?;
+                    self.instructions.push(Inst::JumpIfOrPop { offset });
+                }
+                AssemblyInst::JumpIfNotOrPop { label } => {
+                    comment = Some(format!("label:{}", label));
+                    let offset = translate_offset(pos, label, &assembly.labels)?;
+                    self.instructions.push(Inst::JumpIfNotOrPop { offset });
+                }
                 AssemblyInst::JumpIfBranch { branch, label } => {
                     comment = Some(format!("label:{}", label));
                     let offset = translate_offset(pos, label, &assembly.labels)?;

--- a/crates/runestick/src/inst.rs
+++ b/crates/runestick/src/inst.rs
@@ -468,6 +468,32 @@ pub enum Inst {
         /// Offset to jump to.
         offset: isize,
     },
+    /// Jump to `offset` relative to the current instruction pointer if the
+    /// condition is `true`. Will only pop the stack is a jump is not performed.
+    ///
+    /// # Operation
+    ///
+    /// ```text
+    /// <boolean>
+    /// => *nothing*
+    /// ```
+    JumpIfOrPop {
+        /// Offset to jump to.
+        offset: isize,
+    },
+    /// Jump to `offset` relative to the current instruction pointer if the
+    /// condition is `false`. Will only pop the stack is a jump is not performed.
+    ///
+    /// # Operation
+    ///
+    /// ```text
+    /// <boolean>
+    /// => *nothing*
+    /// ```
+    JumpIfNotOrPop {
+        /// Offset to jump to.
+        offset: isize,
+    },
     /// Compares the `branch` register with the top of the stack, and if they
     /// match pops the top of the stack and performs the jump to offset.
     ///
@@ -990,6 +1016,12 @@ impl fmt::Display for Inst {
             }
             Self::JumpIfNot { offset } => {
                 write!(fmt, "jump-if-not {}", offset)?;
+            }
+            Self::JumpIfOrPop { offset } => {
+                write!(fmt, "jump-if-or-pop {}", offset)?;
+            }
+            Self::JumpIfNotOrPop { offset } => {
+                write!(fmt, "jump-if-not-or-pop {}", offset)?;
             }
             Self::JumpIfBranch { branch, offset } => {
                 write!(fmt, "jump-if-branch {}, {}", branch, offset)?;

--- a/crates/runestick/src/value.rs
+++ b/crates/runestick/src/value.rs
@@ -239,6 +239,15 @@ impl Value {
         }
     }
 
+    /// Try to coerce value into a boolean.
+    #[inline]
+    pub fn as_bool(&self) -> Result<bool, VmError> {
+        match self {
+            Self::Bool(b) => Ok(*b),
+            actual => Err(VmError::expected::<bool>(actual.type_info()?)),
+        }
+    }
+
     /// Try to coerce value into a byte.
     #[inline]
     pub fn into_byte(self) -> Result<u8, VmError> {

--- a/crates/runestick/src/vm.rs
+++ b/crates/runestick/src/vm.rs
@@ -573,6 +573,32 @@ impl Vm {
         Ok(())
     }
 
+    /// Perform a conditional jump operation. Pops the stack if the jump is
+    /// not performed.
+    #[inline]
+    fn op_jump_if_or_pop(&mut self, offset: isize) -> Result<(), VmError> {
+        if self.stack.last()?.as_bool()? {
+            self.modify_ip(offset)?;
+        } else {
+            self.stack.pop()?;
+        }
+
+        Ok(())
+    }
+
+    /// Perform a conditional jump operation. Pops the stack if the jump is
+    /// not performed.
+    #[inline]
+    fn op_jump_if_not_or_pop(&mut self, offset: isize) -> Result<(), VmError> {
+        if !self.stack.last()?.as_bool()? {
+            self.modify_ip(offset)?;
+        } else {
+            self.stack.pop()?;
+        }
+
+        Ok(())
+    }
+
     /// Perform a branch-conditional jump operation.
     #[inline]
     fn op_jump_if_branch(&mut self, branch: i64, offset: isize) -> Result<(), VmError> {
@@ -2195,6 +2221,12 @@ impl Vm {
                 }
                 Inst::JumpIfNot { offset } => {
                     self.op_jump_if_not(offset)?;
+                }
+                Inst::JumpIfOrPop { offset } => {
+                    self.op_jump_if_or_pop(offset)?;
+                }
+                Inst::JumpIfNotOrPop { offset } => {
+                    self.op_jump_if_not_or_pop(offset)?;
                 }
                 Inst::JumpIfBranch { branch, offset } => {
                     self.op_jump_if_branch(branch, offset)?;


### PR DESCRIPTION
Here's my current progress on rewriting the logic for `&&` and `||` operations to be lazily evaluated. Following @udoprog's suggestion, the new logic is quite similar to how `if` statements are handled.

Currently, though, this logic does not actually evaluate `&&` and `||` lazily. Based off of stack traces, values that should be skipped over are still being evaluated. 