### PR TITLE
Hook up a few browser functions to showcase async functionality in rune-wasm

### DIFF
--- a/crates/rune-wasm/Cargo.toml
+++ b/crates/rune-wasm/Cargo.toml
@@ -17,11 +17,17 @@ A WASM module for Rune, an embeddable dynamic programming language for Rust.
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 wasm-bindgen = {version = "0.2.68", features = ["serde-serialize"]}
-futures-executor = "0.3.5"
+wasm-bindgen-futures = "0.4.18"
+js-sys = "0.3.45"
 
 rune = {version = "0.6.16", path = "../rune", features = []}
 rune-macros = {version = "0.6.16", path = "../rune-macros"}
+rune-modules = {version = "0.6.16", path = "../rune-modules", features = ["json", "toml"]}
 runestick = {version = "0.6.16", path = "../runestick"}
+
+[dependencies.web-sys]
+version = "0.3.45"
+features = ["Request", "Response", "Window", "RequestInit", "RequestMode"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/crates/rune-wasm/module.js
+++ b/crates/rune-wasm/module.js
@@ -1,0 +1,4 @@
+/// Hook used to construct an async sleep function.
+export function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/crates/rune-wasm/src/core.rs
+++ b/crates/rune-wasm/src/core.rs
@@ -1,0 +1,58 @@
+use runestick::{ContextError, Module, Panic, Stack, Value, VmError};
+use std::cell;
+use std::io;
+
+/// Provide a bunch of `std` functions which does something appropriate to the
+/// wasm context.
+pub fn module() -> Result<Module, ContextError> {
+    let mut module = Module::new(&["std"]);
+    module.function(&["print"], print_impl)?;
+    module.function(&["println"], println_impl)?;
+    module.raw_fn(&["dbg"], dbg_impl)?;
+    Ok(module)
+}
+
+thread_local!(static OUT: cell::RefCell<io::Cursor<Vec<u8>>> = cell::RefCell::new(io::Cursor::new(Vec::new())));
+
+/// Drain all output that has been written to `OUT`. If `OUT` contains non -
+/// UTF-8, will drain but will still return `None`.
+pub fn drain_output() -> Option<String> {
+    OUT.with(|out| {
+        let mut out = out.borrow_mut();
+        let out = std::mem::take(&mut *out).into_inner();
+        String::from_utf8(out).ok()
+    })
+}
+
+fn print_impl(m: &str) -> Result<(), Panic> {
+    use std::io::Write as _;
+
+    OUT.with(|out| {
+        let mut out = out.borrow_mut();
+        write!(out, "{}", m).map_err(Panic::custom)
+    })
+}
+
+fn println_impl(m: &str) -> Result<(), Panic> {
+    use std::io::Write as _;
+
+    OUT.with(|out| {
+        let mut out = out.borrow_mut();
+        writeln!(out, "{}", m).map_err(Panic::custom)
+    })
+}
+
+fn dbg_impl(stack: &mut Stack, args: usize) -> Result<(), VmError> {
+    use std::io::Write as _;
+
+    OUT.with(|out| {
+        let mut out = out.borrow_mut();
+
+        for value in stack.drain_stack_top(args)? {
+            writeln!(out, "{:?}", value).map_err(VmError::panic)?;
+        }
+
+        stack.push(Value::Unit);
+        Ok(())
+    })
+}

--- a/crates/rune-wasm/src/http.rs
+++ b/crates/rune-wasm/src/http.rs
@@ -1,0 +1,46 @@
+use runestick::{Any, ContextError, Module};
+use wasm_bindgen::JsCast as _;
+use wasm_bindgen_futures::JsFuture;
+
+/// The wasm `http` module.
+pub fn module() -> Result<Module, ContextError> {
+    let mut module = Module::new(&["http"]);
+    module.ty::<Response>()?;
+    module.ty::<Error>()?;
+    module.async_function(&["get"], get)?;
+    module.async_inst_fn("text", Response::text)?;
+    Ok(module)
+}
+
+#[derive(Any)]
+struct Response {
+    inner: web_sys::Response,
+}
+
+#[derive(Any)]
+struct Error;
+
+/// Perform a `get` request.
+async fn get(url: &str) -> Result<Response, Error> {
+    let mut opts = web_sys::RequestInit::new();
+    opts.method("GET");
+    opts.mode(web_sys::RequestMode::Cors);
+
+    let window = web_sys::window().ok_or_else(|| Error)?;
+    let request = web_sys::Request::new_with_str(url).map_err(|_| Error)?;
+    let inner = JsFuture::from(window.fetch_with_request(&request))
+        .await
+        .map_err(|_| Error)?;
+    let inner: web_sys::Response = inner.dyn_into().map_err(|_| Error)?;
+
+    Ok(Response { inner })
+}
+
+impl Response {
+    /// Try to get the text of the respponse.
+    async fn text(&self) -> Result<String, Error> {
+        let text = self.inner.text().map_err(|_| Error)?;
+        let text = JsFuture::from(text).await.map_err(|_| Error)?;
+        text.as_string().ok_or_else(|| Error)
+    }
+}

--- a/crates/rune-wasm/src/time.rs
+++ b/crates/rune-wasm/src/time.rs
@@ -1,0 +1,34 @@
+use js_sys::Promise;
+use runestick::{Any, ContextError, Module, VmError};
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::JsFuture;
+
+#[wasm_bindgen(module = "/module.js")]
+extern "C" {
+    fn sleep(ms: i32) -> Promise;
+}
+
+/// The wasm 'time' module.
+pub fn module() -> Result<Module, ContextError> {
+    let mut module = Module::new(&["time"]);
+    module.ty::<Duration>()?;
+    module.function(&["Duration", "from_secs"], Duration::from_secs)?;
+    module.async_function(&["delay_for"], delay_for)?;
+    Ok(module)
+}
+
+#[derive(Any)]
+struct Duration(i32);
+
+impl Duration {
+    fn from_secs(value: i64) -> Self {
+        Self(value as i32 * 1000)
+    }
+}
+
+async fn delay_for(duration: Duration) -> Result<(), VmError> {
+    let promise = sleep(duration.0);
+    let js_fut = JsFuture::from(promise);
+    js_fut.await.map_err(|_| VmError::panic("future errored"))?;
+    Ok(())
+}

--- a/site/README.md
+++ b/site/README.md
@@ -3,3 +3,29 @@
 The static site for https://rune-rs.github.io/
 
 Based on the [Ergo Theme](https://www.getzola.org/themes/ergo/).
+
+#### Contributing
+
+So you want to work on the site?
+
+It has the following prerequisities:
+
+* [Rust and Cargo](https://www.rust-lang.org/).
+* [Node and NPM](https://nodejs.org).
+* [Zola](https://www.getzola.org/) version 11 (12 has a bug which prevents posts
+  from rendering).
+
+The first thing you need to do is rebuild `rune-wasm`:
+
+```
+cd crates/rune-wasm
+npm i
+npm run build
+```
+
+Now you can run the Zola site:
+
+```
+cd site
+zola serve
+```

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -13,21 +13,29 @@ Rune prioritized excellent support for `async` with support for async functions,
 [closures], [blocks], and [generators]. And native support for [`select`], a
 popular control flow mechanism for asynchronous code.
 
-```rune
+{% rune(footnote = "Asynchronous programming using select", manually = true) %}
+use std::future;
+
 struct Timeout;
 
 async fn request(timeout) {
-    let request = http::get("https://google.com");
-    let timeout = time::delay_for(time::Duration::from_secs(2));
+    let request = http::get(`http://httpstat.us/200?sleep={timeout}`);
+    let timeout = time::delay_for(time::Duration::from_secs(1));
 
     let result = select {
-        _ = timeout => Err(Timeout),
         res = request => res,
+        _ = timeout => Err(Timeout),
     }?;
 
-    Ok(result)
+    let text = result.text().await?;
+    Ok(text)
 }
-```
+
+async fn main() {
+    let result = future::join((request(0), request(1500))).await;
+    dbg(result);
+}
+{% end %}
 
 [closures]: https://rune-rs.github.io/book/async.html#async-closures
 [blocks]: https://rune-rs.github.io/book/async.html#async-blocks

--- a/site/sass/style.scss
+++ b/site/sass/style.scss
@@ -438,10 +438,6 @@ nav.pagination {
         width: 100%;
         font-size: 14px;
 
-        &.big {
-            font-size: 20px;
-        }
-
         .error {
             position: absolute;
             background-color: $error-color;
@@ -454,18 +450,15 @@ nav.pagination {
     }
 
     &-console {
+        position: relative;
         display: block;
         background-color: black;
-        padding: 6px;
         font-size: 14px;
-
-        &.big {
-            font-size: 20px;
-            padding: 10px;
-        }
     }
     
     &-output {
+        padding: 6px;
+        overflow-x: auto;
         font-family: monospace;
         color: $accent2;
         white-space: pre;
@@ -482,6 +475,10 @@ nav.pagination {
         padding: 4px 0px;
         font-size: 0.7em;
         text-align: center;
+    }
+
+    &-run {
+        font-size: 14px;
     }
 
     .hidden {

--- a/site/templates/play.html
+++ b/site/templates/play.html
@@ -13,10 +13,9 @@
 
 {% block content %}
 
-<div class="rune big" rune-update-url="true">
-  <div class="rune-editor big">{{config.extra.playground}}</div>
-  <div class="rune-console big">
-    <h4 class="rune-title"></h4>
+<div class="rune" rune-update-url="true">
+  <div class="rune-editor">{{config.extra.playground}}</div>
+  <div class="rune-console">
     <div class="rune-output"></div>
   </div>
 </div>

--- a/site/templates/shortcodes/rune.html
+++ b/site/templates/shortcodes/rune.html
@@ -1,7 +1,9 @@
-<div class="rune big" rune-update-url="false">
-    <div class="rune-editor {% if classes %}{{classes}}{% endif %}">{{body}}</div>
+<div class="rune big"
+    rune-update-url="false"
+    rune-run-on-change="{% if manually %}false{% else %}true{% endif %}"">
+    <div class="rune-editor {% if classes %}{{classes}}{% endif %}">{{body | safe}}</div>
     <div class="rune-console {% if classes %}{{classes}}{% endif %}">
-        <div class="rune-output"></div>
+        <div class="rune-output"><button class="rune-run">Run</button></div>
     </div>
     {% if footnote %}<div class="rune-footnote">{{footnote}}</div>{% endif %}
 </div>


### PR DESCRIPTION
This uses the following browser APIs:
* `setTimeout` and `Promise` to implement `time::delay_for`
* [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) to implement `http::get`.

This allows for the following to run fully in the browser (it's used as an example), and it can be modified by the user:

```rust
use std::future;

struct Timeout;

async fn request(timeout) {
    let request = http::get(`http://httpstat.us/200?sleep={timeout}`);
    let timeout = time::delay_for(time::Duration::from_secs(1));

    let result = select {
        res = request => res,
        _ = timeout => Err(Timeout),
    }?;

    let text = result.text().await?;
    Ok(text)
}

async fn main() {
    let result = future::join((request(0), request(1500))).await;
    dbg(result);
}
```