### PR TITLE
languageserver: Support diagnostics for multi-file projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let mut warnings = rune::Warnings::new();
     let mut sources = rune::Sources::new();
 
-    sources.insert_default(Source::new(
+    sources.insert(Source::new(
         "script",
         r#"
         fn calculate(a, b) {

--- a/book/src/compiler_guide.md
+++ b/book/src/compiler_guide.md
@@ -8,7 +8,7 @@ people who want to hack on it.
 Compiling a rune program involves the following stages:
 
 * Parse and queue the initial source files into [`AST`], specified by
-  [`Source::insert_default`].
+  [`Source::insert`].
 * **Indexing and macro expansion**, which processes tasks in the [`Worker`]
   queue until it is empty. These are:
   * `Task::Index` - Index language items.
@@ -19,7 +19,7 @@ Compiling a rune program involves the following stages:
 * **Compilation** which processes a queue of items to be compiled.
 
 [`AST`]: https://github.com/rune-rs/rune/tree/master/crates/rune/src/ast
-[`Source::insert_default`]: https://docs.rs/runestick/0/runestick/struct.Source.html#method.insert_default
+[`Source::insert`]: https://docs.rs/runestick/0/runestick/struct.Source.html#method.insert
 [`Worker`]: https://github.com/rune-rs/rune/blob/master/crates/rune/src/worker.rs
 
 ## Indexing

--- a/crates/rune-languageserver/src/main.rs
+++ b/crates/rune-languageserver/src/main.rs
@@ -55,7 +55,7 @@ fn setup_logging() -> Result<()> {
         use log4rs::encode::pattern::PatternEncoder;
 
         let logfile = FileAppender::builder()
-            .encoder(Box::new(PatternEncoder::new("{l} - {m}\n")))
+            .encoder(Box::new(PatternEncoder::default()))
             .build(log_path)?;
 
         let config = Config::builder()
@@ -239,14 +239,7 @@ async fn did_close_text_document(
     params: lsp::DidCloseTextDocumentParams,
 ) -> Result<()> {
     let mut sources = state.sources_mut().await;
-
-    if sources.remove(&params.text_document.uri).is_none() {
-        log::warn!(
-            "tried to close text document `{}`, but it was not open!",
-            params.text_document.uri
-        );
-    }
-
+    sources.remove(&params.text_document.uri);
     state.rebuild_interest().await?;
     Ok(())
 }

--- a/crates/rune-testing/Cargo.toml
+++ b/crates/rune-testing/Cargo.toml
@@ -17,6 +17,7 @@ Test helpers for Rune, an embeddable dynamic programming language for Rust.
 [dependencies]
 futures-executor = "0.3.5"
 tokio = {version = "0.2.12", features = ["macros"]}
+thiserror = "1.0.20"
 
 rune = {version = "0.6.16", path = "../rune"}
 runestick = {version = "0.6.16", path = "../runestick"}

--- a/crates/rune-testing/examples/basic_add.rs
+++ b/crates/rune-testing/examples/basic_add.rs
@@ -6,7 +6,7 @@ fn main() -> runestick::Result<()> {
     let context = Context::with_default_modules()?;
     let mut sources = Sources::new();
 
-    sources.insert_default(Source::new(
+    sources.insert(Source::new(
         "test",
         r#"
          fn main(number) {

--- a/crates/rune-testing/examples/basic_add.rs
+++ b/crates/rune-testing/examples/basic_add.rs
@@ -1,4 +1,4 @@
-use rune::{Options, Sources, Warnings};
+use rune::{Errors, Options, Sources, Warnings};
 use runestick::{Context, FromValue, Source, Vm};
 use std::sync::Arc;
 
@@ -15,10 +15,13 @@ fn main() -> runestick::Result<()> {
          "#,
     ));
 
+    let mut errors = Errors::new();
+
     let unit = rune::load_sources(
         &context,
         &Options::default(),
         &mut sources,
+        &mut errors,
         &mut Warnings::disabled(),
     )?;
 

--- a/crates/rune-testing/examples/custom_instance_fn.rs
+++ b/crates/rune-testing/examples/custom_instance_fn.rs
@@ -18,7 +18,7 @@ async fn main() -> runestick::Result<()> {
     let mut warnings = Warnings::disabled();
     let mut sources = Sources::new();
 
-    sources.insert_default(Source::new(
+    sources.insert(Source::new(
         "test",
         r#"
         fn main(number) {

--- a/crates/rune-testing/examples/custom_instance_fn.rs
+++ b/crates/rune-testing/examples/custom_instance_fn.rs
@@ -1,4 +1,4 @@
-use rune::{Options, Sources, Warnings};
+use rune::{Errors, Options, Sources, Warnings};
 use runestick::{Context, FromValue, Module, Source, Vm};
 use std::sync::Arc;
 
@@ -15,9 +15,8 @@ async fn main() -> runestick::Result<()> {
     context.install(&my_module)?;
 
     let options = Options::default();
-    let mut warnings = Warnings::disabled();
-    let mut sources = Sources::new();
 
+    let mut sources = Sources::new();
     sources.insert(Source::new(
         "test",
         r#"
@@ -27,7 +26,10 @@ async fn main() -> runestick::Result<()> {
         "#,
     ));
 
-    let unit = rune::load_sources(&context, &options, &mut sources, &mut warnings)?;
+    let mut errors = Errors::new();
+    let mut warnings = Warnings::disabled();
+
+    let unit = rune::load_sources(&context, &options, &mut sources, &mut errors, &mut warnings)?;
 
     let vm = Vm::new(Arc::new(context), Arc::new(unit));
     let output = vm.execute(&["main"], (33i64,))?.complete()?;

--- a/crates/rune-testing/examples/object.rs
+++ b/crates/rune-testing/examples/object.rs
@@ -1,7 +1,7 @@
-use rune_testing::{run, Result};
+use rune_testing::run;
 use runestick::{Object, Value};
 
-fn main() -> Result<()> {
+fn main() -> runestick::Result<()> {
     let mut object = Object::new();
     object.insert(String::from("Hello"), Value::from(42i64));
 

--- a/crates/rune-testing/examples/run_diagnostics.rs
+++ b/crates/rune-testing/examples/run_diagnostics.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let mut warnings = Warnings::new();
     let mut sources = Sources::new();
 
-    sources.insert_default(Source::new(
+    sources.insert(Source::new(
         "script",
         r#"
         fn calculate(a, b) {

--- a/crates/rune-testing/examples/run_minimal.rs
+++ b/crates/rune-testing/examples/run_minimal.rs
@@ -1,4 +1,4 @@
-use rune::{Options, Sources, Warnings};
+use rune::{Errors, Options, Sources, Warnings};
 use runestick::{Context, FromValue, Module, Source};
 use std::sync::Arc;
 
@@ -12,10 +12,13 @@ fn main() -> runestick::Result<()> {
     let mut sources = Sources::new();
     sources.insert(Source::new("test", r#"fn main(a) { add(a) }"#));
 
+    let mut errors = Errors::new();
+
     let unit = rune::load_sources(
         &context,
         &Options::default(),
         &mut sources,
+        &mut errors,
         &mut Warnings::disabled(),
     )?;
 

--- a/crates/rune-testing/examples/run_minimal.rs
+++ b/crates/rune-testing/examples/run_minimal.rs
@@ -10,7 +10,7 @@ fn main() -> runestick::Result<()> {
     context.install(&module)?;
 
     let mut sources = Sources::new();
-    sources.insert_default(Source::new("test", r#"fn main(a) { add(a) }"#));
+    sources.insert(Source::new("test", r#"fn main(a) { add(a) }"#));
 
     let unit = rune::load_sources(
         &context,

--- a/crates/rune-testing/examples/tuple.rs
+++ b/crates/rune-testing/examples/tuple.rs
@@ -1,6 +1,6 @@
-use rune_testing::{run, Result};
+use rune_testing::run;
 
-fn main() -> Result<()> {
+fn main() -> runestick::Result<()> {
     let object: (i64, i64) = run(
         &["calc"],
         ((1, 2),),

--- a/crates/rune-testing/examples/use_references.rs
+++ b/crates/rune-testing/examples/use_references.rs
@@ -25,7 +25,7 @@ fn main() -> runestick::Result<()> {
 
     let mut sources = Sources::new();
 
-    sources.insert_default(Source::new(
+    sources.insert(Source::new(
         "test",
         r#"
         fn main(number) {

--- a/crates/rune-testing/examples/use_references.rs
+++ b/crates/rune-testing/examples/use_references.rs
@@ -1,4 +1,4 @@
-use rune::{Options, Sources, Warnings};
+use rune::{Errors, Options, Sources, Warnings};
 use runestick::{Any, Context, Item, Module, Source, Vm};
 use std::sync::Arc;
 
@@ -24,7 +24,6 @@ fn main() -> runestick::Result<()> {
     let context = Arc::new(context);
 
     let mut sources = Sources::new();
-
     sources.insert(Source::new(
         "test",
         r#"
@@ -34,10 +33,13 @@ fn main() -> runestick::Result<()> {
         "#,
     ));
 
+    let mut errors = Errors::new();
+
     let unit = rune::load_sources(
         &context,
         &Options::default(),
         &mut sources,
+        &mut errors,
         &mut Warnings::disabled(),
     )?;
 

--- a/crates/rune-testing/examples/vec_tuple.rs
+++ b/crates/rune-testing/examples/vec_tuple.rs
@@ -1,7 +1,7 @@
-use rune_testing::{run, Result};
+use rune_testing::run;
 use runestick::VecTuple;
 
-fn main() -> Result<()> {
+fn main() -> runestick::Result<()> {
     let input: VecTuple<(i64, String)> = VecTuple::new((1, String::from("Hello")));
 
     let output: VecTuple<(i64, String)> = run(

--- a/crates/rune-testing/examples/vector.rs
+++ b/crates/rune-testing/examples/vector.rs
@@ -1,6 +1,6 @@
 use rune_testing::*;
 
-fn main() -> Result<()> {
+fn main() -> runestick::Result<()> {
     let input: Vec<i64> = vec![1, 2, 3, 4];
 
     let output: Vec<i64> = run(

--- a/crates/rune-testing/src/lib.rs
+++ b/crates/rune-testing/src/lib.rs
@@ -61,7 +61,7 @@ use std::sync::Arc;
 pub fn compile_source(context: &runestick::Context, source: &str) -> Result<(Unit, Warnings)> {
     let mut warnings = Warnings::new();
     let mut sources = Sources::new();
-    sources.insert_default(Source::new("main", source.to_owned()));
+    sources.insert(Source::new("main", source.to_owned()));
     let unit = Rc::new(RefCell::new(UnitBuilder::with_default_prelude()));
 
     rune::compile(context, &mut sources, &unit, &mut warnings)?;

--- a/crates/rune-testing/tests/vm_test_external_fn_ptr.rs
+++ b/crates/rune-testing/tests/vm_test_external_fn_ptr.rs
@@ -1,7 +1,7 @@
 use rune_testing::*;
 
 #[test]
-fn test_external_function() -> Result<()> {
+fn test_external_function() -> runestick::Result<()> {
     // NB: here we test passing the function from one virtual machine instance
     // into another, making sure that the function holds everything it needs to
     // be called.
@@ -28,7 +28,7 @@ fn test_external_function() -> Result<()> {
 }
 
 #[test]
-fn test_external_generator() -> Result<()> {
+fn test_external_generator() -> runestick::Result<()> {
     // NB: here we test passing the generator from one virtual machine instance
     // into another, making sure that the function holds everything it needs to
     // be called.

--- a/crates/rune-testing/tests/vm_test_from_value_derive.rs
+++ b/crates/rune-testing/tests/vm_test_from_value_derive.rs
@@ -67,8 +67,8 @@ fn test_missing_dynamic_field() {
         }
         "#,
         MissingDynamicStructField { target, name } => {
-            assert_eq!(*target, "vm_test_from_value_derive::test_missing_dynamic_field::ProxyStruct");
-            assert_eq!(*name, "missing");
+            assert_eq!(target, "vm_test_from_value_derive::test_missing_dynamic_field::ProxyStruct");
+            assert_eq!(name, "missing");
         }
     );
 
@@ -84,8 +84,8 @@ fn test_missing_dynamic_field() {
         }
         "#,
         MissingDynamicStructTupleIndex { target, index } => {
-            assert_eq!(*target, "vm_test_from_value_derive::test_missing_dynamic_field::ProxyTuple");
-            assert_eq!(*index, 1);
+            assert_eq!(target, "vm_test_from_value_derive::test_missing_dynamic_field::ProxyTuple");
+            assert_eq!(index, 1);
         }
     );
 }

--- a/crates/rune-testing/tests/vm_test_references.rs
+++ b/crates/rune-testing/tests/vm_test_references.rs
@@ -1,4 +1,4 @@
-use rune::{Options, Sources, Warnings};
+use rune::{Errors, Options, Sources, Warnings};
 use runestick::{Any, AnyObj, Context, Module, Shared, Source, Value, Vm, VmError};
 use std::sync::Arc;
 
@@ -27,7 +27,6 @@ fn vm_test_references() {
     let context = Arc::new(context);
 
     let mut sources = Sources::new();
-
     sources.insert(Source::new(
         "test",
         r#"
@@ -37,10 +36,13 @@ fn vm_test_references() {
         "#,
     ));
 
+    let mut errors = Errors::new();
+
     let unit = rune::load_sources(
         &context,
         &Options::default(),
         &mut sources,
+        &mut errors,
         &mut Warnings::disabled(),
     )
     .unwrap();
@@ -71,16 +73,18 @@ fn vm_test_references_error() {
     let context = Arc::new(context);
 
     let mut sources = Sources::new();
-
     sources.insert(Source::new(
         "test",
         r#"fn main(number) { take_it(number) }"#,
     ));
 
+    let mut errors = Errors::new();
+
     let unit = rune::load_sources(
         &context,
         &Options::default(),
         &mut sources,
+        &mut errors,
         &mut Warnings::disabled(),
     )
     .unwrap();

--- a/crates/rune-testing/tests/vm_test_references.rs
+++ b/crates/rune-testing/tests/vm_test_references.rs
@@ -28,7 +28,7 @@ fn vm_test_references() {
 
     let mut sources = Sources::new();
 
-    sources.insert_default(Source::new(
+    sources.insert(Source::new(
         "test",
         r#"
         fn main(number) {
@@ -72,7 +72,7 @@ fn vm_test_references_error() {
 
     let mut sources = Sources::new();
 
-    sources.insert_default(Source::new(
+    sources.insert(Source::new(
         "test",
         r#"fn main(number) { take_it(number) }"#,
     ));

--- a/crates/rune/README.md
+++ b/crates/rune/README.md
@@ -109,7 +109,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let mut warnings = rune::Warnings::new();
     let mut sources = rune::Sources::new();
 
-    sources.insert_default(Source::new(
+    sources.insert(Source::new(
         "script",
         r#"
         fn calculate(a, b) {

--- a/crates/rune/src/ast/expr.rs
+++ b/crates/rune/src/ast/expr.rs
@@ -472,11 +472,11 @@ impl Expr {
                         Expr::Path(path) => {
                             let span = path.span();
 
-                            if let Some(name) = path.try_into_ident() {
+                            if let Some(name) = path.try_as_ident() {
                                 expr = Expr::ExprFieldAccess(ast::ExprFieldAccess {
                                     expr: Box::new(expr),
                                     dot,
-                                    expr_field: ast::ExprField::Ident(name),
+                                    expr_field: ast::ExprField::Ident(name.clone()),
                                 });
 
                                 continue;

--- a/crates/rune/src/compile/expr_async.rs
+++ b/crates/rune/src/compile/expr_async.rs
@@ -28,7 +28,9 @@ impl Compile<(&ast::ExprAsync, Needs)> for Compiler<'_> {
         };
 
         for ident in &**captures {
-            let var = self.scopes.get_var(&ident.ident, self.visitor, span)?;
+            let var = self
+                .scopes
+                .get_var(&ident.ident, self.source.url(), self.visitor, span)?;
             var.copy(&mut self.asm, span, format!("captures `{}`", ident.ident));
         }
 

--- a/crates/rune/src/compile/expr_call.rs
+++ b/crates/rune/src/compile/expr_call.rs
@@ -66,7 +66,7 @@ impl Compile<(&ast::ExprCall, Needs)> for Compiler<'_> {
             return Ok(());
         };
 
-        for (expr, _) in expr_call.args.items.iter() {
+        for (expr, _) in &expr_call.args.items {
             self.compile((expr, Needs::Value))?;
             self.scopes.decl_anon(span)?;
         }
@@ -74,7 +74,10 @@ impl Compile<(&ast::ExprCall, Needs)> for Compiler<'_> {
         let item = self.convert_path_to_item(path)?;
 
         if let Some(name) = item.as_local() {
-            if let Some(var) = self.scopes.try_get_var(name, self.visitor, path.span())? {
+            if let Some(var) =
+                self.scopes
+                    .try_get_var(name, self.source.url(), self.visitor, path.span())?
+            {
                 var.copy(&mut self.asm, span, format!("var `{}`", name));
                 self.asm.push(Inst::CallFn { args }, span);
 

--- a/crates/rune/src/compile/expr_closure.rs
+++ b/crates/rune/src/compile/expr_closure.rs
@@ -100,7 +100,9 @@ impl Compile<(&ast::ExprClosure, Needs)> for Compiler<'_> {
         } else {
             // Construct a closure environment.
             for capture in &**captures {
-                let var = self.scopes.get_var(&capture.ident, self.visitor, span)?;
+                let var =
+                    self.scopes
+                        .get_var(&capture.ident, self.source.url(), self.visitor, span)?;
                 var.copy(&mut self.asm, span, format!("capture `{}`", capture.ident));
             }
 

--- a/crates/rune/src/compile/expr_field_access.rs
+++ b/crates/rune/src/compile/expr_field_access.rs
@@ -97,10 +97,12 @@ fn try_immediate_field_access_optimization(
         Err(..) => return Ok(false),
     };
 
-    let var = match this
-        .scopes
-        .try_get_var(ident.as_ref(), this.visitor, path.span())?
-    {
+    let var = match this.scopes.try_get_var(
+        ident.as_ref(),
+        this.source.url(),
+        this.visitor,
+        path.span(),
+    )? {
         Some(var) => var,
         None => return Ok(false),
     };

--- a/crates/rune/src/compile/expr_path.rs
+++ b/crates/rune/src/compile/expr_path.rs
@@ -12,14 +12,16 @@ impl Compile<(&ast::Path, Needs)> for Compiler<'_> {
         // NB: do nothing if we don't need a value.
         if !needs.value() {
             self.warnings.not_used(self.source_id, span, self.context());
-            return Ok(());
         }
 
         let item = self.convert_path_to_item(path)?;
 
         if let Needs::Value = needs {
             if let Some(local) = item.as_local() {
-                if let Some(var) = self.scopes.try_get_var(local, self.visitor, span)? {
+                if let Some(var) =
+                    self.scopes
+                        .try_get_var(local, self.source.url(), self.visitor, span)?
+                {
                     var.copy(&mut self.asm, span, format!("var `{}`", local));
                     return Ok(());
                 }

--- a/crates/rune/src/compile/expr_select.rs
+++ b/crates/rune/src/compile/expr_select.rs
@@ -58,7 +58,7 @@ impl Compile<(&ast::ExprSelect, Needs)> for Compiler<'_> {
                         let item = self.convert_path_to_item(&path.path)?;
 
                         if let Some(local) = item.as_local() {
-                            self.scopes.decl_var(local, span)?;
+                            self.scopes.decl_var(local, path.span())?;
                             break;
                         }
                     }

--- a/crates/rune/src/compile/expr_self.rs
+++ b/crates/rune/src/compile/expr_self.rs
@@ -8,7 +8,9 @@ impl Compile<(&ast::Self_, Needs)> for Compiler<'_> {
     fn compile(&mut self, (self_, needs): (&ast::Self_, Needs)) -> CompileResult<()> {
         let span = self_.span();
         log::trace!("Self_ => {:?}", self.source.source(span));
-        let var = self.scopes.get_var("self", self.visitor, span)?;
+        let var = self
+            .scopes
+            .get_var("self", self.source.url(), self.visitor, span)?;
 
         if !needs.value() {
             return Ok(());

--- a/crates/rune/src/compile/lit_object.rs
+++ b/crates/rune/src/compile/lit_object.rs
@@ -54,7 +54,9 @@ impl Compile<(&ast::LitObject, Needs)> for Compiler<'_> {
                 }
             } else {
                 let key = assign.key.resolve(&self.storage, &*self.source)?;
-                let var = self.scopes.get_var(&*key, self.visitor, span)?;
+                let var = self
+                    .scopes
+                    .get_var(&*key, self.source.url(), self.visitor, span)?;
 
                 if needs.value() {
                     var.copy(&mut self.asm, span, format!("name `{}`", key));

--- a/crates/rune/src/compile_visitor.rs
+++ b/crates/rune/src/compile_visitor.rs
@@ -1,13 +1,16 @@
 use crate::Var;
-use runestick::{CompileMeta, Span};
+use runestick::{CompileMeta, Span, Url};
 
 /// A visitor that will be called for every language item compiled.
 pub trait CompileVisitor {
     /// Mark that we've encountered a specific compile meta at the given span.
-    fn visit_meta(&mut self, _meta: &CompileMeta, _span: Span) {}
+    fn visit_meta(&mut self, _url: &Url, _meta: &CompileMeta, _span: Span) {}
 
     /// Visit a variable use.
-    fn visit_variable_use(&mut self, _var: &Var, _span: Span) {}
+    fn visit_variable_use(&mut self, _url: &Url, _var: &Var, _span: Span) {}
+
+    /// Visit something that is a module.
+    fn visit_mod(&mut self, _url: &Url, _span: Span) {}
 }
 
 /// A compile visitor that does nothing.

--- a/crates/rune/src/error.rs
+++ b/crates/rune/src/error.rs
@@ -2,7 +2,7 @@ use crate::ast;
 use crate::ast::Kind;
 use crate::unit_builder::UnitBuilderError;
 use crate::SourceId;
-use runestick::{CompileMeta, Item, Span};
+use runestick::{CompileMeta, Item, Span, Url};
 use std::io;
 use std::path::PathBuf;
 use thiserror::Error;
@@ -551,6 +551,14 @@ pub enum CompileError {
         /// The span of the missing label.
         span: Span,
     },
+    /// Encountered an unsupported URL when loading a module.
+    #[error("cannot load the url `{url}`")]
+    UnsupportedLoadUrl {
+        /// The span where the unsupported URL was encountered.
+        span: Span,
+        /// The URL that was unsupported.
+        url: Url,
+    },
     /// Unsupported wildcard component in use.
     #[error("wildcard support not supported in this position")]
     UnsupportedWildcard {
@@ -842,6 +850,7 @@ impl CompileError {
             Self::MissingType { span, .. } => span,
             Self::MissingModule { span, .. } => span,
             Self::MissingLabel { span, .. } => span,
+            Self::UnsupportedLoadUrl { span, .. } => span,
             Self::UnsupportedWildcard { span, .. } => span,
             Self::UnsupportedRef { span, .. } => span,
             Self::UnsupportedAwait { span, .. } => span,

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -107,7 +107,7 @@
 //!     let mut warnings = rune::Warnings::new();
 //!     let mut sources = rune::Sources::new();
 //!
-//!     sources.insert_default(Source::new(
+//!     sources.insert(Source::new(
 //!         "script",
 //!         r#"
 //!         fn calculate(a, b) {
@@ -187,6 +187,7 @@ mod parser;
 mod query;
 mod quote;
 mod scopes;
+mod source_loader;
 mod sources;
 mod storage;
 mod token_stream;
@@ -214,6 +215,7 @@ pub use crate::macro_context::MacroContext;
 pub use crate::options::Options;
 pub use crate::parser::Parser;
 pub use crate::scopes::Var;
+pub use crate::source_loader::{FileSourceLoader, SourceLoader};
 pub use crate::sources::Sources;
 pub use crate::storage::Storage;
 pub use crate::token_stream::{IntoTokens, TokenStream, TokenStreamIter};

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -104,9 +104,8 @@
 //! async fn main() -> Result<(), Box<dyn Error>> {
 //!     let context = Arc::new(rune::default_context()?);
 //!     let options = rune::Options::default();
-//!     let mut warnings = rune::Warnings::new();
-//!     let mut sources = rune::Sources::new();
 //!
+//!     let mut sources = rune::Sources::new();
 //!     sources.insert(Source::new(
 //!         "script",
 //!         r#"
@@ -117,11 +116,14 @@
 //!         "#,
 //!     ));
 //!
-//!     let unit = match rune::load_sources(&*context, &options, &mut sources, &mut warnings) {
+//!     let mut errors = rune::Errors::new();
+//!     let mut warnings = rune::Warnings::new();
+//!
+//!     let unit = match rune::load_sources(&*context, &options, &mut sources, &mut errors, &mut warnings) {
 //!         Ok(unit) => unit,
-//!         Err(error) => {
+//!         Err(rune::LoadSourcesError) => {
 //!             let mut writer = StandardStream::stderr(ColorChoice::Always);
-//!             error.emit_diagnostics(&mut writer, &sources)?;
+//!             errors.emit_diagnostics(&mut writer, &sources)?;
 //!             return Ok(());
 //!         }
 //!     };
@@ -209,8 +211,8 @@ pub use crate::assembly::Assembly;
 pub use crate::compile_visitor::{CompileVisitor, NoopCompileVisitor};
 pub use crate::error::{CompileError, ParseError};
 pub use crate::lexer::Lexer;
-pub use crate::load::{load_path, load_sources, load_sources_with_visitor};
-pub use crate::load_error::{LoadError, LoadErrorKind};
+pub use crate::load::{load_sources, load_sources_with_visitor, LoadSourcesError};
+pub use crate::load_error::{Errors, LoadError, LoadErrorKind};
 pub use crate::macro_context::MacroContext;
 pub use crate::options::Options;
 pub use crate::parser::Parser;
@@ -222,7 +224,7 @@ pub use crate::token_stream::{IntoTokens, TokenStream, TokenStreamIter};
 pub use crate::traits::{Parse, Peek, Resolve};
 pub use crate::warning::{Warning, WarningKind, Warnings};
 pub use compiler::compile;
-pub use unit_builder::{ImportEntry, ImportKey, LinkerError, LinkerErrors, UnitBuilder};
+pub use unit_builder::{ImportEntry, ImportKey, LinkerError, UnitBuilder};
 
 #[cfg(feature = "diagnostics")]
 pub use diagnostics::{termcolor, DiagnosticsError, EmitDiagnostics};
@@ -232,7 +234,7 @@ pub use diagnostics::{termcolor, DiagnosticsError, EmitDiagnostics};
 /// If built with the `modules` feature, this includes all available native
 /// modules.
 ///
-/// See [load_path](crate::load_path) for how to use.
+/// See [load_sources](crate::load_sources) for how to use.
 pub fn default_context() -> Result<runestick::Context, runestick::ContextError> {
     #[allow(unused_mut)]
     let mut context = runestick::Context::with_default_modules()?;

--- a/crates/rune/src/load.rs
+++ b/crates/rune/src/load.rs
@@ -1,83 +1,22 @@
-use crate::unit_builder::LinkerErrors;
 use crate::unit_builder::UnitBuilder;
 use crate::{compiler, CompileVisitor};
 use crate::{
-    FileSourceLoader, LoadError, LoadErrorKind, NoopCompileVisitor, Options, SourceLoader, Sources,
+    Errors, FileSourceLoader, LoadError, NoopCompileVisitor, Options, SourceLoader, Sources,
     Warnings,
 };
-use runestick::{Context, Source, Unit};
+use runestick::{Context, Unit};
 use std::cell::RefCell;
-use std::path::Path;
 use std::rc::Rc;
+use thiserror::Error;
 
-/// Load the given path.
+/// Error raised when we failed to load sources.
 ///
-/// The name of the loaded source will be the path as a string.
-///
-/// If you want to load a script from memory use [load_sources].
-///
-/// [load_sources]: crate::load_sources
-///
-/// # Examples
-///
-/// Note: these must be built with the `diagnostics` feature enabled to give
-/// access to `rune::termcolor`.
-///
-/// ```rust,no_run
-/// use rune::termcolor::{ColorChoice, StandardStream};
-/// use rune::EmitDiagnostics as _;
-///
-/// use std::path::Path;
-/// use std::sync::Arc;
-/// use std::error::Error;
-///
-/// # fn main() -> Result<(), Box<dyn Error>> {
-/// let path = Path::new("script.rn");
-///
-/// let context = Arc::new(rune::default_context()?);
-/// let mut options = rune::Options::default();
-/// let mut sources = rune::Sources::new();
-/// let mut warnings = rune::Warnings::new();
-///
-/// let unit = match rune::load_path(&*context, &options, &mut sources, &path, &mut warnings) {
-///     Ok(unit) => unit,
-///     Err(error) => {
-///         let mut writer = StandardStream::stderr(ColorChoice::Always);
-///         error.emit_diagnostics(&mut writer, &sources)?;
-///         return Ok(());
-///     }
-/// };
-///
-/// let unit = Arc::new(unit);
-/// let vm = runestick::Vm::new(context.clone(), unit.clone());
-///
-/// if !warnings.is_empty() {
-///     let mut writer = StandardStream::stderr(ColorChoice::Always);
-///     warnings.emit_diagnostics(&mut writer, &sources)?;
-/// }
-///
-/// # Ok(())
-/// # }
-/// ```
-pub fn load_path(
-    context: &Context,
-    options: &Options,
-    sources: &mut Sources,
-    path: &Path,
-    warnings: &mut Warnings,
-) -> Result<Unit, LoadError> {
-    sources.insert(Source::from_path(path).map_err(|error| {
-        LoadError::from(LoadErrorKind::ReadFile {
-            error,
-            path: path.to_owned(),
-        })
-    })?);
+/// Look at the passed in [Errors] instance for details.
+#[derive(Debug, Error)]
+#[error("failed to load sources (see `errors` for details)")]
+pub struct LoadSourcesError;
 
-    let unit = load_sources(context, options, sources, warnings)?;
-    Ok(unit)
-}
-
-/// Load and compile the given source.
+/// Load and compile the given sources.
 ///
 /// Uses the [Source::name] when generating diagnostics to reference the file.
 ///
@@ -99,19 +38,20 @@ pub fn load_path(
 /// let context = Arc::new(rune::default_context()?);
 /// let mut options = rune::Options::default();
 /// let mut sources = rune::Sources::new();
-/// let mut warnings = rune::Warnings::new();
-///
 /// sources.insert(Source::new("entry", r#"
 /// fn main() {
 ///     println("Hello World");
 /// }
 /// "#));
 ///
-/// let unit = match rune::load_sources(&*context, &options, &mut sources, &mut warnings) {
+/// let mut errors = rune::Errors::new();
+/// let mut warnings = rune::Warnings::new();
+///
+/// let unit = match rune::load_sources(&*context, &options, &mut sources, &mut errors, &mut warnings) {
 ///     Ok(unit) => unit,
-///     Err(error) => {
+///     Err(rune::LoadSourcesError) => {
 ///         let mut writer = StandardStream::stderr(ColorChoice::Always);
-///         error.emit_diagnostics(&mut writer, &sources)?;
+///         errors.emit_diagnostics(&mut writer, &sources)?;
 ///         return Ok(());
 ///     }
 /// };
@@ -131,14 +71,17 @@ pub fn load_sources(
     context: &Context,
     options: &Options,
     sources: &mut Sources,
+    errors: &mut Errors,
     warnings: &mut Warnings,
-) -> Result<Unit, LoadError> {
+) -> Result<Unit, LoadSourcesError> {
     let mut visitor = NoopCompileVisitor::new();
     let mut source_loader = FileSourceLoader::new();
+
     load_sources_with_visitor(
         context,
         options,
         sources,
+        errors,
         warnings,
         &mut visitor,
         &mut source_loader,
@@ -150,10 +93,11 @@ pub fn load_sources_with_visitor(
     context: &Context,
     options: &Options,
     sources: &mut Sources,
+    errors: &mut Errors,
     warnings: &mut Warnings,
     visitor: &mut dyn CompileVisitor,
     source_loader: &mut dyn SourceLoader,
-) -> Result<Unit, LoadError> {
+) -> Result<Unit, LoadSourcesError> {
     let unit = if context.has_default_modules() {
         UnitBuilder::with_default_prelude()
     } else {
@@ -161,30 +105,36 @@ pub fn load_sources_with_visitor(
     };
 
     let unit = Rc::new(RefCell::new(unit));
-    compiler::compile_with_options(
+
+    let result = compiler::compile_with_options(
         &*context,
         sources,
         &unit,
+        errors,
         warnings,
         &options,
         visitor,
         source_loader,
-    )?;
+    );
+
+    if let Err(()) = result {
+        return Err(LoadSourcesError);
+    }
 
     let unit = match Rc::try_unwrap(unit) {
         Ok(unit) => unit.into_inner(),
         Err(..) => {
-            return Err(LoadError::from(LoadErrorKind::Internal {
-                message: "unit is not exlusively held",
-            }));
+            errors.push(LoadError::internal(0, "unit is not exlusively held"));
+
+            return Err(LoadSourcesError);
         }
     };
 
     if options.link_checks {
-        let mut errors = LinkerErrors::new();
+        unit.link(&*context, errors);
 
-        if !unit.link(&*context, &mut errors) {
-            return Err(LoadError::from(LoadErrorKind::LinkError { errors }));
+        if !errors.is_empty() {
+            return Err(LoadSourcesError);
         }
     }
 

--- a/crates/rune/src/query.rs
+++ b/crates/rune/src/query.rs
@@ -292,12 +292,15 @@ impl Query {
         for (item, entry) in unused {
             let span = entry.span;
             let source_id = entry.source_id;
+            let url = entry.source.url().cloned();
 
             let meta = self
                 .build_indexed_entry(item, entry, true)
                 .map_err(|error| (source_id, error))?;
 
-            visitor.visit_meta(&meta, span);
+            if let Some(url) = url {
+                visitor.visit_meta(&url, &meta, span);
+            }
         }
 
         Ok(true)
@@ -333,6 +336,8 @@ impl Query {
             source,
             source_id,
         } = entry;
+
+        let url = source.url().cloned();
 
         let kind = match indexed {
             Indexed::Enum => CompileMetaKind::Enum {
@@ -397,6 +402,7 @@ impl Query {
 
         let meta = CompileMeta {
             span: Some(entry_span),
+            url,
             kind,
         };
 

--- a/crates/rune/src/source_loader.rs
+++ b/crates/rune/src/source_loader.rs
@@ -1,0 +1,75 @@
+use crate::CompileError;
+use runestick::{Source, Span, Url};
+
+/// A source loader.
+pub trait SourceLoader {
+    /// Load the given URL.
+    fn load(&mut self, url: &Url, name: &str, span: Span) -> Result<Source, CompileError>;
+}
+
+/// A filesystem-based source loader.
+pub struct FileSourceLoader {}
+
+impl FileSourceLoader {
+    /// Construct a new filesystem-based source loader.
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl SourceLoader for FileSourceLoader {
+    fn load(&mut self, url: &Url, name: &str, span: Span) -> Result<Source, CompileError> {
+        if url.scheme() != "file" {
+            return Err(CompileError::UnsupportedLoadUrl {
+                span,
+                url: url.clone(),
+            });
+        }
+
+        let path = url
+            .to_file_path()
+            .map_err(|_| CompileError::UnsupportedLoadUrl {
+                span,
+                url: url.clone(),
+            })?;
+
+        let base = match path.parent() {
+            Some(parent) => parent.join(name),
+            None => {
+                return Err(CompileError::UnsupportedFileMod { span });
+            }
+        };
+
+        let candidates = [
+            base.join("mod").with_extension("rn"),
+            base.with_extension("rn"),
+        ];
+
+        let mut found = None;
+
+        for path in &candidates[..] {
+            if path.is_file() {
+                found = Some(path);
+                break;
+            }
+        }
+
+        let path = match found {
+            Some(path) => path,
+            None => {
+                return Err(CompileError::ModNotFound { path: base, span });
+            }
+        };
+
+        match Source::from_path(path) {
+            Ok(source) => Ok(source),
+            Err(error) => {
+                return Err(CompileError::ModFileError {
+                    span,
+                    path: path.to_owned(),
+                    error,
+                });
+            }
+        }
+    }
+}

--- a/crates/rune/src/sources.rs
+++ b/crates/rune/src/sources.rs
@@ -1,12 +1,11 @@
-use runestick::{Item, Source};
-use std::collections::VecDeque;
+use crate::SourceId;
+use runestick::Source;
 use std::sync::Arc;
 
 /// A collection of source files, and a queue of things to compile.
 #[derive(Debug, Default)]
 pub struct Sources {
     sources: Vec<Arc<Source>>,
-    queue: VecDeque<(Item, usize)>,
 }
 
 impl Sources {
@@ -14,7 +13,6 @@ impl Sources {
     pub fn new() -> Self {
         Self {
             sources: Vec::new(),
-            queue: VecDeque::new(),
         }
     }
 
@@ -23,17 +21,17 @@ impl Sources {
         self.sources.get(source_id)
     }
 
-    /// Insert a new source and return its associated id.
-    pub fn insert(&mut self, item: Item, source: Source) -> usize {
-        let source_id = self.sources.len();
-        self.queue.push_back((item, source_id));
-        self.sources.push(Arc::new(source));
-        source_id
+    /// Insert a source to be built and return its id.
+    #[deprecated = "use `insert` instead"]
+    pub fn insert_default(&mut self, source: Source) -> usize {
+        self.insert(source)
     }
 
-    /// Insert a new source and return its associated id.
-    pub fn insert_default(&mut self, source: Source) -> usize {
-        self.insert(Item::default(), source)
+    /// Insert a source to be built and return its id.
+    pub fn insert(&mut self, source: Source) -> usize {
+        let source_id = self.sources.len();
+        self.sources.push(Arc::new(source));
+        source_id
     }
 
     /// Get the source matching the given source id.
@@ -41,9 +39,9 @@ impl Sources {
         self.sources.get(source_id)
     }
 
-    /// Get the next source in the queue to compile.
-    pub(crate) fn next_source(&mut self) -> Option<(Item, usize)> {
-        self.queue.pop_front()
+    /// Get all available source ids.
+    pub(crate) fn source_ids(&self) -> impl Iterator<Item = SourceId> {
+        0..self.sources.len()
     }
 
     /// Iterate over all sources in order by index.

--- a/crates/runestick/Cargo.toml
+++ b/crates/runestick/Cargo.toml
@@ -30,6 +30,7 @@ futures-util = "0.3.5"
 anyhow = "1.0.32"
 pin-project = "0.4.23"
 byteorder = "1.3.4"
+url = "2.1.1"
 
 runestick-macros = {version = "0.6.16", path = "../runestick-macros"}
 

--- a/crates/runestick/src/compile_meta.rs
+++ b/crates/runestick/src/compile_meta.rs
@@ -1,5 +1,5 @@
 use crate::collections::HashSet;
-use crate::{Hash, Item, Span, Type};
+use crate::{Hash, Item, Span, Type, Url};
 use std::fmt;
 use std::sync::Arc;
 
@@ -15,6 +15,8 @@ pub struct CompileMetaCapture {
 pub struct CompileMeta {
     /// The span where the meta is declared.
     pub span: Option<Span>,
+    /// The optional source id where the meta is declared.
+    pub url: Option<Url>,
     /// The kind of the compile meta.
     pub kind: CompileMetaKind,
 }

--- a/crates/runestick/src/context.rs
+++ b/crates/runestick/src/context.rs
@@ -392,6 +392,7 @@ impl Context {
             name.clone(),
             CompileMeta {
                 span: None,
+                url: None,
                 kind: CompileMetaKind::Struct {
                     type_of,
                     object: CompileMetaStruct {
@@ -457,6 +458,7 @@ impl Context {
             name.clone(),
             CompileMeta {
                 span: None,
+                url: None,
                 kind: CompileMetaKind::Function {
                     type_of: Type::from(hash),
                     item: name,
@@ -486,6 +488,7 @@ impl Context {
             name.clone(),
             CompileMeta {
                 span: None,
+                url: None,
                 kind: CompileMetaKind::Macro { item: name },
             },
         );
@@ -580,6 +583,7 @@ impl Context {
             enum_item.clone(),
             CompileMeta {
                 span: None,
+                url: None,
                 kind: CompileMetaKind::Enum {
                     type_of: Type::from(internal_enum.static_type),
                     item: enum_item.clone(),
@@ -619,6 +623,7 @@ impl Context {
 
             let meta = CompileMeta {
                 span: None,
+                url: None,
                 kind: CompileMetaKind::TupleVariant {
                     type_of: variant.type_of,
                     enum_item: enum_item.clone(),
@@ -670,6 +675,7 @@ impl Context {
         let meta = match enum_item {
             Some(enum_item) => CompileMeta {
                 span: None,
+                url: None,
                 kind: CompileMetaKind::TupleVariant {
                     type_of,
                     enum_item,
@@ -678,6 +684,7 @@ impl Context {
             },
             None => CompileMeta {
                 span: None,
+                url: None,
                 kind: CompileMetaKind::Tuple { type_of, tuple },
             },
         };

--- a/crates/runestick/src/lib.rs
+++ b/crates/runestick/src/lib.rs
@@ -165,6 +165,7 @@ pub use crate::vm_execution::VmExecution;
 pub use crate::vm_halt::{VmHalt, VmHaltInfo};
 pub(crate) use runestick_macros::__internal_impl_any;
 pub use runestick_macros::{Any, FromValue};
+pub use url::Url;
 
 mod collections {
     pub use hashbrown::{hash_map, HashMap};

--- a/crates/runestick/src/source.rs
+++ b/crates/runestick/src/source.rs
@@ -1,7 +1,8 @@
 use crate::Span;
 use std::fs;
 use std::io;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+use url::Url;
 
 /// A single source file.
 #[derive(Default, Debug, Clone)]
@@ -11,7 +12,9 @@ pub struct Source {
     /// The source string.
     source: String,
     /// The (optional) path of a source file.
-    path: Option<PathBuf>,
+    url: Option<Url>,
+    /// The starting byte indices in the source code.
+    line_starts: Vec<usize>,
 }
 
 impl Source {
@@ -21,21 +24,34 @@ impl Source {
         N: AsRef<str>,
         S: AsRef<str>,
     {
+        let source = source.as_ref();
+        let line_starts = line_starts(source).collect::<Vec<_>>();
+
         Self {
             name: name.as_ref().to_owned(),
-            source: source.as_ref().to_owned(),
-            path: None,
+            source: source.to_owned(),
+            url: None,
+            line_starts,
         }
     }
 
     /// Load a source from a path.
     pub fn from_path(path: &Path) -> io::Result<Self> {
+        let name = path.display().to_string();
+        let path = &path.canonicalize()?;
+
+        let url = url::Url::from_file_path(path).map_err(|_| {
+            io::Error::new(io::ErrorKind::Other, "path could not be converted to url")
+        })?;
+
         let source = fs::read_to_string(path)?;
+        let line_starts = line_starts(&source).collect::<Vec<_>>();
 
         Ok(Self {
-            name: path.display().to_string(),
+            name,
             source,
-            path: Some(path.to_owned()),
+            url: Some(url),
+            line_starts,
         })
     }
 
@@ -60,7 +76,45 @@ impl Source {
     }
 
     /// Get the (optional) path of the source.
-    pub fn path(&self) -> Option<&Path> {
-        self.path.as_deref()
+    pub fn url(&self) -> Option<&Url> {
+        self.url.as_ref()
     }
+
+    /// Get a mutable path.
+    pub fn url_mut(&mut self) -> &mut Option<Url> {
+        &mut self.url
+    }
+
+    /// Convert the given offset to a utf-16 line and character.
+    pub fn position_to_utf16cu_line_char(&self, offset: usize) -> Option<(usize, usize)> {
+        let line = match self.line_starts.binary_search(&offset) {
+            Ok(exact) => exact,
+            Err(0) => return None,
+            Err(n) => n - 1,
+        };
+
+        let line_start = self.line_starts[line];
+
+        let rest = &self.source[line_start..];
+        let offset = offset - line_start;
+        let mut line_count = 0;
+
+        for (n, c) in rest.char_indices() {
+            if n == offset {
+                return Some((line, line_count));
+            }
+
+            if n > offset {
+                break;
+            }
+
+            line_count += c.encode_utf16(&mut [0u16; 2]).len();
+        }
+
+        None
+    }
+}
+
+fn line_starts(source: &str) -> impl Iterator<Item = usize> + '_ {
+    std::iter::once(0).chain(source.match_indices('\n').map(|(i, _)| i + 1))
 }

--- a/crates/runestick/src/vm_error.rs
+++ b/crates/runestick/src/vm_error.rs
@@ -57,6 +57,11 @@ impl VmError {
         &*self.kind
     }
 
+    /// Access the underlying error kind while consuming the error.
+    pub fn into_kind(self) -> VmErrorKind {
+        *self.kind
+    }
+
     /// Convert into an unwinded vm error.
     pub fn into_unwinded(self, unit: &Arc<Unit>, ip: usize) -> Self {
         if let VmErrorKind::Unwound { .. } = &*self.kind {


### PR DESCRIPTION
The language server can now correctly report diagnostics for imported modules and jump to definition works across files.

The compiler changes allows multiple items to produce independent errors, so instead of erroring on the first issue, one issue per item is reported instead:

![O5oGLfx6W7](https://user-images.githubusercontent.com/111092/93108847-9fdf1e80-f6b3-11ea-8b0c-b3bfa191a01a.gif)

To clarify, a language item are typically different forms of declarations, like function or type declarations.