### PR TITLE
Reduced loop{} overhead

### DIFF
--- a/crates/rune/src/compile/expr_loop.rs
+++ b/crates/rune/src/compile/expr_loop.rs
@@ -13,11 +13,10 @@ impl Compile<(&ast::ExprLoop, Needs)> for Compiler<'_> {
 
         let start_label = self.asm.new_label("loop_start");
         let end_label = self.asm.new_label("loop_end");
-        let break_label = self.asm.new_label("loop_break");
 
         let _guard = self.loops.push(Loop {
             label: expr_loop.label.map(|(label, _)| label),
-            break_label,
+            break_label: end_label,
             total_var_count: self.scopes.last(span)?.total_var_count,
             needs,
             drop: None,
@@ -28,12 +27,6 @@ impl Compile<(&ast::ExprLoop, Needs)> for Compiler<'_> {
         self.asm.jump(start_label, span);
         self.asm.label(end_label)?;
 
-        // NB: If a value is needed from a while loop, encode it as a unit.
-        if needs.value() {
-            self.asm.push(Inst::Unit, span);
-        }
-
-        self.asm.label(break_label)?;
         Ok(())
     }
 }


### PR DESCRIPTION
I believe this will reduce the overhead of loop{} a little bit. Did not seems to need to do a Unit return either as the Tests functioned correctly.