### PR TITLE
Fix issue with wrong number of locals in the middle of get/set expressions

### DIFF
--- a/crates/rune/src/compile/expr_binary.rs
+++ b/crates/rune/src/compile/expr_binary.rs
@@ -117,14 +117,14 @@ fn compile_assign_binop(
                         let index = index.resolve(this.storage, &*this.source)?;
                         let index = this.unit.borrow_mut().new_static_string(index.as_ref())?;
 
+                        this.compile((rhs, Needs::Value))?;
+                        this.scopes.decl_anon(rhs.span())?;
+
                         this.compile((&*field_access.expr, Needs::Value))?;
                         this.scopes.decl_anon(span)?;
 
                         this.asm.push(Inst::String { slot: index }, span);
                         this.scopes.decl_anon(span)?;
-
-                        this.compile((rhs, Needs::Value))?;
-                        this.scopes.decl_anon(rhs.span())?;
 
                         this.asm.push(Inst::IndexSet, span);
                         this.scopes.undecl_anon(3, span)?;

--- a/crates/rune/src/compile/expr_binary.rs
+++ b/crates/rune/src/compile/expr_binary.rs
@@ -117,15 +117,17 @@ fn compile_assign_binop(
                         let index = index.resolve(this.storage, &*this.source)?;
                         let index = this.unit.borrow_mut().new_static_string(index.as_ref())?;
 
-                        this.compile((rhs, Needs::Value))?;
-                        this.scopes.decl_anon(rhs.span())?;
+                        this.compile((&*field_access.expr, Needs::Value))?;
+                        this.scopes.decl_anon(span)?;
 
                         this.asm.push(Inst::String { slot: index }, span);
                         this.scopes.decl_anon(span)?;
 
-                        this.compile((&*field_access.expr, Needs::Value))?;
+                        this.compile((rhs, Needs::Value))?;
+                        this.scopes.decl_anon(rhs.span())?;
+
                         this.asm.push(Inst::IndexSet, span);
-                        this.scopes.undecl_anon(2, span)?;
+                        this.scopes.undecl_anon(3, span)?;
                         true
                     }
                     ast::ExprField::LitNumber(field) => {

--- a/crates/rune/src/compile/expr_index_get.rs
+++ b/crates/rune/src/compile/expr_index_get.rs
@@ -16,13 +16,14 @@ impl Compile<(&ast::ExprIndexGet, Needs)> for Compiler<'_> {
 
         let guard = self.scopes.push_child(span)?;
 
-        self.compile((&*expr_index_get.index, Needs::Value))?;
-        self.scopes.decl_anon(span)?;
-
         self.compile((&*expr_index_get.target, Needs::Value))?;
         self.scopes.decl_anon(span)?;
 
+        self.compile((&*expr_index_get.index, Needs::Value))?;
+        self.scopes.decl_anon(span)?;
+
         self.asm.push(Inst::IndexGet, span);
+        self.scopes.undecl_anon(2, span)?;
 
         // NB: we still need to perform the operation since it might have side
         // effects, but pop the result in case a value is not needed.

--- a/crates/rune/src/compile/expr_index_set.rs
+++ b/crates/rune/src/compile/expr_index_set.rs
@@ -14,13 +14,13 @@ impl Compile<(&ast::ExprIndexSet, Needs)> for Compiler<'_> {
         let span = expr_index_set.span();
         log::trace!("ExprIndexSet => {:?}", self.source.source(span));
 
+        self.compile((&*expr_index_set.value, Needs::Value))?;
+        self.scopes.decl_anon(span)?;
+
         self.compile((&*expr_index_set.target, Needs::Value))?;
         self.scopes.decl_anon(span)?;
 
         self.compile((&*expr_index_set.index, Needs::Value))?;
-        self.scopes.decl_anon(span)?;
-
-        self.compile((&*expr_index_set.value, Needs::Value))?;
         self.scopes.decl_anon(span)?;
 
         self.asm.push(Inst::IndexSet, span);

--- a/crates/rune/src/compile/expr_index_set.rs
+++ b/crates/rune/src/compile/expr_index_set.rs
@@ -14,10 +14,17 @@ impl Compile<(&ast::ExprIndexSet, Needs)> for Compiler<'_> {
         let span = expr_index_set.span();
         log::trace!("ExprIndexSet => {:?}", self.source.source(span));
 
-        self.compile((&*expr_index_set.value, Needs::Value))?;
-        self.compile((&*expr_index_set.index, Needs::Value))?;
         self.compile((&*expr_index_set.target, Needs::Value))?;
+        self.scopes.decl_anon(span)?;
+
+        self.compile((&*expr_index_set.index, Needs::Value))?;
+        self.scopes.decl_anon(span)?;
+
+        self.compile((&*expr_index_set.value, Needs::Value))?;
+        self.scopes.decl_anon(span)?;
+
         self.asm.push(Inst::IndexSet, span);
+        self.scopes.undecl_anon(3, span)?;
 
         // Encode a unit in case a value is needed.
         if needs.value() {

--- a/crates/rune/src/tests/mod.rs
+++ b/crates/rune/src/tests/mod.rs
@@ -8,6 +8,7 @@ mod vm_assign_exprs;
 mod vm_async_block;
 mod vm_blocks;
 mod vm_closures;
+mod vm_early_termination;
 mod vm_function;
 mod vm_general;
 mod vm_generators;

--- a/crates/rune/src/tests/vm_early_termination.rs
+++ b/crates/rune/src/tests/vm_early_termination.rs
@@ -1,0 +1,87 @@
+macro_rules! test_case {
+    ($kind:literal, $field:tt, $index:tt, $extra:literal) => {
+        assert_eq! {
+            rune!(bool => &format!(
+                r#"fn main() {{ let m = {kind}; m[return true]; false }} {extra}"#,
+                kind = $kind, extra = $extra,
+            )),
+            true,
+        };
+
+        assert_eq! {
+            rune!(bool => &format!(
+                r#"fn main() {{ let m = {kind}; m[return true] = 0; false }} {extra}"#,
+                kind = $kind, extra = $extra,
+            )),
+            true,
+        };
+
+        assert_eq! {
+            rune!(bool => &format!(
+                r#"fn main() {{ let m = {kind}; m[{index}] = return true; false }} {extra}"#,
+                kind = $kind, index = stringify!($index), extra = $extra,
+            )),
+            true,
+        };
+
+        assert_eq! {
+            rune!(bool => &format!(
+                r#"fn main() {{ let m = {kind}; m.{field} = return true; false }} {extra}"#,
+                kind = $kind, field = stringify!($field), extra = $extra,
+            )),
+            true,
+        };
+
+        assert_eq! {
+            rune!(bool => &format!(
+                r#"fn main() {{ {kind}[return true]; false }} {extra}"#,
+                kind = $kind, extra = $extra,
+            )),
+            true,
+        };
+
+        assert_eq! {
+            rune!(bool => &format!(
+                r#"fn main() {{ {kind}[return true] = 0; false }} {extra}"#,
+                kind = $kind, extra = $extra,
+            )),
+            true,
+        };
+
+        assert_eq! {
+            rune!(bool => &format!(
+                r#"fn main() {{ {kind}[{index}] = return true; false }} {extra}"#,
+                kind = $kind, index = stringify!($index), extra = $extra,
+            )),
+            true,
+        };
+
+        assert_eq! {
+            rune!(bool => &format!(
+                r#"fn main() {{ {kind}.{field} = return true; false }} {extra}"#,
+                kind = $kind, field = stringify!($field), extra = $extra,
+            )),
+            true,
+        };
+    };
+}
+
+#[test]
+fn test_object_like_early_term() {
+    test_case!("#{}", test, "test", "");
+}
+
+#[test]
+fn test_tuple_like_early_term() {
+    test_case!("()", 0, 0, "");
+}
+
+#[test]
+fn test_typed_object_early_term() {
+    test_case!("Foo()", 0, 0, "struct Foo();");
+}
+
+#[test]
+fn test_typed_tuple_early_term() {
+    test_case!("Foo{test: 0}", test, "test", "struct Foo{test};");
+}

--- a/crates/runestick/src/vm.rs
+++ b/crates/runestick/src/vm.rs
@@ -808,9 +808,9 @@ impl Vm {
     /// Perform an index set operation.
     #[inline]
     fn op_index_set(&mut self) -> Result<(), VmError> {
-        let target = self.stack.pop()?;
-        let index = self.stack.pop()?;
         let value = self.stack.pop()?;
+        let index = self.stack.pop()?;
+        let target = self.stack.pop()?;
 
         // This is a useful pattern.
         #[allow(clippy::never_loop)]
@@ -1183,8 +1183,8 @@ impl Vm {
     /// Perform an index get operation.
     #[inline]
     fn op_index_get(&mut self) -> Result<(), VmError> {
-        let target = self.stack.pop()?;
         let index = self.stack.pop()?;
+        let target = self.stack.pop()?;
 
         // This is a useful pattern.
         #[allow(clippy::never_loop)]

--- a/crates/runestick/src/vm.rs
+++ b/crates/runestick/src/vm.rs
@@ -808,9 +808,9 @@ impl Vm {
     /// Perform an index set operation.
     #[inline]
     fn op_index_set(&mut self) -> Result<(), VmError> {
-        let value = self.stack.pop()?;
         let index = self.stack.pop()?;
         let target = self.stack.pop()?;
+        let value = self.stack.pop()?;
 
         // This is a useful pattern.
         #[allow(clippy::never_loop)]


### PR DESCRIPTION
Also re-ordered the stack operands for related ops to be in line with other operations (left-to-right, bottom-to-top).

This will have to be fixed to be in line with how Rust does it at some point. See issue #70.

CC: @seanchen1991, since this is similar to what you need to do.