### PR TITLE
Add runtime type information (rtti)

### DIFF
--- a/crates/rune-languageserver/src/state.rs
+++ b/crates/rune-languageserver/src/state.rs
@@ -496,7 +496,7 @@ pub enum DefinitionKind {
     /// A struct.
     Struct,
     /// A struct variant.
-    StructVariant,
+    ObjectVariant,
     /// An enum.
     Enum,
     /// A function.
@@ -533,7 +533,7 @@ impl rune::CompileVisitor for Visitor<'_> {
             CompileMetaKind::Tuple { .. } => DefinitionKind::Tuple,
             CompileMetaKind::TupleVariant { .. } => DefinitionKind::TupleVariant,
             CompileMetaKind::Struct { .. } => DefinitionKind::Struct,
-            CompileMetaKind::StructVariant { .. } => DefinitionKind::StructVariant,
+            CompileMetaKind::ObjectVariant { .. } => DefinitionKind::ObjectVariant,
             CompileMetaKind::Enum { .. } => DefinitionKind::Enum,
             CompileMetaKind::Function { .. } => DefinitionKind::Function,
             _ => return,

--- a/crates/rune/src/compile/lit_object.rs
+++ b/crates/rune/src/compile/lit_object.rs
@@ -97,7 +97,7 @@ impl Compile<(&ast::LitObject, Needs)> for Compiler<'_> {
                         let hash = Hash::type_hash(&object.item);
                         self.asm.push(Inst::TypedObject { hash, slot }, span);
                     }
-                    CompileMetaKind::StructVariant {
+                    CompileMetaKind::ObjectVariant {
                         enum_item, object, ..
                     } => {
                         check_object_fields(
@@ -111,7 +111,7 @@ impl Compile<(&ast::LitObject, Needs)> for Compiler<'_> {
                         let hash = Hash::type_hash(&object.item);
 
                         self.asm.push(
-                            Inst::VariantObject {
+                            Inst::ObjectVariant {
                                 enum_hash,
                                 hash,
                                 slot,

--- a/crates/rune/src/compile/lit_object.rs
+++ b/crates/rune/src/compile/lit_object.rs
@@ -97,9 +97,7 @@ impl Compile<(&ast::LitObject, Needs)> for Compiler<'_> {
                         let hash = Hash::type_hash(&object.item);
                         self.asm.push(Inst::TypedObject { hash, slot }, span);
                     }
-                    CompileMetaKind::ObjectVariant {
-                        enum_item, object, ..
-                    } => {
+                    CompileMetaKind::ObjectVariant { object, .. } => {
                         check_object_fields(
                             object.fields.as_ref(),
                             check_keys,
@@ -107,17 +105,8 @@ impl Compile<(&ast::LitObject, Needs)> for Compiler<'_> {
                             &object.item,
                         )?;
 
-                        let enum_hash = Hash::type_hash(enum_item);
                         let hash = Hash::type_hash(&object.item);
-
-                        self.asm.push(
-                            Inst::ObjectVariant {
-                                enum_hash,
-                                hash,
-                                slot,
-                            },
-                            span,
-                        );
+                        self.asm.push(Inst::ObjectVariant { hash, slot }, span);
                     }
                     _ => {
                         return Err(CompileError::new(

--- a/crates/rune/src/compiler.rs
+++ b/crates/rune/src/compiler.rs
@@ -807,7 +807,7 @@ impl<'a> Compiler<'a> {
                         let type_check = TypeCheck::Type(**type_of);
                         (object, type_check)
                     }
-                    CompileMetaKind::StructVariant {
+                    CompileMetaKind::ObjectVariant {
                         object, type_of, ..
                     } => {
                         let type_check = TypeCheck::Variant(**type_of);

--- a/crates/rune/src/query.rs
+++ b/crates/rune/src/query.rs
@@ -481,7 +481,7 @@ impl Query {
         };
 
         Ok(match enum_item {
-            Some(enum_item) => CompileMetaKind::StructVariant {
+            Some(enum_item) => CompileMetaKind::ObjectVariant {
                 type_of,
                 enum_item,
                 object,

--- a/crates/rune/src/unit_builder.rs
+++ b/crates/rune/src/unit_builder.rs
@@ -648,7 +648,7 @@ impl UnitBuilder {
 
                 object.item.clone()
             }
-            CompileMetaKind::StructVariant {
+            CompileMetaKind::ObjectVariant {
                 enum_item, object, ..
             } => {
                 let hash = Hash::type_hash(&object.item);

--- a/crates/runestick-macros/tests/test_rename.rs
+++ b/crates/runestick-macros/tests/test_rename.rs
@@ -20,8 +20,8 @@ fn test_rename() {
     let e = context.install(&module).unwrap_err();
 
     match e {
-        ContextError::ConflictingType { name, .. } => {
-            assert_eq!(name, Item::of(&["Bar"]));
+        ContextError::ConflictingType { item, .. } => {
+            assert_eq!(item, Item::of(&["Bar"]));
         }
         actual => {
             panic!("expected conflicting type but got: {:?}", actual);

--- a/crates/runestick/src/compile_meta.rs
+++ b/crates/runestick/src/compile_meta.rs
@@ -38,7 +38,7 @@ impl CompileMeta {
             CompileMetaKind::Tuple { tuple, .. } => &tuple.item,
             CompileMetaKind::TupleVariant { tuple, .. } => &tuple.item,
             CompileMetaKind::Struct { object, .. } => &object.item,
-            CompileMetaKind::StructVariant { object, .. } => &object.item,
+            CompileMetaKind::ObjectVariant { object, .. } => &object.item,
             CompileMetaKind::Enum { item, .. } => item,
             CompileMetaKind::Function { item, .. } => item,
             CompileMetaKind::Closure { item, .. } => item,
@@ -53,7 +53,7 @@ impl CompileMeta {
             CompileMetaKind::Tuple { type_of, .. } => Some(*type_of),
             CompileMetaKind::TupleVariant { .. } => None,
             CompileMetaKind::Struct { type_of, .. } => Some(*type_of),
-            CompileMetaKind::StructVariant { .. } => None,
+            CompileMetaKind::ObjectVariant { .. } => None,
             CompileMetaKind::Enum { type_of, .. } => Some(*type_of),
             CompileMetaKind::Function { type_of, .. } => Some(*type_of),
             CompileMetaKind::Closure { type_of, .. } => Some(*type_of),
@@ -75,7 +75,7 @@ impl fmt::Display for CompileMeta {
             CompileMetaKind::Struct { object, .. } => {
                 write!(fmt, "struct {}", object.item)?;
             }
-            CompileMetaKind::StructVariant { object, .. } => {
+            CompileMetaKind::ObjectVariant { object, .. } => {
                 write!(fmt, "variant {}", object.item)?;
             }
             CompileMetaKind::Enum { item, .. } => {
@@ -126,7 +126,7 @@ pub enum CompileMetaKind {
         object: CompileMetaStruct,
     },
     /// Metadata about a variant object.
-    StructVariant {
+    ObjectVariant {
         /// The value type associated with this meta item.
         type_of: Type,
         /// The item of the enum.

--- a/crates/runestick/src/inst.rs
+++ b/crates/runestick/src/inst.rs
@@ -595,9 +595,7 @@ pub enum Inst {
     /// => <object>
     /// ```
     ObjectVariant {
-        /// The enum the variant belongs to.
-        enum_hash: Hash,
-        /// The type of the object to construct.
+        /// The type hash of the object variant to construct.
         hash: Hash,
         /// The static slot of the object keys.
         slot: usize,
@@ -1038,12 +1036,8 @@ impl fmt::Display for Inst {
             Self::TypedObject { hash, slot } => {
                 write!(fmt, "typed-object {}, {}", hash, slot)?;
             }
-            Self::ObjectVariant {
-                enum_hash,
-                hash,
-                slot,
-            } => {
-                write!(fmt, "variant-object {}, {}, {}", enum_hash, hash, slot)?;
+            Self::ObjectVariant { hash, slot } => {
+                write!(fmt, "object-variant {}, {}", hash, slot)?;
             }
             Self::Object { slot } => {
                 write!(fmt, "object {}", slot)?;

--- a/crates/runestick/src/inst.rs
+++ b/crates/runestick/src/inst.rs
@@ -594,7 +594,7 @@ pub enum Inst {
     /// <value..>
     /// => <object>
     /// ```
-    VariantObject {
+    ObjectVariant {
         /// The enum the variant belongs to.
         enum_hash: Hash,
         /// The type of the object to construct.
@@ -1038,7 +1038,7 @@ impl fmt::Display for Inst {
             Self::TypedObject { hash, slot } => {
                 write!(fmt, "typed-object {}, {}", hash, slot)?;
             }
-            Self::VariantObject {
+            Self::ObjectVariant {
                 enum_hash,
                 hash,
                 slot,

--- a/crates/runestick/src/lib.rs
+++ b/crates/runestick/src/lib.rs
@@ -165,7 +165,7 @@ pub use crate::shared::{Mut, RawMut, RawRef, Ref, Shared, SharedPointerGuard};
 pub use crate::stack::{Stack, StackError};
 pub use crate::type_of::TypeOf;
 pub use crate::unit::{Unit, UnitFn, UnitTypeInfo};
-pub use crate::value::{TupleVariant, TypedObject, TypedTuple, Value, VariantObject};
+pub use crate::value::{ObjectVariant, TupleVariant, TypedObject, TypedTuple, Value};
 pub use crate::vec_tuple::VecTuple;
 pub use crate::vm::{CallFrame, Vm};
 pub use crate::vm_call::VmCall;

--- a/crates/runestick/src/lib.rs
+++ b/crates/runestick/src/lib.rs
@@ -165,7 +165,9 @@ pub use crate::shared::{Mut, RawMut, RawRef, Ref, Shared, SharedPointerGuard};
 pub use crate::stack::{Stack, StackError};
 pub use crate::type_of::TypeOf;
 pub use crate::unit::{Unit, UnitFn, UnitTypeInfo};
-pub use crate::value::{ObjectVariant, TupleVariant, TypedObject, TypedTuple, Value};
+pub use crate::value::{
+    ObjectVariant, Rtti, TupleVariant, TypedObject, TypedTuple, Value, VariantRtti,
+};
 pub use crate::vec_tuple::VecTuple;
 pub use crate::vm::{CallFrame, Vm};
 pub use crate::vm_call::VmCall;

--- a/crates/runestick/src/modules/core.rs
+++ b/crates/runestick/src/modules/core.rs
@@ -8,7 +8,7 @@ use std::io::Write as _;
 pub fn module(io: bool) -> Result<Module, ContextError> {
     let mut module = Module::new(&["std"]);
 
-    module.unit(&["unit"])?;
+    module.unit("unit")?;
     module.ty::<bool>()?;
     module.ty::<char>()?;
     module.ty::<u8>()?;

--- a/crates/runestick/src/modules/core.rs
+++ b/crates/runestick/src/modules/core.rs
@@ -55,7 +55,7 @@ fn drop_impl(value: Value) -> Result<(), VmError> {
         Value::TypedObject(object) => {
             object.take()?;
         }
-        Value::VariantObject(object) => {
+        Value::ObjectVariant(object) => {
             object.take()?;
         }
         _ => (),
@@ -103,7 +103,7 @@ fn is_readable(value: Value) -> bool {
         Value::TupleVariant(tuple) => tuple.is_readable(),
         Value::Object(object) => object.is_readable(),
         Value::TypedObject(object) => object.is_readable(),
-        Value::VariantObject(object) => object.is_readable(),
+        Value::ObjectVariant(object) => object.is_readable(),
         _ => true,
     }
 }
@@ -119,7 +119,7 @@ fn is_writable(value: Value) -> bool {
         Value::TupleVariant(tuple) => tuple.is_writable(),
         Value::Object(object) => object.is_writable(),
         Value::TypedObject(object) => object.is_writable(),
-        Value::VariantObject(object) => object.is_writable(),
+        Value::ObjectVariant(object) => object.is_writable(),
         _ => true,
     }
 }

--- a/crates/runestick/src/serde.rs
+++ b/crates/runestick/src/serde.rs
@@ -74,7 +74,7 @@ impl ser::Serialize for Value {
             Value::TypedTuple(..) => Err(ser::Error::custom("cannot serialize tuple types")),
             Value::TupleVariant(..) => Err(ser::Error::custom("cannot serialize variant tuples")),
             Value::TypedObject(..) => Err(ser::Error::custom("cannot serialize object types")),
-            Value::VariantObject(..) => Err(ser::Error::custom("cannot serialize variant objects")),
+            Value::ObjectVariant(..) => Err(ser::Error::custom("cannot serialize variant objects")),
             Value::Result(..) => Err(ser::Error::custom("cannot serialize results")),
             Value::Type(..) => Err(ser::Error::custom("cannot serialize types")),
             Value::Future(..) => Err(ser::Error::custom("cannot serialize futures")),

--- a/crates/runestick/src/type_info.rs
+++ b/crates/runestick/src/type_info.rs
@@ -1,9 +1,10 @@
-use crate::{Hash, RawStr, StaticType};
+use crate::{Hash, RawStr, Rtti, StaticType, VariantRtti};
 use std::fmt;
+use std::sync::Arc;
 
 /// Type information about a value, that can be printed for human consumption
 /// through its [Display][fmt::Display] implementation.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub enum TypeInfo {
     /// The static type of a value.
     StaticType(&'static StaticType),
@@ -11,19 +12,29 @@ pub enum TypeInfo {
     Hash(Hash),
     /// Reference to an external type.
     Any(RawStr),
+    /// A named type.
+    Typed(Arc<Rtti>),
+    /// A variant.
+    Variant(Arc<VariantRtti>),
 }
 
 impl fmt::Display for TypeInfo {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match *self {
+        match self {
             Self::StaticType(ty) => {
                 write!(fmt, "{}", ty.name)?;
             }
             Self::Hash(ty) => {
-                write!(fmt, "Type({})", ty)?;
+                write!(fmt, "Type({})", *ty)?;
             }
             Self::Any(type_name) => {
-                write!(fmt, "{}", type_name)?;
+                write!(fmt, "{}", *type_name)?;
+            }
+            Self::Typed(rtti) => {
+                write!(fmt, "{}", rtti.item)?;
+            }
+            Self::Variant(rtti) => {
+                write!(fmt, "{}", rtti.item)?;
             }
         }
 

--- a/crates/runestick/src/value.rs
+++ b/crates/runestick/src/value.rs
@@ -97,7 +97,7 @@ impl TypedObject {
 
 /// An object with a well-defined variant of an enum.
 #[derive(Debug)]
-pub struct VariantObject {
+pub struct ObjectVariant {
     /// The type hash of the enum.
     pub enum_hash: Hash,
     /// The type variant hash.
@@ -106,7 +106,7 @@ pub struct VariantObject {
     pub object: Object,
 }
 
-impl VariantObject {
+impl ObjectVariant {
     /// Get type info for the typed object.
     pub fn type_info(&self) -> TypeInfo {
         TypeInfo::Hash(self.enum_hash)
@@ -186,7 +186,7 @@ pub enum Value {
     /// An object with a well-defined type.
     TypedObject(Shared<TypedObject>),
     /// An object variant with a well-defined type.
-    VariantObject(Shared<VariantObject>),
+    ObjectVariant(Shared<ObjectVariant>),
     /// A stored function pointer.
     Function(Shared<Function>),
     /// An opaque value that can be downcasted.
@@ -475,7 +475,7 @@ impl Value {
             Self::Function(..) => Type::from(crate::FUNCTION_TYPE),
             Self::Type(hash) => Type::from(*hash),
             Self::TypedObject(object) => Type::from(object.borrow_ref()?.hash),
-            Self::VariantObject(object) => {
+            Self::ObjectVariant(object) => {
                 let object = object.borrow_ref()?;
                 Type::from(object.enum_hash)
             }
@@ -512,7 +512,7 @@ impl Value {
             Self::Function(..) => TypeInfo::StaticType(crate::FUNCTION_TYPE),
             Self::Type(hash) => TypeInfo::Hash(*hash),
             Self::TypedObject(object) => object.borrow_ref()?.type_info(),
-            Self::VariantObject(object) => object.borrow_ref()?.type_info(),
+            Self::ObjectVariant(object) => object.borrow_ref()?.type_info(),
             Self::TypedTuple(tuple) => tuple.borrow_ref()?.type_info(),
             Self::TupleVariant(tuple) => tuple.borrow_ref()?.type_info(),
             Self::Any(any) => TypeInfo::Any(any.borrow_ref()?.type_name()),
@@ -659,7 +659,7 @@ impl fmt::Debug for Value {
             Value::TypedObject(value) => {
                 write!(f, "{:?}", value)?;
             }
-            Value::VariantObject(value) => {
+            Value::ObjectVariant(value) => {
                 write!(f, "{:?}", value)?;
             }
             Value::Function(value) => {
@@ -756,7 +756,7 @@ impl_from!(Shared<Result<Value, Value>>, Result);
 impl_from_shared!(Shared<TypedTuple>, TypedTuple);
 impl_from_shared!(Shared<TupleVariant>, TupleVariant);
 impl_from_shared!(Shared<TypedObject>, TypedObject);
-impl_from_shared!(Shared<VariantObject>, VariantObject);
+impl_from_shared!(Shared<ObjectVariant>, ObjectVariant);
 impl_from_shared!(Shared<Function>, Function);
 impl_from_shared!(Shared<AnyObj>, Any);
 

--- a/crates/runestick/src/vm.rs
+++ b/crates/runestick/src/vm.rs
@@ -3,9 +3,9 @@ use crate::future::SelectFuture;
 use crate::unit::UnitFn;
 use crate::{
     Args, Awaited, BorrowMut, Bytes, Call, Context, FromValue, Function, Future, Generator,
-    GuardedArgs, Hash, Inst, InstFnNameHash, InstOp, InstTarget, IntoTypeHash, Object, Panic,
-    Select, Shared, Stack, Stream, Tuple, TypeCheck, TypedObject, Unit, Value, VariantObject,
-    VmError, VmErrorKind, VmExecution, VmHalt, VmIntegerRepr,
+    GuardedArgs, Hash, Inst, InstFnNameHash, InstOp, InstTarget, IntoTypeHash, Object,
+    ObjectVariant, Panic, Select, Shared, Stack, Stream, Tuple, TypeCheck, TypedObject, Unit,
+    Value, VmError, VmErrorKind, VmExecution, VmHalt, VmIntegerRepr,
 };
 use std::fmt;
 use std::mem;
@@ -873,7 +873,7 @@ impl Vm {
                         target: typed_object.type_info(),
                     }));
                 }
-                Value::VariantObject(variant_object) => {
+                Value::ObjectVariant(variant_object) => {
                     let mut variant_object = variant_object.borrow_mut()?;
 
                     if let Some(v) = variant_object.object.get_mut(field) {
@@ -951,7 +951,7 @@ impl Vm {
         let value = match &target {
             Value::Object(target) => target.borrow_ref()?.get(field).cloned(),
             Value::TypedObject(target) => target.borrow_ref()?.object.get(field).cloned(),
-            Value::VariantObject(target) => target.borrow_ref()?.object.get(field).cloned(),
+            Value::ObjectVariant(target) => target.borrow_ref()?.object.get(field).cloned(),
             _ => return Ok(false),
         };
 
@@ -1112,7 +1112,7 @@ impl Vm {
                 let target = target.borrow_mut()?;
                 BorrowMut::try_map(target, |target| target.get_mut(field))
             }
-            Value::VariantObject(target) => {
+            Value::ObjectVariant(target) => {
                 let target = target.borrow_mut()?;
                 BorrowMut::try_map(target, |target| target.get_mut(field))
             }
@@ -1339,7 +1339,7 @@ impl Vm {
                     }
                 }
             }
-            Value::VariantObject(variant_object) => {
+            Value::ObjectVariant(variant_object) => {
                 let variant_object = variant_object.borrow_ref()?;
 
                 match variant_object.object.get(&***index).cloned() {
@@ -1454,7 +1454,7 @@ impl Vm {
             object.insert(key.clone(), value);
         }
 
-        self.stack.push(VariantObject {
+        self.stack.push(ObjectVariant {
             enum_hash,
             hash,
             object,
@@ -1851,7 +1851,7 @@ impl Vm {
                     return Ok(Some(f(&typed_object.object, keys)));
                 }
             }
-            (TypeCheck::Variant(hash), Value::VariantObject(variant_object)) => {
+            (TypeCheck::Variant(hash), Value::ObjectVariant(variant_object)) => {
                 let variant_object = variant_object.borrow_ref()?;
 
                 if variant_object.hash == hash {
@@ -2246,7 +2246,7 @@ impl Vm {
                 Inst::TypedObject { hash, slot } => {
                     self.op_typed_object(hash, slot)?;
                 }
-                Inst::VariantObject {
+                Inst::ObjectVariant {
                     enum_hash,
                     hash,
                     slot,

--- a/crates/runestick/src/vm_error.rs
+++ b/crates/runestick/src/vm_error.rs
@@ -246,6 +246,19 @@ pub enum VmErrorKind {
         /// Slot which is missing a static object keys.
         slot: usize,
     },
+    /// Trying to create a variant that doesn't have runtime information
+    /// available in the unit.
+    #[error("missing runtime information for variant with hash `{hash}`")]
+    MissingVariantRtti {
+        /// The type hash of the variant missing runtime information.
+        hash: Hash,
+    },
+    /// Trying to create a typed object with a hash that is not registered.
+    #[error("missing runtime information for type with hash `{hash}`")]
+    MissingRtti {
+        /// The type hash of the type missing runtime information.
+        hash: Hash,
+    },
     /// Wrong number of arguments provided in call.
     #[error("wrong number of arguments `{actual}`, expected `{expected}`")]
     BadArgumentCount {


### PR DESCRIPTION
This introduces more detailed type information, in particular the *item* of each type. This is important to implement a number of future features, like `FromValue` and `ToValue` derives for enums. This type information is associated with the value through two new structures:
* [`Rtti`](https://github.com/rune-rs/rune/pull/90/files#diff-e8b7c9caaf547e046ca876761b0ae2b4R164).
* [`VariantRtti`](https://github.com/rune-rs/rune/pull/90/files#diff-e8b7c9caaf547e046ca876761b0ae2b4R153).

These are both [stored in the appropriate value](https://github.com/rune-rs/rune/pull/90/files#diff-e8b7c9caaf547e046ca876761b0ae2b4R13) through an `Arc<T>`. We need `Arc` here to make sure the `Unit` stays being thread safe.

#### Items

The item contains the full path of the type. Take the below program:

```rust
mod http {
    struct Timeout;

    enum Method {
        Get,
        Post,
    }
}

struct Client;

fn main() {
    (http::Timeout, Client, http::Method::Get)
}
```

This declares the following items: `main`, `Client` and `http::Timeout`, `http::Method`, `http::Method::Get`, and `http::Method::Post`.

#### Improved diagnostics

Before this change, this would print the following when run:
```
(TypedTuple { hash: Hash(0xe377002d5e8609e4), tuple: [] }, TypedTuple { hash: Hash(0x160728984d39f6c0), tuple: [] }, TupleVariant { enum_hash: Hash(0x211eadd6d977304c), hash: Hash(0xc408725408555302), tuple: [] })
```

After this change, this prints:
```
(http::Timeout(), Client(), http::Method::Get())
```

#### Future work

Using this information it is now possible to identify which variant of an enum is used, by inspecting the last component in the item, i.e. for `http::Method::Get` would have `value.rtti.item.as_local() == Some("Get")`.

It will also be possible to implement serde serialization/deserialization for this.