### PR TITLE
languageserver: Add initial support for GotoDefinition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - name: Cache Cargo
+      - name: Caching
         uses: actions/cache@v2
         with:
           path: |
@@ -23,5 +23,5 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ steps.rust_toolchain.outputs.rustc_hash }}
       - name: Run tests
         run: cargo test --all
-      - name: Execute example scripts
-        run: cargo run --bin rune --release -- --experimental -O macros=true scripts/*.rn
+      - name: Run example scripts
+        run: cargo run --bin rune -- --experimental -O macros=true scripts/*.rn

--- a/crates/rune-languageserver/src/main.rs
+++ b/crates/rune-languageserver/src/main.rs
@@ -174,7 +174,6 @@ async fn goto_definition(
         )
         .await;
 
-    // log::info!("Found: {:?}", definition);
     Ok(position.map(lsp::GotoDefinitionResponse::Scalar))
 }
 

--- a/crates/rune-testing/src/lib.rs
+++ b/crates/rune-testing/src/lib.rs
@@ -51,7 +51,7 @@ pub use rune::WarningKind::*;
 use rune::Warnings;
 pub use runestick::Result;
 pub use runestick::VmErrorKind::*;
-pub use runestick::{CompileMeta, Function, Span, Value};
+pub use runestick::{CompileMeta, CompileMetaKind, Function, Span, Value};
 use runestick::{Component, Item, Source, Unit};
 use std::cell::RefCell;
 use std::rc::Rc;

--- a/crates/rune-testing/tests/compiler_general.rs
+++ b/crates/rune-testing/tests/compiler_general.rs
@@ -4,7 +4,7 @@ use rune_testing::*;
 fn test_use_variant_as_type() {
     assert_compile_error! {
         r#"fn main() { Err(0) is Err }"#,
-        UnsupportedType { span, meta: CompileMeta::TupleVariant { .. } } => {
+        UnsupportedType { span, meta: CompileMeta { kind: CompileMetaKind::TupleVariant { .. }, .. } } => {
             assert_eq!(span, Span::new(22, 25));
         }
     };

--- a/crates/rune/src/compile/expr_async.rs
+++ b/crates/rune/src/compile/expr_async.rs
@@ -3,7 +3,7 @@ use crate::compiler::{Compiler, Needs};
 use crate::error::CompileResult;
 use crate::traits::Compile;
 use crate::CompileError;
-use runestick::{CompileMeta, Hash, Inst};
+use runestick::{CompileMetaKind, Hash, Inst};
 
 /// Call an async block.
 impl Compile<(&ast::ExprAsync, Needs)> for Compiler<'_> {
@@ -20,15 +20,15 @@ impl Compile<(&ast::ExprAsync, Needs)> for Compiler<'_> {
             }
         };
 
-        let captures = match &meta {
-            CompileMeta::AsyncBlock { captures, .. } => captures,
+        let captures = match &meta.kind {
+            CompileMetaKind::AsyncBlock { captures, .. } => captures,
             _ => {
                 return Err(CompileError::UnsupportedAsyncBlock { span, meta });
             }
         };
 
         for ident in &**captures {
-            let var = self.scopes.get_var(&ident.ident, span)?;
+            let var = self.scopes.get_var(&ident.ident, self.visitor, span)?;
             var.copy(&mut self.asm, span, format!("captures `{}`", ident.ident));
         }
 

--- a/crates/rune/src/compile/expr_binary.rs
+++ b/crates/rune/src/compile/expr_binary.rs
@@ -135,7 +135,7 @@ fn compile_assign_binop(
                 compiler.compile((rhs, Needs::Value))?;
 
                 let ident = path.first.resolve(compiler.storage, &*compiler.source)?;
-                let var = compiler.scopes.get_var(&*ident, span)?;
+                let var = compiler.scopes.get_var(&*ident, compiler.visitor, span)?;
                 compiler
                     .asm
                     .push(Inst::Replace { offset: var.offset }, span);
@@ -194,7 +194,7 @@ fn compile_assign_binop(
             // <var> <op> <expr>
             ast::Expr::Path(path) if path.rest.is_empty() => {
                 let ident = path.first.resolve(compiler.storage, &*compiler.source)?;
-                let var = compiler.scopes.get_var(&*ident, span)?;
+                let var = compiler.scopes.get_var(&*ident, compiler.visitor, span)?;
                 Some(var.offset)
             }
             // Note: we would like to support assign operators for tuples and

--- a/crates/rune/src/compile/expr_call.rs
+++ b/crates/rune/src/compile/expr_call.rs
@@ -3,7 +3,7 @@ use crate::compiler::{Compiler, Needs};
 use crate::error::CompileResult;
 use crate::traits::{Compile, Resolve as _};
 use crate::CompileError;
-use runestick::{CompileMeta, Hash, Inst};
+use runestick::{CompileMetaKind, Hash, Inst};
 
 /// Compile a call expression.
 impl Compile<(&ast::ExprCall, Needs)> for Compiler<'_> {
@@ -75,7 +75,7 @@ impl Compile<(&ast::ExprCall, Needs)> for Compiler<'_> {
         let item = self.convert_path_to_item(path)?;
 
         if let Some(name) = item.as_local() {
-            if let Some(var) = self.scopes.try_get_var(name)? {
+            if let Some(var) = self.scopes.try_get_var(name, self.visitor, path.span())? {
                 var.copy(&mut self.asm, span, format!("var `{}`", name));
                 self.asm.push(Inst::CallFn { args }, span);
 
@@ -95,8 +95,8 @@ impl Compile<(&ast::ExprCall, Needs)> for Compiler<'_> {
             }
         };
 
-        let item = match &meta {
-            CompileMeta::Tuple { tuple, .. } | CompileMeta::TupleVariant { tuple, .. } => {
+        let item = match &meta.kind {
+            CompileMetaKind::Tuple { tuple, .. } | CompileMetaKind::TupleVariant { tuple, .. } => {
                 if tuple.args != expr_call.args.items.len() {
                     return Err(CompileError::UnsupportedArgumentCount {
                         span,
@@ -118,7 +118,7 @@ impl Compile<(&ast::ExprCall, Needs)> for Compiler<'_> {
 
                 tuple.item.clone()
             }
-            CompileMeta::Function { item, .. } => item.clone(),
+            CompileMetaKind::Function { item, .. } => item.clone(),
             _ => {
                 return Err(CompileError::MissingFunction { span, item });
             }

--- a/crates/rune/src/compile/expr_closure.rs
+++ b/crates/rune/src/compile/expr_closure.rs
@@ -74,13 +74,13 @@ impl Compile<(&ast::ExprClosure, Needs)> for Compiler<'_> {
         let item = self.items.item();
         let hash = Hash::type_hash(&item);
 
-        let meta =
-            self.query
-                .query_meta(&item, span)?
-                .ok_or_else(|| CompileError::MissingType {
-                    item: item.clone(),
-                    span,
-                })?;
+        let meta = self
+            .query
+            .query_meta(&item)?
+            .ok_or_else(|| CompileError::MissingType {
+                item: item.clone(),
+                span,
+            })?;
 
         let captures = match &meta.kind {
             CompileMetaKind::Closure { captures, .. } => captures,

--- a/crates/rune/src/compile/expr_field_access.rs
+++ b/crates/rune/src/compile/expr_field_access.rs
@@ -97,7 +97,10 @@ fn try_immediate_field_access_optimization(
         Err(..) => return Ok(false),
     };
 
-    let var = match this.scopes.try_get_var(ident.as_ref())? {
+    let var = match this
+        .scopes
+        .try_get_var(ident.as_ref(), this.visitor, path.span())?
+    {
         Some(var) => var,
         None => return Ok(false),
     };

--- a/crates/rune/src/compile/expr_path.rs
+++ b/crates/rune/src/compile/expr_path.rs
@@ -19,7 +19,7 @@ impl Compile<(&ast::Path, Needs)> for Compiler<'_> {
 
         if let Needs::Value = needs {
             if let Some(local) = item.as_local() {
-                if let Some(var) = self.scopes.try_get_var(local)? {
+                if let Some(var) = self.scopes.try_get_var(local, self.visitor, span)? {
                     var.copy(&mut self.asm, span, format!("var `{}`", local));
                     return Ok(());
                 }

--- a/crates/rune/src/compile/expr_self.rs
+++ b/crates/rune/src/compile/expr_self.rs
@@ -8,7 +8,7 @@ impl Compile<(&ast::Self_, Needs)> for Compiler<'_> {
     fn compile(&mut self, (self_, needs): (&ast::Self_, Needs)) -> CompileResult<()> {
         let span = self_.span();
         log::trace!("Self_ => {:?}", self.source.source(span));
-        let var = self.scopes.get_var("self", span)?;
+        let var = self.scopes.get_var("self", self.visitor, span)?;
 
         if !needs.value() {
             return Ok(());

--- a/crates/rune/src/compile_visitor.rs
+++ b/crates/rune/src/compile_visitor.rs
@@ -1,9 +1,13 @@
+use crate::Var;
 use runestick::{CompileMeta, Span};
 
 /// A visitor that will be called for every language item compiled.
 pub trait CompileVisitor {
     /// Mark that we've encountered a specific compile meta at the given span.
     fn visit_meta(&mut self, _meta: &CompileMeta, _span: Span) {}
+
+    /// Visit a variable use.
+    fn visit_variable_use(&mut self, _var: &Var, _span: Span) {}
 }
 
 /// A compile visitor that does nothing.

--- a/crates/rune/src/index.rs
+++ b/crates/rune/src/index.rs
@@ -190,6 +190,7 @@ impl Index<ast::ItemFn> for Indexer<'_> {
                 build: Build::InstanceFunction(f),
                 source: self.source.clone(),
                 source_id: self.source_id,
+                unused: false,
             });
 
             let meta = CompileMeta {
@@ -208,6 +209,7 @@ impl Index<ast::ItemFn> for Indexer<'_> {
                 build: Build::Function(fun),
                 source: self.source.clone(),
                 source_id: self.source_id,
+                unused: false,
             });
 
             self.query.unit.borrow_mut().insert_meta(CompileMeta {

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -213,6 +213,7 @@ pub use crate::load_error::{LoadError, LoadErrorKind};
 pub use crate::macro_context::MacroContext;
 pub use crate::options::Options;
 pub use crate::parser::Parser;
+pub use crate::scopes::Var;
 pub use crate::sources::Sources;
 pub use crate::storage::Storage;
 pub use crate::token_stream::{IntoTokens, TokenStream, TokenStreamIter};

--- a/crates/rune/src/unit_builder.rs
+++ b/crates/rune/src/unit_builder.rs
@@ -10,8 +10,8 @@ use crate::error::CompileResult;
 use crate::{Resolve as _, Storage};
 use runestick::debug::{DebugArgs, DebugSignature};
 use runestick::{
-    Call, CompileMeta, Component, Context, DebugInfo, DebugInst, Hash, Inst, Item, Label, Names,
-    Source, Span, StaticString, Type, Unit, UnitFn, UnitTypeInfo,
+    Call, CompileMeta, CompileMetaKind, Component, Context, DebugInfo, DebugInst, Hash, Inst, Item,
+    Label, Names, Source, Span, StaticString, Type, Unit, UnitFn, UnitTypeInfo,
 };
 use std::sync::Arc;
 use thiserror::Error;
@@ -559,8 +559,8 @@ impl UnitBuilder {
 
     /// Declare a new struct.
     pub(crate) fn insert_meta(&mut self, meta: CompileMeta) -> Result<(), UnitBuilderError> {
-        let item = match &meta {
-            CompileMeta::Tuple { tuple, .. } => {
+        let item = match &meta.kind {
+            CompileMetaKind::Tuple { tuple, .. } => {
                 let info = UnitFn::Tuple {
                     hash: tuple.hash,
                     args: tuple.args,
@@ -594,7 +594,7 @@ impl UnitBuilder {
 
                 tuple.item.clone()
             }
-            CompileMeta::TupleVariant {
+            CompileMetaKind::TupleVariant {
                 enum_item, tuple, ..
             } => {
                 let enum_hash = Hash::type_hash(enum_item);
@@ -633,7 +633,7 @@ impl UnitBuilder {
 
                 tuple.item.clone()
             }
-            CompileMeta::Struct { object, .. } => {
+            CompileMetaKind::Struct { object, .. } => {
                 let hash = Hash::type_hash(&object.item);
 
                 let info = UnitTypeInfo {
@@ -649,7 +649,7 @@ impl UnitBuilder {
 
                 object.item.clone()
             }
-            CompileMeta::StructVariant {
+            CompileMetaKind::StructVariant {
                 enum_item, object, ..
             } => {
                 let hash = Hash::type_hash(&object.item);
@@ -668,7 +668,7 @@ impl UnitBuilder {
 
                 object.item.clone()
             }
-            CompileMeta::Enum { item, .. } => {
+            CompileMetaKind::Enum { item, .. } => {
                 let hash = Hash::type_hash(item);
 
                 let info = UnitTypeInfo {
@@ -684,10 +684,10 @@ impl UnitBuilder {
 
                 item.clone()
             }
-            CompileMeta::Function { item, .. } => item.clone(),
-            CompileMeta::Closure { item, .. } => item.clone(),
-            CompileMeta::AsyncBlock { item, .. } => item.clone(),
-            CompileMeta::Macro { item, .. } => item.clone(),
+            CompileMetaKind::Function { item, .. } => item.clone(),
+            CompileMetaKind::Closure { item, .. } => item.clone(),
+            CompileMetaKind::AsyncBlock { item, .. } => item.clone(),
+            CompileMetaKind::Macro { item, .. } => item.clone(),
         };
 
         if let Some(existing) = self.meta.insert(item, meta.clone()) {

--- a/crates/rune/src/worker.rs
+++ b/crates/rune/src/worker.rs
@@ -312,6 +312,8 @@ impl Import {
                     unit.new_import(item, &name, span, source_id)?;
                 }
             }
+        } else {
+            unit.new_import(item, &name, span, source_id)?;
         }
 
         Ok(())

--- a/crates/runestick/src/compile_meta.rs
+++ b/crates/runestick/src/compile_meta.rs
@@ -1,5 +1,5 @@
 use crate::collections::HashSet;
-use crate::{Hash, Item, Type};
+use crate::{Hash, Item, Span, Type};
 use std::fmt;
 use std::sync::Arc;
 
@@ -12,7 +12,84 @@ pub struct CompileMetaCapture {
 
 /// Compile-time metadata about a unit.
 #[derive(Debug, Clone)]
-pub enum CompileMeta {
+pub struct CompileMeta {
+    /// The span where the meta is declared.
+    pub span: Option<Span>,
+    /// The kind of the compile meta.
+    pub kind: CompileMetaKind,
+}
+
+impl CompileMeta {
+    /// Get the item of the meta.
+    pub fn item(&self) -> &Item {
+        match &self.kind {
+            CompileMetaKind::Tuple { tuple, .. } => &tuple.item,
+            CompileMetaKind::TupleVariant { tuple, .. } => &tuple.item,
+            CompileMetaKind::Struct { object, .. } => &object.item,
+            CompileMetaKind::StructVariant { object, .. } => &object.item,
+            CompileMetaKind::Enum { item, .. } => item,
+            CompileMetaKind::Function { item, .. } => item,
+            CompileMetaKind::Closure { item, .. } => item,
+            CompileMetaKind::AsyncBlock { item, .. } => item,
+            CompileMetaKind::Macro { item, .. } => item,
+        }
+    }
+
+    /// Get the value type of the meta item.
+    pub fn type_of(&self) -> Option<Type> {
+        match &self.kind {
+            CompileMetaKind::Tuple { type_of, .. } => Some(*type_of),
+            CompileMetaKind::TupleVariant { .. } => None,
+            CompileMetaKind::Struct { type_of, .. } => Some(*type_of),
+            CompileMetaKind::StructVariant { .. } => None,
+            CompileMetaKind::Enum { type_of, .. } => Some(*type_of),
+            CompileMetaKind::Function { type_of, .. } => Some(*type_of),
+            CompileMetaKind::Closure { type_of, .. } => Some(*type_of),
+            CompileMetaKind::AsyncBlock { type_of, .. } => Some(*type_of),
+            CompileMetaKind::Macro { .. } => None,
+        }
+    }
+}
+
+impl fmt::Display for CompileMeta {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.kind {
+            CompileMetaKind::Tuple { tuple, .. } => {
+                write!(fmt, "struct {}", tuple.item)?;
+            }
+            CompileMetaKind::TupleVariant { tuple, .. } => {
+                write!(fmt, "variant {}", tuple.item)?;
+            }
+            CompileMetaKind::Struct { object, .. } => {
+                write!(fmt, "struct {}", object.item)?;
+            }
+            CompileMetaKind::StructVariant { object, .. } => {
+                write!(fmt, "variant {}", object.item)?;
+            }
+            CompileMetaKind::Enum { item, .. } => {
+                write!(fmt, "enum {}", item)?;
+            }
+            CompileMetaKind::Function { item, .. } => {
+                write!(fmt, "fn {}", item)?;
+            }
+            CompileMetaKind::Closure { item, .. } => {
+                write!(fmt, "closure {}", item)?;
+            }
+            CompileMetaKind::AsyncBlock { item, .. } => {
+                write!(fmt, "async block {}", item)?;
+            }
+            CompileMetaKind::Macro { item, .. } => {
+                write!(fmt, "macro {}", item)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Compile-time metadata kind about a unit.
+#[derive(Debug, Clone)]
+pub enum CompileMetaKind {
     /// Metadata about a tuple.
     Tuple {
         /// The value type associated with this meta item.
@@ -70,7 +147,7 @@ pub enum CompileMeta {
     },
     /// An async block.
     AsyncBlock {
-        /// The value type associated with this meta item.
+        /// The span where the async block is declared.
         type_of: Type,
         /// The item of the closure.
         item: Item,
@@ -82,74 +159,6 @@ pub enum CompileMeta {
         /// The item of the macro.
         item: Item,
     },
-}
-
-impl CompileMeta {
-    /// Get the item of the meta.
-    pub fn item(&self) -> &Item {
-        match self {
-            CompileMeta::Tuple { tuple, .. } => &tuple.item,
-            CompileMeta::TupleVariant { tuple, .. } => &tuple.item,
-            CompileMeta::Struct { object, .. } => &object.item,
-            CompileMeta::StructVariant { object, .. } => &object.item,
-            CompileMeta::Enum { item, .. } => item,
-            CompileMeta::Function { item, .. } => item,
-            CompileMeta::Closure { item, .. } => item,
-            CompileMeta::AsyncBlock { item, .. } => item,
-            CompileMeta::Macro { item, .. } => item,
-        }
-    }
-
-    /// Get the value type of the meta item.
-    pub fn type_of(&self) -> Option<Type> {
-        match self {
-            Self::Tuple { type_of, .. } => Some(*type_of),
-            Self::TupleVariant { .. } => None,
-            Self::Struct { type_of, .. } => Some(*type_of),
-            Self::StructVariant { .. } => None,
-            Self::Enum { type_of, .. } => Some(*type_of),
-            Self::Function { type_of, .. } => Some(*type_of),
-            Self::Closure { type_of, .. } => Some(*type_of),
-            Self::AsyncBlock { type_of, .. } => Some(*type_of),
-            Self::Macro { .. } => None,
-        }
-    }
-}
-
-impl fmt::Display for CompileMeta {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Tuple { tuple, .. } => {
-                write!(fmt, "struct {}", tuple.item)?;
-            }
-            Self::TupleVariant { tuple, .. } => {
-                write!(fmt, "variant {}", tuple.item)?;
-            }
-            Self::Struct { object, .. } => {
-                write!(fmt, "struct {}", object.item)?;
-            }
-            Self::StructVariant { object, .. } => {
-                write!(fmt, "variant {}", object.item)?;
-            }
-            Self::Enum { item, .. } => {
-                write!(fmt, "enum {}", item)?;
-            }
-            Self::Function { item, .. } => {
-                write!(fmt, "fn {}", item)?;
-            }
-            Self::Closure { item, .. } => {
-                write!(fmt, "closure {}", item)?;
-            }
-            Self::AsyncBlock { item, .. } => {
-                write!(fmt, "async block {}", item)?;
-            }
-            Self::Macro { item, .. } => {
-                write!(fmt, "macro {}", item)?;
-            }
-        }
-
-        Ok(())
-    }
 }
 
 /// The metadata about a type.

--- a/crates/runestick/src/context.rs
+++ b/crates/runestick/src/context.rs
@@ -3,8 +3,8 @@ use crate::module::{
     ModuleAssociatedFn, ModuleFn, ModuleInternalEnum, ModuleMacro, ModuleType, ModuleUnitType,
 };
 use crate::{
-    CompileMeta, CompileMetaStruct, CompileMetaTuple, Component, Hash, Item, Module, Names, Stack,
-    StaticType, Type, TypeCheck, TypeInfo, TypeOf, VmError,
+    CompileMeta, CompileMetaKind, CompileMetaStruct, CompileMetaTuple, Component, Hash, Item,
+    Module, Names, Stack, StaticType, Type, TypeCheck, TypeInfo, TypeOf, VmError,
 };
 use std::any;
 use std::fmt;
@@ -389,11 +389,14 @@ impl Context {
 
         self.install_meta(
             name.clone(),
-            CompileMeta::Struct {
-                type_of,
-                object: CompileMetaStruct {
-                    item: name,
-                    fields: None,
+            CompileMeta {
+                span: None,
+                kind: CompileMetaKind::Struct {
+                    type_of,
+                    object: CompileMetaStruct {
+                        item: name,
+                        fields: None,
+                    },
                 },
             },
         )?;
@@ -451,9 +454,12 @@ impl Context {
 
         self.meta.insert(
             name.clone(),
-            CompileMeta::Function {
-                type_of: Type::from(hash),
-                item: name,
+            CompileMeta {
+                span: None,
+                kind: CompileMetaKind::Function {
+                    type_of: Type::from(hash),
+                    item: name,
+                },
             },
         );
 
@@ -475,8 +481,13 @@ impl Context {
 
         self.macros.insert(hash, m.handler.clone());
 
-        self.meta
-            .insert(name.clone(), CompileMeta::Macro { item: name });
+        self.meta.insert(
+            name.clone(),
+            CompileMeta {
+                span: None,
+                kind: CompileMetaKind::Macro { item: name },
+            },
+        );
 
         Ok(())
     }
@@ -566,9 +577,12 @@ impl Context {
 
         self.install_meta(
             enum_item.clone(),
-            CompileMeta::Enum {
-                type_of: Type::from(internal_enum.static_type),
-                item: enum_item.clone(),
+            CompileMeta {
+                span: None,
+                kind: CompileMetaKind::Enum {
+                    type_of: Type::from(internal_enum.static_type),
+                    item: enum_item.clone(),
+                },
             },
         )?;
 
@@ -602,10 +616,13 @@ impl Context {
                 hash,
             };
 
-            let meta = CompileMeta::TupleVariant {
-                type_of: variant.type_of,
-                enum_item: enum_item.clone(),
-                tuple,
+            let meta = CompileMeta {
+                span: None,
+                kind: CompileMetaKind::TupleVariant {
+                    type_of: variant.type_of,
+                    enum_item: enum_item.clone(),
+                    tuple,
+                },
             };
 
             self.install_meta(item.clone(), meta)?;
@@ -650,12 +667,18 @@ impl Context {
         };
 
         let meta = match enum_item {
-            Some(enum_item) => CompileMeta::TupleVariant {
-                type_of,
-                enum_item,
-                tuple,
+            Some(enum_item) => CompileMeta {
+                span: None,
+                kind: CompileMetaKind::TupleVariant {
+                    type_of,
+                    enum_item,
+                    tuple,
+                },
             },
-            None => CompileMeta::Tuple { type_of, tuple },
+            None => CompileMeta {
+                span: None,
+                kind: CompileMetaKind::Tuple { type_of, tuple },
+            },
         };
 
         self.install_meta(item.clone(), meta)?;

--- a/crates/runestick/src/lib.rs
+++ b/crates/runestick/src/lib.rs
@@ -105,7 +105,7 @@ pub type Error = anyhow::Error;
 pub use self::any_obj::{AnyObj, AnyObjVtable};
 pub use self::args::Args;
 pub use self::compile_meta::{
-    CompileMeta, CompileMetaCapture, CompileMetaStruct, CompileMetaTuple,
+    CompileMeta, CompileMetaCapture, CompileMetaKind, CompileMetaStruct, CompileMetaTuple,
 };
 pub use self::from_value::{FromValue, UnsafeFromValue};
 pub use self::generator::Generator;

--- a/editors/code/syntaxes/rune.tmGrammar.json
+++ b/editors/code/syntaxes/rune.tmGrammar.json
@@ -88,6 +88,9 @@
 			"include": "#raw_string_literal"
 		},
 		{
+			"include": "#template"
+		},
+		{
 			"comment": "Floating point literal (fraction)",
 			"name": "constant.numeric.float.rune",
 			"match": "\\b[0-9][0-9_]*\\.[0-9][0-9_]*([eE][+-]?[0-9_]+)?(f32|f64)?\\b"
@@ -373,6 +376,17 @@
 			"name": "string.quoted.double.raw.rune",
 			"begin": "b?r(#*)\"",
 			"end": "\"\\1"
+		},
+		"template": {
+			"comment": "Template string",
+			"name": "string.quoted.single.template.rune",
+			"begin": "b?`",
+			"end": "`",
+			"patterns": [
+				{
+					"include": "#escaped_character"
+				}
+			]
 		},
 		"sigils": {
 			"comment": "Sigil",

--- a/scripts/publish.rn
+++ b/scripts/publish.rn
@@ -1,5 +1,0 @@
-use command;
-
-fn main() {
-    
-}

--- a/scripts/strings.rn
+++ b/scripts/strings.rn
@@ -1,5 +1,3 @@
-use string;
-
 fn main() {
     let a = "foo";
 


### PR DESCRIPTION
Relates: #44 

This adds some hooks to `CompileVisitor` to capture all meta and local variable lookups that happens during a compile, making it pretty straight forward to build a goto index for them which can be queried.

The good news is that since it hooks into the compiler for meta and local variable lookup, it will catch everything that compiles and uses language items. Which should work everywhere (including macro output!).

It should work for everything. With the following caveats:
* The languageserver compiles the file in in-memory mode, so module includes are not support (this will be fixed soon).
* Native modules do not have a source location to jump to, so goto is not support for them. This might be solvable by external definition files, possibly generated on-the-fly.
* Incremental compilation has not been implemented (this will be fixed eventually), so it only works well for as long as the project is small enough. Exactly how small depends on the speed of your dev box and how fast the compiler really is, which is hard to say since there's no huge projects in Rune yet.

This showcases how it work (by holding `CTRL`):
![B5XBGmKyBs](https://user-images.githubusercontent.com/111092/93017349-32a28f00-f5c8-11ea-9301-5fcb586c89c8.gif)
