### PR TITLE
Implement assign operations for objects and tuples (fixes #39)

### DIFF
--- a/crates/rune-testing/tests/vm_arithmetic.rs
+++ b/crates/rune-testing/tests/vm_arithmetic.rs
@@ -1,359 +1,163 @@
 use rune_testing::*;
 
+macro_rules! op_tests {
+    ($lhs:literal $op:tt $rhs:literal = $out:expr) => {
+        assert_eq! {
+            rune!(i64 => &format!(
+                r#"fn main() {{ let a = {lhs}; let b = {rhs}; a {op} b}}"#,
+                lhs = $lhs, rhs = $rhs, op = stringify!($op),
+            )),
+            $out,
+        };
+
+        assert_eq! {
+            rune!(i64 => &format!(
+                r#"fn main() {{ let a = {lhs}; let b = {rhs}; a {op}= b; a }}"#,
+                lhs = $lhs, rhs = $rhs, op = stringify!($op),
+            )),
+            $out,
+        };
+
+        assert_eq! {
+            rune!(i64 => &format!(
+                r#"struct Foo {{ padding, field }}; fn main() {{ let a = Foo{{ padding: 0, field: {lhs} }}; let b = {rhs}; a.field {op}= b; a.field }}"#,
+                lhs = $lhs, rhs = $rhs, op = stringify!($op),
+            )),
+            $out,
+        };
+
+        assert_eq! {
+            rune!(i64 => &format!(
+                r#"enum Enum {{ Foo {{ padding, field }} }}; fn main() {{ let a = Enum::Foo {{ padding: 0, field: {lhs} }}; let b = {rhs}; a.field {op}= b; a.field }}"#,
+                lhs = $lhs, rhs = $rhs, op = stringify!($op),
+            )),
+            $out,
+        };
+
+        assert_eq! {
+            rune!(i64 => &format!(
+                r#"fn main() {{ let a = #{{ padding: 0, field: {lhs} }}; let b = {rhs}; a.field {op}= b; a.field }}"#,
+                lhs = $lhs, rhs = $rhs, op = stringify!($op),
+            )),
+            $out,
+        };
+
+        assert_eq! {
+            rune!(i64 => &format!(
+                r#"fn main() {{ let a = (0, {lhs}); let b = {rhs}; a.1 {op}= b; a.1 }}"#,
+                lhs = $lhs, rhs = $rhs, op = stringify!($op),
+            )),
+            $out,
+        };
+
+        assert_eq! {
+            rune!(i64 => &format!(
+                r#"struct Foo(padding, a); fn main() {{ let a = Foo(0, {lhs}); let b = {rhs}; a.1 {op}= b; a.1 }}"#,
+                lhs = $lhs, rhs = $rhs, op = stringify!($op),
+            )),
+            $out,
+        };
+
+        assert_eq! {
+            rune!(i64 => &format!(
+                r#"enum Enum {{ Foo(padding, a) }}; fn main() {{ let a = Enum::Foo(0, {lhs}); let b = {rhs}; a.1 {op}= b; a.1 }}"#,
+                lhs = $lhs, rhs = $rhs, op = stringify!($op),
+            )),
+            $out,
+        };
+
+        assert_eq! {
+            rune!(i64 => &format!(
+                r#"fn main() {{ let a = Ok({lhs}); let b = {rhs}; a.0 {op}= b; a.0 }}"#,
+                lhs = $lhs, rhs = $rhs, op = stringify!($op),
+            )),
+            $out,
+        };
+
+        assert_eq! {
+            rune!(i64 => &format!(
+                r#"fn main() {{ let a = Some({lhs}); let b = {rhs}; a.0 {op}= b; a.0 }}"#,
+                lhs = $lhs, rhs = $rhs, op = stringify!($op),
+            )),
+            $out,
+        };
+    }
+}
+
+macro_rules! error_test {
+    ($lhs:literal $op:tt $rhs:literal = $error:ident) => {
+        assert_vm_error!(
+            &format!(
+                r#"fn main() {{ let a = {lhs}; let b = {rhs}; a {op} b; }}"#,
+                lhs = $lhs, rhs = $rhs, op = stringify!($op),
+            ),
+            $error => {}
+        );
+
+        assert_vm_error!(
+            &format!(
+                r#"fn main() {{ let a = {lhs}; let b = {rhs}; a {op}= b; }}"#,
+                lhs = $lhs, rhs = $rhs, op = stringify!($op),
+            ),
+            $error => {}
+        );
+
+        assert_vm_error!(
+            &format!(
+                r#"fn main() {{ let a = #{{ padding: 0, field: {lhs} }}; let b = {rhs}; a.field {op}= b; }}"#,
+                lhs = $lhs, rhs = $rhs, op = stringify!($op),
+            ),
+            $error => {}
+        );
+
+        assert_vm_error!(
+            &format!(
+                r#"fn main() {{ let a = (0, {lhs}); let b = {rhs}; a.1 {op}= b; }}"#,
+                lhs = $lhs, rhs = $rhs, op = stringify!($op),
+            ),
+            $error => {}
+        );
+    }
+}
+
 #[test]
 fn test_add() {
-    assert_eq! {
-        rune! {
-            i64 => r#"
-            fn main() {
-                let a = 10;
-                let b = 2;
-                a + b
-            }
-            "#
-        },
-        12,
-    };
-
-    assert_eq! {
-        rune! {
-            i64 => r#"
-            fn main() {
-                let a = 10;
-                let b = 2;
-                a += b;
-                a
-            }
-            "#
-        },
-        12,
-    };
-
-    assert_vm_error!(
-        r#"
-        fn main() {
-            let a = 9223372036854775807;
-            let b = 2;
-            a += b;
-        }
-        "#,
-        Overflow => {}
-    );
-
-    assert_vm_error!(
-        r#"
-        fn main() {
-            let a = 9223372036854775807;
-            let b = 2;
-            a + b;
-        }
-        "#,
-        Overflow => {}
-    );
+    op_tests!(10 + 2 = 12);
+    error_test!(9223372036854775807i64 + 2 = Overflow);
 }
 
 #[test]
 fn test_sub() {
-    assert_eq! {
-        rune! {
-            i64 => r#"
-            fn main() {
-                let a = 10;
-                let b = 2;
-                a - b
-            }
-            "#
-        },
-        8,
-    };
-
-    assert_eq! {
-        rune! {
-            i64 => r#"
-            fn main() {
-                let a = 10;
-                let b = 2;
-                a -= b;
-                a
-            }
-            "#
-        },
-        8,
-    };
-
-    assert_vm_error!(
-        r#"
-        fn main() {
-            let a = -9223372036854775808;
-            let b = 2;
-            a -= b;
-        }
-        "#,
-        Underflow => {}
-    );
-
-    assert_vm_error!(
-        r#"
-        fn main() {
-            let a = -9223372036854775808;
-            let b = 2;
-            a - b;
-        }
-        "#,
-        Underflow => {}
-    );
+    op_tests!(10 - 2 = 8);
+    error_test!(-9223372036854775808i64 - 2 = Underflow);
 }
 
 #[test]
 fn test_mul() {
-    assert_eq! {
-        rune! {
-            i64 => r#"
-            fn main() {
-                let a = 10;
-                let b = 2;
-                a * b
-            }
-            "#
-        },
-        20,
-    };
-
-    assert_eq! {
-        rune! {
-            i64 => r#"
-            fn main() {
-                let a = 10;
-                let b = 2;
-                a *= b;
-                a
-            }
-            "#
-        },
-        20,
-    };
-
-    assert_vm_error!(
-        r#"
-        fn main() {
-            let a = 9223372036854775807;
-            let b = 2;
-            a *= b;
-        }
-        "#,
-        Overflow => {}
-    );
-
-    assert_vm_error!(
-        r#"
-        fn main() {
-            let a = 9223372036854775807;
-            let b = 2;
-            a * b;
-        }
-        "#,
-        Overflow => {}
-    );
+    op_tests!(10 * 2 = 20);
+    error_test!(9223372036854775807i64 * 2 = Overflow);
 }
 
 #[test]
 fn test_div() {
-    assert_eq! {
-        rune! {
-            i64 => r#"
-            fn main() {
-                let a = 10;
-                let b = 2;
-                a / b
-            }
-            "#
-        },
-        5,
-    };
-
-    assert_eq! {
-        rune! {
-            i64 => r#"
-            fn main() {
-                let a = 10;
-                let b = 2;
-                a /= b;
-                a
-            }
-            "#
-        },
-        5,
-    };
-
-    assert_vm_error!(
-        r#"
-        fn main() {
-            let a = 10;
-            let b = 0;
-            a /= b;
-        }
-        "#,
-        DivideByZero => {}
-    );
-
-    assert_vm_error!(
-        r#"
-        fn main() {
-            let a = 10;
-            let b = 0;
-            let c = a / b;
-        }
-        "#,
-        DivideByZero => {}
-    );
+    op_tests!(10 / 2 = 5);
+    error_test!(10 / 0 = DivideByZero);
 }
 
 #[test]
 fn test_rem() {
-    assert_eq! {
-        rune! {
-            i64 => r#"
-            fn main() {
-                let a = 10;
-                let b = 3;
-                a % b
-            }
-            "#
-        },
-        1,
-    };
-
-    assert_eq! {
-        rune! {
-            i64 => r#"
-            fn main() {
-                let a = 10;
-                let b = 3;
-                a %= b;
-                a
-            }
-            "#
-        },
-        1,
-    };
-
-    assert_vm_error!(
-        r#"
-        fn main() {
-            let a = 10;
-            let b = 0;
-            a %= b;
-        }
-        "#,
-        DivideByZero => {}
-    );
-
-    assert_vm_error!(
-        r#"
-        fn main() {
-            let a = 10;
-            let b = 0;
-            let c = a % b;
-        }
-        "#,
-        DivideByZero => {}
-    );
+    op_tests!(10 % 3 = 1);
+    error_test!(10 % 0 = DivideByZero);
 }
 
 #[test]
 fn test_bit_ops() {
-    assert_eq! {
-        rune! {
-            i64 => r#"
-            fn main() { let a = 0b1100; let b = 0b0110; a & b }
-            "#
-        },
-        0b1100 & 0b0110,
-    };
-
-    assert_eq! {
-        rune! {
-            i64 => r#"
-            fn main() { let a = 0b1100; a &= 0b0110; a }
-            "#
-        },
-        0b1100 & 0b0110,
-    };
-
-    assert_eq! {
-        rune! {
-            i64 => r#"
-            fn main() { let a = 0b1100; let b = 0b0110; a ^ b }
-            "#
-        },
-        0b1100 ^ 0b0110,
-    };
-
-    assert_eq! {
-        rune! {
-            i64 => r#"
-            fn main() { let a = 0b1100; a ^= 0b0110; a }
-            "#
-        },
-        0b1100 ^ 0b0110,
-    };
-
-    assert_eq! {
-        rune! {
-            i64 => r#"
-            fn main() { let a = 0b1100; let b = 0b0110; a | b }
-            "#
-        },
-        0b1100 | 0b0110,
-    };
-
-    assert_eq! {
-        rune! {
-            i64 => r#"
-            fn main() { let a = 0b1100; a |= 0b0110; a }
-            "#
-        },
-        0b1100 | 0b0110,
-    };
-}
-
-#[test]
-fn test_shift_ops() {
-    assert_eq! {
-        rune! {
-            i64 => r#"
-            fn main() { let a = 0b10100; let b = 2; a >> b }
-            "#
-        },
-        0b101,
-    };
-
-    assert_eq! {
-        rune! {
-            i64 => r#"
-            fn main() { let a = 0b10100; a >>= 2; a }
-            "#
-        },
-        0b101,
-    };
-
-    assert_eq! {
-        rune! {
-            i64 => r#"
-            fn main() { let a = 0b10100; let b = 2; a << b }
-            "#
-        },
-        0b1010000,
-    };
-
-    assert_eq! {
-        rune! {
-            i64 => r#"
-            fn main() { let a = 0b10100; a <<= 2; a }
-            "#
-        },
-        0b1010000,
-    };
+    op_tests!(0b1100 & 0b0110 = 0b1100 & 0b0110);
+    op_tests!(0b1100 ^ 0b0110 = 0b1100 ^ 0b0110);
+    op_tests!(0b1100 | 0b0110 = 0b1100 | 0b0110);
+    op_tests!(0b1100 << 2 = 0b1100 << 2);
+    op_tests!(0b1100 >> 2 = 0b1100 >> 2);
+    error_test!(0b1 << 64 = Overflow);
 }
 
 #[test]

--- a/crates/runestick/src/access.rs
+++ b/crates/runestick/src/access.rs
@@ -416,16 +416,30 @@ impl<'a, T: ?Sized> BorrowMut<'a, T> {
     }
 
     /// Map the mutable reference.
-    pub fn try_map<M, U: ?Sized, E>(this: Self, m: M) -> Result<BorrowMut<'a, U>, E>
+    pub fn map<M, U: ?Sized>(this: Self, m: M) -> BorrowMut<'a, U>
     where
-        M: FnOnce(&mut T) -> Result<&mut U, E>,
+        M: FnOnce(&mut T) -> &mut U,
     {
-        let data = m(unsafe { &mut *this.data })?;
+        let data = m(unsafe { &mut *this.data });
         let guard = this.guard;
 
-        Ok(BorrowMut {
+        BorrowMut {
             data,
             guard,
+            _marker: marker::PhantomData,
+        }
+    }
+
+    /// Try to optionally map the mutable reference.
+    pub fn try_map<M, U: ?Sized>(this: Self, m: M) -> Option<BorrowMut<'a, U>>
+    where
+        M: FnOnce(&mut T) -> Option<&mut U>,
+    {
+        let data = m(unsafe { &mut *this.data })?;
+
+        Some(BorrowMut {
+            data,
+            guard: this.guard,
             _marker: marker::PhantomData,
         })
     }

--- a/crates/runestick/src/inst.rs
+++ b/crates/runestick/src/inst.rs
@@ -92,70 +92,6 @@ pub enum Inst {
     /// => <bool>
     /// ```
     Not,
-    /// Add two things together.
-    ///
-    /// This is the result of an `<a> + <b>` expression.
-    Add,
-    /// Add a value to the given frame offset.
-    ///
-    /// This is the result of an `<offset> += <b>` expression.
-    AddAssign {
-        /// The frame offset to assign to.
-        offset: usize,
-    },
-    /// Subtract two things.
-    ///
-    /// This is the result of an `<a> - <b>` expression.
-    Sub,
-    /// Subtract a value to the given frame offset.
-    ///
-    /// This is the result of an `<offset> -= <b>` expression.
-    SubAssign {
-        /// The frame offset to assign to.
-        offset: usize,
-    },
-    /// Multiply two things.
-    ///
-    /// This is the result of an `<a> * <b>` expression.
-    Mul,
-    /// Multiply a value to the given frame offset.
-    ///
-    /// This is the result of an `<offset> *= <b>` expression.
-    MulAssign {
-        /// The frame offset to assign to.
-        offset: usize,
-    },
-    /// Divide two things.
-    ///
-    /// This is the result of an `<a> / <b>` expression.
-    Div,
-    /// Divide a value to the given frame offset.
-    ///
-    /// This is the result of an `<offset> /= <b>` expression.
-    DivAssign {
-        /// The frame offset to assign to.
-        offset: usize,
-    },
-    /// Remainder operation.
-    ///
-    /// This is the result of an `<a> % <b>` expression.
-    ///
-    /// # Operation
-    ///
-    /// ```text
-    /// <value>
-    /// <value>
-    /// => <value>
-    /// ```
-    Rem,
-    /// Calculate the remainder based on the value of the given offset and the
-    /// top of the stack.
-    ///
-    /// This is the result of an `<offset> %= <b>` expression.
-    RemAssign {
-        /// The frame offset to assign to.
-        offset: usize,
-    },
     /// Encode a function pointer on the stack.
     ///
     /// # Operation
@@ -762,126 +698,6 @@ pub enum Inst {
     /// => <boolean>
     /// ```
     Or,
-    /// Pop two values from the stack and perform a bitwise and operation over
-    /// them.
-    ///
-    /// # Operation
-    ///
-    /// ```text
-    /// <value>
-    /// <value>
-    /// => <value>
-    /// ```
-    BitAnd,
-    /// Pop a value from the stack and perform a bitwise and operation over the
-    /// offset and that value.
-    ///
-    /// # Operation
-    ///
-    /// ```text
-    /// <value>
-    /// => <value>
-    /// ```
-    BitAndAssign {
-        /// The offset to assign the result to.
-        offset: usize,
-    },
-    /// Pop two values from the stack and perform a bitwise xor operation over
-    /// them.
-    ///
-    /// # Operation
-    ///
-    /// ```text
-    /// <value>
-    /// <value>
-    /// => <value>
-    /// ```
-    BitXor,
-    /// Pop a value from the stack and perform a bitwise xor operation over the
-    /// offset and that value.
-    ///
-    /// # Operation
-    ///
-    /// ```text
-    /// <value>
-    /// => <value>
-    /// ```
-    BitXorAssign {
-        /// The offset to assign the result to.
-        offset: usize,
-    },
-    /// Pop two values from the stack and perform a bitwise or operation over
-    /// them.
-    ///
-    /// # Operation
-    ///
-    /// ```text
-    /// <value>
-    /// <value>
-    /// => <value>
-    /// ```
-    BitOr,
-    /// Pop a value from the stack and perform a bitwise or operation over the
-    /// offset and that value.
-    ///
-    /// # Operation
-    ///
-    /// ```text
-    /// <value>
-    /// => <value>
-    /// ```
-    BitOrAssign {
-        /// The offset to assign the result to.
-        offset: usize,
-    },
-    /// Pop two values from the stack and perform a bitwise shift left operation
-    /// over them.
-    ///
-    /// # Operation
-    ///
-    /// ```text
-    /// <value>
-    /// <value>
-    /// => <value>
-    /// ```
-    Shl,
-    /// Pop a value from the stack and perform a bitwise shift left operation
-    /// over the offset and that value.
-    ///
-    /// # Operation
-    ///
-    /// ```text
-    /// <value>
-    /// => <value>
-    /// ```
-    ShlAssign {
-        /// The offset to assign the result to.
-        offset: usize,
-    },
-    /// Pop two values from the stack and perform a bitwise shift right
-    /// operation over them.
-    ///
-    /// # Operation
-    ///
-    /// ```text
-    /// <value>
-    /// <value>
-    /// => <value>
-    /// ```
-    Shr,
-    /// Pop a value from the stack and perform a bitwise shift right operation
-    /// over the offset and that value.
-    ///
-    /// # Operation
-    ///
-    /// ```text
-    /// <value>
-    /// => <value>
-    /// ```
-    ShrAssign {
-        /// The offset to assign the result to.
-        offset: usize,
-    },
     /// Test if the top of the stack is a unit.
     ///
     /// # Operation
@@ -1030,6 +846,37 @@ pub enum Inst {
     /// => <unit>
     /// ```
     YieldUnit,
+    /// A built-in operation like `a + b` that takes its operands and pushes its
+    /// result to and from the stack.
+    ///
+    /// # Operation
+    ///
+    /// ```text
+    /// <value>
+    /// <value>
+    /// => <value>
+    /// ```
+    StackNumeric {
+        /// The actual operation.
+        op: InstNumericOp,
+    },
+    /// A built-in operation that assigns to the left-hand side operand. Like
+    /// `a += b`.
+    ///
+    /// The target determines the left hand side operation.
+    ///
+    /// # Operation
+    ///
+    /// ```text
+    /// <value>
+    /// =>
+    /// ```
+    AssignNumeric {
+        /// The target of the operation.
+        target: InstTarget,
+        /// The actual operation.
+        op: InstNumericOp,
+    },
     /// Cause the VM to panic and error out without a reason.
     ///
     /// This should only be used during testing or extreme scenarios that are
@@ -1048,36 +895,6 @@ impl fmt::Display for Inst {
             }
             Self::Not => {
                 write!(fmt, "not")?;
-            }
-            Self::Add => {
-                write!(fmt, "add")?;
-            }
-            Self::AddAssign { offset } => {
-                write!(fmt, "add-assign {}", offset)?;
-            }
-            Self::Sub => {
-                write!(fmt, "sub")?;
-            }
-            Self::SubAssign { offset } => {
-                write!(fmt, "sub-assign {}", offset)?;
-            }
-            Self::Mul => {
-                write!(fmt, "mul")?;
-            }
-            Self::MulAssign { offset } => {
-                write!(fmt, "mul-assign {}", offset)?;
-            }
-            Self::Div => {
-                write!(fmt, "div")?;
-            }
-            Self::DivAssign { offset } => {
-                write!(fmt, "div-assign {}", offset)?;
-            }
-            Self::Rem => {
-                write!(fmt, "rem")?;
-            }
-            Self::RemAssign { offset } => {
-                write!(fmt, "rem-assign {}", offset)?;
             }
             Self::Call { hash, args } => {
                 write!(fmt, "call {}, {}", hash, args)?;
@@ -1242,36 +1059,6 @@ impl fmt::Display for Inst {
             Self::Or => {
                 write!(fmt, "or")?;
             }
-            Self::BitAnd => {
-                write!(fmt, "bit-and")?;
-            }
-            Self::BitAndAssign { offset } => {
-                write!(fmt, "bit-and-assign {}", offset)?;
-            }
-            Self::BitXor => {
-                write!(fmt, "bit-xor")?;
-            }
-            Self::BitXorAssign { offset } => {
-                write!(fmt, "bit-xor-assign {}", offset)?;
-            }
-            Self::BitOr => {
-                write!(fmt, "bit-or")?;
-            }
-            Self::BitOrAssign { offset } => {
-                write!(fmt, "bit-or-assign {}", offset)?;
-            }
-            Self::Shl => {
-                write!(fmt, "shl")?;
-            }
-            Self::ShlAssign { offset } => {
-                write!(fmt, "shl-assign {}", offset)?;
-            }
-            Self::Shr => {
-                write!(fmt, "shr")?;
-            }
-            Self::ShrAssign { offset } => {
-                write!(fmt, "shr-assign {}", offset)?;
-            }
             Self::IsUnit => {
                 write!(fmt, "is-unit")?;
             }
@@ -1316,11 +1103,80 @@ impl fmt::Display for Inst {
             Self::YieldUnit => {
                 write!(fmt, "yield-unit")?;
             }
+            Self::StackNumeric { op } => {
+                write!(fmt, "stack-numeric {}", op)?;
+            }
+            Self::AssignNumeric { target, op } => {
+                write!(fmt, "assign-numeric {}, {}", target, op)?;
+            }
             Self::Panic { reason } => {
                 write!(fmt, "panic {}", reason.ident())?;
             }
         }
 
         Ok(())
+    }
+}
+
+/// The target of an operation.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum InstTarget {
+    /// Target is an offset to the current call frame.
+    Offset(usize),
+    /// Target the field of an object.
+    Field(usize),
+    /// Target a tuple field.
+    TupleField(usize),
+}
+
+impl fmt::Display for InstTarget {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Offset(offset) => write!(f, "offset({})", offset),
+            Self::Field(slot) => write!(f, "field({})", slot),
+            Self::TupleField(slot) => write!(f, "tuple-field({})", slot),
+        }
+    }
+}
+
+/// An operation between two values on the machine.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum InstNumericOp {
+    /// The add operation. `a + b`.
+    Add,
+    /// The sub operation. `a - b`.
+    Sub,
+    /// The multiply operation. `a * b`.
+    Mul,
+    /// The division operation. `a / b`.
+    Div,
+    /// The remainder operation. `a % b`.
+    Rem,
+    /// The bitwise and operation. `a & b`.
+    BitAnd,
+    /// The bitwise xor operation. `a ^ b`.
+    BitXor,
+    /// The bitwise or operation. `a | b`.
+    BitOr,
+    /// The shift left operation. `a << b`.
+    Shl,
+    /// The shift right operation. `a << b`.
+    Shr,
+}
+
+impl fmt::Display for InstNumericOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Add => write!(f, "+"),
+            Self::Sub => write!(f, "-"),
+            Self::Mul => write!(f, "*"),
+            Self::Div => write!(f, "/"),
+            Self::Rem => write!(f, "%"),
+            Self::BitAnd => write!(f, "&"),
+            Self::BitXor => write!(f, "^"),
+            Self::BitOr => write!(f, "|"),
+            Self::Shl => write!(f, "<<"),
+            Self::Shr => write!(f, ">>"),
+        }
     }
 }

--- a/crates/runestick/src/lib.rs
+++ b/crates/runestick/src/lib.rs
@@ -142,7 +142,7 @@ pub use crate::debug::{DebugInfo, DebugInst};
 pub use crate::function::Function;
 pub use crate::future::Future;
 pub use crate::hash::{Hash, IntoHash};
-pub use crate::inst::{Inst, PanicReason, TypeCheck};
+pub use crate::inst::{Inst, InstNumericOp, InstTarget, PanicReason, TypeCheck};
 pub use crate::item::{Component, IntoComponent, Item};
 pub use crate::names::Names;
 pub use crate::object::Object;

--- a/crates/runestick/src/tuple.rs
+++ b/crates/runestick/src/tuple.rs
@@ -15,9 +15,14 @@ impl Tuple {
         self.inner
     }
 
-    /// Get the typle at the given index.
+    /// Get the value at the given index.
     pub fn get(&self, index: usize) -> Option<&Value> {
         self.inner.get(index)
+    }
+
+    /// Get the mutable value at the given index.
+    pub fn get_mut(&mut self, index: usize) -> Option<&mut Value> {
+        self.inner.get_mut(index)
     }
 }
 

--- a/crates/runestick/src/value.rs
+++ b/crates/runestick/src/value.rs
@@ -25,6 +25,11 @@ impl TypedTuple {
     pub fn get(&self, index: usize) -> Option<&Value> {
         self.tuple.get(index)
     }
+
+    /// Get the mutable value at the given index in the tuple.
+    pub fn get_mut(&mut self, index: usize) -> Option<&mut Value> {
+        self.tuple.get_mut(index)
+    }
 }
 
 /// A tuple with a well-defined type as a variant of an enum.
@@ -79,6 +84,15 @@ impl TypedObject {
     {
         self.object.get(k)
     }
+
+    /// Get the given mutable value by key in the object.
+    pub fn get_mut<Q: ?Sized>(&mut self, k: &Q) -> Option<&mut Value>
+    where
+        String: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + std::cmp::Eq,
+    {
+        self.object.get_mut(k)
+    }
 }
 
 /// An object with a well-defined variant of an enum.
@@ -96,6 +110,24 @@ impl VariantObject {
     /// Get type info for the typed object.
     pub fn type_info(&self) -> TypeInfo {
         TypeInfo::Hash(self.enum_hash)
+    }
+
+    /// Get the given key in the object.
+    pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&Value>
+    where
+        String: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + std::cmp::Eq,
+    {
+        self.object.get(k)
+    }
+
+    /// Get the given mutable value by key in the object.
+    pub fn get_mut<Q: ?Sized>(&mut self, k: &Q) -> Option<&mut Value>
+    where
+        String: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + std::cmp::Eq,
+    {
+        self.object.get_mut(k)
     }
 }
 


### PR DESCRIPTION
This adds support for assign operators like these:

```rust
struct Foo {
    field,
}

fn main() {
    let foo = Foo { field: 0 };
    foo.field += 10;
    foo.field /= 2;
    // and so forth
}
```

After this, these are supported on all object, and tuple-like types. That means, structs, anonymous objects, tuples, tuple structs.

The `vm_arithmetic` test has been expanded to test for most combinations between dynamic and native types.