### PR TITLE
Parse both attributes and visibility externally from Item

### DIFF
--- a/crates/rune/src/ast/item_const.rs
+++ b/crates/rune/src/ast/item_const.rs
@@ -1,5 +1,5 @@
 use crate::ast;
-use crate::{Parse, Spanned, ToTokens};
+use crate::{Parse, ParseError, Parser, Spanned, ToTokens};
 
 /// A const declaration.
 ///
@@ -13,8 +13,11 @@ use crate::{Parse, Spanned, ToTokens};
 #[derive(Debug, Clone, Parse, ToTokens, Spanned)]
 pub struct ItemConst {
     /// The *inner* attributes that are applied to the const declaration.
-    #[rune(iter, attributes)]
+    #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,
+    /// The visibility of the const.
+    #[rune(optional)]
+    pub visibility: ast::Visibility,
     /// The `const` keyword.
     pub const_token: ast::Const,
     /// The name of the constant.
@@ -25,4 +28,23 @@ pub struct ItemConst {
     pub expr: Box<ast::Expr>,
     /// Terminating semicolon.
     pub semi: ast::SemiColon,
+}
+
+impl ItemConst {
+    /// Parse a `const` item with the given attributes
+    pub fn parse_with_meta(
+        parser: &mut Parser<'_>,
+        attributes: Vec<ast::Attribute>,
+        visibility: ast::Visibility,
+    ) -> Result<Self, ParseError> {
+        Ok(Self {
+            attributes,
+            visibility,
+            const_token: parser.parse()?,
+            name: parser.parse()?,
+            eq: parser.parse()?,
+            expr: parser.parse()?,
+            semi: parser.parse()?,
+        })
+    }
 }

--- a/crates/rune/src/ast/item_enum.rs
+++ b/crates/rune/src/ast/item_enum.rs
@@ -24,11 +24,11 @@ pub struct ItemEnum {
 
 impl ItemEnum {
     /// Parse a `enum` item with the given attributes
-    pub fn parse_with_attributes(
+    pub fn parse_with_meta(
         parser: &mut Parser<'_>,
         attributes: Vec<ast::Attribute>,
+        visibility: ast::Visibility,
     ) -> Result<Self, ParseError> {
-        let visibility = parser.parse()?;
         let enum_ = parser.parse()?;
         let name = parser.parse()?;
         let open = parser.parse()?;
@@ -80,7 +80,8 @@ impl ItemEnum {
 impl Parse for ItemEnum {
     fn parse(parser: &mut Parser<'_>) -> Result<Self, ParseError> {
         let attributes = parser.parse()?;
-        Self::parse_with_attributes(parser, attributes)
+        let visibility = parser.parse()?;
+        Self::parse_with_meta(parser, attributes, visibility)
     }
 }
 

--- a/crates/rune/src/ast/item_fn.rs
+++ b/crates/rune/src/ast/item_fn.rs
@@ -40,13 +40,14 @@ impl ItemFn {
     }
 
     /// Parse a `fn` item with the given attributes
-    pub fn parse_with_attributes(
+    pub fn parse_with_meta(
         parser: &mut Parser<'_>,
         attributes: Vec<ast::Attribute>,
+        visibility: ast::Visibility,
     ) -> Result<Self, ParseError> {
         Ok(Self {
             attributes,
-            visibility: parser.parse()?,
+            visibility,
             async_: parser.parse()?,
             fn_: parser.parse()?,
             name: parser.parse()?,
@@ -93,6 +94,7 @@ impl Peek for ItemFn {
 impl Parse for ItemFn {
     fn parse(parser: &mut Parser<'_>) -> Result<Self, ParseError> {
         let attributes = parser.parse()?;
-        Self::parse_with_attributes(parser, attributes)
+        let visibility = parser.parse()?;
+        Self::parse_with_meta(parser, attributes, visibility)
     }
 }

--- a/crates/rune/src/ast/item_impl.rs
+++ b/crates/rune/src/ast/item_impl.rs
@@ -20,7 +20,7 @@ pub struct ItemImpl {
 }
 
 impl ItemImpl {
-    /// Parse an `impl` item with the given attributes
+    /// Parse an `impl` item with the given attributes.
     pub fn parse_with_attributes(
         parser: &mut Parser<'_>,
         attributes: Vec<ast::Attribute>,
@@ -32,8 +32,7 @@ impl ItemImpl {
         let mut functions = vec![];
 
         while !parser.peek::<ast::CloseBrace>()? {
-            let attributes = parser.parse()?;
-            functions.push(ast::ItemFn::parse_with_attributes(parser, attributes)?);
+            functions.push(ast::ItemFn::parse(parser)?);
         }
 
         let close = parser.parse()?;

--- a/crates/rune/src/ast/item_mod.rs
+++ b/crates/rune/src/ast/item_mod.rs
@@ -20,13 +20,14 @@ pub struct ItemMod {
 
 impl ItemMod {
     /// Parse a `mod` item with the given attributes
-    pub fn parse_with_attributes(
+    pub fn parse_with_meta(
         parser: &mut Parser<'_>,
         attributes: Vec<ast::Attribute>,
+        visibility: ast::Visibility,
     ) -> Result<Self, ParseError> {
         Ok(Self {
             attributes,
-            visibility: parser.parse()?,
+            visibility,
             mod_: parser.parse()?,
             name: parser.parse()?,
             body: parser.parse()?,
@@ -59,7 +60,8 @@ impl ItemMod {
 impl Parse for ItemMod {
     fn parse(parser: &mut Parser) -> Result<Self, ParseError> {
         let attributes = parser.parse()?;
-        Self::parse_with_attributes(parser, attributes)
+        let visibility = parser.parse()?;
+        Self::parse_with_meta(parser, attributes, visibility)
     }
 }
 

--- a/crates/rune/src/ast/item_struct.rs
+++ b/crates/rune/src/ast/item_struct.rs
@@ -20,13 +20,14 @@ pub struct ItemStruct {
 
 impl ItemStruct {
     /// Parse a `struct` item with the given attributes
-    pub fn parse_with_attributes(
+    pub fn parse_with_meta(
         parser: &mut Parser,
         attributes: Vec<ast::Attribute>,
+        visibility: ast::Visibility,
     ) -> Result<Self, ParseError> {
         Ok(Self {
             attributes,
-            visibility: parser.parse()?,
+            visibility,
             struct_: parser.parse()?,
             ident: parser.parse()?,
             body: parser.parse()?,
@@ -50,7 +51,8 @@ impl ItemStruct {
 impl Parse for ItemStruct {
     fn parse(parser: &mut Parser<'_>) -> Result<Self, ParseError> {
         let attributes = parser.parse()?;
-        Self::parse_with_attributes(parser, attributes)
+        let visibility = parser.parse()?;
+        Self::parse_with_meta(parser, attributes, visibility)
     }
 }
 

--- a/crates/rune/src/ast/item_use.rs
+++ b/crates/rune/src/ast/item_use.rs
@@ -25,14 +25,15 @@ pub struct ItemUse {
 
 impl ItemUse {
     /// Parse a `use` item with the given attributes
-    pub fn parse_with_attributes(
+    pub fn parse_with_meta(
         parser: &mut Parser,
         attributes: Vec<ast::Attribute>,
+        visibility: ast::Visibility,
     ) -> Result<Self, ParseError> {
         Ok(Self {
             attributes,
+            visibility,
             leading_colon: parser.parse()?,
-            visibility: parser.parse()?,
             use_: parser.parse()?,
             first: parser.parse()?,
             rest: parser.parse()?,
@@ -57,7 +58,8 @@ impl ItemUse {
 impl Parse for ItemUse {
     fn parse(parser: &mut Parser) -> Result<Self, ParseError> {
         let attributes = parser.parse()?;
-        Self::parse_with_attributes(parser, attributes)
+        let visibility = parser.parse()?;
+        Self::parse_with_meta(parser, attributes, visibility)
     }
 }
 

--- a/crates/rune/src/ast/vis.rs
+++ b/crates/rune/src/ast/vis.rs
@@ -20,6 +20,12 @@ impl Visibility {
     }
 }
 
+impl Default for Visibility {
+    fn default() -> Self {
+        Self::Inherited
+    }
+}
+
 /// Parsing Visibility specifiers
 ///
 /// # Examples
@@ -56,7 +62,10 @@ impl Visibility {
 /// ```
 impl Parse for Visibility {
     fn parse(parser: &mut Parser<'_>) -> Result<Self, ParseError> {
-        let token = parser.token_peek_eof()?;
+        let token = match parser.token_peek()? {
+            Some(token) => token,
+            None => return Ok(Self::Inherited),
+        };
 
         if token.kind == ast::Kind::Pub {
             let pub_ = parser.parse()?;

--- a/crates/rune/src/parse_error.rs
+++ b/crates/rune/src/parse_error.rs
@@ -79,6 +79,15 @@ pub enum ParseErrorKind {
         /// The actual token kind.
         actual: ast::Kind,
     },
+    /// The given item does not support an attribute, like `#[foo]`.
+    #[error("item does not support attributes")]
+    UnsupportedItemAttributes,
+    /// The given item does not support a visibility modifier, like `pub`.
+    #[error("item does not support visibility")]
+    UnsupportedItemVisibility,
+    /// When we try to use a visibility modifer for an expression.
+    #[error("visibility modifier is not supported for expressions")]
+    UnsupportedExprVisibility,
     /// Error encountered when we see a string escape sequence without a
     /// character being escaped.
     #[error("expected escape")]

--- a/crates/rune/src/traits.rs
+++ b/crates/rune/src/traits.rs
@@ -164,3 +164,24 @@ where
         OptionSpanned::option_span(&**self)
     }
 }
+
+/// Take the span of a vector of spanned.
+/// Provides the span between the first and the last element.
+impl<T> OptionSpanned for Vec<T>
+where
+    T: Spanned,
+{
+    fn option_span(&self) -> Option<Span> {
+        let first = if let Some(first) = self.first() {
+            first.span()
+        } else {
+            return self.last().map(Spanned::span);
+        };
+
+        if let Some(last) = self.last() {
+            Some(first.join(last.span()))
+        } else {
+            Some(first)
+        }
+    }
+}


### PR DESCRIPTION
Follow up from [comment](https://github.com/rune-rs/rune/pull/92#discussion_r492443440).

Apart from parsing both attributes and visibility externally, the only other change was permitting visibility to be parsed at eof. `Visibility::Inherited` is treated as "empty".

I also added an implementation for `OptionSpanned` to `Vec<T> where T: Spanned`, which allows for relatively compact presence checking. 

Finally `ConstItem` also has visibility now.

CC: @dillonhicks