### PR TITLE
Make the representation of items more compact

### DIFF
--- a/crates/rune-testing/examples/use_references.rs
+++ b/crates/rune-testing/examples/use_references.rs
@@ -14,7 +14,7 @@ impl Foo {
 }
 
 fn main() -> runestick::Result<()> {
-    let mut module = Module::new(Item::empty());
+    let mut module = Module::new(Item::new());
     module.ty::<Foo>()?;
     module.inst_fn(runestick::ADD_ASSIGN, Foo::add_assign)?;
 

--- a/crates/rune-testing/src/lib.rs
+++ b/crates/rune-testing/src/lib.rs
@@ -51,8 +51,8 @@ pub use rune::WarningKind::*;
 use rune::Warnings;
 pub use runestick::Result;
 pub use runestick::VmErrorKind::*;
-pub use runestick::{CompileMeta, CompileMetaKind, Function, Span, Value};
-use runestick::{Component, Item, Source, Unit};
+pub use runestick::{CompileMeta, CompileMetaKind, Function, IntoComponent, Span, Value};
+use runestick::{Item, Source, Unit};
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -74,7 +74,7 @@ pub fn compile_source(context: &runestick::Context, source: &str) -> Result<(Uni
 pub async fn run_async<N, A, T>(function: N, args: A, source: &str) -> Result<T>
 where
     N: IntoIterator,
-    N::Item: Into<Component>,
+    N::Item: IntoComponent,
     A: runestick::Args,
     T: runestick::FromValue,
 {
@@ -94,7 +94,7 @@ where
 pub fn run<N, A, T>(function: N, args: A, source: &str) -> Result<T>
 where
     N: IntoIterator,
-    N::Item: Into<Component>,
+    N::Item: IntoComponent,
     A: runestick::Args,
     T: runestick::FromValue,
 {

--- a/crates/rune/src/ast/path.rs
+++ b/crates/rune/src/ast/path.rs
@@ -55,7 +55,7 @@ impl Path {
     }
 
     /// Iterate over all components in path.
-    pub fn components(&self) -> impl Iterator<Item = &'_ ast::Ident> + '_ {
+    pub fn into_components(&self) -> impl Iterator<Item = &'_ ast::Ident> + '_ {
         let mut first = Some(&self.first);
         let mut it = self.rest.iter();
 

--- a/crates/rune/src/index.rs
+++ b/crates/rune/src/index.rs
@@ -609,7 +609,7 @@ impl Index<ast::Item> for Indexer<'_> {
             ast::Item::ItemImpl(decl_impl) => {
                 let mut guards = Vec::new();
 
-                for ident in decl_impl.path.components() {
+                for ident in decl_impl.path.into_components() {
                     let ident = ident.resolve(&self.storage, &*self.source)?;
                     guards.push(self.items.push_name(ident.as_ref()));
                 }

--- a/crates/rune/src/items.rs
+++ b/crates/rune/src/items.rs
@@ -116,9 +116,9 @@ impl Items {
 
     /// Push a component and return a guard to it.
     pub fn push_name(&mut self, name: &str) -> Guard {
-        self.path
-            .borrow_mut()
-            .push(Node::from(Component::String(name.to_owned())));
+        self.path.borrow_mut().push(Node::from(Component::String(
+            name.to_owned().into_boxed_str(),
+        )));
 
         Guard {
             path: self.path.clone(),

--- a/crates/rune/src/worker.rs
+++ b/crates/rune/src/worker.rs
@@ -266,7 +266,7 @@ impl Import {
 
         let span = decl_use.span();
 
-        let mut name = Item::empty();
+        let mut name = Item::new();
         let first = decl_use.first.resolve(storage, &*source)?;
         name.push(first.as_ref());
 

--- a/crates/runestick/Cargo.toml
+++ b/crates/runestick/Cargo.toml
@@ -29,6 +29,7 @@ futures-util = "0.3.5"
 # used to store errors raised in user-defined functions.
 anyhow = "1.0.32"
 pin-project = "0.4.23"
+byteorder = "1.3.4"
 
 runestick-macros = {version = "0.6.16", path = "../runestick-macros"}
 

--- a/crates/runestick/src/context.rs
+++ b/crates/runestick/src/context.rs
@@ -3,8 +3,9 @@ use crate::module::{
     ModuleAssociatedFn, ModuleFn, ModuleInternalEnum, ModuleMacro, ModuleType, ModuleUnitType,
 };
 use crate::{
-    CompileMeta, CompileMetaKind, CompileMetaStruct, CompileMetaTuple, Component, Hash, Item,
-    Module, Names, Stack, StaticType, Type, TypeCheck, TypeInfo, TypeOf, VmError,
+    CompileMeta, CompileMetaKind, CompileMetaStruct, CompileMetaTuple, Component, Hash,
+    IntoComponent, Item, Module, Names, Stack, StaticType, Type, TypeCheck, TypeInfo, TypeOf,
+    VmError,
 };
 use std::any;
 use std::fmt;
@@ -267,10 +268,10 @@ impl Context {
     }
 
     /// Iterate over known child components of the given name.
-    pub fn iter_components<I>(&self, iter: I) -> impl Iterator<Item = &Component>
+    pub fn iter_components<'a, I: 'a>(&'a self, iter: I) -> impl Iterator<Item = Component> + 'a
     where
         I: IntoIterator,
-        I::Item: Into<Component>,
+        I::Item: IntoComponent,
     {
         self.names.iter_components(iter)
     }
@@ -597,7 +598,7 @@ impl Context {
         )?;
 
         for variant in &internal_enum.variants {
-            let item = enum_item.clone().extended(variant.name);
+            let item = enum_item.extended(variant.name);
             let hash = Hash::type_hash(&item);
 
             self.install_type_info(

--- a/crates/runestick/src/hash.rs
+++ b/crates/runestick/src/hash.rs
@@ -1,4 +1,4 @@
-use crate::{Any, Component, Item, Type};
+use crate::{Any, IntoComponent, Item, Type};
 use serde::{Deserialize, Serialize};
 use std::any;
 use std::fmt;
@@ -99,13 +99,13 @@ impl Hash {
     fn path_hash<I>(kind: usize, path: I) -> Self
     where
         I: IntoIterator,
-        I::Item: Into<Component>,
+        I::Item: IntoComponent,
     {
         let mut hasher = Self::new_hasher();
         kind.hash(&mut hasher);
 
-        for part in path {
-            part.into().hash(&mut hasher);
+        for c in path {
+            c.hash_component(&mut hasher);
         }
 
         Self(hasher.finish())
@@ -139,14 +139,14 @@ impl IntoHash for Hash {
     }
 
     fn into_item(self) -> Item {
-        Item::empty()
+        Item::new()
     }
 }
 
 impl<I> IntoHash for I
 where
     I: Copy + IntoIterator,
-    I::Item: Into<Component>,
+    I::Item: IntoComponent,
 {
     fn into_hash(self) -> Hash {
         Hash::path_hash(TYPE, self)

--- a/crates/runestick/src/item.rs
+++ b/crates/runestick/src/item.rs
@@ -1,71 +1,101 @@
 use crate::RawStr;
+use byteorder::{ByteOrder as _, LittleEndian, ReadBytesExt as _, WriteBytesExt as _};
 use serde::{Deserialize, Serialize};
-use std::convert;
+use std::convert::TryFrom as _;
 use std::fmt;
+use std::hash;
+use std::hash::Hash as _;
+use std::io::Cursor;
+use std::io::Read as _;
+
+const STRING: u8 = 0;
+const BLOCK: u8 = 1;
+const CLOSURE: u8 = 2;
+const ASYNC_BLOCK: u8 = 3;
+const MACRO: u8 = 4;
 
 /// The name of an item.
 ///
 /// This is made up of a collection of strings, like `["foo", "bar"]`.
 /// This is indicated in rune as `foo::bar`.
+///
+/// # Panics
+///
+/// The max length of an item is 2**16 = 65536. Attempting to create an item
+/// larger than that will panic.
+///
+/// # Component encoding
+///
+/// A component is encoded as:
+/// * A single byte prefix identifying the type of the component.
+/// * The payload of the component, specific to its type.
+/// * The offset to the start of the last component.
 #[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct Item {
-    path: Vec<Component>,
+    content: Vec<u8>,
 }
 
 impl Item {
     /// Construct an empty item.
-    pub const fn empty() -> Self {
-        Self { path: Vec::new() }
-    }
-
-    /// Construct a new item path.
-    pub fn new(path: Vec<Component>) -> Self {
-        Self { path }
+    pub const fn new() -> Self {
+        Self {
+            content: Vec::new(),
+        }
     }
 
     /// Construct a new item path.
     pub fn of<I>(iter: I) -> Self
     where
         I: IntoIterator,
-        I::Item: Into<Component>,
+        I::Item: IntoComponent,
     {
-        Self {
-            path: iter.into_iter().map(Into::into).collect::<Vec<Component>>(),
+        let mut content = Vec::new();
+
+        for c in iter {
+            c.write_component(&mut content);
         }
+
+        Self { content }
     }
 
     /// Check if the item is empty.
     pub fn is_empty(&self) -> bool {
-        self.path.is_empty()
+        self.content.is_empty()
     }
 
     /// Push the given component to the current item.
-    pub fn push<C>(&mut self, component: C)
+    pub fn push<C>(&mut self, c: C)
     where
-        C: Into<Component>,
+        C: IntoComponent,
     {
-        self.path.push(component.into());
+        c.write_component(&mut self.content);
     }
 
     /// Push the given component to the current item.
     pub fn pop(&mut self) -> Option<Component> {
-        self.path.pop()
+        let mut it = self.iter();
+        let c = it.next_back()?;
+        let new_len = it.content.len();
+        self.content.resize(new_len, 0);
+        Some(c)
     }
 
     /// Construct a new vector from the current item.
     pub fn as_vec(&self) -> Vec<Component> {
-        self.path.clone()
+        self.iter().collect::<Vec<_>>()
     }
 
     /// Convert into a vector from the current item.
     pub fn into_vec(self) -> Vec<Component> {
-        self.path
+        self.iter().collect::<Vec<_>>()
     }
 
     /// If the item only contains one element, return that element.
     pub fn as_local(&self) -> Option<&str> {
-        match self.path.last() {
-            Some(Component::String(last)) if self.path.len() == 1 => Some(&*last),
+        let mut it = self.iter();
+
+        match it.next_back_str() {
+            Some(last) if it.is_empty() => Some(last),
             _ => None,
         }
     }
@@ -74,30 +104,37 @@ impl Item {
     pub fn join<I>(&self, other: I) -> Self
     where
         I: IntoIterator,
-        I::Item: Into<Component>,
+        I::Item: IntoComponent,
     {
-        let mut path = self.path.to_vec();
+        let mut content = self.content.clone();
 
-        for part in other {
-            path.push(part.into());
+        for c in other {
+            c.write_component(&mut content);
         }
 
-        Self::new(path)
+        Self { content }
     }
 
     /// Clone and extend the item path.
     pub fn extended<C>(&self, part: C) -> Self
     where
-        C: Into<Component>,
+        C: IntoComponent,
     {
-        let mut path = self.path.clone();
-        path.push(part.into());
-        Self::new(path)
+        let mut content = self.content.clone();
+        part.write_component(&mut content);
+        Self { content }
     }
 
     /// Access the last component in the path.
-    pub fn last(&self) -> Option<&Component> {
-        self.path.last()
+    pub fn last(&self) -> Option<Component> {
+        self.iter().next_back()
+    }
+
+    /// Implement an iterator.
+    pub fn iter(&self) -> Iter<'_> {
+        Iter {
+            content: &self.content,
+        }
     }
 }
 
@@ -110,12 +147,12 @@ impl Item {
 /// ```rust
 /// use runestick::{Item, Component::*};
 ///
-/// assert_eq!("{empty}", Item::empty().to_string());
+/// assert_eq!("{empty}", Item::new().to_string());
 /// assert_eq!("hello::$block0", Item::of(&[String("hello".into()), Block(0)]).to_string());
 /// ```
 impl fmt::Display for Item {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut it = self.path.iter();
+        let mut it = self.iter();
 
         if let Some(last) = it.next_back() {
             for p in it {
@@ -134,16 +171,89 @@ impl<'a> IntoIterator for Item {
     type Item = Component;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.path.to_vec().into_iter()
+        self.as_vec().into_iter()
     }
 }
 
 impl<'a> IntoIterator for &'a Item {
-    type IntoIter = std::slice::Iter<'a, Component>;
-    type Item = &'a Component;
+    type IntoIter = Iter<'a>;
+    type Item = Component;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.path.iter()
+        self.iter()
+    }
+}
+
+/// An item over the iterator.
+///
+/// Constructed using [Item::iter].
+pub struct Iter<'a> {
+    content: &'a [u8],
+}
+
+impl<'a> Iter<'a> {
+    /// Check if the iterator is empty.
+    pub fn is_empty(&self) -> bool {
+        self.content.is_empty()
+    }
+
+    /// Get the next component as a string.
+    ///
+    /// Will consume the next component in the iterator, but will only indicate
+    /// if the next component was present, and was a [Component::String].
+    pub fn next_str(&mut self) -> Option<&'a str> {
+        if self.content.is_empty() {
+            return None;
+        }
+
+        let mut cursor = Cursor::new(&self.content[..]);
+        let c = Component::try_decode_str(&mut cursor);
+        let start = usize::try_from(cursor.position()).unwrap();
+        self.content = &self.content[start..];
+        c
+    }
+
+    /// Get the next back as a string component.
+    ///
+    /// Will consume the next component in the iterator, but will only indicate
+    /// if the next component was present, and was a [Component::String].
+    pub fn next_back_str(&mut self) -> Option<&'a str> {
+        if self.content.is_empty() {
+            return None;
+        }
+
+        let (head, tail) = split_tail(&self.content);
+        self.content = head;
+        Component::try_decode_str(&mut Cursor::new(tail))
+    }
+}
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = Component;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.content.is_empty() {
+            return None;
+        }
+
+        let mut cursor = Cursor::new(&self.content[..]);
+        let c = Component::decode(&mut cursor);
+        let start = usize::try_from(cursor.position()).unwrap();
+        self.content = &self.content[start..];
+        Some(c)
+    }
+}
+
+impl<'a> DoubleEndedIterator for Iter<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.content.is_empty() {
+            return None;
+        }
+
+        let (head, tail) = split_tail(&self.content);
+        self.content = head;
+        let c = Component::decode(&mut Cursor::new(tail));
+        Some(c)
     }
 }
 
@@ -151,7 +261,7 @@ impl<'a> IntoIterator for &'a Item {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum Component {
     /// A regular string component.
-    String(String),
+    String(Box<str>),
     /// A nested block with an index.
     ///
     /// The block for the current function is always `0`.
@@ -162,6 +272,69 @@ pub enum Component {
     AsyncBlock(usize),
     /// An expanded macro.
     Macro(usize),
+}
+
+impl Component {
+    /// Encode the given string onto the buffer.
+    fn write_str(output: &mut Vec<u8>, s: &str) {
+        let len = output.len();
+        Self::internal_write_str(output, s);
+        write_usize(output, output.len() - len);
+    }
+
+    /// Encode only the string.
+    fn internal_write_str(output: &mut Vec<u8>, s: &str) {
+        output.push(STRING);
+        let len = u16::try_from(s.len()).unwrap();
+        output.write_u16::<LittleEndian>(len).unwrap();
+        output.extend(s.as_bytes());
+    }
+
+    /// Internal function to decode a borrowed string component without cloning
+    /// it.
+    fn try_decode_str<'a>(content: &mut Cursor<&'a [u8]>) -> Option<&'a str> {
+        let c = match read_u8(content) {
+            STRING => {
+                let len = read_usize(content);
+                let bytes = read_bytes(content, len);
+
+                // Safety: all code paths which construct a string component
+                // are safe input paths which ensure that the input is a string.
+                Some(unsafe { std::str::from_utf8_unchecked(bytes) })
+            }
+            BLOCK | CLOSURE | ASYNC_BLOCK | MACRO => None,
+            b => panic!("unexpected control byte `{:?}`", b),
+        };
+
+        // read the suffix offset used for reading backwards.
+        let _ = read_usize(content);
+        c
+    }
+
+    /// Internal function to decode a component from the given content.
+    fn decode(content: &mut Cursor<&[u8]>) -> Component {
+        let c = match read_u8(content) {
+            STRING => {
+                let len = read_usize(content);
+                let bytes = read_bytes(content, len);
+
+                // Safety: all code paths which construct a string component
+                // are safe input paths which ensure that the input is a string.
+                unsafe {
+                    Component::String(String::from_utf8_unchecked(bytes.to_vec()).into_boxed_str())
+                }
+            }
+            BLOCK => Component::Block(read_usize(content)),
+            CLOSURE => Component::Closure(read_usize(content)),
+            ASYNC_BLOCK => Component::AsyncBlock(read_usize(content)),
+            MACRO => Component::Macro(read_usize(content)),
+            b => panic!("unexpected control byte `{:?}`", b),
+        };
+
+        // read the suffix offset used for reading backwards.
+        let _ = read_usize(content);
+        c
+    }
 }
 
 impl fmt::Display for Component {
@@ -176,50 +349,355 @@ impl fmt::Display for Component {
     }
 }
 
-impl convert::AsRef<Component> for Component {
-    fn as_ref(&self) -> &Component {
+/// Trait for encoding the current type into a component.
+pub trait IntoComponent {
+    /// Convert into a component directly.
+    fn into_component(self) -> Component;
+
+    /// Write a component directly to a buffer.
+    fn write_component(self, output: &mut Vec<u8>);
+
+    /// Hash the current component.
+    fn hash_component<H>(self, hasher: &mut H)
+    where
+        H: hash::Hasher;
+}
+
+impl IntoComponent for Component {
+    fn into_component(self) -> Component {
         self
     }
-}
 
-impl From<RawStr> for Component {
-    fn from(value: RawStr) -> Self {
-        Self::String((&*value).to_owned())
+    fn write_component(self, output: &mut Vec<u8>) {
+        <&Component>::write_component(&self, output)
+    }
+
+    fn hash_component<H>(self, hasher: &mut H)
+    where
+        H: hash::Hasher,
+    {
+        <&Component>::hash_component(&self, hasher);
     }
 }
 
-impl From<&RawStr> for Component {
-    fn from(value: &RawStr) -> Self {
-        Self::String((&**value).to_owned())
+impl IntoComponent for &Component {
+    fn into_component(self) -> Component {
+        self.clone()
+    }
+
+    fn write_component(self, output: &mut Vec<u8>) {
+        let offset = output.len();
+
+        match self {
+            Component::String(s) => {
+                Component::internal_write_str(output, s.as_ref());
+            }
+            Component::Block(c) => {
+                output.push(BLOCK);
+                write_usize(output, *c);
+            }
+            Component::Closure(c) => {
+                output.push(CLOSURE);
+                write_usize(output, *c);
+            }
+            Component::AsyncBlock(c) => {
+                output.push(ASYNC_BLOCK);
+                write_usize(output, *c);
+            }
+            Component::Macro(c) => {
+                output.push(MACRO);
+                write_usize(output, *c);
+            }
+        }
+
+        write_usize(output, output.len() - offset);
+    }
+
+    fn hash_component<H>(self, hasher: &mut H)
+    where
+        H: hash::Hasher,
+    {
+        match self {
+            Component::String(s) => {
+                STRING.hash(hasher);
+                s.hash(hasher);
+            }
+            Component::Block(c) => {
+                BLOCK.hash(hasher);
+                c.hash(hasher);
+            }
+            Component::Closure(c) => {
+                CLOSURE.hash(hasher);
+                c.hash(hasher);
+            }
+            Component::AsyncBlock(c) => {
+                ASYNC_BLOCK.hash(hasher);
+                c.hash(hasher);
+            }
+            Component::Macro(c) => {
+                MACRO.hash(hasher);
+                c.hash(hasher);
+            }
+        }
     }
 }
 
-impl From<&str> for Component {
-    fn from(value: &str) -> Self {
-        Self::String(value.to_owned())
+impl IntoComponent for RawStr {
+    fn into_component(self) -> Component {
+        Component::String((*self).to_owned().into_boxed_str())
+    }
+
+    fn write_component(self, output: &mut Vec<u8>) {
+        Component::write_str(output, &*self)
+    }
+
+    fn hash_component<H>(self, hasher: &mut H)
+    where
+        H: hash::Hasher,
+    {
+        <&str>::hash_component(&*self, hasher);
     }
 }
 
-impl From<&&str> for Component {
-    fn from(value: &&str) -> Self {
-        Self::String((*value).to_owned())
+impl IntoComponent for &RawStr {
+    fn into_component(self) -> Component {
+        Component::String((**self).to_owned().into_boxed_str())
+    }
+
+    fn write_component(self, output: &mut Vec<u8>) {
+        Component::write_str(output, &**self)
+    }
+
+    fn hash_component<H>(self, hasher: &mut H)
+    where
+        H: hash::Hasher,
+    {
+        <&str>::hash_component(&**self, hasher);
     }
 }
 
-impl From<String> for Component {
-    fn from(value: String) -> Self {
-        Self::String(value)
+impl IntoComponent for &str {
+    fn into_component(self) -> Component {
+        Component::String(self.to_owned().into_boxed_str())
+    }
+
+    fn write_component(self, output: &mut Vec<u8>) {
+        Component::write_str(output, self)
+    }
+
+    fn hash_component<H>(self, hasher: &mut H)
+    where
+        H: hash::Hasher,
+    {
+        STRING.hash(hasher);
+        self.hash(hasher);
     }
 }
 
-impl From<&String> for Component {
-    fn from(value: &String) -> Self {
-        Self::String(value.clone())
+impl IntoComponent for &&str {
+    fn into_component(self) -> Component {
+        Component::String((*self).to_owned().into_boxed_str())
+    }
+
+    fn write_component(self, output: &mut Vec<u8>) {
+        Component::write_str(output, *self)
+    }
+
+    fn hash_component<H>(self, hasher: &mut H)
+    where
+        H: hash::Hasher,
+    {
+        <&str>::hash_component(*self, hasher);
     }
 }
 
-impl From<&Component> for Component {
-    fn from(value: &Component) -> Self {
-        value.clone()
+impl IntoComponent for String {
+    fn into_component(self) -> Component {
+        Component::String(self.into_boxed_str())
+    }
+
+    fn write_component(self, output: &mut Vec<u8>) {
+        Component::write_str(output, self.as_str())
+    }
+
+    fn hash_component<H>(self, hasher: &mut H)
+    where
+        H: hash::Hasher,
+    {
+        <&str>::hash_component(self.as_str(), hasher);
+    }
+}
+
+impl IntoComponent for &String {
+    fn into_component(self) -> Component {
+        Component::String(self.clone().into_boxed_str())
+    }
+
+    fn write_component(self, output: &mut Vec<u8>) {
+        Component::write_str(output, self.as_str())
+    }
+
+    fn hash_component<H>(self, hasher: &mut H)
+    where
+        H: hash::Hasher,
+    {
+        <&str>::hash_component(self.as_str(), hasher);
+    }
+}
+
+/// Split the tail end of the content buffer.
+fn split_tail(content: &[u8]) -> (&[u8], &[u8]) {
+    let start = content.len().checked_sub(2).unwrap();
+    let len = LittleEndian::read_u16(&content[start..]);
+    let len = usize::try_from(len).unwrap();
+    let start = start.checked_sub(len).unwrap();
+    let start = usize::try_from(start).unwrap();
+    content.split_at(start)
+}
+
+/// Read a single byte from the cursor.
+fn read_u8(cursor: &mut Cursor<&[u8]>) -> u8 {
+    let mut buf = [0u8; 1];
+    cursor.read_exact(&mut buf).unwrap();
+    buf[0]
+}
+
+/// Read a usize out of the cursor.
+///
+/// Internally we encode usize's as LE u32's.
+///
+/// # Panics
+///
+/// panics if the cursor doesn't contain enough data to decode.
+fn read_usize(cursor: &mut Cursor<&[u8]>) -> usize {
+    let c = cursor.read_u16::<LittleEndian>().unwrap();
+    usize::try_from(c).unwrap()
+}
+
+/// Helper function to write a usize.
+///
+/// # Panics
+///
+/// Panics if the provided value cannot fit in a u16.
+fn write_usize(output: &mut Vec<u8>, value: usize) {
+    let value = u16::try_from(value).unwrap();
+    output.write_u16::<LittleEndian>(value).unwrap();
+}
+
+/// Read the given number of bytes from the cursor without copying them.
+///
+/// # Panics
+///
+/// Panics if the provided number of bytes are not available in the cursor.
+fn read_bytes<'a>(cursor: &mut Cursor<&'a [u8]>, len: usize) -> &'a [u8] {
+    let pos = usize::try_from(cursor.position()).unwrap();
+    let end = pos.checked_add(len).unwrap();
+    let bytes = &(*cursor.get_ref())[pos..end];
+    let end = u64::try_from(end).unwrap();
+    cursor.set_position(end);
+    bytes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Component, IntoComponent as _, Item};
+
+    #[test]
+    fn test_pop() {
+        let mut item = Item::new();
+
+        item.push("start");
+        item.push(Component::Block(1));
+        item.push(Component::Closure(2));
+        item.push("middle");
+        item.push(Component::AsyncBlock(3));
+        item.push(Component::Macro(4));
+        item.push("end");
+
+        assert_eq!(item.pop(), Some("end".into_component()));
+        assert_eq!(item.pop(), Some(Component::Macro(4)));
+        assert_eq!(item.pop(), Some(Component::AsyncBlock(3)));
+        assert_eq!(item.pop(), Some("middle".into_component()));
+        assert_eq!(item.pop(), Some(Component::Closure(2)));
+        assert_eq!(item.pop(), Some(Component::Block(1)));
+        assert_eq!(item.pop(), Some("start".into_component()));
+        assert_eq!(item.pop(), None);
+
+        assert!(item.is_empty());
+    }
+
+    #[test]
+    fn test_iter() {
+        let mut item = Item::new();
+
+        item.push("start");
+        item.push(Component::Block(1));
+        item.push(Component::Closure(2));
+        item.push("middle");
+        item.push(Component::AsyncBlock(3));
+        item.push(Component::Macro(4));
+        item.push("end");
+
+        let mut it = item.iter();
+
+        assert_eq!(it.next(), Some("start".into_component()));
+        assert_eq!(it.next(), Some(Component::Block(1)));
+        assert_eq!(it.next(), Some(Component::Closure(2)));
+        assert_eq!(it.next(), Some("middle".into_component()));
+        assert_eq!(it.next(), Some(Component::AsyncBlock(3)));
+        assert_eq!(it.next(), Some(Component::Macro(4)));
+        assert_eq!(it.next(), Some("end".into_component()));
+        assert_eq!(it.next(), None);
+
+        assert!(!item.is_empty());
+    }
+
+    #[test]
+    fn test_next_back_str() {
+        let mut item = Item::new();
+
+        item.push("start");
+        item.push(Component::Block(1));
+        item.push(Component::Closure(2));
+        item.push("middle");
+        item.push(Component::AsyncBlock(3));
+        item.push(Component::Macro(4));
+        item.push("end");
+
+        let mut it = item.iter();
+
+        assert_eq!(it.next_back_str(), Some("end"));
+        assert_eq!(it.next_back(), Some(Component::Macro(4)));
+        assert_eq!(it.next_back(), Some(Component::AsyncBlock(3)));
+        assert_eq!(it.next_back_str(), Some("middle"));
+        assert_eq!(it.next_back(), Some(Component::Closure(2)));
+        assert_eq!(it.next_back(), Some(Component::Block(1)));
+        assert_eq!(it.next_back_str(), Some("start"));
+        assert_eq!(it.next_back(), None);
+    }
+
+    #[test]
+    fn alternate() {
+        let mut item = Item::new();
+
+        item.push("start");
+        item.push(Component::Block(1));
+        item.push(Component::Closure(2));
+        item.push("middle");
+        item.push(Component::AsyncBlock(3));
+        item.push(Component::Macro(4));
+        item.push("end");
+
+        let mut it = item.iter();
+
+        assert_eq!(it.next_str(), Some("start"));
+        assert_eq!(it.next_back_str(), Some("end"));
+        assert_eq!(it.next(), Some(Component::Block(1)));
+        assert_eq!(it.next_back(), Some(Component::Macro(4)));
+        assert_eq!(it.next(), Some(Component::Closure(2)));
+        assert_eq!(it.next_back(), Some(Component::AsyncBlock(3)));
+        assert_eq!(it.next_str(), Some("middle"));
+        assert_eq!(it.next_back(), None);
+        assert_eq!(it.next(), None);
     }
 }

--- a/crates/runestick/src/lib.rs
+++ b/crates/runestick/src/lib.rs
@@ -143,7 +143,7 @@ pub use crate::function::Function;
 pub use crate::future::Future;
 pub use crate::hash::{Hash, IntoHash};
 pub use crate::inst::{Inst, PanicReason, TypeCheck};
-pub use crate::item::{Component, Item};
+pub use crate::item::{Component, IntoComponent, Item};
 pub use crate::names::Names;
 pub use crate::object::Object;
 pub use crate::panic::Panic;

--- a/crates/runestick/src/module.rs
+++ b/crates/runestick/src/module.rs
@@ -5,7 +5,7 @@
 
 use crate::collections::HashMap;
 use crate::{
-    Component, Future, Hash, Named, Stack, ToValue, Type, TypeInfo, TypeOf, UnsafeFromValue,
+    Future, Hash, IntoComponent, Named, Stack, ToValue, Type, TypeInfo, TypeOf, UnsafeFromValue,
     VmError, VmErrorKind,
 };
 use std::any;
@@ -39,7 +39,7 @@ impl ModuleInternalEnum {
     pub fn new<N>(name: &'static str, base_type: N, static_type: &'static StaticType) -> Self
     where
         N: IntoIterator,
-        N::Item: Into<Component>,
+        N::Item: IntoComponent,
     {
         ModuleInternalEnum {
             name,
@@ -153,7 +153,7 @@ impl Module {
     pub fn new<I>(path: I) -> Self
     where
         I: IntoIterator,
-        I::Item: Into<Component>,
+        I::Item: IntoComponent,
     {
         Self {
             path: Item::of(path),
@@ -254,7 +254,7 @@ impl Module {
     pub fn unit<N>(&mut self, name: N) -> Result<(), ContextError>
     where
         N: IntoIterator,
-        N::Item: Into<Component>,
+        N::Item: IntoComponent,
     {
         if self.unit_type.is_some() {
             return Err(ContextError::UnitAlreadyPresent);
@@ -283,7 +283,7 @@ impl Module {
     pub fn option<N>(&mut self, name: N) -> Result<(), ContextError>
     where
         N: IntoIterator,
-        N::Item: Into<Component>,
+        N::Item: IntoComponent,
     {
         let mut enum_ = ModuleInternalEnum::new("Option", name, crate::OPTION_TYPE);
 
@@ -314,7 +314,7 @@ impl Module {
     pub fn result<N>(&mut self, name: N) -> Result<(), ContextError>
     where
         N: IntoIterator,
-        N::Item: Into<Component>,
+        N::Item: IntoComponent,
     {
         let mut enum_ = ModuleInternalEnum::new("Result", name, crate::RESULT_TYPE);
 
@@ -346,7 +346,7 @@ impl Module {
     pub fn generator_state<N>(&mut self, name: N) -> Result<(), ContextError>
     where
         N: IntoIterator,
-        N::Item: Into<Component>,
+        N::Item: IntoComponent,
     {
         let mut enum_ =
             ModuleInternalEnum::new("GeneratorState", name, crate::GENERATOR_STATE_TYPE);
@@ -392,7 +392,7 @@ impl Module {
     where
         Func: Function<Args>,
         N: IntoIterator,
-        N::Item: Into<Component>,
+        N::Item: IntoComponent,
     {
         let name = Item::of(name);
 
@@ -419,7 +419,7 @@ impl Module {
         B: any::Any,
         O: any::Any,
         N: IntoIterator,
-        N::Item: Into<Component>,
+        N::Item: IntoComponent,
     {
         let name = Item::of(name);
 
@@ -475,7 +475,7 @@ impl Module {
     where
         Func: AsyncFunction<Args>,
         N: IntoIterator,
-        N::Item: Into<Component>,
+        N::Item: IntoComponent,
     {
         let name = Item::of(name);
 
@@ -500,7 +500,7 @@ impl Module {
     where
         F: 'static + Copy + Fn(&mut Stack, usize) -> Result<(), VmError> + Send + Sync,
         N: IntoIterator,
-        N::Item: Into<Component>,
+        N::Item: IntoComponent,
     {
         let name = Item::of(name);
 


### PR DESCRIPTION
We also avoid a number of unnecessary string conversion by making more liberal use of an internal trait called `IntoComponent`.

This should make compilations more memory efficient, since items are used liberally.