### PR TITLE
Limit execution and support output in Playground

### DIFF
--- a/crates/rune-wasm/Cargo.toml
+++ b/crates/rune-wasm/Cargo.toml
@@ -17,6 +17,7 @@ A WASM module for Rune, an embeddable dynamic programming language for Rust.
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 wasm-bindgen = {version = "0.2.68", features = ["serde-serialize"]}
+futures-executor = "0.3.5"
 
 rune = {version = "0.6.16", path = "../rune", features = []}
 rune-macros = {version = "0.6.16", path = "../rune-macros"}

--- a/crates/runestick/src/budget.rs
+++ b/crates/runestick/src/budget.rs
@@ -1,0 +1,94 @@
+//! Budgeting module for Runestick.
+//!
+//! This module contains methods which allows for limiting the execution of the
+//! virtual machine to abide by the specified budget.
+//!
+//! By default the budget is disabled, but can be enabled by wrapping your
+//! function call in [with].
+
+use pin_project::pin_project;
+use std::cell::Cell;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+thread_local!(static BUDGET: Cell<usize> = Cell::new(usize::max_value()));
+
+/// Wrap the given value with a budget.
+///
+/// The value can either be a function, after which you can use [Budget::call],
+/// or it can be a [Future] which can be polled.
+pub fn with<T>(budget: usize, value: T) -> Budget<T> {
+    Budget { budget, value }
+}
+
+/// Take a ticket from the budget, indicating with `true` if the budget is
+/// maintained
+pub fn take() -> bool {
+    BUDGET.with(|tls| {
+        let v = tls.get();
+
+        if v == usize::max_value() {
+            true
+        } else if v == 0 {
+            false
+        } else {
+            tls.set(v - 1);
+            true
+        }
+    })
+}
+
+#[repr(transparent)]
+struct BudgetGuard(usize);
+
+impl Drop for BudgetGuard {
+    fn drop(&mut self) {
+        BUDGET.with(|tls| {
+            tls.set(self.0);
+        });
+    }
+}
+
+/// A budgeted future.
+#[pin_project]
+pub struct Budget<T> {
+    /// The current budget.
+    budget: usize,
+    /// The future being budgeted.
+    #[pin]
+    value: T,
+}
+
+impl<T, O> Budget<T>
+where
+    T: FnOnce() -> O,
+{
+    /// Call the wrapped function.
+    pub fn call(self) -> O {
+        BUDGET.with(|tls| {
+            let _guard = BudgetGuard(tls.get());
+            tls.set(self.budget);
+            (self.value)()
+        })
+    }
+}
+
+impl<T> Future for Budget<T>
+where
+    T: Future,
+{
+    type Output = T::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+
+        BUDGET.with(|tls| {
+            let _guard = BudgetGuard(tls.get());
+            tls.set(*this.budget);
+            let poll = this.value.poll(cx);
+            *this.budget = tls.get();
+            poll
+        })
+    }
+}

--- a/crates/runestick/src/context.rs
+++ b/crates/runestick/src/context.rs
@@ -238,8 +238,16 @@ impl Context {
 
     /// Construct a new collection of functions with default packages installed.
     pub fn with_default_modules() -> Result<Self, ContextError> {
+        Self::with_config(true)
+    }
+
+    /// Construct a default set of modules with the given configuration.
+    ///
+    /// * `io` determines if we include I/O functions, like `dbg`, `print`, and
+    ///   `println`.
+    pub fn with_config(io: bool) -> Result<Self, ContextError> {
         let mut this = Self::new();
-        this.install(&crate::modules::core::module()?)?;
+        this.install(&crate::modules::core::module(io)?)?;
         this.install(&crate::modules::generator::module()?)?;
         this.install(&crate::modules::bytes::module()?)?;
         this.install(&crate::modules::string::module()?)?;

--- a/crates/runestick/src/lib.rs
+++ b/crates/runestick/src/lib.rs
@@ -57,6 +57,7 @@ mod access;
 mod any_obj;
 mod args;
 mod awaited;
+pub mod budget;
 mod bytes;
 mod call;
 mod compile_meta;

--- a/crates/runestick/src/stack.rs
+++ b/crates/runestick/src/stack.rs
@@ -154,8 +154,9 @@ impl Stack {
         Ok(self.drain_stack_top(count)?.collect::<Vec<_>>())
     }
 
-    /// Pop a sub stack of the given size.
-    pub(crate) fn drain_stack_top(
+    /// Drain the top `count` elements of the stack in the order that they were
+    /// pushed, from bottom to top.
+    pub fn drain_stack_top(
         &mut self,
         count: usize,
     ) -> Result<impl DoubleEndedIterator<Item = Value> + '_, StackError> {

--- a/crates/runestick/src/vm.rs
+++ b/crates/runestick/src/vm.rs
@@ -1,3 +1,4 @@
+use crate::budget;
 use crate::future::SelectFuture;
 use crate::unit::UnitFn;
 use crate::{
@@ -2060,8 +2061,12 @@ impl Vm {
     }
 
     /// Evaluate a single instruction.
-    pub(crate) fn run_for(&mut self, mut limit: Option<usize>) -> Result<VmHalt, VmError> {
+    pub(crate) fn run(&mut self) -> Result<VmHalt, VmError> {
         loop {
+            if !budget::take() {
+                return Ok(VmHalt::Limited);
+            }
+
             let inst = *self
                 .unit
                 .instruction_at(self.ip)
@@ -2295,14 +2300,6 @@ impl Vm {
             }
 
             self.advance();
-
-            if let Some(limit) = &mut limit {
-                if *limit <= 1 {
-                    return Ok(VmHalt::Limited);
-                }
-
-                *limit -= 1;
-            }
         }
     }
 

--- a/site/templates/play.html
+++ b/site/templates/play.html
@@ -29,6 +29,10 @@
       let output = document.getElementById("play-output");
       let outputTitle = output.getElementsByClassName("title")[0];
       let outputContent = output.getElementsByClassName("content")[0];
+      // Only permit running 10_000 instructions.
+      let budget = 1_000_000;
+      let outputTrim = 100;
+      let outputLineTrim = 80;
   
       let markers = [];
 
@@ -62,22 +66,41 @@
 
         markers = [];
 
-        let result = rune.module.compile(content);
+        let result = rune.module.compile(content, budget);
+        let text = "";
+        
+        if (!!result.diagnostics_output) {
+          text += result.diagnostics_output + "\n";
+        }
+
+        if (!!result.output) {
+          let parts = result.output.split("\n").map(part => {
+            if (part.length > outputLineTrim) {
+              let trimmed = part.length - outputLineTrim;
+              return part.slice(0, outputLineTrim) + ` ... (${trimmed} trimmed)`;
+            } else {
+              return part;
+            }
+          });
+
+          if (parts.length > outputTrim) {
+            text += parts.slice(0, outputTrim).join("\n") + "\n";
+            text += `${parts.length - outputTrim} more lines trimmed...\n`;
+          } else {
+            text += parts.join("\n");
+          }
+        }
 
         if (!!result.error) {
           outputTitle.textContent = "Error when running playground";
-          outputContent.textContent = result.diagnostics_output;
           output.className = "";
         } else {
-          if (!!result.diagnostics_output) {
-            outputContent.textContent  = result.diagnostics_output + "\n== " + result.output;
-          } else {
-            outputContent.textContent  = "== " + result.output;
-          }
-
+          text +=  "== " + result.result;
           outputTitle.className = "hidden";
           output.className = "";
         }
+
+        outputContent.textContent = text;
 
         let annotations = [];
 


### PR DESCRIPTION
This adds the following to the playground:
* `println`, `print` and `dbg` support with output trimming.
* Support `async` functions.
* Limit the number of instructions that are allowed to run to `1_000_000` to avoid infinite executions from locking up the browser.