### PR TITLE
Rename IntoTokens to ToTokens, remove Ast derive, and fill last Spanned gap

### DIFF
--- a/crates/rune-macros/src/internals.rs
+++ b/crates/rune-macros/src/internals.rs
@@ -5,12 +5,10 @@ use std::fmt;
 #[derive(Copy, Clone)]
 pub struct Symbol(&'static str);
 
-pub const AST: Symbol = Symbol("ast");
+pub const RUNE: Symbol = Symbol("rune");
 pub const SKIP: Symbol = Symbol("skip");
-pub const PARSE: Symbol = Symbol("parse");
-
-pub const SPANNED: Symbol = Symbol("spanned");
 pub const ITER: Symbol = Symbol("iter");
+pub const OPTIONAL: Symbol = Symbol("optional");
 
 impl PartialEq<Symbol> for syn::Ident {
     fn eq(&self, word: &Symbol) -> bool {

--- a/crates/rune-macros/src/lib.rs
+++ b/crates/rune-macros/src/lib.rs
@@ -49,33 +49,42 @@ extern crate proc_macro;
 
 use quote::quote;
 
-mod ast;
 mod context;
 mod internals;
+mod option_spanned;
 mod parse;
 mod spanned;
+mod to_tokens;
 
-/// Helper derive to implement AST nodes in a less error prone manner.
-#[proc_macro_derive(Ast, attributes(ast))]
+/// Helper derive to implement `ToTokens`.
+#[proc_macro_derive(ToTokens, attributes(rune))]
 #[doc(hidden)]
-pub fn ast(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let derive = syn::parse_macro_input!(input as ast::Derive);
+pub fn to_tokens(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let derive = syn::parse_macro_input!(input as to_tokens::Derive);
     derive.expand().unwrap_or_else(to_compile_errors).into()
 }
 
-/// Helper derive to implement AST nodes in a less error prone manner.
-#[proc_macro_derive(Parse, attributes(parse))]
+/// Helper derive to implement `Parse`.
+#[proc_macro_derive(Parse, attributes(rune))]
 #[doc(hidden)]
 pub fn parse(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let derive = syn::parse_macro_input!(input as parse::Derive);
     derive.expand().unwrap_or_else(to_compile_errors).into()
 }
 
-/// Helper derive to implement AST nodes in a less error prone manner.
-#[proc_macro_derive(Spanned, attributes(spanned))]
+/// Helper derive to implement `Spanned`.
+#[proc_macro_derive(Spanned, attributes(rune))]
 #[doc(hidden)]
 pub fn spanned(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let derive = syn::parse_macro_input!(input as spanned::Derive);
+    derive.expand().unwrap_or_else(to_compile_errors).into()
+}
+
+/// Helper derive to implement `OptionSpanned`.
+#[proc_macro_derive(OptionSpanned, attributes(rune))]
+#[doc(hidden)]
+pub fn option_spanned(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let derive = syn::parse_macro_input!(input as option_spanned::Derive);
     derive.expand().unwrap_or_else(to_compile_errors).into()
 }
 

--- a/crates/rune-macros/src/parse.rs
+++ b/crates/rune-macros/src/parse.rs
@@ -98,7 +98,7 @@ impl Expander {
         let mut fields = Vec::new();
 
         for field in &named.named {
-            let _ = self.ctx.parse_parse_fields(&field.attrs)?;
+            let _ = self.ctx.parse_field_attributes(&field.attrs)?;
             let ident = self.ctx.field_ident(&field)?;
             fields.push(quote_spanned! { field.span() => #ident: parser.parse()? })
         }

--- a/crates/rune/src/ast/attribute.rs
+++ b/crates/rune/src/ast/attribute.rs
@@ -1,9 +1,9 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Peek, Spanned, TokenStream};
+use crate::{Parse, ParseError, ParseErrorKind, Parser, Peek, Spanned, ToTokens, TokenStream};
 use runestick::Span;
 
 /// Attribute like `#[derive(Debug)]`
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct Attribute {
     /// The `#` character
     pub hash: ast::Hash,
@@ -90,7 +90,7 @@ impl Peek for Attribute {
 }
 
 /// Whether or not the attribute is an outer `#!` or inner `#` attribute
-#[derive(Debug, Copy, Clone, Ast)]
+#[derive(Debug, Copy, Clone, ToTokens)]
 pub enum AttrStyle {
     /// `#`
     Inner,

--- a/crates/rune/src/ast/block.rs
+++ b/crates/rune/src/ast/block.rs
@@ -1,8 +1,8 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Spanned};
+use crate::{Parse, ParseError, ParseErrorKind, Parser, Spanned, ToTokens};
 
 /// A block of expressions.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct Block {
     /// The close brace.
     pub open: ast::OpenBrace,

--- a/crates/rune/src/ast/condition.rs
+++ b/crates/rune/src/ast/condition.rs
@@ -1,8 +1,8 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, Parser, Spanned};
+use crate::{Parse, ParseError, Parser, Spanned, ToTokens};
 
 /// An if condition.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub enum Condition {
     /// A regular expression.
     Expr(Box<ast::Expr>),

--- a/crates/rune/src/ast/expr.rs
+++ b/crates/rune/src/ast/expr.rs
@@ -1,5 +1,5 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Peek, Spanned};
+use crate::{Parse, ParseError, ParseErrorKind, Parser, Peek, Spanned, ToTokens};
 use std::mem::take;
 use std::ops;
 
@@ -28,7 +28,7 @@ impl ops::Deref for ExprChain {
 }
 
 /// A rune expression.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub enum Expr {
     /// The `self` keyword.
     Self_(ast::Self_),

--- a/crates/rune/src/ast/expr_async.rs
+++ b/crates/rune/src/ast/expr_async.rs
@@ -1,11 +1,11 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, Parser, Spanned};
+use crate::{Parse, ParseError, Parser, Spanned, ToTokens};
 
 /// A block of expressions.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct ExprAsync {
     /// The attributes for the block.
-    #[spanned(iter)]
+    #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,
     /// The `async` keyword.
     pub async_: ast::Async,

--- a/crates/rune/src/ast/expr_await.rs
+++ b/crates/rune/src/ast/expr_await.rs
@@ -1,8 +1,8 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, Parser, Spanned};
+use crate::{Parse, ParseError, Parser, Spanned, ToTokens};
 
 /// A return statement `<expr>.await`.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct ExprAwait {
     /// The expression being awaited.
     pub expr: Box<ast::Expr>,

--- a/crates/rune/src/ast/expr_binary.rs
+++ b/crates/rune/src/ast/expr_binary.rs
@@ -1,9 +1,9 @@
 use crate::ast;
-use crate::{Ast, Peek, Spanned};
+use crate::{Peek, Spanned, ToTokens};
 use std::fmt;
 
 /// A binary expression.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct ExprBinary {
     /// The left-hand side of a binary operation.
     pub lhs: Box<ast::Expr>,
@@ -14,8 +14,7 @@ pub struct ExprBinary {
     /// The right-hand side of a binary operation.
     pub rhs: Box<ast::Expr>,
     /// The operation to apply.
-    #[ast(skip)]
-    #[spanned(skip)]
+    #[rune(skip)]
     pub op: BinOp,
 }
 

--- a/crates/rune/src/ast/expr_block.rs
+++ b/crates/rune/src/ast/expr_block.rs
@@ -1,11 +1,11 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, Parser, Spanned};
+use crate::{Parse, ParseError, Parser, Spanned, ToTokens};
 
 /// A block of expressions.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct ExprBlock {
     /// The attributes for the block.
-    #[spanned(iter)]
+    #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,
     /// The close brace.
     pub block: ast::Block,

--- a/crates/rune/src/ast/expr_break.rs
+++ b/crates/rune/src/ast/expr_break.rs
@@ -1,18 +1,18 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, Parser, Peek, Spanned};
+use crate::{Parse, ParseError, Parser, Peek, Spanned, ToTokens};
 
 /// A return statement `break [expr]`.
-#[derive(Debug, Clone, Ast, Parse, Spanned)]
+#[derive(Debug, Clone, ToTokens, Parse, Spanned)]
 pub struct ExprBreak {
     /// The return token.
     pub break_: ast::Break,
     /// An optional expression to break with.
-    #[spanned(iter)]
+    #[rune(iter)]
     pub expr: Option<ExprBreakValue>,
 }
 
 /// Things that we can break on.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub enum ExprBreakValue {
     /// Breaking a value out of a loop.
     Expr(Box<ast::Expr>),

--- a/crates/rune/src/ast/expr_call.rs
+++ b/crates/rune/src/ast/expr_call.rs
@@ -1,8 +1,8 @@
 use crate::ast;
-use crate::{Ast, Spanned};
+use crate::{Spanned, ToTokens};
 
 /// A function call `<expr>(<args>)`.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct ExprCall {
     /// The name of the function being called.
     pub expr: Box<ast::Expr>,

--- a/crates/rune/src/ast/expr_closure.rs
+++ b/crates/rune/src/ast/expr_closure.rs
@@ -1,15 +1,15 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, Parser, Spanned};
+use crate::{Parse, ParseError, Parser, Spanned, ToTokens};
 use runestick::Span;
 
 /// A closure.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct ExprClosure {
     /// The attributes for the async closure
-    #[spanned(iter)]
+    #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,
     /// If the closure is async or not.
-    #[spanned(iter)]
+    #[rune(iter)]
     pub async_: Option<ast::Async>,
     /// Arguments to the closure.
     pub args: ExprClosureArgs,
@@ -90,7 +90,7 @@ impl Parse for ExprClosure {
     }
 }
 
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, ToTokens)]
 pub enum ExprClosureArgs {
     Empty {
         /// The `||` token.

--- a/crates/rune/src/ast/expr_else.rs
+++ b/crates/rune/src/ast/expr_else.rs
@@ -1,8 +1,8 @@
 use crate::ast;
-use crate::{Ast, Parse, Spanned};
+use crate::{Parse, Spanned, ToTokens};
 
 /// An else branch of an if expression.
-#[derive(Debug, Clone, Ast, Parse, Spanned)]
+#[derive(Debug, Clone, ToTokens, Parse, Spanned)]
 pub struct ExprElse {
     /// The `else` token.
     pub else_: ast::Else,

--- a/crates/rune/src/ast/expr_else_if.rs
+++ b/crates/rune/src/ast/expr_else_if.rs
@@ -1,8 +1,8 @@
 use crate::ast;
-use crate::{Ast, Parse, Spanned};
+use crate::{Parse, Spanned, ToTokens};
 
 /// An else branch of an if expression.
-#[derive(Debug, Clone, Ast, Parse, Spanned)]
+#[derive(Debug, Clone, ToTokens, Parse, Spanned)]
 pub struct ExprElseIf {
     /// The `else` token.
     pub else_: ast::Else,

--- a/crates/rune/src/ast/expr_field_access.rs
+++ b/crates/rune/src/ast/expr_field_access.rs
@@ -1,8 +1,8 @@
 use crate::ast;
-use crate::{Ast, Spanned};
+use crate::{Spanned, ToTokens};
 
 /// The field being accessed.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub enum ExprField {
     /// An identifier.
     Ident(ast::Ident),
@@ -11,7 +11,7 @@ pub enum ExprField {
 }
 
 /// A field access `<expr>.<field>`.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct ExprFieldAccess {
     /// The expr where the field is being accessed.
     pub expr: Box<ast::Expr>,

--- a/crates/rune/src/ast/expr_for.rs
+++ b/crates/rune/src/ast/expr_for.rs
@@ -1,11 +1,11 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, Parser, Spanned};
+use crate::{Parse, ParseError, Parser, Spanned, ToTokens};
 
 /// A for loop expression `for i in [1, 2, 3] {}`
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct ExprFor {
     /// The label of the loop.
-    #[spanned(iter)]
+    #[rune(iter)]
     pub label: Option<(ast::Label, ast::Colon)>,
     /// The `for` keyword.
     pub for_: ast::For,

--- a/crates/rune/src/ast/expr_group.rs
+++ b/crates/rune/src/ast/expr_group.rs
@@ -1,8 +1,8 @@
 use crate::ast;
-use crate::{Ast, Parse, Spanned};
+use crate::{Parse, Spanned, ToTokens};
 
 /// A prioritized expression group `(<expr>)`.
-#[derive(Debug, Clone, Ast, Parse, Spanned)]
+#[derive(Debug, Clone, ToTokens, Parse, Spanned)]
 pub struct ExprGroup {
     /// The open parenthesis.
     pub open: ast::OpenParen,

--- a/crates/rune/src/ast/expr_if.rs
+++ b/crates/rune/src/ast/expr_if.rs
@@ -1,8 +1,8 @@
 use crate::ast::{Condition, Else, ExprBlock, ExprElse, ExprElseIf, If};
-use crate::{Ast, Parse, ParseError, Parser, Spanned};
+use crate::{Parse, ParseError, Parser, Spanned, ToTokens};
 
 /// An if expression.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct ExprIf {
     /// The `if` token.
     pub if_: If,
@@ -11,10 +11,10 @@ pub struct ExprIf {
     /// The body of the if statement.
     pub block: Box<ExprBlock>,
     /// Else if branches.
-    #[spanned(iter)]
+    #[rune(iter)]
     pub expr_else_ifs: Vec<ExprElseIf>,
     /// The else part of the if expression.
-    #[spanned(iter)]
+    #[rune(iter)]
     pub expr_else: Option<ExprElse>,
 }
 

--- a/crates/rune/src/ast/expr_index_get.rs
+++ b/crates/rune/src/ast/expr_index_get.rs
@@ -1,8 +1,8 @@
 use crate::ast;
-use crate::{Ast, Spanned};
+use crate::{Spanned, ToTokens};
 
 /// An index get operation `<target>[<index>]`.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct ExprIndexGet {
     /// The target of the index set.
     pub target: Box<ast::Expr>,

--- a/crates/rune/src/ast/expr_index_set.rs
+++ b/crates/rune/src/ast/expr_index_set.rs
@@ -1,8 +1,8 @@
 use crate::ast;
-use crate::{Ast, Spanned};
+use crate::{Spanned, ToTokens};
 
 /// An index set operation `<target>[<index>] = <value>`.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct ExprIndexSet {
     /// The target of the index set.
     pub target: Box<ast::Expr>,

--- a/crates/rune/src/ast/expr_is.rs
+++ b/crates/rune/src/ast/expr_is.rs
@@ -1,8 +1,8 @@
 use crate::ast;
-use crate::{Ast, Parse, Spanned};
+use crate::{Parse, Spanned, ToTokens};
 
 /// An is expression.
-#[derive(Debug, Clone, Ast, Parse, Spanned)]
+#[derive(Debug, Clone, ToTokens, Parse, Spanned)]
 pub struct ExprIs {
     /// The left-hand side of a is operation.
     pub lhs: Box<ast::Expr>,

--- a/crates/rune/src/ast/expr_is_not.rs
+++ b/crates/rune/src/ast/expr_is_not.rs
@@ -1,8 +1,8 @@
 use crate::ast;
-use crate::{Ast, Parse, Spanned};
+use crate::{Parse, Spanned, ToTokens};
 
 /// An is expression.
-#[derive(Debug, Clone, Ast, Parse, Spanned)]
+#[derive(Debug, Clone, ToTokens, Parse, Spanned)]
 pub struct ExprIsNot {
     /// The left-hand side of a is operation.
     pub lhs: Box<ast::Expr>,

--- a/crates/rune/src/ast/expr_let.rs
+++ b/crates/rune/src/ast/expr_let.rs
@@ -1,8 +1,8 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, Parser, Spanned};
+use crate::{Parse, ParseError, Parser, Spanned, ToTokens};
 
 /// A let expression `let <name> = <expr>;`
-#[derive(Debug, Clone, Ast, Parse, Spanned)]
+#[derive(Debug, Clone, ToTokens, Parse, Spanned)]
 pub struct ExprLet {
     /// The `let` keyword.
     pub let_: ast::Let,

--- a/crates/rune/src/ast/expr_lit.rs
+++ b/crates/rune/src/ast/expr_lit.rs
@@ -1,12 +1,12 @@
 use crate::ast;
-use crate::{Ast, Spanned};
 use crate::{ParseError, Parser};
+use crate::{Spanned, ToTokens};
 
 /// A literal expression.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct ExprLit {
     /// Attributes associated with the literal expression.
-    #[spanned(iter)]
+    #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,
     /// The literal in the expression.
     pub lit: ast::Lit,

--- a/crates/rune/src/ast/expr_loop.rs
+++ b/crates/rune/src/ast/expr_loop.rs
@@ -1,11 +1,11 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, Parser, Spanned};
+use crate::{Parse, ParseError, Parser, Spanned, ToTokens};
 
 /// A let expression `let <name> = <expr>;`
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct ExprLoop {
     /// A label followed by a colon.
-    #[spanned(iter)]
+    #[rune(iter)]
     pub label: Option<(ast::Label, ast::Colon)>,
     /// The `loop` keyword.
     pub loop_: ast::Loop,

--- a/crates/rune/src/ast/expr_match.rs
+++ b/crates/rune/src/ast/expr_match.rs
@@ -1,11 +1,11 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, Parser, Spanned};
+use crate::{Parse, ParseError, Parser, Spanned, ToTokens};
 
 /// A match expression.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct ExprMatch {
     /// The attributes for the match expression
-    #[spanned(iter)]
+    #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,
     /// The `match` token.
     pub match_: ast::Match,
@@ -89,7 +89,7 @@ impl Parse for ExprMatch {
 ///
 /// parse_all::<ast::ExprMatchBranch>("1 => { foo }").unwrap();
 /// ```
-#[derive(Debug, Clone, Ast, Parse, Spanned)]
+#[derive(Debug, Clone, ToTokens, Parse, Spanned)]
 pub struct ExprMatchBranch {
     /// The pattern to match.
     pub pat: ast::Pat,

--- a/crates/rune/src/ast/expr_return.rs
+++ b/crates/rune/src/ast/expr_return.rs
@@ -1,12 +1,12 @@
 use crate::ast;
-use crate::{Ast, Parse, Spanned};
+use crate::{Parse, Spanned, ToTokens};
 
 /// A return statement `return [expr]`.
-#[derive(Debug, Clone, Ast, Parse, Spanned)]
+#[derive(Debug, Clone, ToTokens, Parse, Spanned)]
 pub struct ExprReturn {
     /// The return token.
     pub return_: ast::Return,
     /// An optional expression to return.
-    #[spanned(iter)]
+    #[rune(iter)]
     pub expr: Option<Box<ast::Expr>>,
 }

--- a/crates/rune/src/ast/expr_select.rs
+++ b/crates/rune/src/ast/expr_select.rs
@@ -1,9 +1,9 @@
 use crate::ast;
 use crate::ast::utils;
-use crate::{Ast, Parse, ParseError, Parser, Spanned};
+use crate::{Parse, ParseError, Parser, Spanned, ToTokens};
 
 /// A select expression that selects over a collection of futures.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct ExprSelect {
     /// The `select` keyword.
     pub select: ast::Select,
@@ -60,7 +60,7 @@ impl Parse for ExprSelect {
 }
 
 /// A single selection branch.
-#[derive(Debug, Clone, Ast, Parse, Spanned)]
+#[derive(Debug, Clone, ToTokens, Parse, Spanned)]
 pub struct ExprSelectBranch {
     /// The identifier to bind the result to.
     pub pat: ast::Pat,
@@ -75,7 +75,7 @@ pub struct ExprSelectBranch {
 }
 
 /// A single selection branch.
-#[derive(Debug, Clone, Ast, Parse, Spanned)]
+#[derive(Debug, Clone, ToTokens, Parse, Spanned)]
 pub struct ExprDefaultBranch {
     /// The `default` keyword.
     pub default: ast::Default,

--- a/crates/rune/src/ast/expr_try.rs
+++ b/crates/rune/src/ast/expr_try.rs
@@ -1,8 +1,8 @@
 use crate::ast;
-use crate::{Ast, Spanned};
+use crate::{Spanned, ToTokens};
 
 /// A try expression `<expr>?`.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct ExprTry {
     /// The expression being awaited.
     pub expr: Box<ast::Expr>,

--- a/crates/rune/src/ast/expr_unary.rs
+++ b/crates/rune/src/ast/expr_unary.rs
@@ -1,19 +1,18 @@
 use crate::ast;
 use crate::ast::expr::{EagerBrace, ExprChain};
-use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Spanned};
+use crate::{Parse, ParseError, ParseErrorKind, Parser, Spanned, ToTokens};
 use std::fmt;
 
 /// A unary expression.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct ExprUnary {
-    /// The operation to apply.
-    #[ast(skip)]
-    #[spanned(skip)]
-    pub op: UnaryOp,
     /// Token associated with operator.
     pub token: ast::Token,
     /// The expression of the operation.
     pub expr: Box<ast::Expr>,
+    /// The operation to apply.
+    #[rune(skip)]
+    pub op: UnaryOp,
 }
 
 /// Parse a unary statement.

--- a/crates/rune/src/ast/expr_while.rs
+++ b/crates/rune/src/ast/expr_while.rs
@@ -1,11 +1,11 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, Parser, Spanned};
+use crate::{Parse, ParseError, Parser, Spanned, ToTokens};
 
 /// A let expression `let <name> = <expr>;`
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct ExprWhile {
     /// A label for the while loop.
-    #[spanned(iter)]
+    #[rune(iter)]
     pub label: Option<(ast::Label, ast::Colon)>,
     /// The `while` keyword.
     pub while_: ast::While,

--- a/crates/rune/src/ast/expr_yield.rs
+++ b/crates/rune/src/ast/expr_yield.rs
@@ -1,5 +1,5 @@
 use crate::ast;
-use crate::{Ast, Parse, Spanned};
+use crate::{Parse, Spanned, ToTokens};
 
 /// A return statement `break [expr]`.
 ///
@@ -11,11 +11,11 @@ use crate::{Ast, Parse, Spanned};
 /// parse_all::<ast::ExprYield>("yield").unwrap();
 /// parse_all::<ast::ExprYield>("yield 42").unwrap();
 /// ```
-#[derive(Debug, Clone, Ast, Parse, Spanned)]
+#[derive(Debug, Clone, ToTokens, Parse, Spanned)]
 pub struct ExprYield {
     /// The return token.
     pub yield_: ast::Yield,
     /// An optional expression to yield.
-    #[spanned(iter)]
+    #[rune(iter)]
     pub expr: Option<Box<ast::Expr>>,
 }

--- a/crates/rune/src/ast/file.rs
+++ b/crates/rune/src/ast/file.rs
@@ -1,8 +1,8 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, Parser};
+use crate::{Parse, ParseError, Parser, ToTokens};
 
 /// A parsed file.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, ToTokens)]
 pub struct File {
     /// Top level "Outer" `#![...]` attributes for the file
     pub attributes: Vec<ast::Attribute>,

--- a/crates/rune/src/ast/fn_arg.rs
+++ b/crates/rune/src/ast/fn_arg.rs
@@ -1,5 +1,5 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Spanned};
+use crate::{Parse, ParseError, ParseErrorKind, Parser, Spanned, ToTokens};
 
 /// A single argument in a closure.
 ///
@@ -12,7 +12,7 @@ use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Spanned};
 /// parse_all::<ast::FnArg>("_").unwrap();
 /// parse_all::<ast::FnArg>("abc").unwrap();
 /// ```
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub enum FnArg {
     /// The `self` parameter.
     Self_(ast::Self_),

--- a/crates/rune/src/ast/ident.rs
+++ b/crates/rune/src/ast/ident.rs
@@ -1,16 +1,15 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Peek, Resolve, Spanned, Storage};
+use crate::{Parse, ParseError, ParseErrorKind, Parser, Peek, Resolve, Spanned, Storage, ToTokens};
 use runestick::Source;
 use std::borrow::Cow;
 
 /// An identifier, like `foo` or `Hello`.".
-#[derive(Debug, Clone, Copy, Ast, Spanned)]
+#[derive(Debug, Clone, Copy, ToTokens, Spanned)]
 pub struct Ident {
     /// The kind of the identifier.
     pub token: ast::Token,
     /// The kind of the identifier.
-    #[ast(skip)]
-    #[spanned(skip)]
+    #[rune(skip)]
     pub kind: ast::StringSource,
 }
 

--- a/crates/rune/src/ast/item.rs
+++ b/crates/rune/src/ast/item.rs
@@ -1,8 +1,8 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Peek, Spanned};
+use crate::{Parse, ParseError, ParseErrorKind, Parser, Peek, Spanned, ToTokens};
 
 /// A declaration.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub enum Item {
     /// A use declaration.
     ItemUse(ast::ItemUse),

--- a/crates/rune/src/ast/item_enum.rs
+++ b/crates/rune/src/ast/item_enum.rs
@@ -1,11 +1,11 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, Parser, Spanned};
+use crate::{OptionSpanned, Parse, ParseError, Parser, Spanned, ToTokens};
 
 /// An enum declaration.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct ItemEnum {
     /// The attributes for the enum block
-    #[spanned(iter)]
+    #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,
     /// The `enum` token.
     pub enum_: ast::Enum,
@@ -79,23 +79,23 @@ impl Parse for ItemEnum {
 }
 
 /// An enum variant.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct ItemVariant {
     /// The attributes associated with the variant.
-    #[spanned(iter)]
+    #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,
     /// The name of the variant.
     pub name: ast::Ident,
     /// The body of the variant.
-    #[spanned(skip)]
+    #[rune(optional)]
     pub body: ItemVariantBody,
     /// Optional trailing comma in variant.
-    #[spanned(iter)]
+    #[rune(iter)]
     pub comma: Option<ast::Comma>,
 }
 
 /// An item body declaration.
-#[derive(Debug, Clone, Ast)]
+#[derive(Debug, Clone, ToTokens, OptionSpanned)]
 pub enum ItemVariantBody {
     /// An empty enum body.
     EmptyBody,

--- a/crates/rune/src/ast/item_fn.rs
+++ b/crates/rune/src/ast/item_fn.rs
@@ -1,15 +1,15 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, Parser, Peek, Spanned};
+use crate::{Parse, ParseError, Parser, Peek, Spanned, ToTokens};
 use runestick::Span;
 
 /// A function.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct ItemFn {
     /// The attributes for the fn
-    #[spanned(iter)]
+    #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,
     /// The optional `async` keyword.
-    #[spanned(iter)]
+    #[rune(iter)]
     pub async_: Option<ast::Async>,
     /// The `fn` token.
     pub fn_: ast::Fn,

--- a/crates/rune/src/ast/item_impl.rs
+++ b/crates/rune/src/ast/item_impl.rs
@@ -1,11 +1,11 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, Parser, Spanned};
+use crate::{Parse, ParseError, Parser, Spanned, ToTokens};
 
 /// An impl declaration.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct ItemImpl {
     /// The attributes of the `impl` block
-    #[spanned(iter)]
+    #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,
     /// The `impl` keyword.
     pub impl_: ast::Impl,

--- a/crates/rune/src/ast/item_mod.rs
+++ b/crates/rune/src/ast/item_mod.rs
@@ -1,11 +1,11 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, Parser, Peek, Spanned};
+use crate::{Parse, ParseError, Parser, Peek, Spanned, ToTokens};
 
 /// A module declaration.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct ItemMod {
     /// The *inner* attributes are applied to the module  `#[cfg(test)] mod tests {  }`
-    #[spanned(iter)]
+    #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,
     /// The `mod` keyword.
     pub mod_: ast::Mod,
@@ -60,7 +60,7 @@ impl Parse for ItemMod {
 }
 
 /// An item body.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub enum ItemModBody {
     /// An empty body terminated by a semicolon.
     EmptyBody(ast::SemiColon),
@@ -80,7 +80,7 @@ impl Parse for ItemModBody {
 }
 
 /// A module declaration.
-#[derive(Debug, Clone, Ast, Parse, Spanned)]
+#[derive(Debug, Clone, ToTokens, Parse, Spanned)]
 pub struct ItemInlineBody {
     /// The open brace.
     pub open: ast::OpenBrace,

--- a/crates/rune/src/ast/item_struct.rs
+++ b/crates/rune/src/ast/item_struct.rs
@@ -1,11 +1,11 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, Parser, Spanned};
+use crate::{Parse, ParseError, Parser, Spanned, ToTokens};
 
 /// A struct declaration.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct ItemStruct {
     /// The attributes for the struct
-    #[spanned(iter)]
+    #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,
     /// The `struct` keyword.
     pub struct_: ast::Struct,
@@ -51,7 +51,7 @@ impl Parse for ItemStruct {
 }
 
 /// A struct declaration.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub enum ItemStructBody {
     /// An empty struct declaration.
     EmptyBody(ast::SemiColon),
@@ -102,7 +102,7 @@ impl Parse for ItemStructBody {
 }
 
 /// A variant declaration.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct TupleBody {
     /// The opening paren.
     pub open: ast::OpenParen,
@@ -147,7 +147,7 @@ impl Parse for TupleBody {
 }
 
 /// A variant declaration.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct StructBody {
     /// The opening brace.
     pub open: ast::OpenBrace,
@@ -202,14 +202,14 @@ impl Parse for StructBody {
 /// parse_all::<ast::Field>("a").unwrap();
 /// parse_all::<ast::Field>("#[x] a").unwrap();
 /// ```
-#[derive(Debug, Clone, Ast, Parse, Spanned)]
+#[derive(Debug, Clone, ToTokens, Parse, Spanned)]
 pub struct Field {
     /// Attributes associated with field.
-    #[spanned(iter)]
+    #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,
     /// Name of the field.
     pub name: ast::Ident,
     /// Trailing comma of the field.
-    #[spanned(iter)]
+    #[rune(iter)]
     pub comma: Option<ast::Comma>,
 }

--- a/crates/rune/src/ast/item_use.rs
+++ b/crates/rune/src/ast/item_use.rs
@@ -1,11 +1,11 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Peek, Spanned};
+use crate::{Parse, ParseError, ParseErrorKind, Parser, Peek, Spanned, ToTokens};
 
 /// An imported declaration.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct ItemUse {
     /// The attributes on use item
-    #[spanned(iter)]
+    #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,
     /// The use token.
     pub use_: ast::Use,
@@ -52,7 +52,7 @@ impl Parse for ItemUse {
 }
 
 /// A use component.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub enum ItemUseComponent {
     /// An identifier import.
     Ident(ast::Ident),

--- a/crates/rune/src/ast/label.rs
+++ b/crates/rune/src/ast/label.rs
@@ -1,16 +1,15 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Peek, Resolve, Spanned, Storage};
+use crate::{Parse, ParseError, ParseErrorKind, Parser, Peek, Resolve, Spanned, Storage, ToTokens};
 use runestick::Source;
 use std::borrow::Cow;
 
 /// A label, like `'foo`
-#[derive(Debug, Clone, Copy, Ast, Spanned)]
+#[derive(Debug, Clone, Copy, ToTokens, Spanned)]
 pub struct Label {
     /// The token of the label.
     pub token: ast::Token,
     /// The kind of the label.
-    #[ast(skip)]
-    #[spanned(skip)]
+    #[rune(skip)]
     pub kind: ast::StringSource,
 }
 

--- a/crates/rune/src/ast/lit.rs
+++ b/crates/rune/src/ast/lit.rs
@@ -1,8 +1,8 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Spanned};
+use crate::{Parse, ParseError, ParseErrorKind, Parser, Spanned, ToTokens};
 
 /// A literal value
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub enum Lit {
     /// A unit literal
     Unit(ast::LitUnit),

--- a/crates/rune/src/ast/lit_bool.rs
+++ b/crates/rune/src/ast/lit_bool.rs
@@ -1,15 +1,14 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Peek, Spanned};
+use crate::{Parse, ParseError, ParseErrorKind, Parser, Peek, Spanned, ToTokens};
 
 /// The unit literal `()`.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct LitBool {
-    /// The value of the literal.
-    #[ast(skip)]
-    #[spanned(skip)]
-    pub value: bool,
     /// The token of the literal.
     pub token: ast::Token,
+    /// The value of the literal.
+    #[rune(skip)]
+    pub value: bool,
 }
 
 /// Parsing a unit literal

--- a/crates/rune/src/ast/lit_byte.rs
+++ b/crates/rune/src/ast/lit_byte.rs
@@ -1,15 +1,14 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Resolve, Spanned, Storage};
+use crate::{Parse, ParseError, ParseErrorKind, Parser, Resolve, Spanned, Storage, ToTokens};
 use runestick::Source;
 
 /// A byte literal.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct LitByte {
     /// The token corresponding to the literal.
     pub token: ast::Token,
     /// The source of the byte.
-    #[ast(skip)]
-    #[spanned(skip)]
+    #[rune(skip)]
     pub source: ast::CopySource<u8>,
 }
 

--- a/crates/rune/src/ast/lit_byte_str.rs
+++ b/crates/rune/src/ast/lit_byte_str.rs
@@ -1,16 +1,15 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Resolve, Spanned, Storage};
+use crate::{Parse, ParseError, ParseErrorKind, Parser, Resolve, Spanned, Storage, ToTokens};
 use runestick::{Source, Span};
 use std::borrow::Cow;
 
 /// A string literal.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct LitByteStr {
     /// The token corresponding to the literal.
     token: ast::Token,
     /// If the string literal is escaped.
-    #[ast(skip)]
-    #[spanned(skip)]
+    #[rune(skip)]
     source: ast::LitByteStrSource,
 }
 

--- a/crates/rune/src/ast/lit_char.rs
+++ b/crates/rune/src/ast/lit_char.rs
@@ -1,15 +1,14 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Resolve, Spanned, Storage};
+use crate::{Parse, ParseError, ParseErrorKind, Parser, Resolve, Spanned, Storage, ToTokens};
 use runestick::Source;
 
 /// A character literal.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct LitChar {
     /// The token corresponding to the literal.
     pub token: ast::Token,
     /// The source of the literal character.
-    #[ast(skip)]
-    #[spanned(skip)]
+    #[rune(skip)]
     pub source: ast::CopySource<char>,
 }
 

--- a/crates/rune/src/ast/lit_number.rs
+++ b/crates/rune/src/ast/lit_number.rs
@@ -1,15 +1,14 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Resolve, Spanned, Storage};
+use crate::{Parse, ParseError, ParseErrorKind, Parser, Resolve, Spanned, Storage, ToTokens};
 use runestick::{Source, Span};
 
 /// A number literal.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct LitNumber {
     /// The token corresponding to the literal.
     token: ast::Token,
     /// The source of the number.
-    #[ast(skip)]
-    #[spanned(skip)]
+    #[rune(skip)]
     source: ast::NumberSource,
 }
 

--- a/crates/rune/src/ast/lit_object.rs
+++ b/crates/rune/src/ast/lit_object.rs
@@ -1,10 +1,10 @@
 use crate::{ast, Peek};
-use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Resolve, Spanned, Storage};
+use crate::{Parse, ParseError, ParseErrorKind, Parser, Resolve, Spanned, Storage, ToTokens};
 use runestick::Source;
 use std::borrow::Cow;
 
 /// A literal object identifier.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub enum LitObjectIdent {
     /// An anonymous object.
     Anonymous(ast::Hash),
@@ -24,12 +24,12 @@ impl Parse for LitObjectIdent {
 }
 
 /// A literal object field.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct LitObjectFieldAssign {
     /// The key of the field.
     pub key: LitObjectKey,
     /// The assigned expression of the field.
-    #[spanned(iter)]
+    #[rune(iter)]
     pub assign: Option<(ast::Colon, ast::Expr)>,
 }
 
@@ -71,7 +71,7 @@ impl Parse for LitObjectFieldAssign {
 }
 
 /// Possible literal object keys.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub enum LitObjectKey {
     /// A literal string (with escapes).
     LitStr(ast::LitStr),
@@ -118,7 +118,7 @@ impl<'a> Resolve<'a> for LitObjectKey {
 }
 
 /// A number literal.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct LitObject {
     /// An object identifier.
     pub ident: LitObjectIdent,
@@ -130,8 +130,7 @@ pub struct LitObject {
     pub close: ast::CloseBrace,
     /// Indicates if the object is completely literal and cannot have side
     /// effects.
-    #[ast(skip)]
-    #[spanned(skip)]
+    #[rune(skip)]
     is_const: bool,
 }
 

--- a/crates/rune/src/ast/lit_str.rs
+++ b/crates/rune/src/ast/lit_str.rs
@@ -1,16 +1,15 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Resolve, Spanned, Storage};
+use crate::{Parse, ParseError, ParseErrorKind, Parser, Resolve, Spanned, Storage, ToTokens};
 use runestick::{Source, Span};
 use std::borrow::Cow;
 
 /// A string literal.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct LitStr {
     /// The token corresponding to the literal.
     token: ast::Token,
     /// The source of the literal string.
-    #[ast(skip)]
-    #[spanned(skip)]
+    #[rune(skip)]
     source: ast::LitStrSource,
 }
 

--- a/crates/rune/src/ast/lit_template.rs
+++ b/crates/rune/src/ast/lit_template.rs
@@ -1,16 +1,15 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Resolve, Spanned, Storage};
+use crate::{Parse, ParseError, ParseErrorKind, Parser, Resolve, Spanned, Storage, ToTokens};
 use runestick::{Source, Span};
 use std::borrow::Cow;
 
 /// A string literal.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct LitTemplate {
     /// The token corresponding to the literal.
     token: ast::Token,
     /// The source string of the literal template.
-    #[ast(skip)]
-    #[spanned(skip)]
+    #[rune(skip)]
     source: ast::LitStrSource,
 }
 

--- a/crates/rune/src/ast/lit_tuple.rs
+++ b/crates/rune/src/ast/lit_tuple.rs
@@ -1,8 +1,8 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, Parser, Spanned};
+use crate::{Parse, ParseError, Parser, Spanned, ToTokens};
 
 /// An expression to construct a literal tuple.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct LitTuple {
     /// The open bracket.
     pub open: ast::OpenParen,
@@ -11,8 +11,7 @@ pub struct LitTuple {
     /// The close bracket.
     pub close: ast::CloseParen,
     /// If the entire tuple is constant.
-    #[ast(skip)]
-    #[spanned(skip)]
+    #[rune(skip)]
     is_const: bool,
 }
 

--- a/crates/rune/src/ast/lit_unit.rs
+++ b/crates/rune/src/ast/lit_unit.rs
@@ -1,5 +1,5 @@
 use crate::ast;
-use crate::{Ast, Parse, Peek, Spanned};
+use crate::{Parse, Peek, Spanned, ToTokens};
 
 /// The unit literal `()`.
 ///
@@ -10,7 +10,7 @@ use crate::{Ast, Parse, Peek, Spanned};
 ///
 /// parse_all::<ast::LitUnit>("()").unwrap();
 /// ```
-#[derive(Debug, Clone, Ast, Parse, Spanned)]
+#[derive(Debug, Clone, ToTokens, Parse, Spanned)]
 pub struct LitUnit {
     /// The open parenthesis.
     pub open: ast::OpenParen,

--- a/crates/rune/src/ast/lit_vec.rs
+++ b/crates/rune/src/ast/lit_vec.rs
@@ -1,8 +1,8 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, Parser, Spanned};
+use crate::{Parse, ParseError, Parser, Spanned, ToTokens};
 
 /// A number literal.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct LitVec {
     /// The open bracket.
     pub open: ast::OpenBracket,
@@ -11,8 +11,7 @@ pub struct LitVec {
     /// The close bracket.
     pub close: ast::CloseBracket,
     /// If the entire array is constant.
-    #[ast(skip)]
-    #[spanned(skip)]
+    #[rune(skip)]
     is_const: bool,
 }
 

--- a/crates/rune/src/ast/macro_call.rs
+++ b/crates/rune/src/ast/macro_call.rs
@@ -1,9 +1,9 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Spanned, TokenStream};
+use crate::{Parse, ParseError, ParseErrorKind, Parser, Spanned, ToTokens, TokenStream};
 use runestick::Span;
 
 /// A function call `<expr>!(<args>)`.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct MacroCall {
     /// The expression being called over.
     pub path: ast::Path,

--- a/crates/rune/src/ast/mod.rs
+++ b/crates/rune/src/ast/mod.rs
@@ -180,8 +180,8 @@ macro_rules! decl_tokens {
                 }
             }
 
-            impl crate::IntoTokens for $parser {
-                fn into_tokens(&self, _: &mut crate::MacroContext, stream: &mut crate::TokenStream) {
+            impl crate::ToTokens for $parser {
+                fn to_tokens(&self, _: &mut crate::MacroContext, stream: &mut crate::TokenStream) {
                     stream.push(self.token);
                 }
             }

--- a/crates/rune/src/ast/parenthesized.rs
+++ b/crates/rune/src/ast/parenthesized.rs
@@ -1,5 +1,5 @@
 use crate::ast;
-use crate::{IntoTokens, Parse, ParseError, Parser, Peek, Spanned};
+use crate::{Parse, ParseError, Parser, Peek, Spanned, ToTokens};
 use runestick::Span;
 
 /// Something parenthesized and comma separated `(<T,>*)`.
@@ -56,14 +56,14 @@ where
     }
 }
 
-impl<T, S> IntoTokens for Parenthesized<T, S>
+impl<T, S> ToTokens for Parenthesized<T, S>
 where
-    T: IntoTokens,
-    S: IntoTokens,
+    T: ToTokens,
+    S: ToTokens,
 {
-    fn into_tokens(&self, context: &mut crate::MacroContext, stream: &mut crate::TokenStream) {
-        self.open.into_tokens(context, stream);
-        self.items.into_tokens(context, stream);
-        self.close.into_tokens(context, stream);
+    fn to_tokens(&self, context: &mut crate::MacroContext, stream: &mut crate::TokenStream) {
+        self.open.to_tokens(context, stream);
+        self.items.to_tokens(context, stream);
+        self.close.to_tokens(context, stream);
     }
 }

--- a/crates/rune/src/ast/pat.rs
+++ b/crates/rune/src/ast/pat.rs
@@ -1,8 +1,8 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, ParseErrorKind, Parser, Peek, Spanned};
+use crate::{Parse, ParseError, ParseErrorKind, Parser, Peek, Spanned, ToTokens};
 
 /// A pattern match.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub enum Pat {
     /// An ignored binding `_`.
     PatIgnore(ast::Underscore),

--- a/crates/rune/src/ast/pat_object.rs
+++ b/crates/rune/src/ast/pat_object.rs
@@ -1,8 +1,8 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, Parser, Spanned};
+use crate::{Parse, ParseError, Parser, Spanned, ToTokens};
 
 /// An object pattern.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct PatObject {
     /// The identifier of the object pattern.
     pub ident: ast::LitObjectIdent,
@@ -70,11 +70,11 @@ impl Parse for PatObject {
 }
 
 /// An object item.
-#[derive(Debug, Clone, Ast, Spanned, Parse)]
+#[derive(Debug, Clone, ToTokens, Spanned, Parse)]
 pub struct PatObjectItem {
     /// The key of an object.
     pub key: ast::LitObjectKey,
     /// The binding used for the pattern object.
-    #[spanned(iter)]
+    #[rune(iter)]
     pub binding: Option<(ast::Colon, ast::Pat)>,
 }

--- a/crates/rune/src/ast/pat_path.rs
+++ b/crates/rune/src/ast/pat_path.rs
@@ -1,8 +1,8 @@
 use crate::ast;
-use crate::{Ast, Spanned};
+use crate::{Spanned, ToTokens};
 
 /// A tuple pattern.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct PatPath {
     /// The path, if the tuple is typed.
     pub path: ast::Path,

--- a/crates/rune/src/ast/pat_tuple.rs
+++ b/crates/rune/src/ast/pat_tuple.rs
@@ -1,11 +1,11 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, Parser, Spanned};
+use crate::{Parse, ParseError, Parser, Spanned, ToTokens};
 
 /// A tuple pattern.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct PatTuple {
     /// The path, if the tuple is typed.
-    #[spanned(iter)]
+    #[rune(iter)]
     pub path: Option<ast::Path>,
     /// The open bracket.
     pub open: ast::OpenParen,

--- a/crates/rune/src/ast/pat_vec.rs
+++ b/crates/rune/src/ast/pat_vec.rs
@@ -1,8 +1,8 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, Parser, Spanned};
+use crate::{Parse, ParseError, Parser, Spanned, ToTokens};
 
 /// An array pattern.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub struct PatVec {
     /// The open bracket.
     pub open: ast::OpenBracket,

--- a/crates/rune/src/ast/path.rs
+++ b/crates/rune/src/ast/path.rs
@@ -1,18 +1,18 @@
 use crate::ast;
-use crate::{Ast, Parse, ParseError, Peek, Resolve, Spanned, Storage};
+use crate::{Parse, ParseError, Peek, Resolve, Spanned, Storage, ToTokens};
 use runestick::Source;
 use std::borrow::Cow;
 
 /// A path, where each element is separated by a `::`.
-#[derive(Debug, Clone, Ast, Spanned, Parse)]
+#[derive(Debug, Clone, ToTokens, Spanned, Parse)]
 pub struct Path {
     /// The first component in the path.
     pub first: ast::Ident,
     /// The rest of the components in the path.
-    #[spanned(iter)]
+    #[rune(iter)]
     pub rest: Vec<(ast::Scope, ast::Ident)>,
     /// Trailing scope.
-    #[spanned(iter)]
+    #[rune(iter)]
     pub trailing: Option<ast::Scope>,
 }
 

--- a/crates/rune/src/ast/stmt.rs
+++ b/crates/rune/src/ast/stmt.rs
@@ -1,8 +1,8 @@
 use crate::ast;
-use crate::{Ast, Spanned};
+use crate::{Spanned, ToTokens};
 
 /// A statement within a block.
-#[derive(Debug, Clone, Ast, Spanned)]
+#[derive(Debug, Clone, ToTokens, Spanned)]
 pub enum Stmt {
     /// A declaration.
     Item(ast::Item),

--- a/crates/rune/src/ast/token.rs
+++ b/crates/rune/src/ast/token.rs
@@ -11,8 +11,8 @@ pub struct Token {
     pub kind: Kind,
 }
 
-impl crate::IntoTokens for Token {
-    fn into_tokens(&self, _: &mut MacroContext, stream: &mut crate::TokenStream) {
+impl crate::ToTokens for Token {
+    fn to_tokens(&self, _: &mut MacroContext, stream: &mut crate::TokenStream) {
         stream.push(*self);
     }
 }
@@ -478,8 +478,8 @@ impl fmt::Display for Kind {
     }
 }
 
-impl crate::IntoTokens for Kind {
-    fn into_tokens(&self, context: &mut crate::MacroContext, stream: &mut crate::TokenStream) {
+impl crate::ToTokens for Kind {
+    fn to_tokens(&self, context: &mut crate::MacroContext, stream: &mut crate::TokenStream) {
         stream.push(Token {
             kind: *self,
             span: context.default_span(),

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -232,13 +232,13 @@ pub use crate::scopes::Var;
 pub use crate::source_loader::{FileSourceLoader, SourceLoader};
 pub use crate::sources::Sources;
 pub use crate::storage::Storage;
-pub use crate::token_stream::{IntoTokens, TokenStream, TokenStreamIter};
-pub use crate::traits::{Parse, Peek, Resolve, Spanned};
+pub use crate::token_stream::{ToTokens, TokenStream, TokenStreamIter};
+pub use crate::traits::{OptionSpanned, Parse, Peek, Resolve, Spanned};
 pub use crate::warning::{Warning, WarningKind, Warnings};
 pub use compiler::compile;
 pub use unit_builder::{ImportEntry, ImportKey, LinkerError, UnitBuilder};
 
-pub(crate) use rune_macros::{Ast, Parse, Spanned};
+pub(crate) use rune_macros::{OptionSpanned, Parse, Spanned, ToTokens};
 
 #[cfg(feature = "diagnostics")]
 pub use diagnostics::{termcolor, DiagnosticsError, EmitDiagnostics};

--- a/crates/rune/src/quote.rs
+++ b/crates/rune/src/quote.rs
@@ -30,18 +30,18 @@ macro_rules! quote {
     }};
 
     (@wrap $ctx:expr, $s:expr, $variant:ident => $($tt:tt)*) => {{
-        $crate::IntoTokens::into_tokens(&$crate::ast::Kind::Open($crate::ast::Delimiter::$variant), $ctx, $s);
+        $crate::ToTokens::to_tokens(&$crate::ast::Kind::Open($crate::ast::Delimiter::$variant), $ctx, $s);
         $crate::quote!(@push $ctx, $s => $($tt)*);
-        $crate::IntoTokens::into_tokens(&$crate::ast::Kind::Close($crate::ast::Delimiter::$variant), $ctx, $s);
+        $crate::ToTokens::to_tokens(&$crate::ast::Kind::Close($crate::ast::Delimiter::$variant), $ctx, $s);
     }};
 
     (@token $ctx:expr, $s:expr, $variant:ident => $($tt:tt)*) => {{
-        $crate::IntoTokens::into_tokens(&$crate::ast::Kind::$variant, $ctx, $s);
+        $crate::ToTokens::to_tokens(&$crate::ast::Kind::$variant, $ctx, $s);
         $crate::quote!(@push $ctx, $s => $($tt)*);
     }};
 
     (@push $ctx:expr, $s:expr => #$var:ident $($tt:tt)*) => {{
-        $crate::IntoTokens::into_tokens(&$var, $ctx, $s);
+        $crate::ToTokens::to_tokens(&$var, $ctx, $s);
         $crate::quote!(@push $ctx, $s => $($tt)*);
     }};
 
@@ -49,7 +49,7 @@ macro_rules! quote {
         let mut it = std::iter::IntoIterator::into_iter($expr).peekable();
 
         while let Some(v) = it.next() {
-            $crate::IntoTokens::into_tokens(&v, $ctx, $s);
+            $crate::ToTokens::to_tokens(&v, $ctx, $s);
 
             if it.peek().is_some() {
                 $crate::quote!(@push $ctx, $s => $repeat);
@@ -61,7 +61,7 @@ macro_rules! quote {
 
     (@push $ctx:expr, $s:expr => #($expr:expr)* $($tt:tt)*) => {{
         for v in $expr {
-            $crate::IntoTokens::into_tokens(&v, $ctx, $s);
+            $crate::ToTokens::to_tokens(&v, $ctx, $s);
         }
 
         $crate::quote!(@push $ctx, $s => $($tt)*);
@@ -361,13 +361,13 @@ macro_rules! quote {
 
     (@push $ctx:expr, $s:expr => $ident:ident $($tt:tt)*) => {{
         let kind = $ctx.ident(stringify!($ident));
-        $crate::IntoTokens::into_tokens(&kind, $ctx, $s);
+        $crate::ToTokens::to_tokens(&kind, $ctx, $s);
         $crate::quote!(@push $ctx, $s => $($tt)*);
     }};
 
     (@push $ctx:expr, $s:expr => $lit:literal $($tt:tt)*) => {{
         let token = $ctx.lit($lit);
-        $crate::IntoTokens::into_tokens(&token, $ctx, $s);
+        $crate::ToTokens::to_tokens(&token, $ctx, $s);
         $crate::quote!(@push $ctx, $s => $($tt)*);
     }};
 

--- a/crates/rune/src/token_stream.rs
+++ b/crates/rune/src/token_stream.rs
@@ -85,69 +85,69 @@ impl IntoIterator for TokenStream {
 }
 
 /// Trait for things that can be turned into tokens.
-pub trait IntoTokens {
+pub trait ToTokens {
     /// Turn the current item into tokens.
-    fn into_tokens(&self, context: &mut MacroContext, stream: &mut TokenStream);
+    fn to_tokens(&self, context: &mut MacroContext, stream: &mut TokenStream);
 }
 
-impl<T> IntoTokens for Box<T>
+impl<T> ToTokens for Box<T>
 where
-    T: IntoTokens,
+    T: ToTokens,
 {
-    fn into_tokens(&self, context: &mut MacroContext, stream: &mut TokenStream) {
-        (**self).into_tokens(context, stream);
+    fn to_tokens(&self, context: &mut MacroContext, stream: &mut TokenStream) {
+        (**self).to_tokens(context, stream);
     }
 }
 
-impl<T> IntoTokens for Option<T>
+impl<T> ToTokens for Option<T>
 where
-    T: IntoTokens,
+    T: ToTokens,
 {
-    fn into_tokens(&self, context: &mut MacroContext, stream: &mut TokenStream) {
+    fn to_tokens(&self, context: &mut MacroContext, stream: &mut TokenStream) {
         if let Some(this) = self {
-            this.into_tokens(context, stream);
+            this.to_tokens(context, stream);
         }
     }
 }
 
-impl<T> IntoTokens for Vec<T>
+impl<T> ToTokens for Vec<T>
 where
-    T: IntoTokens,
+    T: ToTokens,
 {
-    fn into_tokens(&self, context: &mut MacroContext, stream: &mut TokenStream) {
+    fn to_tokens(&self, context: &mut MacroContext, stream: &mut TokenStream) {
         for item in self {
-            item.into_tokens(context, stream);
+            item.to_tokens(context, stream);
         }
     }
 }
 
-impl<A, B> IntoTokens for (A, B)
+impl<A, B> ToTokens for (A, B)
 where
-    A: IntoTokens,
-    B: IntoTokens,
+    A: ToTokens,
+    B: ToTokens,
 {
-    fn into_tokens(&self, context: &mut MacroContext, stream: &mut TokenStream) {
-        self.0.into_tokens(context, stream);
-        self.1.into_tokens(context, stream);
+    fn to_tokens(&self, context: &mut MacroContext, stream: &mut TokenStream) {
+        self.0.to_tokens(context, stream);
+        self.1.to_tokens(context, stream);
     }
 }
 
-impl<A, B, C> IntoTokens for (A, B, C)
+impl<A, B, C> ToTokens for (A, B, C)
 where
-    A: IntoTokens,
-    B: IntoTokens,
-    C: IntoTokens,
+    A: ToTokens,
+    B: ToTokens,
+    C: ToTokens,
 {
-    fn into_tokens(&self, context: &mut MacroContext, stream: &mut TokenStream) {
-        self.0.into_tokens(context, stream);
-        self.1.into_tokens(context, stream);
-        self.2.into_tokens(context, stream);
+    fn to_tokens(&self, context: &mut MacroContext, stream: &mut TokenStream) {
+        self.0.to_tokens(context, stream);
+        self.1.to_tokens(context, stream);
+        self.2.to_tokens(context, stream);
     }
 }
 
-impl IntoTokens for TokenStream {
-    fn into_tokens(&self, context: &mut MacroContext, stream: &mut TokenStream) {
-        self.stream.into_tokens(context, stream);
+impl ToTokens for TokenStream {
+    fn to_tokens(&self, context: &mut MacroContext, stream: &mut TokenStream) {
+        self.stream.to_tokens(context, stream);
     }
 }
 

--- a/crates/rune/src/traits.rs
+++ b/crates/rune/src/traits.rs
@@ -140,3 +140,18 @@ where
         Spanned::span(&**self)
     }
 }
+
+/// Types for which we can optionally get a span.
+pub trait OptionSpanned {
+    /// Get the optional span of the type.
+    fn option_span(&self) -> Option<Span>;
+}
+
+impl<T> OptionSpanned for Box<T>
+where
+    T: OptionSpanned,
+{
+    fn option_span(&self) -> Option<Span> {
+        OptionSpanned::option_span(&**self)
+    }
+}


### PR DESCRIPTION
Hoping this will be the last big rename in a while.

* `IntoTokens` was renamed `ToTokens`, since it takes `&self` instead of as previously `self`.
* `Ast` didn't represent the trait it actually implemented, so it was renamed to `ToTokens`.
* Introduced `OptionSpanned` to fill the last `Spanned` derive gap.

All the derives now use the same attributes under `#[rune(...)]`.