### PR TITLE
Add support for breaking out of loops in const exprs

### DIFF
--- a/crates/rune/src/ast/lit_vec.rs
+++ b/crates/rune/src/ast/lit_vec.rs
@@ -7,7 +7,7 @@ pub struct LitVec {
     /// The open bracket.
     pub open: ast::OpenBracket,
     /// Items in the array.
-    pub items: Vec<ast::Expr>,
+    pub items: Vec<(ast::Expr, Option<ast::Comma>)>,
     /// The close bracket.
     pub close: ast::CloseBracket,
     /// If the entire array is constant.
@@ -47,11 +47,11 @@ impl Parse for LitVec {
                 is_const = false;
             }
 
-            items.push(expr);
+            let comma = parser.parse::<Option<ast::Comma>>()?;
+            let end = comma.is_none();
+            items.push((expr, comma));
 
-            if parser.peek::<ast::Comma>()? {
-                parser.parse::<ast::Comma>()?;
-            } else {
+            if end {
                 break;
             }
         }

--- a/crates/rune/src/compile/block.rs
+++ b/crates/rune/src/compile/block.rs
@@ -1,9 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::traits::Compile;
-use crate::CompileResult;
-use crate::{CompileError, Spanned as _};
-use runestick::{CompileMetaCapture, Inst};
+use crate::compile::prelude::*;
 
 /// Compile the async block.
 impl Compile<(&ast::Block, &[CompileMetaCapture])> for Compiler<'_> {

--- a/crates/rune/src/compile/const_value.rs
+++ b/crates/rune/src/compile/const_value.rs
@@ -1,0 +1,34 @@
+use crate::compile::prelude::*;
+
+/// Call an async block.
+impl Compile<(&ConstValue, Span)> for Compiler<'_> {
+    fn compile(&mut self, (const_value, span): (&ConstValue, Span)) -> CompileResult<()> {
+        match const_value {
+            ConstValue::Unit => {
+                self.asm.push(Inst::unit(), span);
+            }
+            ConstValue::Integer(n) => {
+                self.asm.push(Inst::integer(*n), span);
+            }
+            ConstValue::Float(n) => {
+                self.asm.push(Inst::float(*n), span);
+            }
+            ConstValue::Bool(b) => {
+                self.asm.push(Inst::bool(*b), span);
+            }
+            ConstValue::String(s) => {
+                let slot = self.unit.borrow_mut().new_static_string(&s)?;
+                self.asm.push(Inst::String { slot }, span);
+            }
+            ConstValue::Tuple(tuple) => {
+                for value in tuple.iter() {
+                    self.compile((value, span))?;
+                }
+
+                self.asm.push(Inst::Tuple { count: tuple.len() }, span);
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/crates/rune/src/compile/expr.rs
+++ b/crates/rune/src/compile/expr.rs
@@ -1,10 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::traits::Compile;
-use crate::worker::Expanded;
-use crate::CompileResult;
-use crate::{CompileError, Spanned as _};
-use runestick::Inst;
+use crate::compile::prelude::*;
 
 /// Compile an expression.
 impl Compile<(&ast::Expr, Needs)> for Compiler<'_> {

--- a/crates/rune/src/compile/expr_async.rs
+++ b/crates/rune/src/compile/expr_async.rs
@@ -1,9 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::traits::Compile;
-use crate::CompileResult;
-use crate::{CompileError, CompileErrorKind, Spanned as _};
-use runestick::{CompileMetaKind, Hash, Inst};
+use crate::compile::prelude::*;
 
 /// Call an async block.
 impl Compile<(&ast::ExprAsync, Needs)> for Compiler<'_> {

--- a/crates/rune/src/compile/expr_await copy.rs
+++ b/crates/rune/src/compile/expr_await copy.rs
@@ -1,8 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::error::CompileResult;
-use crate::traits::Compile;
-use runestick::Inst;
+use crate::compile::prelude::*;
 
 /// Compile an `.await` expression.
 impl Compile<(&ast::ExprAwait, Needs)> for Compiler<'_>{

--- a/crates/rune/src/compile/expr_await.rs
+++ b/crates/rune/src/compile/expr_await.rs
@@ -1,9 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::traits::Compile;
-use crate::CompileResult;
-use crate::Spanned as _;
-use runestick::Inst;
+use crate::compile::prelude::*;
 
 /// Compile an `.await` expression.
 impl Compile<(&ast::ExprAwait, Needs)> for Compiler<'_> {

--- a/crates/rune/src/compile/expr_binary.rs
+++ b/crates/rune/src/compile/expr_binary.rs
@@ -1,9 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::traits::{Compile, Resolve as _};
-use crate::CompileResult;
-use crate::{CompileError, CompileErrorKind, Spanned as _};
-use runestick::{Inst, InstOp, InstTarget};
+use crate::compile::prelude::*;
 
 /// Compile a binary expression.
 impl Compile<(&ast::ExprBinary, Needs)> for Compiler<'_> {

--- a/crates/rune/src/compile/expr_block.rs
+++ b/crates/rune/src/compile/expr_block.rs
@@ -1,8 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::traits::Compile;
-use crate::CompileResult;
-use crate::Spanned as _;
+use crate::compile::prelude::*;
 
 /// Compile a block expression.
 ///

--- a/crates/rune/src/compile/expr_break.rs
+++ b/crates/rune/src/compile/expr_break.rs
@@ -1,9 +1,4 @@
-use crate::ast;
-use crate::compiler::Compiler;
-use crate::traits::Compile;
-use crate::CompileResult;
-use crate::{CompileError, CompileErrorKind, Spanned as _};
-use runestick::Inst;
+use crate::compile::prelude::*;
 
 /// Compile a break expression.
 ///

--- a/crates/rune/src/compile/expr_call.rs
+++ b/crates/rune/src/compile/expr_call.rs
@@ -1,9 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::traits::Compile;
-use crate::CompileResult;
-use crate::{CompileError, CompileErrorKind, Resolve as _, Spanned as _};
-use runestick::{CompileMetaKind, Hash, Inst};
+use crate::compile::prelude::*;
 
 /// Compile a call expression.
 impl Compile<(&ast::ExprCall, Needs)> for Compiler<'_> {

--- a/crates/rune/src/compile/expr_closure.rs
+++ b/crates/rune/src/compile/expr_closure.rs
@@ -1,9 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::traits::Compile;
-use crate::CompileResult;
-use crate::{CompileError, CompileErrorKind, Resolve as _, Spanned as _};
-use runestick::{CompileMetaCapture, CompileMetaKind, Hash, Inst};
+use crate::compile::prelude::*;
 
 /// Compile the body of a closure function.
 impl Compile<(ast::ExprClosure, &[CompileMetaCapture])> for Compiler<'_> {

--- a/crates/rune/src/compile/expr_field_access.rs
+++ b/crates/rune/src/compile/expr_field_access.rs
@@ -1,10 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::traits::Compile;
-use crate::CompileResult;
-use crate::{CompileError, CompileErrorKind, Resolve as _, Spanned as _};
-use runestick::{Inst, Span};
-use std::convert::TryFrom as _;
+use crate::compile::prelude::*;
 
 /// Compile an expr field access, like `<value>.<field>`.
 impl Compile<(&ast::ExprFieldAccess, Needs)> for Compiler<'_> {

--- a/crates/rune/src/compile/expr_for.rs
+++ b/crates/rune/src/compile/expr_for.rs
@@ -1,10 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::loops::Loop;
-use crate::traits::{Compile, Resolve as _};
-use crate::CompileResult;
-use crate::Spanned as _;
-use runestick::Inst;
+use crate::compile::prelude::*;
 
 /// Compile a for loop.
 impl Compile<(&ast::ExprFor, Needs)> for Compiler<'_> {

--- a/crates/rune/src/compile/expr_if.rs
+++ b/crates/rune/src/compile/expr_if.rs
@@ -1,9 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::traits::Compile;
-use crate::CompileResult;
-use crate::Spanned as _;
-use runestick::Inst;
+use crate::compile::prelude::*;
 
 /// Compile an if expression.
 impl Compile<(&ast::ExprIf, Needs)> for Compiler<'_> {

--- a/crates/rune/src/compile/expr_index_get.rs
+++ b/crates/rune/src/compile/expr_index_get.rs
@@ -1,9 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::traits::Compile;
-use crate::CompileResult;
-use crate::Spanned as _;
-use runestick::Inst;
+use crate::compile::prelude::*;
 
 /// Compile an expression.
 impl Compile<(&ast::ExprIndexGet, Needs)> for Compiler<'_> {

--- a/crates/rune/src/compile/expr_index_set.rs
+++ b/crates/rune/src/compile/expr_index_set.rs
@@ -1,9 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::traits::Compile;
-use crate::CompileResult;
-use crate::Spanned as _;
-use runestick::Inst;
+use crate::compile::prelude::*;
 
 /// An expr index set operation.
 impl Compile<(&ast::ExprIndexSet, Needs)> for Compiler<'_> {

--- a/crates/rune/src/compile/expr_let.rs
+++ b/crates/rune/src/compile/expr_let.rs
@@ -1,9 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::traits::Compile;
-use crate::CompileResult;
-use crate::Spanned as _;
-use runestick::Inst;
+use crate::compile::prelude::*;
 
 /// Compile a let expression.
 impl Compile<(&ast::ExprLet, Needs)> for Compiler<'_> {

--- a/crates/rune/src/compile/expr_loop.rs
+++ b/crates/rune/src/compile/expr_loop.rs
@@ -1,9 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::loops::Loop;
-use crate::traits::Compile;
-use crate::CompileResult;
-use crate::Spanned as _;
+use crate::compile::prelude::*;
 
 /// Compile a loop.
 impl Compile<(&ast::ExprLoop, Needs)> for Compiler<'_> {

--- a/crates/rune/src/compile/expr_match.rs
+++ b/crates/rune/src/compile/expr_match.rs
@@ -1,9 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::traits::Compile;
-use crate::CompileResult;
-use crate::Spanned as _;
-use runestick::Inst;
+use crate::compile::prelude::*;
 
 impl Compile<(&ast::ExprMatch, Needs)> for Compiler<'_> {
     fn compile(&mut self, (expr_match, needs): (&ast::ExprMatch, Needs)) -> CompileResult<()> {

--- a/crates/rune/src/compile/expr_path.rs
+++ b/crates/rune/src/compile/expr_path.rs
@@ -1,8 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::traits::Compile;
-use crate::CompileResult;
-use crate::{CompileError, CompileErrorKind, Spanned as _};
+use crate::compile::prelude::*;
 
 /// Compile `self`.
 impl Compile<(&ast::Path, Needs)> for Compiler<'_> {

--- a/crates/rune/src/compile/expr_return.rs
+++ b/crates/rune/src/compile/expr_return.rs
@@ -1,9 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::traits::Compile;
-use crate::CompileResult;
-use crate::Spanned as _;
-use runestick::Inst;
+use crate::compile::prelude::*;
 
 /// Compile a return.
 impl Compile<(&ast::ExprReturn, Needs)> for Compiler<'_> {

--- a/crates/rune/src/compile/expr_select.rs
+++ b/crates/rune/src/compile/expr_select.rs
@@ -1,9 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::traits::Compile;
-use crate::CompileResult;
-use crate::{CompileError, CompileErrorKind, Spanned as _};
-use runestick::Inst;
+use crate::compile::prelude::*;
 
 /// Compile a select expression.
 impl Compile<(&ast::ExprSelect, Needs)> for Compiler<'_> {

--- a/crates/rune/src/compile/expr_self.rs
+++ b/crates/rune/src/compile/expr_self.rs
@@ -1,8 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::traits::Compile;
-use crate::CompileResult;
-use crate::Spanned as _;
+use crate::compile::prelude::*;
 
 /// Compile `self`.
 impl Compile<(&ast::Self_, Needs)> for Compiler<'_> {

--- a/crates/rune/src/compile/expr_try.rs
+++ b/crates/rune/src/compile/expr_try.rs
@@ -1,9 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::traits::Compile;
-use crate::CompileResult;
-use crate::Spanned as _;
-use runestick::Inst;
+use crate::compile::prelude::*;
 
 /// Compile a try expression.
 impl Compile<(&ast::ExprTry, Needs)> for Compiler<'_> {

--- a/crates/rune/src/compile/expr_unary.rs
+++ b/crates/rune/src/compile/expr_unary.rs
@@ -1,9 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::traits::Compile;
-use crate::CompileResult;
-use crate::{CompileError, CompileErrorKind, Spanned as _};
-use runestick::Inst;
+use crate::compile::prelude::*;
 
 /// Compile a unary expression.
 impl Compile<(&ast::ExprUnary, Needs)> for Compiler<'_> {

--- a/crates/rune/src/compile/expr_while.rs
+++ b/crates/rune/src/compile/expr_while.rs
@@ -1,10 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::loops::Loop;
-use crate::traits::Compile;
-use crate::CompileResult;
-use crate::Spanned as _;
-use runestick::Inst;
+use crate::compile::prelude::*;
 
 /// Compile a while loop.
 impl Compile<(&ast::ExprWhile, Needs)> for Compiler<'_> {

--- a/crates/rune/src/compile/expr_yield.rs
+++ b/crates/rune/src/compile/expr_yield.rs
@@ -1,9 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::traits::Compile;
-use crate::CompileResult;
-use crate::Spanned as _;
-use runestick::Inst;
+use crate::compile::prelude::*;
 
 /// Compile a `yield` expression.
 impl Compile<(&ast::ExprYield, Needs)> for Compiler<'_> {

--- a/crates/rune/src/compile/item_fn.rs
+++ b/crates/rune/src/compile/item_fn.rs
@@ -1,9 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::traits::Compile;
-use crate::CompileResult;
-use crate::{CompileError, CompileErrorKind, Resolve as _, Spanned as _};
-use runestick::Inst;
+use crate::compile::prelude::*;
 
 impl Compile<(ast::ItemFn, bool)> for Compiler<'_> {
     fn compile(&mut self, (fn_decl, instance_fn): (ast::ItemFn, bool)) -> CompileResult<()> {

--- a/crates/rune/src/compile/lit_bool.rs
+++ b/crates/rune/src/compile/lit_bool.rs
@@ -1,9 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::traits::Compile;
-use crate::CompileResult;
-use crate::Spanned as _;
-use runestick::Inst;
+use crate::compile::prelude::*;
 
 /// Compile a literal boolean such as `true`.
 impl Compile<(&ast::LitBool, Needs)> for Compiler<'_> {

--- a/crates/rune/src/compile/lit_byte.rs
+++ b/crates/rune/src/compile/lit_byte.rs
@@ -1,9 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::traits::Compile;
-use crate::CompileResult;
-use crate::{Resolve as _, Spanned as _};
-use runestick::Inst;
+use crate::compile::prelude::*;
 
 /// Compile a literal byte such as `b'a'`.
 impl Compile<(&ast::LitByte, Needs)> for Compiler<'_> {

--- a/crates/rune/src/compile/lit_byte_str.rs
+++ b/crates/rune/src/compile/lit_byte_str.rs
@@ -1,9 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::traits::Compile;
-use crate::CompileResult;
-use crate::{Resolve as _, Spanned as _};
-use runestick::Inst;
+use crate::compile::prelude::*;
 
 /// Compile a literal string `b"Hello World"`.
 impl Compile<(&ast::LitByteStr, Needs)> for Compiler<'_> {

--- a/crates/rune/src/compile/lit_char.rs
+++ b/crates/rune/src/compile/lit_char.rs
@@ -1,9 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::traits::Compile;
-use crate::CompileResult;
-use crate::{Resolve as _, Spanned as _};
-use runestick::Inst;
+use crate::compile::prelude::*;
 
 /// Compile a literal character.
 impl Compile<(&ast::LitChar, Needs)> for Compiler<'_> {

--- a/crates/rune/src/compile/lit_number.rs
+++ b/crates/rune/src/compile/lit_number.rs
@@ -1,9 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::traits::Compile;
-use crate::CompileResult;
-use crate::{Resolve as _, Spanned as _};
-use runestick::Inst;
+use crate::compile::prelude::*;
 
 /// Compile a literal number.
 impl Compile<(&ast::LitNumber, Needs)> for Compiler<'_> {

--- a/crates/rune/src/compile/lit_object.rs
+++ b/crates/rune/src/compile/lit_object.rs
@@ -1,10 +1,5 @@
-use crate::ast;
 use crate::collections::{HashMap, HashSet};
-use crate::compiler::{Compiler, Needs};
-use crate::traits::Compile;
-use crate::CompileResult;
-use crate::{CompileError, CompileErrorKind, Resolve as _, Spanned as _};
-use runestick::{CompileMetaKind, Hash, Inst, Item, Span};
+use crate::compile::prelude::*;
 
 /// Compile a literal object.
 impl Compile<(&ast::LitObject, Needs)> for Compiler<'_> {

--- a/crates/rune/src/compile/lit_str.rs
+++ b/crates/rune/src/compile/lit_str.rs
@@ -1,9 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::traits::Compile;
-use crate::CompileResult;
-use crate::{Resolve as _, Spanned as _};
-use runestick::Inst;
+use crate::compile::prelude::*;
 
 /// Compile a literal string `"Hello World"`.
 impl Compile<(&ast::LitStr, Needs)> for Compiler<'_> {

--- a/crates/rune/src/compile/lit_template.rs
+++ b/crates/rune/src/compile/lit_template.rs
@@ -1,9 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::traits::{Compile, Resolve as _};
-use crate::CompileResult;
-use crate::Spanned as _;
-use runestick::Inst;
+use crate::compile::prelude::*;
 
 /// Compile a literal template string.
 impl Compile<(&ast::LitTemplate, Needs)> for Compiler<'_> {

--- a/crates/rune/src/compile/lit_tuple.rs
+++ b/crates/rune/src/compile/lit_tuple.rs
@@ -1,9 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::traits::Compile;
-use crate::CompileResult;
-use crate::Spanned as _;
-use runestick::Inst;
+use crate::compile::prelude::*;
 
 /// Compile a literal tuple.
 impl Compile<(&ast::LitTuple, Needs)> for Compiler<'_> {

--- a/crates/rune/src/compile/lit_unit.rs
+++ b/crates/rune/src/compile/lit_unit.rs
@@ -1,9 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::traits::Compile;
-use crate::CompileResult;
-use crate::Spanned as _;
-use runestick::Inst;
+use crate::compile::prelude::*;
 
 /// Compile a literal unit `()`.
 impl Compile<(&ast::LitUnit, Needs)> for Compiler<'_> {

--- a/crates/rune/src/compile/lit_vec.rs
+++ b/crates/rune/src/compile/lit_vec.rs
@@ -1,9 +1,4 @@
-use crate::ast;
-use crate::compiler::{Compiler, Needs};
-use crate::traits::Compile;
-use crate::CompileResult;
-use crate::Spanned as _;
-use runestick::Inst;
+use crate::compile::prelude::*;
 
 /// Compile a literal vector.
 impl Compile<(&ast::LitVec, Needs)> for Compiler<'_> {
@@ -18,7 +13,7 @@ impl Compile<(&ast::LitVec, Needs)> for Compiler<'_> {
 
         let count = lit_vec.items.len();
 
-        for expr in lit_vec.items.iter() {
+        for (expr, _) in lit_vec.items.iter() {
             self.compile((expr, Needs::Value))?;
 
             // Evaluate the expressions one by one, then pop them to cause any

--- a/crates/rune/src/compile/mod.rs
+++ b/crates/rune/src/compile/mod.rs
@@ -1,4 +1,5 @@
 mod block;
+mod const_value;
 mod expr;
 mod expr_async;
 mod expr_await;
@@ -35,3 +36,4 @@ mod lit_template;
 mod lit_tuple;
 mod lit_unit;
 mod lit_vec;
+mod prelude;

--- a/crates/rune/src/compile/prelude.rs
+++ b/crates/rune/src/compile/prelude.rs
@@ -1,0 +1,10 @@
+pub(crate) use crate::ast;
+pub(crate) use crate::compiler::{Compiler, Needs};
+pub(crate) use crate::loops::Loop;
+pub(crate) use crate::traits::Compile;
+pub(crate) use crate::worker::Expanded;
+pub(crate) use crate::{CompileError, CompileErrorKind, CompileResult, Resolve, Spanned};
+pub(crate) use runestick::{
+    CompileMetaCapture, CompileMetaKind, ConstValue, Hash, Inst, InstOp, InstTarget, Item, Span,
+};
+pub(crate) use std::convert::TryFrom;

--- a/crates/rune/src/compile_error.rs
+++ b/crates/rune/src/compile_error.rs
@@ -75,14 +75,6 @@ impl CompileError {
         )
     }
 
-    /// An error indicating that the given span is not a constant expression.
-    pub fn not_const<S>(spanned: S) -> Self
-    where
-        S: Spanned,
-    {
-        CompileError::new(spanned, CompileErrorKind::NotConst)
-    }
-
     /// Construct an experimental error.
     ///
     /// This should be used when an experimental feature is used which hasn't
@@ -378,7 +370,7 @@ pub enum CompileErrorKind {
     #[error("not a valid binding")]
     UnsupportedBinding,
     /// Error raised when trying to use a break outside of a loop.
-    #[error("break expressions cannot be used as a value")]
+    #[error("break outside of supported loop")]
     BreakOutsideOfLoop,
     /// Attempting to use a float in a match pattern.
     #[error("floating point numbers cannot be used in patterns")]

--- a/crates/rune/src/compiler.rs
+++ b/crates/rune/src/compiler.rs
@@ -14,8 +14,7 @@ use crate::{
     Options, Resolve as _, SourceLoader, Sources, Spanned as _, Storage, UnitBuilder, Warnings,
 };
 use runestick::{
-    CompileMeta, CompileMetaKind, ConstValue, Context, Inst, InstValue, Item, Label, Source, Span,
-    TypeCheck,
+    CompileMeta, CompileMetaKind, Context, Inst, InstValue, Item, Label, Source, Span, TypeCheck,
 };
 use std::cell::RefCell;
 use std::collections::VecDeque;
@@ -530,24 +529,9 @@ impl<'a> Compiler<'a> {
                         format!("fn `{}`", item),
                     );
                 }
-                CompileMetaKind::Const { const_value, .. } => match const_value {
-                    ConstValue::Unit => {
-                        self.asm.push(Inst::unit(), span);
-                    }
-                    ConstValue::Integer(n) => {
-                        self.asm.push(Inst::integer(*n), span);
-                    }
-                    ConstValue::Float(n) => {
-                        self.asm.push(Inst::float(*n), span);
-                    }
-                    ConstValue::Bool(b) => {
-                        self.asm.push(Inst::bool(*b), span);
-                    }
-                    ConstValue::String(s) => {
-                        let slot = self.unit.borrow_mut().new_static_string(&s)?;
-                        self.asm.push(Inst::String { slot }, span);
-                    }
-                },
+                CompileMetaKind::Const { const_value, .. } => {
+                    self.compile((const_value, span))?;
+                }
                 _ => {
                     return Err(CompileError::new(
                         span,

--- a/crates/rune/src/eval/condition.rs
+++ b/crates/rune/src/eval/condition.rs
@@ -1,16 +1,12 @@
 use crate::eval::prelude::*;
 
 impl Eval<&ast::Condition> for ConstCompiler<'_> {
-    fn eval(
-        &mut self,
-        condition: &ast::Condition,
-        used: Used,
-    ) -> Result<Option<ConstValue>, crate::CompileError> {
+    fn eval(&mut self, condition: &ast::Condition, used: Used) -> Result<ConstValue, EvalOutcome> {
         self.budget.take(condition)?;
 
         match condition {
             ast::Condition::Expr(expr) => self.eval(&**expr, used),
-            _ => Ok(None),
+            _ => Err(EvalOutcome::not_const(condition)),
         }
     }
 }

--- a/crates/rune/src/eval/expr_binary.rs
+++ b/crates/rune/src/eval/expr_binary.rs
@@ -1,24 +1,15 @@
 use crate::eval::prelude::*;
 
 impl Eval<&ast::ExprBinary> for ConstCompiler<'_> {
-    fn eval(
-        &mut self,
-        binary: &ast::ExprBinary,
-        used: Used,
-    ) -> Result<Option<ConstValue>, crate::CompileError> {
+    fn eval(&mut self, binary: &ast::ExprBinary, used: Used) -> Result<ConstValue, EvalOutcome> {
         self.budget.take(binary.span())?;
 
         if binary.op.is_assign() {
             return op_assign(self, binary, used);
         }
 
-        let lhs = self
-            .eval(&*binary.lhs, used)?
-            .ok_or_else(|| CompileError::not_const(&binary.lhs))?;
-
-        let rhs = self
-            .eval(&*binary.rhs, used)?
-            .ok_or_else(|| CompileError::not_const(&binary.lhs))?;
+        let lhs = self.eval(&*binary.lhs, used)?;
+        let rhs = self.eval(&*binary.rhs, used)?;
 
         let span = binary.lhs.span().join(binary.rhs.span());
 
@@ -26,40 +17,40 @@ impl Eval<&ast::ExprBinary> for ConstCompiler<'_> {
             (ConstValue::Integer(a), ConstValue::Integer(b)) => {
                 match binary.op {
                     ast::BinOp::Add => {
-                        return Ok(Some(checked_int(
+                        return Ok(checked_int(
                             a,
                             b,
                             i64::checked_add,
                             "integer overflow",
                             span,
-                        )?));
+                        )?);
                     }
                     ast::BinOp::Sub => {
-                        return Ok(Some(checked_int(
+                        return Ok(checked_int(
                             a,
                             b,
                             i64::checked_sub,
                             "integer underflow",
                             span,
-                        )?));
+                        )?);
                     }
                     ast::BinOp::Mul => {
-                        return Ok(Some(checked_int(
+                        return Ok(checked_int(
                             a,
                             b,
                             i64::checked_mul,
                             "integer overflow",
                             span,
-                        )?));
+                        )?);
                     }
                     ast::BinOp::Div => {
-                        return Ok(Some(checked_int(
+                        return Ok(checked_int(
                             a,
                             b,
                             i64::checked_div,
                             "integer division by zero",
                             span,
-                        )?));
+                        )?);
                     }
                     ast::BinOp::Shl => {
                         let b = u32::try_from(b).map_err(|_| {
@@ -73,7 +64,7 @@ impl Eval<&ast::ExprBinary> for ConstCompiler<'_> {
                             CompileError::const_error(span, "integer shift overflow")
                         })?;
 
-                        return Ok(Some(ConstValue::Integer(n)));
+                        return Ok(ConstValue::Integer(n));
                     }
                     ast::BinOp::Shr => {
                         let b = u32::try_from(b).map_err(|_| {
@@ -87,34 +78,34 @@ impl Eval<&ast::ExprBinary> for ConstCompiler<'_> {
                             CompileError::const_error(span, "integer shift underflow")
                         })?;
 
-                        return Ok(Some(ConstValue::Integer(n)));
+                        return Ok(ConstValue::Integer(n));
                     }
-                    ast::BinOp::Lt => return Ok(Some(ConstValue::Bool(a < b))),
-                    ast::BinOp::Lte => return Ok(Some(ConstValue::Bool(a <= b))),
-                    ast::BinOp::Eq => return Ok(Some(ConstValue::Bool(a == b))),
-                    ast::BinOp::Gt => return Ok(Some(ConstValue::Bool(a > b))),
-                    ast::BinOp::Gte => return Ok(Some(ConstValue::Bool(a >= b))),
+                    ast::BinOp::Lt => return Ok(ConstValue::Bool(a < b)),
+                    ast::BinOp::Lte => return Ok(ConstValue::Bool(a <= b)),
+                    ast::BinOp::Eq => return Ok(ConstValue::Bool(a == b)),
+                    ast::BinOp::Gt => return Ok(ConstValue::Bool(a > b)),
+                    ast::BinOp::Gte => return Ok(ConstValue::Bool(a >= b)),
                     _ => (),
                 };
             }
             (ConstValue::Float(a), ConstValue::Float(b)) => {
                 match binary.op {
-                    ast::BinOp::Add => return Ok(Some(ConstValue::Float(a + b))),
-                    ast::BinOp::Sub => return Ok(Some(ConstValue::Float(a - b))),
-                    ast::BinOp::Mul => return Ok(Some(ConstValue::Float(a * b))),
-                    ast::BinOp::Div => return Ok(Some(ConstValue::Float(a / b))),
-                    ast::BinOp::Lt => return Ok(Some(ConstValue::Bool(a < b))),
-                    ast::BinOp::Lte => return Ok(Some(ConstValue::Bool(a <= b))),
-                    ast::BinOp::Eq => return Ok(Some(ConstValue::Bool(a == b))),
-                    ast::BinOp::Gt => return Ok(Some(ConstValue::Bool(a > b))),
-                    ast::BinOp::Gte => return Ok(Some(ConstValue::Bool(a >= b))),
+                    ast::BinOp::Add => return Ok(ConstValue::Float(a + b)),
+                    ast::BinOp::Sub => return Ok(ConstValue::Float(a - b)),
+                    ast::BinOp::Mul => return Ok(ConstValue::Float(a * b)),
+                    ast::BinOp::Div => return Ok(ConstValue::Float(a / b)),
+                    ast::BinOp::Lt => return Ok(ConstValue::Bool(a < b)),
+                    ast::BinOp::Lte => return Ok(ConstValue::Bool(a <= b)),
+                    ast::BinOp::Eq => return Ok(ConstValue::Bool(a == b)),
+                    ast::BinOp::Gt => return Ok(ConstValue::Bool(a > b)),
+                    ast::BinOp::Gte => return Ok(ConstValue::Bool(a >= b)),
                     _ => (),
                 };
             }
             _ => (),
         }
 
-        Ok(None)
+        Err(EvalOutcome::not_const(binary))
     }
 }
 
@@ -133,19 +124,17 @@ fn op_assign(
     this: &mut ConstCompiler<'_>,
     binary: &ast::ExprBinary,
     used: Used,
-) -> Result<Option<ConstValue>, crate::CompileError> {
+) -> Result<ConstValue, EvalOutcome> {
     match binary.op {
         ast::BinOp::Assign => match &*binary.lhs {
             ast::Expr::Path(path) => {
                 if let Some(name) = path.try_as_ident() {
                     let name = this.resolve(name)?;
 
-                    let value = this
-                        .eval(&*binary.rhs, used)?
-                        .ok_or_else(|| CompileError::not_const(&*binary.rhs))?;
+                    let value = this.eval(&*binary.rhs, used)?;
 
                     this.scopes.replace(name.as_ref(), value, binary.span())?;
-                    return Ok(Some(ConstValue::Unit));
+                    return Ok(ConstValue::Unit);
                 }
             }
             _ => (),
@@ -153,5 +142,5 @@ fn op_assign(
         _ => (),
     }
 
-    Ok(None)
+    Err(EvalOutcome::not_const(binary))
 }

--- a/crates/rune/src/eval/expr_block.rs
+++ b/crates/rune/src/eval/expr_block.rs
@@ -1,11 +1,7 @@
 use crate::eval::prelude::*;
 
 impl Eval<&ast::ExprBlock> for ConstCompiler<'_> {
-    fn eval(
-        &mut self,
-        expr_block: &ast::ExprBlock,
-        used: Used,
-    ) -> Result<Option<ConstValue>, crate::CompileError> {
+    fn eval(&mut self, expr_block: &ast::ExprBlock, used: Used) -> Result<ConstValue, EvalOutcome> {
         self.eval(&expr_block.block, used)
     }
 }

--- a/crates/rune/src/eval/expr_break.rs
+++ b/crates/rune/src/eval/expr_break.rs
@@ -1,0 +1,22 @@
+use crate::eval::prelude::*;
+
+impl Eval<&ast::ExprBreak> for ConstCompiler<'_> {
+    fn eval(&mut self, expr_break: &ast::ExprBreak, used: Used) -> Result<ConstValue, EvalOutcome> {
+        let span = expr_break.span();
+        self.budget.take(span)?;
+
+        match &expr_break.expr {
+            Some(expr_break_value) => match expr_break_value {
+                ast::ExprBreakValue::Label(label) => {
+                    let label = self.resolve(label)?;
+                    Err(EvalOutcome::Break(span, EvalBreak::Label(label.into())))
+                }
+                ast::ExprBreakValue::Expr(expr) => {
+                    let value = self.eval(&**expr, used)?;
+                    Err(EvalOutcome::Break(span, EvalBreak::Value(value)))
+                }
+            },
+            None => Err(EvalOutcome::Break(span, EvalBreak::Empty)),
+        }
+    }
+}

--- a/crates/rune/src/eval/expr_if.rs
+++ b/crates/rune/src/eval/expr_if.rs
@@ -1,11 +1,8 @@
 use crate::eval::prelude::*;
 
 impl Eval<&ast::ExprIf> for ConstCompiler<'_> {
-    fn eval(
-        &mut self,
-        expr_if: &ast::ExprIf,
-        used: Used,
-    ) -> Result<Option<ConstValue>, crate::CompileError> {
+    fn eval(&mut self, expr_if: &ast::ExprIf, used: Used) -> Result<ConstValue, EvalOutcome> {
+        self.budget.take(expr_if)?;
         let value = expr_if.condition.as_bool(self, used)?;
 
         if value {
@@ -24,6 +21,6 @@ impl Eval<&ast::ExprIf> for ConstCompiler<'_> {
             return self.eval(&*expr_else.block, used);
         }
 
-        Ok(None)
+        Ok(ConstValue::Unit)
     }
 }

--- a/crates/rune/src/eval/expr_let.rs
+++ b/crates/rune/src/eval/expr_let.rs
@@ -1,25 +1,19 @@
 use crate::eval::prelude::*;
 
 impl Eval<&ast::ExprLet> for ConstCompiler<'_> {
-    fn eval(
-        &mut self,
-        expr_let: &ast::ExprLet,
-        used: Used,
-    ) -> Result<Option<ConstValue>, crate::CompileError> {
+    fn eval(&mut self, expr_let: &ast::ExprLet, used: Used) -> Result<ConstValue, EvalOutcome> {
         match &expr_let.pat {
             ast::Pat::PatPath(path) => {
                 if let Some(ident) = path.path.try_as_ident() {
                     let name = self.resolve(ident)?;
-                    let value = self
-                        .eval(&*expr_let.expr, used)?
-                        .ok_or_else(|| CompileError::not_const(&*expr_let.expr))?;
+                    let value = self.eval(&*expr_let.expr, used)?;
                     self.scopes.decl(name.as_ref(), value, ident.span())?;
-                    return Ok(Some(ConstValue::Unit));
+                    return Ok(ConstValue::Unit);
                 }
             }
             _ => (),
         }
 
-        Ok(None)
+        Err(EvalOutcome::not_const(expr_let))
     }
 }

--- a/crates/rune/src/eval/expr_lit.rs
+++ b/crates/rune/src/eval/expr_lit.rs
@@ -1,35 +1,37 @@
 use crate::eval::prelude::*;
 
 impl Eval<&ast::ExprLit> for ConstCompiler<'_> {
-    fn eval(
-        &mut self,
-        expr_lit: &ast::ExprLit,
-        used: Used,
-    ) -> Result<Option<ConstValue>, crate::CompileError> {
+    fn eval(&mut self, expr_lit: &ast::ExprLit, used: Used) -> Result<ConstValue, EvalOutcome> {
         self.budget.take(expr_lit)?;
 
         match &expr_lit.lit {
             ast::Lit::Bool(b) => {
-                return Ok(Some(ConstValue::Bool(b.value)));
+                return Ok(ConstValue::Bool(b.value));
             }
             ast::Lit::Number(n) => {
                 let n = n.resolve(&self.query.storage, self.source)?;
 
-                return Ok(Some(match n {
+                return Ok(match n {
                     ast::Number::Integer(n) => ConstValue::Integer(n),
                     ast::Number::Float(n) => ConstValue::Float(n),
-                }));
+                });
             }
             ast::Lit::Template(lit_template) => {
                 return self.eval(lit_template, used);
             }
             ast::Lit::Str(s) => {
                 let s = s.resolve(&self.query.storage, self.source)?;
-                return Ok(Some(ConstValue::String(s.into())));
+                return Ok(ConstValue::String(s.into()));
+            }
+            ast::Lit::Tuple(lit_tuple) => {
+                return self.eval(lit_tuple, used);
+            }
+            ast::Lit::Vec(lit_vec) => {
+                return self.eval(lit_vec, used);
             }
             _ => (),
         }
 
-        Ok(None)
+        Err(EvalOutcome::not_const(expr_lit))
     }
 }

--- a/crates/rune/src/eval/expr_loop.rs
+++ b/crates/rune/src/eval/expr_loop.rs
@@ -1,0 +1,38 @@
+use crate::eval::prelude::*;
+
+impl Eval<&ast::ExprLoop> for ConstCompiler<'_> {
+    fn eval(&mut self, expr_loop: &ast::ExprLoop, used: Used) -> Result<ConstValue, EvalOutcome> {
+        let span = expr_loop.span();
+        self.budget.take(span)?;
+
+        let loop_label = match &expr_loop.label {
+            Some((label, _)) => Some(<Box<str>>::from(self.resolve(label)?)),
+            None => None,
+        };
+
+        loop {
+            match self.eval(&*expr_loop.body, used) {
+                Ok(_) => (),
+                Err(outcome) => {
+                    // Handle potential outcomes which apply to this loop.
+                    match outcome {
+                        EvalOutcome::Break(_, EvalBreak::Empty) => break,
+                        EvalOutcome::Break(span, EvalBreak::Label(label)) => {
+                            if let Some(loop_label) = &loop_label {
+                                if label == *loop_label {
+                                    break;
+                                }
+                            }
+
+                            return Err(EvalOutcome::Break(span, EvalBreak::Label(label)));
+                        }
+                        EvalOutcome::Break(_, EvalBreak::Value(value)) => return Ok(value),
+                        outcome => return Err(outcome),
+                    }
+                }
+            }
+        }
+
+        Ok(ConstValue::Unit)
+    }
+}

--- a/crates/rune/src/eval/expr_while.rs
+++ b/crates/rune/src/eval/expr_while.rs
@@ -1,22 +1,35 @@
 use crate::eval::prelude::*;
 
 impl Eval<&ast::ExprWhile> for ConstCompiler<'_> {
-    fn eval(
-        &mut self,
-        expr_while: &ast::ExprWhile,
-        used: Used,
-    ) -> Result<Option<ConstValue>, crate::CompileError> {
+    fn eval(&mut self, expr_while: &ast::ExprWhile, used: Used) -> Result<ConstValue, EvalOutcome> {
         let span = expr_while.span();
+        self.budget.take(span)?;
+
+        let loop_label = match &expr_while.label {
+            Some((label, _)) => Some(<Box<str>>::from(self.resolve(label)?)),
+            None => None,
+        };
 
         while expr_while.condition.as_bool(self, used)? {
-            // NB: use up one budget on each loop, in case the condition is
-            // constant folded.
-            self.budget.take(span)?;
+            match self.eval(&*expr_while.body, used) {
+                Ok(_) => (),
+                Err(outcome) => {
+                    // Handle potential outcomes which apply to this loop.
+                    match &outcome {
+                        EvalOutcome::Break(_, EvalBreak::Empty) => break,
+                        EvalOutcome::Break(_, EvalBreak::Label(label))
+                            if Some(label) == loop_label.as_ref() =>
+                        {
+                            break
+                        }
+                        _ => (),
+                    }
 
-            self.eval(&*expr_while.body, used)?
-                .ok_or_else(|| CompileError::not_const(&*expr_while.body))?;
+                    return Err(outcome);
+                }
+            }
         }
 
-        Ok(Some(ConstValue::Unit))
+        Ok(ConstValue::Unit)
     }
 }

--- a/crates/rune/src/eval/lit_tuple.rs
+++ b/crates/rune/src/eval/lit_tuple.rs
@@ -1,0 +1,14 @@
+use crate::eval::prelude::*;
+
+impl Eval<&ast::LitTuple> for ConstCompiler<'_> {
+    fn eval(&mut self, lit_tuple: &ast::LitTuple, used: Used) -> Result<ConstValue, EvalOutcome> {
+        self.budget.take(lit_tuple)?;
+        let mut tuple = Vec::new();
+
+        for (expr, _) in &lit_tuple.items {
+            tuple.push(self.eval(expr, used)?);
+        }
+
+        Ok(ConstValue::Tuple(tuple.into_boxed_slice()))
+    }
+}

--- a/crates/rune/src/eval/lit_vec.rs
+++ b/crates/rune/src/eval/lit_vec.rs
@@ -1,0 +1,15 @@
+use crate::eval::prelude::*;
+
+impl Eval<&ast::LitVec> for ConstCompiler<'_> {
+    fn eval(&mut self, lit_vec: &ast::LitVec, used: Used) -> Result<ConstValue, EvalOutcome> {
+        self.budget.take(lit_vec)?;
+
+        let mut tuple = Vec::new();
+
+        for (expr, _) in &lit_vec.items {
+            tuple.push(self.eval(expr, used)?);
+        }
+
+        Ok(ConstValue::Tuple(tuple.into_boxed_slice()))
+    }
+}

--- a/crates/rune/src/eval/mod.rs
+++ b/crates/rune/src/eval/mod.rs
@@ -1,17 +1,21 @@
 use crate::const_compiler::ConstCompiler;
-use crate::{CompileError, Spanned};
-use runestick::ConstValue;
+use crate::{CompileError, ParseError, Spanned};
+use runestick::{ConstValue, Span};
 
 mod block;
 mod condition;
 mod expr;
 mod expr_binary;
 mod expr_block;
+mod expr_break;
 mod expr_if;
 mod expr_let;
 mod expr_lit;
+mod expr_loop;
 mod expr_while;
 mod lit_template;
+mod lit_tuple;
+mod lit_vec;
 mod prelude;
 
 /// Indication whether a value is being evaluated because it's being used or not.
@@ -32,12 +36,12 @@ impl Used {
 
 pub(crate) trait Eval<T> {
     /// Evaluate the given type.
-    fn eval(&mut self, value: T, used: Used) -> Result<Option<ConstValue>, CompileError>;
+    fn eval(&mut self, value: T, used: Used) -> Result<ConstValue, EvalOutcome>;
 }
 
 pub(crate) trait ConstAs {
     /// Process constant value as a boolean.
-    fn as_bool(self, compiler: &mut ConstCompiler<'_>, used: Used) -> Result<bool, CompileError>;
+    fn as_bool(self, compiler: &mut ConstCompiler<'_>, used: Used) -> Result<bool, EvalOutcome>;
 }
 
 impl<T> ConstAs for T
@@ -45,13 +49,55 @@ where
     for<'a> ConstCompiler<'a>: Eval<T>,
     T: Spanned,
 {
-    fn as_bool(self, compiler: &mut ConstCompiler<'_>, used: Used) -> Result<bool, CompileError> {
+    fn as_bool(self, compiler: &mut ConstCompiler<'_>, used: Used) -> Result<bool, EvalOutcome> {
         let span = self.span();
 
-        compiler
+        let value = compiler
             .eval(self, used)?
-            .ok_or_else(|| CompileError::not_const(span))?
             .into_bool()
-            .map_err(|actual| CompileError::const_expected::<_, bool>(span, actual))
+            .map_err(|actual| CompileError::const_expected::<_, bool>(span, actual))?;
+
+        Ok(value)
     }
+}
+
+pub(crate) enum EvalOutcome {
+    /// Encountered ast that is not a constant expression.
+    NotConst(Span),
+    /// A compile error.
+    Error(CompileError),
+    /// Break until the next loop, or the optional label.
+    Break(Span, EvalBreak),
+}
+
+impl EvalOutcome {
+    /// Encountered ast that is not a constant expression.
+    pub(crate) fn not_const<S>(spanned: S) -> Self
+    where
+        S: Spanned,
+    {
+        Self::NotConst(spanned.span())
+    }
+}
+
+impl From<CompileError> for EvalOutcome {
+    fn from(error: CompileError) -> Self {
+        Self::Error(error)
+    }
+}
+
+impl From<ParseError> for EvalOutcome {
+    fn from(error: ParseError) -> Self {
+        Self::Error(error.into())
+    }
+}
+
+/// The value of a break.
+pub(crate) enum EvalBreak {
+    /// The break was empty, and will apply to the next loop.
+    Empty,
+    /// The break had a value.
+    Value(ConstValue),
+    /// The break had a label.
+    Label(Box<str>),
 }

--- a/crates/rune/src/eval/prelude.rs
+++ b/crates/rune/src/eval/prelude.rs
@@ -2,7 +2,7 @@
 
 pub(crate) use crate::ast;
 pub(crate) use crate::const_compiler::ConstCompiler;
-pub(crate) use crate::eval::{ConstAs, Eval, Used};
+pub(crate) use crate::eval::{ConstAs, Eval, EvalBreak, EvalOutcome, Used};
 pub(crate) use crate::traits::Resolve as _;
 pub(crate) use crate::CompileError;
 pub(crate) use crate::Spanned;

--- a/crates/rune/src/index.rs
+++ b/crates/rune/src/index.rs
@@ -1116,7 +1116,7 @@ impl Index<ast::LitVec> for Indexer<'_> {
         let span = lit_vec.span();
         log::trace!("LitVec => {:?}", self.source.source(span));
 
-        for expr in &lit_vec.items {
+        for (expr, _) in &lit_vec.items {
             self.index(expr)?;
         }
 

--- a/crates/rune/src/query.rs
+++ b/crates/rune/src/query.rs
@@ -454,7 +454,7 @@ impl Query {
             }
             Indexed::Const(c) => {
                 let mut const_compiler = ConstCompiler {
-                    budget: ConstBudget::new(1_000),
+                    budget: ConstBudget::new(1_000_000),
                     scopes: Default::default(),
                     item: item.clone(),
                     source: &*source,

--- a/crates/runestick/src/const_value.rs
+++ b/crates/runestick/src/const_value.rs
@@ -13,6 +13,8 @@ pub enum ConstValue {
     Integer(i64),
     /// An float constant.
     Float(f64),
+    /// An anonymous tuple.
+    Tuple(Box<[ConstValue]>),
 }
 
 impl ConstValue {
@@ -32,6 +34,7 @@ impl ConstValue {
             Self::String(..) => TypeInfo::StaticType(crate::STRING_TYPE),
             Self::Integer(..) => TypeInfo::StaticType(crate::INTEGER_TYPE),
             Self::Float(..) => TypeInfo::StaticType(crate::FLOAT_TYPE),
+            Self::Tuple(..) => TypeInfo::StaticType(crate::TUPLE_TYPE),
         }
     }
 }


### PR DESCRIPTION
Also bump the const eval budget to 1000000.

Also adds support for the following literals:
* Vectors `[1, a, true]`.
* Tuples `(1, a, true)`.