### PR TITLE
vscode: add preliminary support for downloading languageserver binaries

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
 	"version": "0.2.0",
     "configurations": [
         {
-            "name": "Debug Language Server",
+            "name": "Language Server (Local Debug Build)",
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",
@@ -11,6 +11,18 @@
             ],
             "env": {
                 "RUNE_DEBUG_FOLDER": "${workspaceFolder}/target/debug",
+                "RUNE_TRACE_LOG_FILE": "${workspaceFolder}/target/debug/rune-languageserver.log"
+            }
+        },
+        {
+            "name": "Language Server",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}/editors/code"
+            ],
+            "env": {
                 "RUNE_TRACE_LOG_FILE": "${workspaceFolder}/target/debug/rune-languageserver.log"
             }
         }

--- a/editors/code/package-lock.json
+++ b/editors/code/package-lock.json
@@ -57,6 +57,16 @@
             "integrity": "sha512-Wk7nG1JSaMfMpoMJDKUsWYugliB2Vy55pdjLpmLixeyMi7HizW2I/9QoxsPCkXl3dO+ZOVqPumKaDUv5zJu2uQ==",
             "dev": true
         },
+        "@types/node-fetch": {
+            "version": "2.5.7",
+            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
+            "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*",
+                "form-data": "^3.0.0"
+            }
+        },
         "@types/resolve": {
             "version": "1.17.1",
             "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -89,6 +99,12 @@
             "requires": {
                 "sprintf-js": "~1.0.2"
             }
+        },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+            "dev": true
         },
         "azure-devops-node-api": {
             "version": "7.2.0",
@@ -176,6 +192,15 @@
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
             "dev": true
         },
+        "combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dev": true,
+            "requires": {
+                "delayed-stream": "~1.0.0"
+            }
+        },
         "commander": {
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -222,6 +247,12 @@
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
             "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+            "dev": true
+        },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
             "dev": true
         },
         "denodeify": {
@@ -290,6 +321,17 @@
             "dev": true,
             "requires": {
                 "pend": "~1.2.0"
+            }
+        },
+        "form-data": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+            "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+            "dev": true,
+            "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
             }
         },
         "fs.realpath": {
@@ -433,6 +475,21 @@
             "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
             "dev": true
         },
+        "mime-db": {
+            "version": "1.44.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+            "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+            "dev": true
+        },
+        "mime-types": {
+            "version": "2.1.27",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+            "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+            "dev": true,
+            "requires": {
+                "mime-db": "1.44.0"
+            }
+        },
         "minimatch": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -447,6 +504,11 @@
             "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
             "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
             "dev": true
+        },
+        "node-fetch": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+            "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         },
         "nth-check": {
             "version": "1.0.2",

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -30,12 +30,14 @@
         "watch": "tsc --watch"
     },
     "dependencies": {
-        "vscode-languageclient": "7.0.0-next.9"
+        "vscode-languageclient": "7.0.0-next.9",
+        "node-fetch": "2.6.1"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^13.0.2",
         "@rollup/plugin-node-resolve": "^8.4.0",
         "@types/vscode": "^1.47.1",
+        "@types/node-fetch": "^2.5.7",
         "rollup": "^2.26.9",
         "typescript": "^3.9.7",
         "vsce": "^1.79.5"

--- a/editors/code/src/net.ts
+++ b/editors/code/src/net.ts
@@ -1,0 +1,153 @@
+// Replace with `import fetch from "node-fetch"` once this is fixed in rollup:
+// https://github.com/rollup/plugins/issues/491
+const fetch = require("node-fetch") as typeof import("node-fetch")["default"];
+
+import * as vscode from "vscode";
+import * as stream from "stream";
+import * as crypto from "crypto";
+import * as fs from "fs";
+import * as zlib from "zlib";
+import * as util from "util";
+import * as path from "path";
+import { log, assert } from "./util";
+
+const pipeline = util.promisify(stream.pipeline);
+
+const GITHUB_API_ENDPOINT_URL = "https://api.github.com";
+const OWNER = "rune-rs";
+const REPO = "rune";
+
+export async function fetchRelease(tag: string): Promise<GithubRelease> {
+    const requestUrl = `${GITHUB_API_ENDPOINT_URL}/repos/${OWNER}/${REPO}/releases/tags/${tag}`;
+    log.debug("Issuing request for released artifacts metadata to", requestUrl);
+
+    const response = await fetch(requestUrl, { headers: { Accept: "application/vnd.github.v3+json" } });
+
+    if (!response.ok) {
+        log.error("Error fetching artifact release info", {
+            requestUrl,
+            tag,
+            response: {
+                headers: response.headers,
+                status: response.status,
+                body: await response.text(),
+            }
+        });
+
+        throw new Error(
+            `Got response ${response.status} when trying to fetch ` +
+            `release info for ${tag} release`
+        );
+    }
+
+    // We skip runtime type checks for simplicity (here we cast from `any` to `GithubRelease`)
+    return await response.json();
+}
+
+// Information on a single GitHub asset.
+export interface GithubAsset {
+    // The id of the asset, changes each time its replaced.
+    id: number,
+    // The name of the asset.
+    name: string;
+    // eslint-disable-next-line camelcase
+    browser_download_url: string;
+}
+
+// We omit declaration of tremendous amount of fields that we are not using here
+export interface GithubRelease {
+    // The name of the release.
+    name: string;
+    // The id of the release.
+    id: number;
+    // eslint-disable-next-line camelcase
+    published_at: string;
+    // collection of assets associated with the release.
+    assets: Array<GithubAsset>;
+}
+
+interface DownloadOpts {
+    progressTitle: string;
+    url: string;
+    dest: string;
+    mode?: number;
+    gunzip?: boolean;
+}
+
+export async function download(opts: DownloadOpts) {
+    // Put artifact into a temporary file (in the same dir for simplicity)
+    // to prevent partially downloaded files when user kills vscode
+    const dest = path.parse(opts.dest);
+    const randomHex = crypto.randomBytes(5).toString("hex");
+    const tempFile = path.join(dest.dir, `${dest.name}${randomHex}`);
+
+    await vscode.window.withProgress(
+        {
+            location: vscode.ProgressLocation.Notification,
+            cancellable: false,
+            title: opts.progressTitle
+        },
+        async (progress, _cancellationToken) => {
+            let lastPercentage = 0;
+            await downloadFile(opts.url, tempFile, opts.mode, !!opts.gunzip, (readBytes, totalBytes) => {
+                const newPercentage = (readBytes / totalBytes) * 100;
+                progress.report({
+                    message: newPercentage.toFixed(0) + "%",
+                    increment: newPercentage - lastPercentage
+                });
+
+                lastPercentage = newPercentage;
+            });
+        }
+    );
+
+    await fs.promises.rename(tempFile, opts.dest);
+}
+
+async function downloadFile(
+    url: string,
+    destFilePath: fs.PathLike,
+    mode: number | undefined,
+    gunzip: boolean,
+    onProgress: (readBytes: number, totalBytes: number) => void
+): Promise<void> {
+    const res = await fetch(url);
+
+    if (!res.ok) {
+        log.error("Error", res.status, "while downloading file from", url);
+        log.error({ body: await res.text(), headers: res.headers });
+
+        throw new Error(`Got response ${res.status} when trying to download a file.`);
+    }
+
+    const totalBytes = Number(res.headers.get('content-length'));
+    assert(!Number.isNaN(totalBytes), "Sanity check of content-length protocol");
+
+    log.debug("Downloading file of", totalBytes, "bytes size from", url, "to", destFilePath);
+
+    let readBytes = 0;
+    res.body.on("data", (chunk: Buffer) => {
+        readBytes += chunk.length;
+        onProgress(readBytes, totalBytes);
+    });
+
+    const destFileStream = fs.createWriteStream(destFilePath, { mode });
+    const srcStream = gunzip ? res.body.pipe(zlib.createGunzip()) : res.body;
+
+    await pipeline(srcStream, destFileStream);
+
+    // Don't apply the workaround in fixed versions of nodejs, since the process
+    // freezes on them, the process waits for no-longer emitted `close` event.
+    // The fix was applied in commit 7eed9d6bcc in v13.11.0
+    // See the nodejs changelog:
+    // https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V13.md
+    const [, major, minor] = /v(\d+)\.(\d+)\.(\d+)/.exec(process.version)!;
+    if (+major > 13 || (+major === 13 && +minor >= 11)) return;
+
+    await new Promise<void>(resolve => {
+        destFileStream.on("close", resolve);
+        destFileStream.destroy();
+        // This workaround is awaiting to be removed when vscode moves to newer nodejs version:
+        // https://github.com/rust-analyzer/rust-analyzer/issues/3167
+    });
+}

--- a/editors/code/src/persistent_state.ts
+++ b/editors/code/src/persistent_state.ts
@@ -1,0 +1,25 @@
+import * as vscode from 'vscode';
+import { log } from './util';
+
+export class PersistentState {
+    constructor(private readonly globalState: vscode.Memento) {
+        const { lastCheck, releaseId } = this;
+        log.info("PersistentState:", { lastCheck, releaseId });
+    }
+
+    get lastCheck(): number | undefined {
+        return this.globalState.get("lastCheck");
+    }
+
+    async updateLastCheck(value: number) {
+        await this.globalState.update("lastCheck", value);
+    }
+
+    get releaseId(): number | undefined {
+        return this.globalState.get("releaseId");
+    }
+
+    async updateReleaseId(value: number) {
+        await this.globalState.update("releaseId", value);
+    }
+}

--- a/editors/code/src/util.ts
+++ b/editors/code/src/util.ts
@@ -1,7 +1,23 @@
-import * as vscode from 'vscode';
-import { inspect } from "util";
+// adapted from https://github.com/rust-analyzer/rust-analyzer/blob/ab432b36de5d6a370dbaad923f9a475a00fbf220/editors/code/src/util.ts#L16 under the MIT license.
+// Copyright rust-analyzer developers.
 
-// adapted from https://github.com/rust-analyzer/rust-analyzer/blob/ab432b36de5d6a370dbaad923f9a475a00fbf220/editors/code/src/util.ts#L16
+import * as vscode from 'vscode';
+import { promises as fs, PathLike } from 'fs';
+import { inspect } from "util";
+import { spawnSync } from "child_process";
+import { strict as nativeAssert } from "assert";
+
+/** assert wrapper that logs failures */
+export function assert(condition: boolean, explanation: string): asserts condition {
+    try {
+        nativeAssert(condition, explanation);
+    } catch (err) {
+        log.error(`Assertion failed:`, explanation);
+        throw err;
+    }
+}
+
+/** logging plumbing */
 export const log = new class {
     private enabled = true;
     private readonly output = vscode.window.createOutputChannel("Rune (Client)");
@@ -49,3 +65,20 @@ export const log = new class {
         });
     }
 };
+
+/** Test if the given path is a valid language server executable */
+export function isValidExecutable(path: string): boolean {
+    log.debug("Checking availability of a binary at", path);
+
+    const res = spawnSync(path, ["--version"], { encoding: 'utf8' });
+
+    const printOutput = res.error && (res.error as any).code !== 'ENOENT' ? log.warn : log.debug;
+    printOutput(path, "--version:", res);
+
+    return res.status === 0;
+}
+
+/** Test if the given path exists or not */
+export async function pathExists(p: PathLike): Promise<boolean> {
+    return fs.stat(p).then(() => true, () => false);
+}


### PR DESCRIPTION
This adds support for the vscode extension to download binaries from the `latest` tag. Note that this can be made configurable in the future.

Pushes to the `latest` tag will (hopefully) cause the asset ids to be regenerated, which will allow the extension to pick up the new language server.

Configuration for which release branch to follow has not been added since the project is still highly experimental! But this will be added in the future to follow a nightly/weekly/monthly release cadence.

Relates #44 