### PR TITLE
languageserver: Make use of build sources instead of awkward mapping

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,8 @@
             ],
             "env": {
                 "RUNE_DEBUG_FOLDER": "${workspaceFolder}/target/debug",
-                "RUNE_TRACE_LOG_FILE": "${workspaceFolder}/target/debug/rune-languageserver.log"
+                "RUNE_TRACE_LOG_FILE": "${workspaceFolder}/target/debug/rune-languageserver.log",
+                "RUST_BACKTRACE": "1"
             }
         },
         {
@@ -23,7 +24,8 @@
                 "--extensionDevelopmentPath=${workspaceFolder}/editors/code"
             ],
             "env": {
-                "RUNE_TRACE_LOG_FILE": "${workspaceFolder}/target/debug/rune-languageserver.log"
+                "RUNE_TRACE_LOG_FILE": "${workspaceFolder}/target/debug/rune-languageserver.log",
+                "RUST_BACKTRACE": "1"
             }
         }
     ]

--- a/crates/rune-languageserver/src/state.rs
+++ b/crates/rune-languageserver/src/state.rs
@@ -4,7 +4,7 @@ use hashbrown::HashMap;
 use lsp::Url;
 use ropey::Rope;
 use rune::Spanned as _;
-use runestick::{CompileMeta, CompileMetaKind, Span};
+use runestick::{CompileMeta, CompileMetaKind, CompileSource, Component, Item, SourceId, Span};
 use std::collections::BTreeMap;
 use std::fmt;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -70,25 +70,35 @@ impl State {
         position: lsp::Position,
     ) -> Option<lsp::Location> {
         let sources = self.inner.sources.read().await;
+
         let source = sources.get(uri)?;
         let offset = source.lsp_position_to_offset(position);
-        let definition = source.find_definition_at(Span::point(offset))?;
+        let def = source.find_definition_at(Span::point(offset))?;
 
-        let url = definition.url.as_ref()?;
+        let url = def.source.url.as_ref()?;
+        let source = source.build_sources.as_ref()?.get(def.source.source_id)?;
 
-        let range = match definition.span {
-            Some(span) => {
-                let start = source.offset_to_lsp_position(span.start);
-                let end = source.offset_to_lsp_position(span.end);
-                lsp::Range { start, end }
-            }
-            None => lsp::Range::default(),
+        let (l, c) = source.position_to_utf16cu_line_char(def.source.span.start)?;
+        let start = lsp::Position {
+            line: l as u64,
+            character: c as u64,
         };
 
-        Some(lsp::Location {
+        let (l, c) = source.position_to_utf16cu_line_char(def.source.span.end)?;
+        let end = lsp::Position {
+            line: l as u64,
+            character: c as u64,
+        };
+
+        let range = lsp::Range { start, end };
+
+        let location = lsp::Location {
             uri: url.clone(),
             range,
-        })
+        };
+
+        log::trace!("go to location: {:?}", location);
+        Some(location)
     }
 
     /// Rebuild the current project.
@@ -101,13 +111,13 @@ impl State {
             by_url.insert(url.clone(), Vec::new());
         }
 
-        let mut definitions = HashMap::new();
+        let mut builds = Vec::new();
 
         for (url, source) in &inner.sources {
             log::trace!("build: {}", url);
 
             by_url.insert(url.clone(), Default::default());
-            definitions.insert(url.clone(), Default::default());
+            let mut index = Index::default();
 
             let mut sources = rune::Sources::new();
 
@@ -118,7 +128,7 @@ impl State {
 
             let mut errors = rune::Errors::new();
             let mut warnings = rune::Warnings::new();
-            let mut visitor = Visitor::new(&mut definitions);
+            let mut visitor = Visitor::new(&mut index);
             let mut source_loader = SourceLoader::new(&inner.sources);
 
             let result = rune::load_sources_with_visitor(
@@ -191,11 +201,14 @@ impl State {
                     display_to_warning,
                 );
             }
+
+            builds.push((url.clone(), sources, index));
         }
 
-        for (url, index) in definitions {
+        for (url, build_sources, index) in builds {
             if let Some(source) = inner.sources.get_mut(&url) {
                 source.index = index;
+                source.build_sources = Some(build_sources);
             }
         }
 
@@ -244,6 +257,7 @@ impl Sources {
         let source = Source {
             content: Rope::from(text),
             index: Default::default(),
+            build_sources: None,
         };
 
         self.sources.insert(url, source)
@@ -273,15 +287,18 @@ pub struct Source {
     content: Rope,
     /// Indexes used to answer queries.
     index: Index,
+    /// Loaded Rune sources for this source file. Will be present after the
+    /// source file has been built.
+    build_sources: Option<rune::Sources>,
 }
 
 impl Source {
     /// Find the definition at the given span.
     pub fn find_definition_at(&self, span: Span) -> Option<&Definition> {
         let (found_span, definition) = self.index.definitions.range(..=span).rev().next()?;
-        log::info!("found {:?} (at {:?})", definition.kind, definition.url);
 
         if span.start >= found_span.start && span.end <= found_span.end {
+            log::trace!("found {:?}", definition);
             return Some(definition);
         }
 
@@ -456,9 +473,10 @@ pub struct Index {
 
 #[derive(Debug, Clone)]
 pub struct Definition {
-    pub(crate) span: Option<Span>,
-    pub(crate) url: Option<Url>,
+    /// The kind of the definition.
     pub(crate) kind: DefinitionKind,
+    /// The id of the source id the definition corresponds to.
+    pub(crate) source: CompileSource,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -482,18 +500,27 @@ pub enum DefinitionKind {
 }
 
 struct Visitor<'a> {
-    indexes: &'a mut HashMap<Url, Index>,
+    index: &'a mut Index,
 }
 
 impl<'a> Visitor<'a> {
     /// Construct a new visitor.
-    pub fn new(indexes: &'a mut HashMap<Url, Index>) -> Self {
-        Self { indexes }
+    pub fn new(index: &'a mut Index) -> Self {
+        Self { index }
     }
 }
 
 impl rune::CompileVisitor for Visitor<'_> {
-    fn visit_meta(&mut self, url: &Url, meta: &CompileMeta, span: Span) {
+    fn visit_meta(&mut self, source_id: SourceId, meta: &CompileMeta, span: Span) {
+        if source_id != 0 {
+            return;
+        }
+
+        let source = match meta.source.as_ref() {
+            Some(source) => source,
+            None => return,
+        };
+
         let kind = match &meta.kind {
             CompileMetaKind::Tuple { .. } => DefinitionKind::Tuple,
             CompileMetaKind::TupleVariant { .. } => DefinitionKind::TupleVariant,
@@ -505,43 +532,50 @@ impl rune::CompileVisitor for Visitor<'_> {
         };
 
         let definition = Definition {
-            span: meta.span,
-            url: meta.url.clone(),
             kind,
+            source: source.clone(),
         };
 
-        if let Some(index) = self.indexes.get_mut(url) {
-            if let Some(d) = index.definitions.insert(span, definition) {
-                log::warn!("replaced definition: {:?}", d.kind)
-            }
+        if let Some(d) = self.index.definitions.insert(span, definition) {
+            log::warn!("replaced definition: {:?}", d.kind)
         }
     }
 
-    fn visit_variable_use(&mut self, url: &Url, var: &rune::Var, span: Span) {
-        if let Some(index) = self.indexes.get_mut(url) {
-            let definition = Definition {
-                span: Some(var.span()),
-                url: Some(url.clone()),
-                kind: DefinitionKind::Local,
-            };
+    fn visit_variable_use(&mut self, source_id: SourceId, var: &rune::Var, span: Span) {
+        if source_id != 0 {
+            return;
+        }
 
-            if let Some(d) = index.definitions.insert(span, definition) {
-                log::warn!("replaced definition: {:?}", d.kind)
-            }
+        let definition = Definition {
+            kind: DefinitionKind::Local,
+            source: CompileSource {
+                span: var.span(),
+                url: None,
+                source_id,
+            },
+        };
+
+        if let Some(d) = self.index.definitions.insert(span, definition) {
+            log::warn!("replaced definition: {:?}", d.kind)
         }
     }
 
-    fn visit_mod(&mut self, url: &Url, span: Span) {
-        if let Some(index) = self.indexes.get_mut(url) {
-            let definition = Definition {
-                span: None,
-                url: Some(url.clone()),
-                kind: DefinitionKind::Module,
-            };
+    fn visit_mod(&mut self, source_id: SourceId, span: Span) {
+        if source_id != 0 {
+            return;
+        }
 
-            if let Some(d) = index.definitions.insert(span, definition) {
-                log::warn!("replaced definition: {:?}", d.kind)
-            }
+        let definition = Definition {
+            kind: DefinitionKind::Module,
+            source: CompileSource {
+                span: Span::empty(),
+                url: None,
+                source_id,
+            },
+        };
+
+        if let Some(d) = self.index.definitions.insert(span, definition) {
+            log::warn!("replaced definition: {:?}", d.kind)
         }
     }
 }
@@ -561,23 +595,37 @@ impl<'a> SourceLoader<'a> {
     }
 
     /// Generate a collection of URl candidates.
-    fn candidates(url: &Url, name: &str) -> Option<[Url; 2]> {
-        let mut a = url.clone();
+    fn candidates(root: &Url, item: &Item) -> Option<[Url; 2]> {
+        let mut base = root.clone();
+
+        let mut it = item.iter();
+
+        let last = match it.next_back()? {
+            Component::String(string) => string,
+            _ => return None,
+        };
 
         {
-            let mut path = a.path_segments_mut().ok()?;
+            let mut path = base.path_segments_mut().ok()?;
             path.pop();
-            path.push(&format!("{}.rn", name));
+
+            for c in it {
+                if let Component::String(string) = c {
+                    path.push(string.as_ref());
+                } else {
+                    return None;
+                }
+            }
         }
 
-        let mut b = url.clone();
+        let mut a = base.clone();
+        a.path_segments_mut().ok()?.push(&format!("{}.rn", last));
 
-        {
-            let mut path = b.path_segments_mut().ok()?;
-            path.pop();
-            path.push(name);
-            path.push("mod.rn");
-        };
+        let mut b = base.clone();
+        b.path_segments_mut()
+            .ok()?
+            .push(last.as_ref())
+            .push("mod.rn");
 
         Some([a, b])
     }
@@ -586,13 +634,13 @@ impl<'a> SourceLoader<'a> {
 impl rune::SourceLoader for SourceLoader<'_> {
     fn load(
         &mut self,
-        url: &Url,
-        name: &str,
+        root: &Url,
+        item: &Item,
         span: Span,
     ) -> Result<runestick::Source, rune::CompileError> {
-        log::trace!("load: {}", url);
+        log::trace!("load {} (root: {})", item, root);
 
-        if let Some(candidates) = Self::candidates(url, name) {
+        if let Some(candidates) = Self::candidates(root, item) {
             for url in candidates.iter() {
                 if let Some(s) = self.sources.get(url) {
                     // TODO: can this clone be avoided? The compiler requires a complete buffer.
@@ -603,6 +651,6 @@ impl rune::SourceLoader for SourceLoader<'_> {
             }
         }
 
-        self.base.load(url, name, span)
+        self.base.load(root, item, span)
     }
 }

--- a/crates/rune/src/compile/expr_async.rs
+++ b/crates/rune/src/compile/expr_async.rs
@@ -36,7 +36,7 @@ impl Compile<(&ast::ExprAsync, Needs)> for Compiler<'_> {
         for ident in &**captures {
             let var = self
                 .scopes
-                .get_var(&ident.ident, self.source.url(), self.visitor, span)?;
+                .get_var(&ident.ident, self.source_id, self.visitor, span)?;
             var.copy(&mut self.asm, span, format!("captures `{}`", ident.ident));
         }
 

--- a/crates/rune/src/compile/expr_binary.rs
+++ b/crates/rune/src/compile/expr_binary.rs
@@ -102,7 +102,7 @@ fn compile_assign_binop(
                 let ident = path.first.resolve(this.storage, &*this.source)?;
                 let var = this
                     .scopes
-                    .get_var(&*ident, this.source.url(), this.visitor, span)?;
+                    .get_var(&*ident, this.source_id, this.visitor, span)?;
                 this.asm.push(Inst::Replace { offset: var.offset }, span);
 
                 true
@@ -168,7 +168,7 @@ fn compile_assign_binop(
                 let ident = path.first.resolve(this.storage, &*this.source)?;
                 let var = this
                     .scopes
-                    .get_var(&*ident, this.source.url(), this.visitor, span)?;
+                    .get_var(&*ident, this.source_id, this.visitor, span)?;
 
                 Some(InstTarget::Offset(var.offset))
             }

--- a/crates/rune/src/compile/expr_call.rs
+++ b/crates/rune/src/compile/expr_call.rs
@@ -76,7 +76,7 @@ impl Compile<(&ast::ExprCall, Needs)> for Compiler<'_> {
         if let Some(name) = item.as_local() {
             if let Some(var) =
                 self.scopes
-                    .try_get_var(name, self.source.url(), self.visitor, path.span())
+                    .try_get_var(name, self.source_id, self.visitor, path.span())
             {
                 var.copy(&mut self.asm, span, format!("var `{}`", name));
                 self.asm.push(Inst::CallFn { args }, span);

--- a/crates/rune/src/compile/expr_closure.rs
+++ b/crates/rune/src/compile/expr_closure.rs
@@ -98,7 +98,7 @@ impl Compile<(&ast::ExprClosure, Needs)> for Compiler<'_> {
             for capture in &**captures {
                 let var =
                     self.scopes
-                        .get_var(&capture.ident, self.source.url(), self.visitor, span)?;
+                        .get_var(&capture.ident, self.source_id, self.visitor, span)?;
                 var.copy(&mut self.asm, span, format!("capture `{}`", capture.ident));
             }
 

--- a/crates/rune/src/compile/expr_field_access.rs
+++ b/crates/rune/src/compile/expr_field_access.rs
@@ -103,7 +103,7 @@ fn try_immediate_field_access_optimization(
     let var =
         match this
             .scopes
-            .try_get_var(ident.as_ref(), this.source.url(), this.visitor, path.span())
+            .try_get_var(ident.as_ref(), this.source_id, this.visitor, path.span())
         {
             Some(var) => var,
             None => return Ok(false),

--- a/crates/rune/src/compile/expr_path.rs
+++ b/crates/rune/src/compile/expr_path.rs
@@ -21,7 +21,7 @@ impl Compile<(&ast::Path, Needs)> for Compiler<'_> {
             if let Some(local) = item.as_local() {
                 if let Some(var) =
                     self.scopes
-                        .try_get_var(local, self.source.url(), self.visitor, span)
+                        .try_get_var(local, self.source_id, self.visitor, span)
                 {
                     var.copy(&mut self.asm, span, format!("var `{}`", local));
                     return Ok(());

--- a/crates/rune/src/compile/expr_self.rs
+++ b/crates/rune/src/compile/expr_self.rs
@@ -11,7 +11,7 @@ impl Compile<(&ast::Self_, Needs)> for Compiler<'_> {
         log::trace!("Self_ => {:?}", self.source.source(span));
         let var = self
             .scopes
-            .get_var("self", self.source.url(), self.visitor, span)?;
+            .get_var("self", self.source_id, self.visitor, span)?;
 
         if !needs.value() {
             return Ok(());

--- a/crates/rune/src/compile/lit_object.rs
+++ b/crates/rune/src/compile/lit_object.rs
@@ -56,7 +56,7 @@ impl Compile<(&ast::LitObject, Needs)> for Compiler<'_> {
                 let key = assign.key.resolve(&self.storage, &*self.source)?;
                 let var = self
                     .scopes
-                    .get_var(&*key, self.source.url(), self.visitor, span)?;
+                    .get_var(&*key, self.source_id, self.visitor, span)?;
 
                 if needs.value() {
                     var.copy(&mut self.asm, span, format!("name `{}`", key));

--- a/crates/rune/src/compile_error.rs
+++ b/crates/rune/src/compile_error.rs
@@ -1,7 +1,7 @@
 use crate::ast;
 use crate::unit_builder::UnitBuilderError;
-use crate::{ParseError, ParseErrorKind, SourceId, Spanned};
-use runestick::{CompileMeta, Item, Span, Url};
+use crate::{ParseError, ParseErrorKind, Spanned};
+use runestick::{CompileMeta, Item, SourceId, Span, Url};
 use std::error;
 use std::fmt;
 use std::io;
@@ -196,11 +196,20 @@ pub enum CompileErrorKind {
     /// A specific label is missing.
     #[error("label not found in scope")]
     MissingLabel,
+    /// Tried to load module in a source where it wasn't supported.
+    #[error("cannot load modules using a source without an associated URL")]
+    UnsupportedModuleSource,
     /// Encountered an unsupported URL when loading a module.
-    #[error("cannot load the url `{url}`")]
-    UnsupportedLoadUrl {
+    #[error("cannot load modules relative to `{url}`")]
+    UnsupportedModuleRoot {
         /// The URL that was unsupported.
         url: Url,
+    },
+    /// Encountered an unsupported Item when loading a module.
+    #[error("cannot load module for `{item}`")]
+    UnsupportedModuleItem {
+        /// The item that cannot be used as a module.
+        item: Item,
     },
     /// Unsupported wildcard component in use.
     #[error("wildcard support not supported in this position")]
@@ -347,9 +356,6 @@ pub enum CompileErrorKind {
         /// The item that didn't exist.
         item: Item,
     },
-    /// Trying to use a filesystem module from an in-memory soruce.
-    #[error("cannot load external modules from in-memory sources")]
-    UnsupportedFileMod,
     /// Trying to use a number as a tuple index for which it is not suported.
     #[error("unsupported tuple index `{number}`")]
     UnsupportedTupleIndex {

--- a/crates/rune/src/compile_visitor.rs
+++ b/crates/rune/src/compile_visitor.rs
@@ -1,16 +1,16 @@
 use crate::Var;
-use runestick::{CompileMeta, Span, Url};
+use runestick::{CompileMeta, SourceId, Span};
 
 /// A visitor that will be called for every language item compiled.
 pub trait CompileVisitor {
     /// Mark that we've encountered a specific compile meta at the given span.
-    fn visit_meta(&mut self, _url: &Url, _meta: &CompileMeta, _span: Span) {}
+    fn visit_meta(&mut self, _source_id: SourceId, _meta: &CompileMeta, _span: Span) {}
 
     /// Visit a variable use.
-    fn visit_variable_use(&mut self, _url: &Url, _var: &Var, _span: Span) {}
+    fn visit_variable_use(&mut self, _source_id: SourceId, _var: &Var, _span: Span) {}
 
     /// Visit something that is a module.
-    fn visit_mod(&mut self, _url: &Url, _span: Span) {}
+    fn visit_mod(&mut self, _source_id: SourceId, _span: Span) {}
 }
 
 /// A compile visitor that does nothing.

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -207,9 +207,6 @@ pub mod testing;
 #[cfg(test)]
 pub mod tests;
 
-/// The identifier of a source file.
-pub type SourceId = usize;
-
 /// Internal collection re-export.
 mod collections {
     pub use hashbrown::{hash_map, HashMap};

--- a/crates/rune/src/sources.rs
+++ b/crates/rune/src/sources.rs
@@ -1,5 +1,4 @@
-use crate::SourceId;
-use runestick::Source;
+use runestick::{Source, SourceId};
 use std::sync::Arc;
 
 /// A collection of source files, and a queue of things to compile.
@@ -17,18 +16,18 @@ impl Sources {
     }
 
     /// Get the source at the given source id.
-    pub fn source_at(&self, source_id: usize) -> Option<&Arc<Source>> {
+    pub fn source_at(&self, source_id: SourceId) -> Option<&Arc<Source>> {
         self.sources.get(source_id)
     }
 
     /// Insert a source to be built and return its id.
     #[deprecated = "use `insert` instead"]
-    pub fn insert_default(&mut self, source: Source) -> usize {
+    pub fn insert_default(&mut self, source: Source) -> SourceId {
         self.insert(source)
     }
 
     /// Insert a source to be built and return its id.
-    pub fn insert(&mut self, source: Source) -> usize {
+    pub fn insert(&mut self, source: Source) -> SourceId {
         let source_id = self.sources.len();
         self.sources.push(Arc::new(source));
         source_id

--- a/crates/runestick/src/compile_meta.rs
+++ b/crates/runestick/src/compile_meta.rs
@@ -1,5 +1,5 @@
 use crate::collections::HashSet;
-use crate::{Hash, Item, Span, Type, Url};
+use crate::{Hash, Item, SourceId, Span, Type, Url};
 use std::fmt;
 use std::sync::Arc;
 
@@ -13,12 +13,21 @@ pub struct CompileMetaCapture {
 /// Compile-time metadata about a unit.
 #[derive(Debug, Clone)]
 pub struct CompileMeta {
-    /// The span where the meta is declared.
-    pub span: Option<Span>,
-    /// The optional source id where the meta is declared.
-    pub url: Option<Url>,
     /// The kind of the compile meta.
     pub kind: CompileMetaKind,
+    /// The source of the meta.
+    pub source: Option<CompileSource>,
+}
+
+/// Information on a compile sourc.
+#[derive(Debug, Clone)]
+pub struct CompileSource {
+    /// The span where the meta is declared.
+    pub span: Span,
+    /// The optional source id where the meta is declared.
+    pub url: Option<Url>,
+    /// The source id where the compile meta is defined.
+    pub source_id: SourceId,
 }
 
 impl CompileMeta {

--- a/crates/runestick/src/context.rs
+++ b/crates/runestick/src/context.rs
@@ -391,8 +391,6 @@ impl Context {
         self.install_meta(
             name.clone(),
             CompileMeta {
-                span: None,
-                url: None,
                 kind: CompileMetaKind::Struct {
                     type_of,
                     object: CompileMetaStruct {
@@ -400,6 +398,7 @@ impl Context {
                         fields: None,
                     },
                 },
+                source: None,
             },
         )?;
 
@@ -457,12 +456,11 @@ impl Context {
         self.meta.insert(
             name.clone(),
             CompileMeta {
-                span: None,
-                url: None,
                 kind: CompileMetaKind::Function {
                     type_of: Type::from(hash),
                     item: name,
                 },
+                source: None,
             },
         );
 
@@ -487,9 +485,8 @@ impl Context {
         self.meta.insert(
             name.clone(),
             CompileMeta {
-                span: None,
-                url: None,
                 kind: CompileMetaKind::Macro { item: name },
+                source: None,
             },
         );
 
@@ -582,12 +579,11 @@ impl Context {
         self.install_meta(
             enum_item.clone(),
             CompileMeta {
-                span: None,
-                url: None,
                 kind: CompileMetaKind::Enum {
                     type_of: Type::from(internal_enum.static_type),
                     item: enum_item.clone(),
                 },
+                source: None,
             },
         )?;
 
@@ -622,13 +618,12 @@ impl Context {
             };
 
             let meta = CompileMeta {
-                span: None,
-                url: None,
                 kind: CompileMetaKind::TupleVariant {
                     type_of: variant.type_of,
                     enum_item: enum_item.clone(),
                     tuple,
                 },
+                source: None,
             };
 
             self.install_meta(item.clone(), meta)?;
@@ -674,18 +669,16 @@ impl Context {
 
         let meta = match enum_item {
             Some(enum_item) => CompileMeta {
-                span: None,
-                url: None,
                 kind: CompileMetaKind::TupleVariant {
                     type_of,
                     enum_item,
                     tuple,
                 },
+                source: None,
             },
             None => CompileMeta {
-                span: None,
-                url: None,
                 kind: CompileMetaKind::Tuple { type_of, tuple },
+                source: None,
             },
         };
 

--- a/crates/runestick/src/lib.rs
+++ b/crates/runestick/src/lib.rs
@@ -96,6 +96,9 @@ mod vm_error;
 mod vm_execution;
 mod vm_halt;
 
+/// The identifier of a source file.
+pub type SourceId = usize;
+
 /// Exported result type for convenience.
 pub type Result<T, E = anyhow::Error> = std::result::Result<T, E>;
 
@@ -106,6 +109,7 @@ pub use self::any_obj::{AnyObj, AnyObjVtable};
 pub use self::args::Args;
 pub use self::compile_meta::{
     CompileMeta, CompileMetaCapture, CompileMetaKind, CompileMetaStruct, CompileMetaTuple,
+    CompileSource,
 };
 pub use self::from_value::{FromValue, UnsafeFromValue};
 pub use self::generator::Generator;

--- a/crates/runestick/src/source.rs
+++ b/crates/runestick/src/source.rs
@@ -87,6 +87,10 @@ impl Source {
 
     /// Convert the given offset to a utf-16 line and character.
     pub fn position_to_utf16cu_line_char(&self, offset: usize) -> Option<(usize, usize)> {
+        if offset == 0 {
+            return Some((0, 0));
+        }
+
         let line = match self.line_starts.binary_search(&offset) {
             Ok(exact) => exact,
             Err(0) => return None,
@@ -111,7 +115,7 @@ impl Source {
             line_count += c.encode_utf16(&mut [0u16; 2]).len();
         }
 
-        None
+        Some((line, line_count))
     }
 }
 


### PR DESCRIPTION
This avoids instances where the in-memory languageserver sources are out-of-sync with what has been built. It does mean that we waste memory by creating one build root per file with associated file loadings. But that's not really something that can be avoided anyway since the module system is a bit over flexible at the moment allowing for sources to belong to multiple build roots at the same time.