### PR TITLE
Expand Spanned derive to cover more cases

### DIFF
--- a/crates/rune-macros/src/internals.rs
+++ b/crates/rune-macros/src/internals.rs
@@ -9,6 +9,10 @@ pub const AST: Symbol = Symbol("ast");
 pub const SKIP: Symbol = Symbol("skip");
 pub const PARSE: Symbol = Symbol("parse");
 
+pub const SPANNED: Symbol = Symbol("spanned");
+pub const FIRST: Symbol = Symbol("first");
+pub const LAST: Symbol = Symbol("last");
+
 impl PartialEq<Symbol> for syn::Ident {
     fn eq(&self, word: &Symbol) -> bool {
         self == word.0

--- a/crates/rune-macros/src/lib.rs
+++ b/crates/rune-macros/src/lib.rs
@@ -53,6 +53,7 @@ mod ast;
 mod context;
 mod internals;
 mod parse;
+mod spanned;
 
 /// Helper derive to implement AST nodes in a less error prone manner.
 #[proc_macro_derive(Ast, attributes(ast))]
@@ -67,6 +68,14 @@ pub fn ast(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 #[doc(hidden)]
 pub fn parse(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let derive = syn::parse_macro_input!(input as parse::Derive);
+    derive.expand().unwrap_or_else(to_compile_errors).into()
+}
+
+/// Helper derive to implement AST nodes in a less error prone manner.
+#[proc_macro_derive(Spanned, attributes(spanned))]
+#[doc(hidden)]
+pub fn spanned(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let derive = syn::parse_macro_input!(input as spanned::Derive);
     derive.expand().unwrap_or_else(to_compile_errors).into()
 }
 

--- a/crates/rune-macros/src/spanned.rs
+++ b/crates/rune-macros/src/spanned.rs
@@ -1,0 +1,285 @@
+use crate::context::Context;
+use proc_macro2::TokenStream;
+use quote::{quote, quote_spanned};
+use syn::spanned::Spanned as _;
+
+/// Derive implementation of the AST macro.
+pub struct Derive {
+    input: syn::DeriveInput,
+}
+
+impl syn::parse::Parse for Derive {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        Ok(Self {
+            input: input.parse()?,
+        })
+    }
+}
+
+impl Derive {
+    pub(super) fn expand(self) -> Result<TokenStream, Vec<syn::Error>> {
+        let mut expander = Expander {
+            ctx: Context::new(),
+        };
+
+        match &self.input.data {
+            syn::Data::Struct(st) => {
+                if let Some(stream) = expander.expand_struct(&self.input, st) {
+                    return Ok(stream);
+                }
+            }
+            syn::Data::Enum(en) => {
+                if let Some(stream) = expander.expand_enum(&self.input, en) {
+                    return Ok(stream);
+                }
+            }
+            syn::Data::Union(un) => {
+                expander.ctx.errors.push(syn::Error::new_spanned(
+                    un.union_token,
+                    "not supported on unions",
+                ));
+            }
+        }
+
+        Err(expander.ctx.errors)
+    }
+}
+
+struct Expander {
+    ctx: Context,
+}
+
+impl Expander {
+    /// Expand on a struct.
+    fn expand_struct(
+        &mut self,
+        input: &syn::DeriveInput,
+        st: &syn::DataStruct,
+    ) -> Option<TokenStream> {
+        let inner = self.expand_struct_fields(&st.fields)?;
+
+        let ident = &input.ident;
+        let spanned = &self.ctx.spanned;
+        let span = &self.ctx.span;
+
+        Some(quote! {
+            impl #spanned for #ident {
+                fn span(&self) -> #span {
+                    #inner
+                }
+            }
+        })
+    }
+
+    /// Expand on a struct.
+    fn expand_enum(&mut self, input: &syn::DeriveInput, st: &syn::DataEnum) -> Option<TokenStream> {
+        let _ = self.ctx.parse_ast_derive(&input.attrs)?;
+
+        let mut impl_spanned = Vec::new();
+
+        for variant in &st.variants {
+            impl_spanned.push(self.expand_variant_fields(variant, &variant.fields)?);
+        }
+
+        let ident = &input.ident;
+        let spanned = &self.ctx.spanned;
+        let span = &self.ctx.span;
+
+        Some(quote_spanned! { input.span() =>
+            impl #spanned for #ident {
+                fn span(&self) -> #span {
+                    match self {
+                        #(#impl_spanned,)*
+                    }
+                }
+            }
+        })
+    }
+
+    /// Expand field decoding.
+    fn expand_struct_fields(&mut self, fields: &syn::Fields) -> Option<TokenStream> {
+        match fields {
+            syn::Fields::Named(named) => self.expand_struct_named(named),
+            syn::Fields::Unnamed(..) => {
+                self.ctx.errors.push(syn::Error::new_spanned(
+                    fields,
+                    "tuple structs are not supported",
+                ));
+                None
+            }
+            syn::Fields::Unit => {
+                self.ctx.errors.push(syn::Error::new_spanned(
+                    fields,
+                    "unit structs are not supported",
+                ));
+                None
+            }
+        }
+    }
+
+    /// Expand named fields.
+    fn expand_struct_named(&mut self, named: &syn::FieldsNamed) -> Option<TokenStream> {
+        let it = named
+            .named
+            .iter()
+            .map(|f| {
+                let var = self.ctx.field_ident(f).map(|n| quote!(&self.#n));
+                (var, f)
+            })
+            .collect::<Vec<_>>();
+
+        let it = it.into_iter();
+        self.build_spanned(named, it)
+    }
+
+    fn build_spanned<'a>(
+        &mut self,
+        tokens: &(impl quote::ToTokens + syn::spanned::Spanned),
+        mut it: impl DoubleEndedIterator<Item = (Option<TokenStream>, &'a syn::Field)>,
+    ) -> Option<TokenStream> {
+        let (begin_trailing, begin) = self.build_decode(&mut it)?;
+
+        let begin = match (begin_trailing, begin) {
+            (false, Some(begin)) => begin,
+            _ => {
+                self.ctx.errors.push(syn::Error::new_spanned(
+                    tokens,
+                    "ran out of fields to calculate span",
+                ));
+                return None;
+            }
+        };
+
+        let mut it = it.rev();
+        let (end_trailing, end) = self.build_decode(&mut it)?;
+
+        Some(if end_trailing {
+            if let Some(end) = end {
+                quote_spanned! { tokens.span() => {
+                    let begin = #begin;
+                    let end = #end;
+
+                    match end {
+                        Some(end) => begin.join(end),
+                        None => begin,
+                    }
+                }}
+            } else {
+                quote_spanned!(tokens.span() => #begin)
+            }
+        } else {
+            quote_spanned!(tokens.span() => #begin.join(#end))
+        })
+    }
+
+    /// Expand variant ast.
+    fn expand_variant_fields(
+        &mut self,
+        variant: &syn::Variant,
+        fields: &syn::Fields,
+    ) -> Option<TokenStream> {
+        match fields {
+            syn::Fields::Named(..) => {
+                self.ctx.errors.push(syn::Error::new_spanned(
+                    fields,
+                    "named enum variants are not supported",
+                ));
+                return None;
+            }
+            syn::Fields::Unnamed(unnamed) => self.expand_variant_unnamed(variant, unnamed),
+            syn::Fields::Unit => {
+                self.ctx.errors.push(syn::Error::new_spanned(
+                    fields,
+                    "unit variants are not supported",
+                ));
+                return None;
+            }
+        }
+    }
+
+    /// Expand named variant fields.
+    fn expand_variant_unnamed(
+        &mut self,
+        variant: &syn::Variant,
+        unnamed: &syn::FieldsUnnamed,
+    ) -> Option<TokenStream> {
+        let it = unnamed
+            .unnamed
+            .iter()
+            .enumerate()
+            .map(|(n, f)| {
+                let ident = syn::Ident::new(&format!("f{}", n), f.span());
+                (Some(quote!(#ident)), f)
+            })
+            .collect::<Vec<_>>();
+
+        let it = it.into_iter();
+        let body = self.build_spanned(unnamed, it);
+
+        let ident = &variant.ident;
+        let vars =
+            (0..unnamed.unnamed.len()).map(|n| syn::Ident::new(&format!("f{}", n), variant.span()));
+
+        Some(quote_spanned!(variant.span() => Self::#ident(#(#vars,)*) => #body))
+    }
+
+    fn build_decode<'a>(
+        &mut self,
+        mut it: impl Iterator<Item = (Option<TokenStream>, &'a syn::Field)>,
+    ) -> Option<(bool, Option<TokenStream>)> {
+        let mut quote = None::<TokenStream>;
+
+        loop {
+            let (var, field) = match it.next() {
+                Some((var, field)) => (var?, field),
+                None => {
+                    return Some((true, quote));
+                }
+            };
+
+            let attrs = self.ctx.parse_spanned_fields(&field.attrs)?;
+
+            let spanned = &self.ctx.spanned;
+
+            if attrs.skip {
+                continue;
+            }
+
+            if attrs.first || attrs.last {
+                let spanned = &self.ctx.spanned;
+
+                let next = if attrs.first {
+                    quote_spanned! {
+                        field.span() => IntoIterator::into_iter(#var).next().map(#spanned::span)
+                    }
+                } else {
+                    quote_spanned! {
+                        field.span() => IntoIterator::into_iter(#var).next_back().map(#spanned::span)
+                    }
+                };
+
+                if quote.is_some() {
+                    quote = Some(quote_spanned! {
+                        field.span() => #quote.or_else(|| #next)
+                    });
+                } else {
+                    quote = Some(next);
+                }
+
+                continue;
+            }
+
+            if quote.is_some() {
+                quote = Some(quote_spanned! {
+                    field.span() => #quote.unwrap_or_else(|| #spanned::span(#var))
+                });
+            } else {
+                quote = Some(quote_spanned! {
+                    field.span() => #spanned::span(#var)
+                });
+            }
+
+            return Some((false, quote));
+        }
+    }
+}

--- a/crates/rune/src/ast/attribute.rs
+++ b/crates/rune/src/ast/attribute.rs
@@ -3,7 +3,7 @@ use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Peek, Spanned, Token
 use runestick::Span;
 
 /// Attribute like `#[derive(Debug)]`
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct Attribute {
     /// The `#` character
     pub hash: ast::Hash,
@@ -17,12 +17,6 @@ pub struct Attribute {
     pub input: TokenStream,
     /// The `]` character
     pub close: ast::CloseBracket,
-}
-
-impl crate::Spanned for Attribute {
-    fn span(&self) -> Span {
-        self.hash.span().join(self.close.span())
-    }
 }
 
 /// Parsing an Attribute

--- a/crates/rune/src/ast/block.rs
+++ b/crates/rune/src/ast/block.rs
@@ -1,9 +1,8 @@
 use crate::ast;
 use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Spanned};
-use runestick::Span;
 
 /// A block of expressions.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct Block {
     /// The close brace.
     pub open: ast::OpenBrace,
@@ -40,12 +39,6 @@ impl Block {
         }
 
         true
-    }
-}
-
-impl Spanned for Block {
-    fn span(&self) -> Span {
-        self.open.span().join(self.close.span())
     }
 }
 

--- a/crates/rune/src/ast/condition.rs
+++ b/crates/rune/src/ast/condition.rs
@@ -1,8 +1,8 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, Parser};
+use crate::{Ast, Parse, ParseError, Parser, Spanned};
 
 /// An if condition.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub enum Condition {
     /// A regular expression.
     Expr(Box<ast::Expr>),

--- a/crates/rune/src/ast/expr.rs
+++ b/crates/rune/src/ast/expr.rs
@@ -28,7 +28,7 @@ impl ops::Deref for ExprChain {
 }
 
 /// A rune expression.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub enum Expr {
     /// The `self` keyword.
     Self_(ast::Self_),

--- a/crates/rune/src/ast/expr_async.rs
+++ b/crates/rune/src/ast/expr_async.rs
@@ -1,26 +1,16 @@
 use crate::ast;
 use crate::{Ast, Parse, ParseError, Parser, Spanned};
-use runestick::Span;
 
 /// A block of expressions.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct ExprAsync {
     /// The attributes for the block.
+    #[spanned(first)]
     pub attributes: Vec<ast::Attribute>,
     /// The `async` keyword.
     pub async_: ast::Async,
     /// The close brace.
     pub block: ast::Block,
-}
-
-impl Spanned for ExprAsync {
-    fn span(&self) -> Span {
-        if let Some(first) = self.attributes.first() {
-            first.span().join(self.block.span())
-        } else {
-            self.async_.span().join(self.block.span())
-        }
-    }
 }
 
 impl ExprAsync {

--- a/crates/rune/src/ast/expr_await.rs
+++ b/crates/rune/src/ast/expr_await.rs
@@ -1,9 +1,8 @@
 use crate::ast;
 use crate::{Ast, Parse, ParseError, Parser, Spanned};
-use runestick::Span;
 
 /// A return statement `<expr>.await`.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct ExprAwait {
     /// The expression being awaited.
     pub expr: Box<ast::Expr>,
@@ -11,12 +10,6 @@ pub struct ExprAwait {
     pub dot: ast::Dot,
     /// The await token.
     pub await_: ast::Await,
-}
-
-impl Spanned for ExprAwait {
-    fn span(&self) -> Span {
-        self.expr.span().join(self.await_.span())
-    }
 }
 
 impl Parse for ExprAwait {

--- a/crates/rune/src/ast/expr_binary.rs
+++ b/crates/rune/src/ast/expr_binary.rs
@@ -1,10 +1,9 @@
 use crate::ast;
 use crate::{Ast, Peek, Spanned};
-use runestick::Span;
 use std::fmt;
 
 /// A binary expression.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct ExprBinary {
     /// The left-hand side of a binary operation.
     pub lhs: Box<ast::Expr>,
@@ -16,6 +15,7 @@ pub struct ExprBinary {
     pub rhs: Box<ast::Expr>,
     /// The operation to apply.
     #[ast(skip)]
+    #[spanned(skip)]
     pub op: BinOp,
 }
 
@@ -29,12 +29,6 @@ impl ExprBinary {
     /// Test if the expression is a constant expression.
     pub fn is_const(&self) -> bool {
         self.lhs.is_const() && self.rhs.is_const()
-    }
-}
-
-impl Spanned for ExprBinary {
-    fn span(&self) -> Span {
-        self.lhs.span().join(self.rhs.span())
     }
 }
 

--- a/crates/rune/src/ast/expr_block.rs
+++ b/crates/rune/src/ast/expr_block.rs
@@ -1,11 +1,11 @@
 use crate::ast;
 use crate::{Ast, Parse, ParseError, Parser, Spanned};
-use runestick::Span;
 
 /// A block of expressions.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct ExprBlock {
     /// The attributes for the block.
+    #[spanned(first)]
     pub attributes: Vec<ast::Attribute>,
     /// The close brace.
     pub block: ast::Block,
@@ -31,16 +31,6 @@ impl ExprBlock {
             attributes,
             block: parser.parse()?,
         })
-    }
-}
-
-impl Spanned for ExprBlock {
-    fn span(&self) -> Span {
-        if let Some(first) = self.attributes.first() {
-            first.span().join(self.block.span())
-        } else {
-            self.block.span()
-        }
     }
 }
 

--- a/crates/rune/src/ast/expr_break.rs
+++ b/crates/rune/src/ast/expr_break.rs
@@ -1,38 +1,18 @@
 use crate::ast;
 use crate::{Ast, Parse, ParseError, Parser, Peek, Spanned};
-use runestick::Span;
 
 /// A return statement `break [expr]`.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Parse, Spanned)]
 pub struct ExprBreak {
     /// The return token.
     pub break_: ast::Break,
     /// An optional expression to break with.
+    #[spanned(last)]
     pub expr: Option<ExprBreakValue>,
 }
 
-impl ExprBreak {
-    /// Access the span of the expression.
-    pub fn span(&self) -> Span {
-        if let Some(expr) = &self.expr {
-            self.break_.span().join(expr.span())
-        } else {
-            self.break_.span()
-        }
-    }
-}
-
-impl Parse for ExprBreak {
-    fn parse(parser: &mut Parser<'_>) -> Result<Self, ParseError> {
-        Ok(Self {
-            break_: parser.parse()?,
-            expr: parser.parse()?,
-        })
-    }
-}
-
 /// Things that we can break on.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub enum ExprBreakValue {
     /// Breaking a value out of a loop.
     Expr(Box<ast::Expr>),

--- a/crates/rune/src/ast/expr_call.rs
+++ b/crates/rune/src/ast/expr_call.rs
@@ -1,18 +1,11 @@
 use crate::ast;
 use crate::{Ast, Spanned};
-use runestick::Span;
 
 /// A function call `<expr>(<args>)`.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct ExprCall {
     /// The name of the function being called.
     pub expr: Box<ast::Expr>,
     /// The arguments of the function call.
     pub args: ast::Parenthesized<ast::Expr, ast::Comma>,
-}
-
-impl Spanned for ExprCall {
-    fn span(&self) -> Span {
-        self.expr.span().join(self.args.span())
-    }
 }

--- a/crates/rune/src/ast/expr_closure.rs
+++ b/crates/rune/src/ast/expr_closure.rs
@@ -3,11 +3,13 @@ use crate::{Ast, Parse, ParseError, Parser, Spanned};
 use runestick::Span;
 
 /// A closure.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct ExprClosure {
     /// The attributes for the async closure
+    #[spanned(first)]
     pub attributes: Vec<ast::Attribute>,
     /// If the closure is async or not.
+    #[spanned(first)]
     pub async_: Option<ast::Async>,
     /// Arguments to the closure.
     pub args: ExprClosureArgs,
@@ -61,16 +63,6 @@ impl ExprClosure {
             args,
             body: Box::new(parser.parse()?),
         })
-    }
-}
-
-impl Spanned for ExprClosure {
-    fn span(&self) -> Span {
-        if let Some(async_) = &self.async_ {
-            async_.span().join(self.body.span())
-        } else {
-            self.args.span().join(self.body.span())
-        }
     }
 }
 

--- a/crates/rune/src/ast/expr_else.rs
+++ b/crates/rune/src/ast/expr_else.rs
@@ -1,18 +1,11 @@
 use crate::ast;
 use crate::{Ast, Parse, Spanned};
-use runestick::Span;
 
 /// An else branch of an if expression.
-#[derive(Debug, Clone, Ast, Parse)]
+#[derive(Debug, Clone, Ast, Parse, Spanned)]
 pub struct ExprElse {
     /// The `else` token.
     pub else_: ast::Else,
     /// The body of the else statement.
     pub block: Box<ast::ExprBlock>,
-}
-
-impl Spanned for ExprElse {
-    fn span(&self) -> Span {
-        self.else_.span().join(self.block.span())
-    }
 }

--- a/crates/rune/src/ast/expr_else_if.rs
+++ b/crates/rune/src/ast/expr_else_if.rs
@@ -1,9 +1,8 @@
 use crate::ast;
 use crate::{Ast, Parse, Spanned};
-use runestick::Span;
 
 /// An else branch of an if expression.
-#[derive(Debug, Clone, Ast, Parse)]
+#[derive(Debug, Clone, Ast, Parse, Spanned)]
 pub struct ExprElseIf {
     /// The `else` token.
     pub else_: ast::Else,
@@ -13,10 +12,4 @@ pub struct ExprElseIf {
     pub condition: ast::Condition,
     /// The body of the else statement.
     pub block: Box<ast::ExprBlock>,
-}
-
-impl Spanned for ExprElseIf {
-    fn span(&self) -> Span {
-        self.else_.span().join(self.block.span())
-    }
 }

--- a/crates/rune/src/ast/expr_field_access.rs
+++ b/crates/rune/src/ast/expr_field_access.rs
@@ -1,9 +1,8 @@
 use crate::ast;
-use crate::Ast;
-use runestick::Span;
+use crate::{Ast, Spanned};
 
 /// The field being accessed.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub enum ExprField {
     /// An identifier.
     Ident(ast::Ident),
@@ -12,7 +11,7 @@ pub enum ExprField {
 }
 
 /// A field access `<expr>.<field>`.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct ExprFieldAccess {
     /// The expr where the field is being accessed.
     pub expr: Box<ast::Expr>,
@@ -20,10 +19,4 @@ pub struct ExprFieldAccess {
     pub dot: ast::Dot,
     /// The field being accessed.
     pub expr_field: ExprField,
-}
-
-impl crate::Spanned for ExprFieldAccess {
-    fn span(&self) -> Span {
-        self.expr.span().join(self.expr_field.span())
-    }
 }

--- a/crates/rune/src/ast/expr_for.rs
+++ b/crates/rune/src/ast/expr_for.rs
@@ -1,11 +1,11 @@
 use crate::ast;
 use crate::{Ast, Parse, ParseError, Parser, Spanned};
-use runestick::Span;
 
 /// A for loop expression `for i in [1, 2, 3] {}`
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct ExprFor {
     /// The label of the loop.
+    #[spanned(first)]
     pub label: Option<(ast::Label, ast::Colon)>,
     /// The `for` keyword.
     pub for_: ast::For,
@@ -34,12 +34,6 @@ impl ExprFor {
             iter: Box::new(ast::Expr::parse_without_eager_brace(parser)?),
             body: Box::new(parser.parse()?),
         })
-    }
-}
-
-impl Spanned for ExprFor {
-    fn span(&self) -> Span {
-        self.for_.token.span().join(self.body.span())
     }
 }
 

--- a/crates/rune/src/ast/expr_group.rs
+++ b/crates/rune/src/ast/expr_group.rs
@@ -1,9 +1,8 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, Parser, Spanned};
-use runestick::Span;
+use crate::{Ast, Parse, Spanned};
 
 /// A prioritized expression group `(<expr>)`.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Parse, Spanned)]
 pub struct ExprGroup {
     /// The open parenthesis.
     pub open: ast::OpenParen,
@@ -17,21 +16,5 @@ impl ExprGroup {
     /// Check if expression is empty.
     pub fn produces_nothing(&self) -> bool {
         self.expr.produces_nothing()
-    }
-}
-
-impl Spanned for ExprGroup {
-    fn span(&self) -> Span {
-        self.open.span().join(self.close.span())
-    }
-}
-
-impl Parse for ExprGroup {
-    fn parse(parser: &mut Parser<'_>) -> Result<Self, ParseError> {
-        Ok(Self {
-            open: parser.parse()?,
-            expr: Box::new(parser.parse()?),
-            close: parser.parse()?,
-        })
     }
 }

--- a/crates/rune/src/ast/expr_if.rs
+++ b/crates/rune/src/ast/expr_if.rs
@@ -1,9 +1,8 @@
 use crate::ast::{Condition, Else, ExprBlock, ExprElse, ExprElseIf, If};
 use crate::{Ast, Parse, ParseError, Parser, Spanned};
-use runestick::Span;
 
 /// An if expression.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct ExprIf {
     /// The `if` token.
     pub if_: If,
@@ -12,8 +11,10 @@ pub struct ExprIf {
     /// The body of the if statement.
     pub block: Box<ExprBlock>,
     /// Else if branches.
+    #[spanned(last)]
     pub expr_else_ifs: Vec<ExprElseIf>,
     /// The else part of the if expression.
+    #[spanned(last)]
     pub expr_else: Option<ExprElse>,
 }
 
@@ -21,18 +22,6 @@ impl ExprIf {
     /// An if statement evaluates to empty if it does not have an else branch.
     pub fn produces_nothing(&self) -> bool {
         self.expr_else.is_none()
-    }
-}
-
-impl Spanned for ExprIf {
-    fn span(&self) -> Span {
-        if let Some(else_) = &self.expr_else {
-            self.if_.token.span().join(else_.block.span())
-        } else if let Some(else_if) = self.expr_else_ifs.last() {
-            self.if_.token.span().join(else_if.block.span())
-        } else {
-            self.if_.token.span().join(self.block.span())
-        }
     }
 }
 

--- a/crates/rune/src/ast/expr_index_get.rs
+++ b/crates/rune/src/ast/expr_index_get.rs
@@ -1,9 +1,8 @@
 use crate::ast;
 use crate::{Ast, Spanned};
-use runestick::Span;
 
 /// An index get operation `<target>[<index>]`.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct ExprIndexGet {
     /// The target of the index set.
     pub target: Box<ast::Expr>,
@@ -13,10 +12,4 @@ pub struct ExprIndexGet {
     pub index: Box<ast::Expr>,
     /// The closening bracket.
     pub close: ast::CloseBracket,
-}
-
-impl Spanned for ExprIndexGet {
-    fn span(&self) -> Span {
-        self.target.span().join(self.close.span())
-    }
 }

--- a/crates/rune/src/ast/expr_index_set.rs
+++ b/crates/rune/src/ast/expr_index_set.rs
@@ -1,9 +1,8 @@
 use crate::ast;
 use crate::{Ast, Spanned};
-use runestick::Span;
 
 /// An index set operation `<target>[<index>] = <value>`.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct ExprIndexSet {
     /// The target of the index set.
     pub target: Box<ast::Expr>,
@@ -17,10 +16,4 @@ pub struct ExprIndexSet {
     pub eq: ast::Eq,
     /// The value expression we are assigning.
     pub value: Box<ast::Expr>,
-}
-
-impl Spanned for ExprIndexSet {
-    fn span(&self) -> Span {
-        self.target.span().join(self.value.span())
-    }
 }

--- a/crates/rune/src/ast/expr_is.rs
+++ b/crates/rune/src/ast/expr_is.rs
@@ -1,9 +1,8 @@
 use crate::ast;
 use crate::{Ast, Parse, Spanned};
-use runestick::Span;
 
 /// An is expression.
-#[derive(Debug, Clone, Ast, Parse)]
+#[derive(Debug, Clone, Ast, Parse, Spanned)]
 pub struct ExprIs {
     /// The left-hand side of a is operation.
     pub lhs: Box<ast::Expr>,
@@ -22,11 +21,5 @@ impl ExprIs {
     /// Test if the expression is a constant expression.
     pub fn is_const(&self) -> bool {
         self.lhs.is_const() && self.rhs.is_const()
-    }
-}
-
-impl Spanned for ExprIs {
-    fn span(&self) -> Span {
-        self.lhs.span().join(self.rhs.span())
     }
 }

--- a/crates/rune/src/ast/expr_is_not.rs
+++ b/crates/rune/src/ast/expr_is_not.rs
@@ -1,9 +1,8 @@
 use crate::ast;
 use crate::{Ast, Parse, Spanned};
-use runestick::Span;
 
 /// An is expression.
-#[derive(Debug, Clone, Ast, Parse)]
+#[derive(Debug, Clone, Ast, Parse, Spanned)]
 pub struct ExprIsNot {
     /// The left-hand side of a is operation.
     pub lhs: Box<ast::Expr>,
@@ -24,11 +23,5 @@ impl ExprIsNot {
     /// Test if the expression is a constant expression.
     pub fn is_const(&self) -> bool {
         self.lhs.is_const() && self.rhs.is_const()
-    }
-}
-
-impl Spanned for ExprIsNot {
-    fn span(&self) -> Span {
-        self.lhs.span().join(self.rhs.span())
     }
 }

--- a/crates/rune/src/ast/expr_let.rs
+++ b/crates/rune/src/ast/expr_let.rs
@@ -1,9 +1,8 @@
 use crate::ast;
 use crate::{Ast, Parse, ParseError, Parser, Spanned};
-use runestick::Span;
 
 /// A let expression `let <name> = <expr>;`
-#[derive(Debug, Clone, Ast, Parse)]
+#[derive(Debug, Clone, Ast, Parse, Spanned)]
 pub struct ExprLet {
     /// The `let` keyword.
     pub let_: ast::Let,
@@ -24,12 +23,5 @@ impl ExprLet {
             eq: parser.parse()?,
             expr: Box::new(ast::Expr::parse_without_eager_brace(parser)?),
         })
-    }
-}
-
-impl Spanned for ExprLet {
-    /// Access the span of the expression.
-    fn span(&self) -> Span {
-        self.let_.span().join(self.expr.span())
     }
 }

--- a/crates/rune/src/ast/expr_lit.rs
+++ b/crates/rune/src/ast/expr_lit.rs
@@ -3,9 +3,10 @@ use crate::{Ast, Spanned};
 use crate::{ParseError, Parser};
 
 /// A literal expression.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct ExprLit {
     /// Attributes associated with the literal expression.
+    #[spanned(first)]
     pub attributes: Vec<ast::Attribute>,
     /// The literal in the expression.
     pub lit: ast::Lit,
@@ -26,15 +27,5 @@ impl ExprLit {
             attributes,
             lit: parser.parse()?,
         })
-    }
-}
-
-impl Spanned for ExprLit {
-    fn span(&self) -> runestick::Span {
-        if let Some(first) = self.attributes.first() {
-            first.span().join(self.lit.span())
-        } else {
-            self.lit.span()
-        }
     }
 }

--- a/crates/rune/src/ast/expr_loop.rs
+++ b/crates/rune/src/ast/expr_loop.rs
@@ -1,11 +1,11 @@
 use crate::ast;
 use crate::{Ast, Parse, ParseError, Parser, Spanned};
-use runestick::Span;
 
 /// A let expression `let <name> = <expr>;`
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct ExprLoop {
     /// A label followed by a colon.
+    #[spanned(first)]
     pub label: Option<(ast::Label, ast::Colon)>,
     /// The `loop` keyword.
     pub loop_: ast::Loop,
@@ -27,20 +27,9 @@ impl ExprLoop {
     }
 }
 
-impl Spanned for ExprLoop {
-    fn span(&self) -> Span {
-        self.loop_.token.span().join(self.body.span())
-    }
-}
-
 impl Parse for ExprLoop {
     fn parse(parser: &mut Parser<'_>) -> Result<Self, ParseError> {
-        let label = if parser.peek::<ast::Label>()? {
-            Some((parser.parse()?, parser.parse()?))
-        } else {
-            None
-        };
-
+        let label = parser.parse()?;
         Self::parse_with_label(parser, label)
     }
 }

--- a/crates/rune/src/ast/expr_match.rs
+++ b/crates/rune/src/ast/expr_match.rs
@@ -1,11 +1,11 @@
 use crate::ast;
 use crate::{Ast, Parse, ParseError, Parser, Spanned};
-use runestick::Span;
 
 /// A match expression.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct ExprMatch {
     /// The attributes for the match expression
+    #[spanned(first)]
     pub attributes: Vec<ast::Attribute>,
     /// The `match` token.
     pub match_: ast::Match,
@@ -62,12 +62,6 @@ impl ExprMatch {
     }
 }
 
-impl Spanned for ExprMatch {
-    fn span(&self) -> Span {
-        self.match_.span().join(self.close.span())
-    }
-}
-
 /// Parse a match statement.
 ///
 /// # Examples
@@ -87,7 +81,15 @@ impl Parse for ExprMatch {
 }
 
 /// A match branch.
-#[derive(Debug, Clone, Ast)]
+///
+/// # Examples
+///
+/// ```rust
+/// use rune::{parse_all, ast};
+///
+/// parse_all::<ast::ExprMatchBranch>("1 => { foo }").unwrap();
+/// ```
+#[derive(Debug, Clone, Ast, Parse, Spanned)]
 pub struct ExprMatchBranch {
     /// The pattern to match.
     pub pat: ast::Pat,
@@ -100,33 +102,8 @@ pub struct ExprMatchBranch {
 }
 
 impl ExprMatchBranch {
-    /// Access the span of the expression.
-    pub fn span(&self) -> Span {
-        self.pat.span().join(self.body.span())
-    }
-
     /// Test if the branch produces nothing.
     pub fn produces_nothing(&self) -> bool {
         self.body.produces_nothing()
-    }
-}
-
-/// Parse a match statement.
-///
-/// # Examples
-///
-/// ```rust
-/// use rune::{parse_all, ast};
-///
-/// parse_all::<ast::ExprMatchBranch>("1 => { foo }").unwrap();
-/// ```
-impl Parse for ExprMatchBranch {
-    fn parse(parser: &mut Parser) -> Result<Self, ParseError> {
-        Ok(Self {
-            pat: parser.parse()?,
-            condition: parser.parse()?,
-            rocket: parser.parse()?,
-            body: Box::new(parser.parse()?),
-        })
     }
 }

--- a/crates/rune/src/ast/expr_return.rs
+++ b/crates/rune/src/ast/expr_return.rs
@@ -1,22 +1,12 @@
 use crate::ast;
 use crate::{Ast, Parse, Spanned};
-use runestick::Span;
 
 /// A return statement `return [expr]`.
-#[derive(Debug, Clone, Ast, Parse)]
+#[derive(Debug, Clone, Ast, Parse, Spanned)]
 pub struct ExprReturn {
     /// The return token.
     pub return_: ast::Return,
     /// An optional expression to return.
+    #[spanned(last)]
     pub expr: Option<Box<ast::Expr>>,
-}
-
-impl Spanned for ExprReturn {
-    fn span(&self) -> Span {
-        if let Some(expr) = &self.expr {
-            self.return_.span().join(expr.span())
-        } else {
-            self.return_.span()
-        }
-    }
 }

--- a/crates/rune/src/ast/expr_try.rs
+++ b/crates/rune/src/ast/expr_try.rs
@@ -1,18 +1,11 @@
 use crate::ast;
 use crate::{Ast, Spanned};
-use runestick::Span;
 
 /// A try expression `<expr>?`.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct ExprTry {
     /// The expression being awaited.
     pub expr: Box<ast::Expr>,
     /// The try operator.
     pub try_: ast::Try,
-}
-
-impl Spanned for ExprTry {
-    fn span(&self) -> Span {
-        self.expr.span().join(self.try_.span())
-    }
 }

--- a/crates/rune/src/ast/expr_unary.rs
+++ b/crates/rune/src/ast/expr_unary.rs
@@ -1,25 +1,19 @@
 use crate::ast;
 use crate::ast::expr::{EagerBrace, ExprChain};
 use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Spanned};
-use runestick::Span;
 use std::fmt;
 
 /// A unary expression.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct ExprUnary {
     /// The operation to apply.
     #[ast(skip)]
+    #[spanned(skip)]
     pub op: UnaryOp,
     /// Token associated with operator.
     pub token: ast::Token,
     /// The expression of the operation.
     pub expr: Box<ast::Expr>,
-}
-
-impl Spanned for ExprUnary {
-    fn span(&self) -> Span {
-        self.token.span().join(self.expr.span())
-    }
 }
 
 /// Parse a unary statement.

--- a/crates/rune/src/ast/expr_while.rs
+++ b/crates/rune/src/ast/expr_while.rs
@@ -1,11 +1,11 @@
 use crate::ast;
 use crate::{Ast, Parse, ParseError, Parser, Spanned};
-use runestick::Span;
 
 /// A let expression `let <name> = <expr>;`
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct ExprWhile {
     /// A label for the while loop.
+    #[spanned(first)]
     pub label: Option<(ast::Label, ast::Colon)>,
     /// The `while` keyword.
     pub while_: ast::While,
@@ -27,12 +27,6 @@ impl ExprWhile {
             condition: parser.parse()?,
             body: Box::new(parser.parse()?),
         })
-    }
-}
-
-impl Spanned for ExprWhile {
-    fn span(&self) -> Span {
-        self.while_.span().join(self.body.span())
     }
 }
 

--- a/crates/rune/src/ast/expr_yield.rs
+++ b/crates/rune/src/ast/expr_yield.rs
@@ -1,31 +1,21 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, Parser, Spanned};
-use runestick::Span;
+use crate::{Ast, Parse, Spanned};
 
 /// A return statement `break [expr]`.
-#[derive(Debug, Clone, Ast)]
+///
+/// # Examples
+///
+/// ```rust
+/// use rune::{parse_all, ast};
+///
+/// parse_all::<ast::ExprYield>("yield").unwrap();
+/// parse_all::<ast::ExprYield>("yield 42").unwrap();
+/// ```
+#[derive(Debug, Clone, Ast, Parse, Spanned)]
 pub struct ExprYield {
     /// The return token.
     pub yield_: ast::Yield,
     /// An optional expression to yield.
+    #[spanned(last)]
     pub expr: Option<Box<ast::Expr>>,
-}
-
-impl Spanned for ExprYield {
-    fn span(&self) -> Span {
-        if let Some(expr) = &self.expr {
-            self.yield_.span().join(expr.span())
-        } else {
-            self.yield_.span()
-        }
-    }
-}
-
-impl Parse for ExprYield {
-    fn parse(parser: &mut Parser<'_>) -> Result<Self, ParseError> {
-        Ok(Self {
-            yield_: parser.parse()?,
-            expr: parser.parse()?,
-        })
-    }
 }

--- a/crates/rune/src/ast/fn_arg.rs
+++ b/crates/rune/src/ast/fn_arg.rs
@@ -1,8 +1,18 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser};
+use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Spanned};
 
 /// A single argument in a closure.
-#[derive(Debug, Clone, Ast)]
+///
+/// # Examples
+///
+/// ```rust
+/// use rune::{parse_all, ast};
+///
+/// parse_all::<ast::FnArg>("self").unwrap();
+/// parse_all::<ast::FnArg>("_").unwrap();
+/// parse_all::<ast::FnArg>("abc").unwrap();
+/// ```
+#[derive(Debug, Clone, Ast, Spanned)]
 pub enum FnArg {
     /// The `self` parameter.
     Self_(ast::Self_),

--- a/crates/rune/src/ast/ident.rs
+++ b/crates/rune/src/ast/ident.rs
@@ -1,21 +1,17 @@
 use crate::ast;
-use crate::{Parse, ParseError, ParseErrorKind, Parser, Peek, Resolve, Spanned, Storage};
-use runestick::{Source, Span};
+use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Peek, Resolve, Spanned, Storage};
+use runestick::Source;
 use std::borrow::Cow;
 
 /// An identifier, like `foo` or `Hello`.".
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Ast, Spanned)]
 pub struct Ident {
     /// The kind of the identifier.
     pub token: ast::Token,
     /// The kind of the identifier.
+    #[ast(skip)]
+    #[spanned(skip)]
     pub kind: ast::StringSource,
-}
-
-impl Spanned for Ident {
-    fn span(&self) -> Span {
-        self.token.span()
-    }
 }
 
 impl Parse for Ident {
@@ -66,11 +62,5 @@ impl<'a> Resolve<'a> for Ident {
                 Ok(Cow::Owned(ident))
             }
         }
-    }
-}
-
-impl crate::IntoTokens for Ident {
-    fn into_tokens(&self, _: &mut crate::MacroContext, stream: &mut crate::TokenStream) {
-        stream.push(self.token);
     }
 }

--- a/crates/rune/src/ast/item.rs
+++ b/crates/rune/src/ast/item.rs
@@ -1,8 +1,8 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Peek};
+use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Peek, Spanned};
 
 /// A declaration.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub enum Item {
     /// A use declaration.
     ItemUse(ast::ItemUse),

--- a/crates/rune/src/ast/item_enum.rs
+++ b/crates/rune/src/ast/item_enum.rs
@@ -1,11 +1,11 @@
 use crate::ast;
 use crate::{Ast, Parse, ParseError, Parser, Spanned};
-use runestick::Span;
 
 /// An enum declaration.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct ItemEnum {
     /// The attributes for the enum block
+    #[spanned(first)]
     pub attributes: Vec<ast::Attribute>,
     /// The `enum` token.
     pub enum_: ast::Enum,
@@ -60,16 +60,6 @@ impl ItemEnum {
     }
 }
 
-impl Spanned for ItemEnum {
-    fn span(&self) -> Span {
-        if let Some(first) = self.attributes.first() {
-            first.span().join(self.close.span())
-        } else {
-            self.enum_.span().join(self.close.span())
-        }
-    }
-}
-
 /// Parse implementation for an enum.
 ///
 /// # Examples
@@ -89,38 +79,19 @@ impl Parse for ItemEnum {
 }
 
 /// An enum variant.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct ItemVariant {
     /// The attributes associated with the variant.
+    #[spanned(first)]
     pub attributes: Vec<ast::Attribute>,
     /// The name of the variant.
     pub name: ast::Ident,
     /// The body of the variant.
+    #[spanned(skip)]
     pub body: ItemVariantBody,
     /// Optional trailing comma in variant.
+    #[spanned(last)]
     pub comma: Option<ast::Comma>,
-}
-
-impl Spanned for ItemVariant {
-    fn span(&self) -> Span {
-        let first = self
-            .attributes
-            .first()
-            .map(Spanned::span)
-            .unwrap_or_else(|| self.name.span());
-
-        let last = self
-            .comma
-            .as_ref()
-            .map(Spanned::span)
-            .unwrap_or_else(|| match &self.body {
-                ItemVariantBody::EmptyBody => self.name.span(),
-                ItemVariantBody::TupleBody(body) => body.span(),
-                ItemVariantBody::StructBody(body) => body.span(),
-            });
-
-        first.join(last)
-    }
 }
 
 /// An item body declaration.

--- a/crates/rune/src/ast/item_fn.rs
+++ b/crates/rune/src/ast/item_fn.rs
@@ -3,11 +3,13 @@ use crate::{Ast, Parse, ParseError, Parser, Peek, Spanned};
 use runestick::Span;
 
 /// A function.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct ItemFn {
     /// The attributes for the fn
+    #[spanned(first)]
     pub attributes: Vec<ast::Attribute>,
     /// The optional `async` keyword.
+    #[spanned(first)]
     pub async_: Option<ast::Async>,
     /// The `fn` token.
     pub fn_: ast::Fn,
@@ -47,18 +49,6 @@ impl ItemFn {
             args: parser.parse()?,
             body: parser.parse()?,
         })
-    }
-}
-
-impl Spanned for ItemFn {
-    fn span(&self) -> Span {
-        if let Some(first) = self.attributes.first() {
-            first.span().join(self.body.span())
-        } else if let Some(async_) = &self.async_ {
-            async_.span().join(self.body.span())
-        } else {
-            self.fn_.span().join(self.body.span())
-        }
     }
 }
 

--- a/crates/rune/src/ast/item_impl.rs
+++ b/crates/rune/src/ast/item_impl.rs
@@ -1,11 +1,11 @@
 use crate::ast;
 use crate::{Ast, Parse, ParseError, Parser, Spanned};
-use runestick::Span;
 
 /// An impl declaration.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct ItemImpl {
     /// The attributes of the `impl` block
+    #[spanned(first)]
     pub attributes: Vec<ast::Attribute>,
     /// The `impl` keyword.
     pub impl_: ast::Impl,
@@ -30,6 +30,7 @@ impl ItemImpl {
         let open = parser.parse()?;
 
         let mut functions = vec![];
+
         while !parser.peek::<ast::CloseBrace>()? {
             let attributes = parser.parse()?;
             functions.push(ast::ItemFn::parse_with_attributes(parser, attributes)?);
@@ -45,16 +46,6 @@ impl ItemImpl {
             functions,
             close,
         })
-    }
-}
-
-impl Spanned for ItemImpl {
-    fn span(&self) -> Span {
-        if let Some(first) = self.attributes.first() {
-            first.span().join(self.close.span())
-        } else {
-            self.impl_.span().join(self.close.span())
-        }
     }
 }
 

--- a/crates/rune/src/ast/item_mod.rs
+++ b/crates/rune/src/ast/item_mod.rs
@@ -1,11 +1,11 @@
 use crate::ast;
 use crate::{Ast, Parse, ParseError, Parser, Peek, Spanned};
-use runestick::Span;
 
 /// A module declaration.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct ItemMod {
     /// The *inner* attributes are applied to the module  `#[cfg(test)] mod tests {  }`
+    #[spanned(first)]
     pub attributes: Vec<ast::Attribute>,
     /// The `mod` keyword.
     pub mod_: ast::Mod,
@@ -27,16 +27,6 @@ impl ItemMod {
             name: parser.parse()?,
             body: parser.parse()?,
         })
-    }
-}
-
-impl Spanned for ItemMod {
-    fn span(&self) -> Span {
-        if let Some(first) = self.attributes.first() {
-            first.span().join(self.body.span())
-        } else {
-            self.mod_.span().join(self.body.span())
-        }
     }
 }
 
@@ -70,7 +60,7 @@ impl Parse for ItemMod {
 }
 
 /// An item body.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub enum ItemModBody {
     /// An empty body terminated by a semicolon.
     EmptyBody(ast::SemiColon),
@@ -90,7 +80,7 @@ impl Parse for ItemModBody {
 }
 
 /// A module declaration.
-#[derive(Debug, Clone, Ast, Parse)]
+#[derive(Debug, Clone, Ast, Parse, Spanned)]
 pub struct ItemInlineBody {
     /// The open brace.
     pub open: ast::OpenBrace,
@@ -98,13 +88,6 @@ pub struct ItemInlineBody {
     pub file: Box<ast::File>,
     /// The close brace.
     pub close: ast::CloseBrace,
-}
-
-impl ItemInlineBody {
-    /// The span of the body.
-    pub fn span(&self) -> Span {
-        self.open.span().join(self.close.span())
-    }
 }
 
 impl Peek for ItemInlineBody {

--- a/crates/rune/src/ast/item_struct.rs
+++ b/crates/rune/src/ast/item_struct.rs
@@ -1,11 +1,11 @@
 use crate::ast;
 use crate::{Ast, Parse, ParseError, Parser, Spanned};
-use runestick::Span;
 
 /// A struct declaration.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct ItemStruct {
     /// The attributes for the struct
+    #[spanned(first)]
     pub attributes: Vec<ast::Attribute>,
     /// The `struct` keyword.
     pub struct_: ast::Struct,
@@ -30,18 +30,6 @@ impl ItemStruct {
     }
 }
 
-impl Spanned for ItemStruct {
-    fn span(&self) -> Span {
-        let start = self.struct_.span();
-
-        match &self.body {
-            ItemStructBody::EmptyBody(semi) => start.join(semi.span()),
-            ItemStructBody::TupleBody(_, semi) => start.join(semi.span()),
-            ItemStructBody::StructBody(body) => start.join(body.span()),
-        }
-    }
-}
-
 /// Parse implementation for a struct.
 ///
 /// # Examples
@@ -63,7 +51,7 @@ impl Parse for ItemStruct {
 }
 
 /// A struct declaration.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub enum ItemStructBody {
     /// An empty struct declaration.
     EmptyBody(ast::SemiColon),
@@ -114,7 +102,7 @@ impl Parse for ItemStructBody {
 }
 
 /// A variant declaration.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct TupleBody {
     /// The opening paren.
     pub open: ast::OpenParen,
@@ -122,13 +110,6 @@ pub struct TupleBody {
     pub fields: Vec<Field>,
     /// The close paren.
     pub close: ast::CloseParen,
-}
-
-impl TupleBody {
-    /// Get the span for the tuple body.
-    pub fn span(&self) -> Span {
-        self.open.span().join(self.close.span())
-    }
 }
 
 /// Parse implementation for a struct body.
@@ -166,7 +147,7 @@ impl Parse for TupleBody {
 }
 
 /// A variant declaration.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct StructBody {
     /// The opening brace.
     pub open: ast::OpenBrace,
@@ -174,13 +155,6 @@ pub struct StructBody {
     pub fields: Vec<Field>,
     /// The close brace.
     pub close: ast::CloseBrace,
-}
-
-impl StructBody {
-    /// Get the span for the tuple body.
-    pub fn span(&self) -> Span {
-        self.open.span().join(self.close.span())
-    }
 }
 
 /// Parse implementation for a struct body.
@@ -228,28 +202,14 @@ impl Parse for StructBody {
 /// parse_all::<ast::Field>("a").unwrap();
 /// parse_all::<ast::Field>("#[x] a").unwrap();
 /// ```
-#[derive(Debug, Clone, Ast, Parse)]
+#[derive(Debug, Clone, Ast, Parse, Spanned)]
 pub struct Field {
     /// Attributes associated with field.
+    #[spanned(first)]
     pub attributes: Vec<ast::Attribute>,
     /// Name of the field.
     pub name: ast::Ident,
     /// Trailing comma of the field.
+    #[spanned(last)]
     pub comma: Option<ast::Comma>,
-}
-
-impl Spanned for Field {
-    fn span(&self) -> Span {
-        let last = self
-            .comma
-            .as_ref()
-            .map(Spanned::span)
-            .unwrap_or_else(|| self.name.span());
-
-        if let Some(first) = self.attributes.first() {
-            first.span().join(last)
-        } else {
-            last
-        }
-    }
 }

--- a/crates/rune/src/ast/item_use.rs
+++ b/crates/rune/src/ast/item_use.rs
@@ -1,11 +1,11 @@
 use crate::ast;
 use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Peek, Spanned};
-use runestick::Span;
 
 /// An imported declaration.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct ItemUse {
     /// The attributes on use item
+    #[spanned(first)]
     pub attributes: Vec<ast::Attribute>,
     /// The use token.
     pub use_: ast::Use,
@@ -32,15 +32,6 @@ impl ItemUse {
         })
     }
 }
-impl Spanned for ItemUse {
-    fn span(&self) -> Span {
-        if let Some(first) = self.attributes.first() {
-            first.span().join(self.semi.span())
-        } else {
-            self.use_.span().join(self.semi.span())
-        }
-    }
-}
 
 /// Parsing an use declaration.
 ///
@@ -61,7 +52,7 @@ impl Parse for ItemUse {
 }
 
 /// A use component.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub enum ItemUseComponent {
     /// An identifier import.
     Ident(ast::Ident),

--- a/crates/rune/src/ast/label.rs
+++ b/crates/rune/src/ast/label.rs
@@ -1,22 +1,17 @@
 use crate::ast;
 use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Peek, Resolve, Spanned, Storage};
-use runestick::{Source, Span};
+use runestick::Source;
 use std::borrow::Cow;
 
 /// A label, like `'foo`
-#[derive(Debug, Clone, Copy, Ast)]
+#[derive(Debug, Clone, Copy, Ast, Spanned)]
 pub struct Label {
     /// The token of the label.
     pub token: ast::Token,
     /// The kind of the label.
     #[ast(skip)]
+    #[spanned(skip)]
     pub kind: ast::StringSource,
-}
-
-impl Spanned for Label {
-    fn span(&self) -> Span {
-        self.token.span()
-    }
 }
 
 impl Parse for Label {

--- a/crates/rune/src/ast/lit.rs
+++ b/crates/rune/src/ast/lit.rs
@@ -1,8 +1,8 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser};
+use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Spanned};
 
 /// A literal value
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub enum Lit {
     /// A unit literal
     Unit(ast::LitUnit),

--- a/crates/rune/src/ast/lit_bool.rs
+++ b/crates/rune/src/ast/lit_bool.rs
@@ -1,21 +1,15 @@
 use crate::ast;
 use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Peek, Spanned};
-use runestick::Span;
 
 /// The unit literal `()`.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct LitBool {
     /// The value of the literal.
     #[ast(skip)]
+    #[spanned(skip)]
     pub value: bool,
     /// The token of the literal.
     pub token: ast::Token,
-}
-
-impl Spanned for LitBool {
-    fn span(&self) -> Span {
-        self.token.span()
-    }
 }
 
 /// Parsing a unit literal

--- a/crates/rune/src/ast/lit_byte.rs
+++ b/crates/rune/src/ast/lit_byte.rs
@@ -1,21 +1,16 @@
 use crate::ast;
 use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Resolve, Spanned, Storage};
-use runestick::{Source, Span};
+use runestick::Source;
 
 /// A byte literal.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct LitByte {
     /// The token corresponding to the literal.
     pub token: ast::Token,
     /// The source of the byte.
     #[ast(skip)]
+    #[spanned(skip)]
     pub source: ast::CopySource<u8>,
-}
-
-impl Spanned for LitByte {
-    fn span(&self) -> Span {
-        self.token.span()
-    }
 }
 
 /// Parse a byte literal.

--- a/crates/rune/src/ast/lit_byte_str.rs
+++ b/crates/rune/src/ast/lit_byte_str.rs
@@ -4,19 +4,14 @@ use runestick::{Source, Span};
 use std::borrow::Cow;
 
 /// A string literal.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct LitByteStr {
     /// The token corresponding to the literal.
     token: ast::Token,
     /// If the string literal is escaped.
     #[ast(skip)]
+    #[spanned(skip)]
     source: ast::LitByteStrSource,
-}
-
-impl Spanned for LitByteStr {
-    fn span(&self) -> Span {
-        self.token.span()
-    }
 }
 
 impl LitByteStr {

--- a/crates/rune/src/ast/lit_char.rs
+++ b/crates/rune/src/ast/lit_char.rs
@@ -1,21 +1,16 @@
 use crate::ast;
 use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Resolve, Spanned, Storage};
-use runestick::{Source, Span};
+use runestick::Source;
 
 /// A character literal.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct LitChar {
     /// The token corresponding to the literal.
     pub token: ast::Token,
     /// The source of the literal character.
     #[ast(skip)]
+    #[spanned(skip)]
     pub source: ast::CopySource<char>,
-}
-
-impl Spanned for LitChar {
-    fn span(&self) -> Span {
-        self.token.span()
-    }
 }
 
 /// Parse a character literal.

--- a/crates/rune/src/ast/lit_number.rs
+++ b/crates/rune/src/ast/lit_number.rs
@@ -3,19 +3,14 @@ use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Resolve, Spanned, St
 use runestick::{Source, Span};
 
 /// A number literal.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct LitNumber {
     /// The token corresponding to the literal.
     token: ast::Token,
     /// The source of the number.
     #[ast(skip)]
+    #[spanned(skip)]
     source: ast::NumberSource,
-}
-
-impl Spanned for LitNumber {
-    fn span(&self) -> Span {
-        self.token.span()
-    }
 }
 
 /// Parse a number literal.

--- a/crates/rune/src/ast/lit_object.rs
+++ b/crates/rune/src/ast/lit_object.rs
@@ -1,10 +1,10 @@
 use crate::{ast, Peek};
 use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Resolve, Spanned, Storage};
-use runestick::{Source, Span};
+use runestick::Source;
 use std::borrow::Cow;
 
 /// A literal object identifier.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub enum LitObjectIdent {
     /// An anonymous object.
     Anonymous(ast::Hash),
@@ -24,22 +24,13 @@ impl Parse for LitObjectIdent {
 }
 
 /// A literal object field.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct LitObjectFieldAssign {
     /// The key of the field.
     pub key: LitObjectKey,
     /// The assigned expression of the field.
+    #[spanned(last)]
     pub assign: Option<(ast::Colon, ast::Expr)>,
-}
-
-impl Spanned for LitObjectFieldAssign {
-    fn span(&self) -> Span {
-        if let Some((_, expr)) = &self.assign {
-            self.key.span().join(expr.span())
-        } else {
-            self.key.span()
-        }
-    }
 }
 
 impl LitObjectFieldAssign {
@@ -80,7 +71,7 @@ impl Parse for LitObjectFieldAssign {
 }
 
 /// Possible literal object keys.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub enum LitObjectKey {
     /// A literal string (with escapes).
     LitStr(ast::LitStr),
@@ -127,7 +118,7 @@ impl<'a> Resolve<'a> for LitObjectKey {
 }
 
 /// A number literal.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct LitObject {
     /// An object identifier.
     pub ident: LitObjectIdent,
@@ -140,6 +131,7 @@ pub struct LitObject {
     /// Indicates if the object is completely literal and cannot have side
     /// effects.
     #[ast(skip)]
+    #[spanned(skip)]
     is_const: bool,
 }
 
@@ -185,12 +177,6 @@ impl LitObject {
             close,
             is_const,
         })
-    }
-}
-
-impl Spanned for LitObject {
-    fn span(&self) -> Span {
-        self.ident.span().join(self.close.span())
     }
 }
 

--- a/crates/rune/src/ast/lit_str.rs
+++ b/crates/rune/src/ast/lit_str.rs
@@ -4,19 +4,14 @@ use runestick::{Source, Span};
 use std::borrow::Cow;
 
 /// A string literal.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct LitStr {
     /// The token corresponding to the literal.
     token: ast::Token,
     /// The source of the literal string.
     #[ast(skip)]
+    #[spanned(skip)]
     source: ast::LitStrSource,
-}
-
-impl Spanned for LitStr {
-    fn span(&self) -> Span {
-        self.token.span()
-    }
 }
 
 impl LitStr {

--- a/crates/rune/src/ast/lit_template.rs
+++ b/crates/rune/src/ast/lit_template.rs
@@ -4,19 +4,14 @@ use runestick::{Source, Span};
 use std::borrow::Cow;
 
 /// A string literal.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct LitTemplate {
     /// The token corresponding to the literal.
     token: ast::Token,
     /// The source string of the literal template.
     #[ast(skip)]
+    #[spanned(skip)]
     source: ast::LitStrSource,
-}
-
-impl Spanned for LitTemplate {
-    fn span(&self) -> Span {
-        self.token.span()
-    }
 }
 
 /// A single template component.

--- a/crates/rune/src/ast/lit_tuple.rs
+++ b/crates/rune/src/ast/lit_tuple.rs
@@ -1,9 +1,8 @@
 use crate::ast;
 use crate::{Ast, Parse, ParseError, Parser, Spanned};
-use runestick::Span;
 
 /// An expression to construct a literal tuple.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct LitTuple {
     /// The open bracket.
     pub open: ast::OpenParen,
@@ -13,6 +12,7 @@ pub struct LitTuple {
     pub close: ast::CloseParen,
     /// If the entire tuple is constant.
     #[ast(skip)]
+    #[spanned(skip)]
     is_const: bool,
 }
 
@@ -60,12 +60,6 @@ impl LitTuple {
             close,
             is_const,
         })
-    }
-}
-
-impl Spanned for LitTuple {
-    fn span(&self) -> Span {
-        self.open.span().join(self.close.span())
     }
 }
 

--- a/crates/rune/src/ast/lit_unit.rs
+++ b/crates/rune/src/ast/lit_unit.rs
@@ -1,6 +1,5 @@
 use crate::ast;
 use crate::{Ast, Parse, Peek, Spanned};
-use runestick::Span;
 
 /// The unit literal `()`.
 ///
@@ -11,18 +10,12 @@ use runestick::Span;
 ///
 /// parse_all::<ast::LitUnit>("()").unwrap();
 /// ```
-#[derive(Debug, Clone, Ast, Parse)]
+#[derive(Debug, Clone, Ast, Parse, Spanned)]
 pub struct LitUnit {
     /// The open parenthesis.
     pub open: ast::OpenParen,
     /// The close parenthesis.
     pub close: ast::CloseParen,
-}
-
-impl Spanned for LitUnit {
-    fn span(&self) -> Span {
-        self.open.span().join(self.close.span())
-    }
 }
 
 impl Peek for LitUnit {

--- a/crates/rune/src/ast/lit_vec.rs
+++ b/crates/rune/src/ast/lit_vec.rs
@@ -1,9 +1,8 @@
 use crate::ast;
 use crate::{Ast, Parse, ParseError, Parser, Spanned};
-use runestick::Span;
 
 /// A number literal.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct LitVec {
     /// The open bracket.
     pub open: ast::OpenBracket,
@@ -13,6 +12,7 @@ pub struct LitVec {
     pub close: ast::CloseBracket,
     /// If the entire array is constant.
     #[ast(skip)]
+    #[spanned(skip)]
     is_const: bool,
 }
 
@@ -20,12 +20,6 @@ impl LitVec {
     /// Test if the entire expression is constant.
     pub fn is_const(&self) -> bool {
         self.is_const
-    }
-}
-
-impl Spanned for LitVec {
-    fn span(&self) -> Span {
-        self.open.span().join(self.close.span())
     }
 }
 

--- a/crates/rune/src/ast/macro_call.rs
+++ b/crates/rune/src/ast/macro_call.rs
@@ -3,7 +3,7 @@ use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Spanned, TokenStream
 use runestick::Span;
 
 /// A function call `<expr>!(<args>)`.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct MacroCall {
     /// The expression being called over.
     pub path: ast::Path,
@@ -15,13 +15,6 @@ pub struct MacroCall {
     pub stream: TokenStream,
     /// Closing paren.
     pub close: ast::Token,
-}
-
-impl Spanned for MacroCall {
-    /// Access the span of expression.
-    fn span(&self) -> Span {
-        self.path.span().join(self.close.span())
-    }
 }
 
 impl MacroCall {

--- a/crates/rune/src/ast/pat.rs
+++ b/crates/rune/src/ast/pat.rs
@@ -1,8 +1,8 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Peek};
+use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Peek, Spanned};
 
 /// A pattern match.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub enum Pat {
     /// An ignored binding `_`.
     PatIgnore(ast::Underscore),

--- a/crates/rune/src/ast/pat_object.rs
+++ b/crates/rune/src/ast/pat_object.rs
@@ -1,9 +1,8 @@
 use crate::ast;
 use crate::{Ast, Parse, ParseError, Parser, Spanned};
-use runestick::Span;
 
 /// An object pattern.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct PatObject {
     /// The identifier of the object pattern.
     pub ident: ast::LitObjectIdent,
@@ -63,12 +62,6 @@ impl PatObject {
     }
 }
 
-impl Spanned for PatObject {
-    fn span(&self) -> Span {
-        self.ident.span().join(self.close.span())
-    }
-}
-
 impl Parse for PatObject {
     fn parse(parser: &mut Parser) -> Result<Self, ParseError> {
         let ident = parser.parse()?;
@@ -77,35 +70,11 @@ impl Parse for PatObject {
 }
 
 /// An object item.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned, Parse)]
 pub struct PatObjectItem {
     /// The key of an object.
     pub key: ast::LitObjectKey,
     /// The binding used for the pattern object.
+    #[spanned(last)]
     pub binding: Option<(ast::Colon, ast::Pat)>,
-}
-
-impl PatObjectItem {
-    /// The span of the expression.
-    pub fn span(&self) -> Span {
-        if let Some((_, pat)) = &self.binding {
-            self.key.span().join(pat.span())
-        } else {
-            self.key.span()
-        }
-    }
-}
-
-impl Parse for PatObjectItem {
-    fn parse(parser: &mut Parser) -> Result<Self, ParseError> {
-        let key = parser.parse()?;
-
-        let binding = if parser.peek::<ast::Colon>()? {
-            Some((parser.parse()?, parser.parse()?))
-        } else {
-            None
-        };
-
-        Ok(Self { key, binding })
-    }
 }

--- a/crates/rune/src/ast/pat_path.rs
+++ b/crates/rune/src/ast/pat_path.rs
@@ -1,16 +1,9 @@
 use crate::ast;
 use crate::{Ast, Spanned};
-use runestick::Span;
 
 /// A tuple pattern.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct PatPath {
     /// The path, if the tuple is typed.
     pub path: ast::Path,
-}
-
-impl Spanned for PatPath {
-    fn span(&self) -> Span {
-        self.path.span()
-    }
 }

--- a/crates/rune/src/ast/pat_tuple.rs
+++ b/crates/rune/src/ast/pat_tuple.rs
@@ -1,11 +1,11 @@
 use crate::ast;
 use crate::{Ast, Parse, ParseError, Parser, Spanned};
-use runestick::Span;
 
 /// A tuple pattern.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct PatTuple {
     /// The path, if the tuple is typed.
+    #[spanned(first)]
     pub path: Option<ast::Path>,
     /// The open bracket.
     pub open: ast::OpenParen,
@@ -56,16 +56,6 @@ impl PatTuple {
             open_pattern,
             close,
         })
-    }
-}
-
-impl Spanned for PatTuple {
-    fn span(&self) -> Span {
-        if let Some(path) = &self.path {
-            path.span().join(self.close.span())
-        } else {
-            self.open.span().join(self.close.span())
-        }
     }
 }
 

--- a/crates/rune/src/ast/pat_vec.rs
+++ b/crates/rune/src/ast/pat_vec.rs
@@ -1,9 +1,8 @@
 use crate::ast;
 use crate::{Ast, Parse, ParseError, Parser, Spanned};
-use runestick::Span;
 
 /// An array pattern.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub struct PatVec {
     /// The open bracket.
     pub open: ast::OpenBracket,
@@ -13,12 +12,6 @@ pub struct PatVec {
     pub open_pattern: Option<ast::DotDot>,
     /// The close bracket.
     pub close: ast::CloseBracket,
-}
-
-impl Spanned for PatVec {
-    fn span(&self) -> Span {
-        self.open.span().join(self.close.span())
-    }
 }
 
 impl Parse for PatVec {

--- a/crates/rune/src/ast/path.rs
+++ b/crates/rune/src/ast/path.rs
@@ -1,16 +1,18 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, Parser, Peek, Resolve, Spanned, Storage};
-use runestick::{Source, Span};
+use crate::{Ast, Parse, ParseError, Peek, Resolve, Spanned, Storage};
+use runestick::Source;
 use std::borrow::Cow;
 
 /// A path, where each element is separated by a `::`.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned, Parse)]
 pub struct Path {
     /// The first component in the path.
     pub first: ast::Ident,
     /// The rest of the components in the path.
+    #[spanned(last)]
     pub rest: Vec<(ast::Scope, ast::Ident)>,
     /// Trailing scope.
+    #[spanned(last)]
     pub trailing: Option<ast::Scope>,
 }
 
@@ -41,33 +43,9 @@ impl Path {
     }
 }
 
-impl Spanned for Path {
-    fn span(&self) -> Span {
-        if let Some(trailing) = &self.trailing {
-            return self.first.span().join(trailing.span());
-        }
-
-        if let Some((_, ident)) = self.rest.last() {
-            return self.first.span().join(ident.span());
-        }
-
-        self.first.span()
-    }
-}
-
 impl Peek for Path {
     fn peek(t1: Option<ast::Token>, _: Option<ast::Token>) -> bool {
         matches!(peek!(t1).kind, ast::Kind::Ident(..))
-    }
-}
-
-impl Parse for Path {
-    fn parse(parser: &mut Parser<'_>) -> Result<Self, ParseError> {
-        Ok(Self {
-            first: parser.parse()?,
-            rest: parser.parse()?,
-            trailing: parser.parse()?,
-        })
     }
 }
 

--- a/crates/rune/src/ast/stmt.rs
+++ b/crates/rune/src/ast/stmt.rs
@@ -1,9 +1,8 @@
 use crate::ast;
 use crate::{Ast, Spanned};
-use runestick::Span;
 
 /// A statement within a block.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, Ast, Spanned)]
 pub enum Stmt {
     /// A declaration.
     Item(ast::Item),
@@ -11,14 +10,4 @@ pub enum Stmt {
     Expr(ast::Expr),
     /// An expression followed by a semicolon.
     Semi(ast::Expr, ast::SemiColon),
-}
-
-impl Spanned for Stmt {
-    fn span(&self) -> Span {
-        match self {
-            Self::Item(decl) => decl.span(),
-            Self::Expr(expr) => expr.span(),
-            Self::Semi(expr, semi) => expr.span().join(semi.span()),
-        }
-    }
 }

--- a/crates/rune/src/compile/block.rs
+++ b/crates/rune/src/compile/block.rs
@@ -79,7 +79,7 @@ impl Compile<(&ast::Block, Needs)> for Compiler<'_> {
 
         self.contexts
             .pop()
-            .ok_or_else(|| CompileError::internal(span, "missing parent context"))?;
+            .ok_or_else(|| CompileError::internal(&span, "missing parent context"))?;
 
         Ok(())
     }

--- a/crates/rune/src/compile/expr.rs
+++ b/crates/rune/src/compile/expr.rs
@@ -129,7 +129,7 @@ impl Compile<(&ast::Expr, Needs)> for Compiler<'_> {
                 } else {
                     let span = expr_call_macro.span();
 
-                    return Err(CompileError::internal(span, "macro has not been expanded"));
+                    return Err(CompileError::internal(&span, "macro has not been expanded"));
                 }
             }
             // NB: declarations are not used in this compilation stage.

--- a/crates/rune/src/compile/expr_break.rs
+++ b/crates/rune/src/compile/expr_break.rs
@@ -2,7 +2,7 @@ use crate::ast;
 use crate::compiler::Compiler;
 use crate::traits::Compile;
 use crate::CompileResult;
-use crate::{CompileError, CompileErrorKind};
+use crate::{CompileError, CompileErrorKind, Spanned as _};
 use runestick::Inst;
 
 /// Compile a break expression.
@@ -49,7 +49,7 @@ impl Compile<&ast::ExprBreak> for Compiler<'_> {
             .scopes
             .total_var_count(span)?
             .checked_sub(last_loop.total_var_count)
-            .ok_or_else(|| CompileError::internal(span, "var count should be larger"))?;
+            .ok_or_else(|| CompileError::internal(&span, "var count should be larger"))?;
 
         if last_loop.needs.value() {
             if has_value {

--- a/crates/rune/src/compile/expr_closure.rs
+++ b/crates/rune/src/compile/expr_closure.rs
@@ -20,7 +20,7 @@ impl Compile<(ast::ExprClosure, &[CompileMetaCapture])> for Compiler<'_> {
 
                 match arg {
                     ast::FnArg::Self_(s) => {
-                        return Err(CompileError::new(s, CompileErrorKind::UnsupportedSelf))
+                        return Err(CompileError::new(*s, CompileErrorKind::UnsupportedSelf))
                     }
                     ast::FnArg::Ident(ident) => {
                         let ident = ident.resolve(&self.storage, &*self.source)?;

--- a/crates/rune/src/compile/expr_select.rs
+++ b/crates/rune/src/compile/expr_select.rs
@@ -90,7 +90,7 @@ impl Compile<(&ast::ExprSelect, Needs)> for Compiler<'_> {
 
         self.contexts
             .pop()
-            .ok_or_else(|| CompileError::internal(span, "missing parent context"))?;
+            .ok_or_else(|| CompileError::internal(&span, "missing parent context"))?;
 
         Ok(())
     }

--- a/crates/rune/src/compile_error.rs
+++ b/crates/rune/src/compile_error.rs
@@ -45,7 +45,7 @@ impl CompileError {
     ///
     /// This should be used for programming invariants of the encoder which are
     /// broken for some reason.
-    pub fn internal<S>(spanned: S, msg: &'static str) -> Self
+    pub fn internal<S>(spanned: &S, msg: &'static str) -> Self
     where
         S: Spanned,
     {

--- a/crates/rune/src/index.rs
+++ b/crates/rune/src/index.rs
@@ -839,7 +839,7 @@ impl Index<ast::ExprClosure> for Indexer<'_> {
         for (arg, _) in expr_closure.args.as_slice() {
             match arg {
                 ast::FnArg::Self_(s) => {
-                    return Err(CompileError::new(s, CompileErrorKind::UnsupportedSelf));
+                    return Err(CompileError::new(*s, CompileErrorKind::UnsupportedSelf));
                 }
                 ast::FnArg::Ident(ident) => {
                     let ident = ident.resolve(&self.storage, &*self.source)?;

--- a/crates/rune/src/index_scopes.rs
+++ b/crates/rune/src/index_scopes.rs
@@ -20,7 +20,7 @@ impl IndexScopeGuard {
             .levels
             .borrow_mut()
             .pop()
-            .ok_or_else(|| CompileError::internal(span, "missing scope"))?;
+            .ok_or_else(|| CompileError::internal(&span, "missing scope"))?;
 
         match level {
             IndexScopeLevel::IndexClosure(closure) => Ok(Closure {
@@ -29,7 +29,7 @@ impl IndexScopeGuard {
                 is_async: closure.is_async,
                 has_await: closure.has_await,
             }),
-            _ => Err(CompileError::internal(span, "expected closure")),
+            _ => Err(CompileError::internal(&span, "expected closure")),
         }
     }
 
@@ -41,7 +41,7 @@ impl IndexScopeGuard {
             .levels
             .borrow_mut()
             .pop()
-            .ok_or_else(|| CompileError::internal(span, "missing scope"))?;
+            .ok_or_else(|| CompileError::internal(&span, "missing scope"))?;
 
         match level {
             IndexScopeLevel::IndexFunction(fun) => Ok(Function {
@@ -49,7 +49,7 @@ impl IndexScopeGuard {
                 is_async: fun.is_async,
                 has_await: fun.has_await,
             }),
-            _ => Err(CompileError::internal(span, "expected function")),
+            _ => Err(CompileError::internal(&span, "expected function")),
         }
     }
 }
@@ -177,7 +177,7 @@ impl IndexScopes {
 
         let level = levels
             .last_mut()
-            .ok_or_else(|| CompileError::internal(span, "empty scopes"))?;
+            .ok_or_else(|| CompileError::internal(&span, "empty scopes"))?;
 
         let scope = match level {
             IndexScopeLevel::IndexScope(scope) => scope,

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -238,7 +238,7 @@ pub use crate::warning::{Warning, WarningKind, Warnings};
 pub use compiler::compile;
 pub use unit_builder::{ImportEntry, ImportKey, LinkerError, UnitBuilder};
 
-pub(crate) use rune_macros::{Ast, Parse};
+pub(crate) use rune_macros::{Ast, Parse, Spanned};
 
 #[cfg(feature = "diagnostics")]
 pub use diagnostics::{termcolor, DiagnosticsError, EmitDiagnostics};

--- a/crates/rune/src/scopes.rs
+++ b/crates/rune/src/scopes.rs
@@ -133,12 +133,12 @@ impl Scope {
         self.total_var_count = self
             .total_var_count
             .checked_sub(n)
-            .ok_or_else(|| CompileError::internal(span, "totals out of bounds"))?;
+            .ok_or_else(|| CompileError::internal(&span, "totals out of bounds"))?;
 
         self.local_var_count = self
             .local_var_count
             .checked_sub(n)
-            .ok_or_else(|| CompileError::internal(span, "locals out of bounds"))?;
+            .ok_or_else(|| CompileError::internal(&span, "locals out of bounds"))?;
 
         Ok(())
     }
@@ -245,7 +245,7 @@ impl Scopes {
 
         if self.scopes.len() != expected {
             return Err(CompileError::internal(
-                span,
+                &span,
                 "the number of scopes do not match",
             ));
         }
@@ -263,7 +263,7 @@ impl Scopes {
         let scope = self
             .scopes
             .pop()
-            .ok_or_else(|| CompileError::internal(span, "missing parent scope"))?;
+            .ok_or_else(|| CompileError::internal(&span, "missing parent scope"))?;
 
         Ok(scope)
     }
@@ -294,7 +294,7 @@ impl Scopes {
         Ok(self
             .scopes
             .last()
-            .ok_or_else(|| CompileError::internal(span, "missing head of locals"))?)
+            .ok_or_else(|| CompileError::internal(&span, "missing head of locals"))?)
     }
 
     /// Get the last locals scope.
@@ -302,6 +302,6 @@ impl Scopes {
         Ok(self
             .scopes
             .last_mut()
-            .ok_or_else(|| CompileError::internal(span, "missing head of locals"))?)
+            .ok_or_else(|| CompileError::internal(&span, "missing head of locals"))?)
     }
 }

--- a/crates/rune/src/traits.rs
+++ b/crates/rune/src/traits.rs
@@ -116,17 +116,27 @@ pub trait Spanned {
     fn span(&self) -> Span;
 }
 
+impl<A, B> Spanned for (A, B)
+where
+    A: Spanned,
+    B: Spanned,
+{
+    fn span(&self) -> Span {
+        self.0.span().join(self.1.span())
+    }
+}
+
 impl Spanned for Span {
     fn span(&self) -> Span {
         *self
     }
 }
 
-impl<T> Spanned for &T
+impl<T> Spanned for Box<T>
 where
     T: Spanned,
 {
     fn span(&self) -> Span {
-        Spanned::span(*self)
+        Spanned::span(&**self)
     }
 }

--- a/crates/rune/src/worker.rs
+++ b/crates/rune/src/worker.rs
@@ -253,7 +253,7 @@ impl<'a> Worker<'a> {
                                 _ => {
                                     self.errors.push(
                                         LoadError::new(source_id, CompileError::internal(
-                                            span,
+                                            &span,
                                             "expected macro item as last component of macro expansion",
                                         ))
                                     );


### PR DESCRIPTION
Now essentially all AST uses the `Spanned` derive to implement `Spanned`. There's a couple of attributes which are important to understand:

* `#[spanned(first)]` - Will treat the field as an iterator and take the span of the **first** element, works for e.g. `Option<T>` and `Vec<T>`.
* `#[spanned(last)]` - Will treat the field as an iterator and take the span of the **last** element, works for e.g. `Option<T>` and `Vec<T>`.
* `#[spanned(skip)]` - Skip over the field.