### PR TITLE
Add complete support for constant dynamic collections

### DIFF
--- a/crates/rune/src/eval/ir.rs
+++ b/crates/rune/src/eval/ir.rs
@@ -18,6 +18,7 @@ impl Eval<&Ir> for IrInterpreter<'_> {
             IrKind::Break(ir_break) => self.eval(ir_break, used),
             IrKind::Vec(ir_vec) => self.eval(ir_vec, used),
             IrKind::Tuple(ir_tuple) => self.eval(ir_tuple, used),
+            IrKind::Object(ir_object) => self.eval(ir_object, used),
         }
     }
 }

--- a/crates/rune/src/eval/ir_object.rs
+++ b/crates/rune/src/eval/ir_object.rs
@@ -1,0 +1,18 @@
+use crate::eval::prelude::*;
+
+impl Eval<&IrObject> for IrInterpreter<'_> {
+    fn eval(&mut self, ir_object: &IrObject, used: Used) -> Result<ConstValue, EvalOutcome> {
+        let mut keys = Vec::new();
+        let mut values = Vec::new();
+
+        for (key, value) in ir_object.assignments.iter() {
+            keys.push(key.clone());
+            values.push(self.eval(value, used)?);
+        }
+
+        Ok(ConstValue::Object(ConstObject {
+            keys: keys.into_boxed_slice(),
+            values: values.into_boxed_slice(),
+        }))
+    }
+}

--- a/crates/rune/src/eval/mod.rs
+++ b/crates/rune/src/eval/mod.rs
@@ -8,6 +8,7 @@ mod ir_branches;
 mod ir_break;
 mod ir_decl;
 mod ir_loop;
+mod ir_object;
 mod ir_scope;
 mod ir_set;
 mod ir_template;

--- a/crates/rune/src/eval/prelude.rs
+++ b/crates/rune/src/eval/prelude.rs
@@ -5,5 +5,5 @@ pub(crate) use crate::ir::*;
 pub(crate) use crate::ir_interpreter::IrInterpreter;
 pub(crate) use crate::CompileError;
 pub(crate) use crate::Spanned;
-pub(crate) use runestick::{ConstValue, Span};
+pub(crate) use runestick::{ConstObject, ConstValue, Span};
 pub(crate) use std::convert::TryFrom;

--- a/crates/rune/src/ir.rs
+++ b/crates/rune/src/ir.rs
@@ -39,12 +39,13 @@ pub struct Ir {
 
 impl Ir {
     /// Construct a new intermediate instruction.
-    pub fn new<K>(span: Span, kind: K) -> Self
+    pub fn new<S, K>(spanned: S, kind: K) -> Self
     where
+        S: Spanned,
         IrKind: From<K>,
     {
         Self {
-            span,
+            span: spanned.span(),
             kind: IrKind::from(kind),
         }
     }
@@ -79,6 +80,8 @@ decl_kind! {
         Vec(IrVec),
         /// Constructing a tuple.
         Tuple(IrTuple),
+        /// Constructing an object.
+        Object(IrObject),
     }
 }
 
@@ -203,6 +206,16 @@ pub struct IrTuple {
     pub span: Span,
     /// Arguments to construct the tuple.
     pub items: Box<[Ir]>,
+}
+
+/// Object expression.
+#[derive(Debug, Clone, Spanned)]
+pub struct IrObject {
+    /// Span of the object.
+    #[rune(span)]
+    pub span: Span,
+    /// Field initializations.
+    pub assignments: Box<[(Box<str>, Ir)]>,
 }
 
 /// Vector expression.

--- a/crates/rune/src/tests/vm_const_exprs.rs
+++ b/crates/rune/src/tests/vm_const_exprs.rs
@@ -88,3 +88,27 @@ fn test_float_ops() {
     test_float_op!(bool => 1 >= 1 = true);
     test_float_op!(bool => 0 >= 2 = false);
 }
+
+#[test]
+fn test_const_collections() {
+    let object = rune!(runestick::Object => "fn main() { VALUE } const VALUE = #{};");
+    assert!(object.is_empty());
+
+    let tuple = rune!(runestick::Tuple => "fn main() { VALUE } const VALUE = ();");
+    assert!(tuple.is_empty());
+
+    let tuple = rune!(runestick::Tuple => r#"fn main() { VALUE } const VALUE = ("Hello World",);"#);
+    assert_eq!(
+        Some("Hello World"),
+        tuple.get_value::<String>(0).unwrap().as_deref()
+    );
+
+    let vec = rune!(runestick::Vec => "fn main() { VALUE } const VALUE = [];");
+    assert!(vec.is_empty());
+
+    let vec = rune!(runestick::Vec => r#"fn main() { VALUE } const VALUE = ["Hello World"];"#);
+    assert_eq!(
+        Some("Hello World"),
+        vec.get_value::<String>(0).unwrap().as_deref()
+    );
+}

--- a/crates/rune/src/unit_builder.rs
+++ b/crates/rune/src/unit_builder.rs
@@ -473,11 +473,19 @@ impl UnitBuilder {
 
     /// Insert a new collection of static object keys, or return one already
     /// existing.
-    pub(crate) fn new_static_object_keys(
+    pub(crate) fn new_static_object_keys<I>(
         &mut self,
-        current: &[String],
-    ) -> Result<usize, UnitBuilderError> {
-        let current = current.to_vec().into_boxed_slice();
+        current: I,
+    ) -> Result<usize, UnitBuilderError>
+    where
+        I: IntoIterator,
+        I::Item: AsRef<str>,
+    {
+        let current = current
+            .into_iter()
+            .map(|s| s.as_ref().to_owned())
+            .collect::<Box<_>>();
+
         let hash = Hash::object_keys(&current[..]);
 
         if let Some(existing_slot) = self.static_object_keys_rev.get(&hash).copied() {

--- a/crates/runestick/src/const_value.rs
+++ b/crates/runestick/src/const_value.rs
@@ -5,10 +5,16 @@ use crate::TypeInfo;
 pub enum ConstValue {
     /// A constant unit.
     Unit,
+    /// A byte.
+    Byte(u8),
+    /// A character.
+    Char(char),
     /// A boolean constant value.
     Bool(bool),
     /// A string constant designated by its slot.
     String(Box<str>),
+    /// A byte string.
+    Bytes(Box<[u8]>),
     /// An integer constant.
     Integer(i64),
     /// An float constant.
@@ -17,6 +23,8 @@ pub enum ConstValue {
     Vec(Box<[ConstValue]>),
     /// An anonymous tuple.
     Tuple(Box<[ConstValue]>),
+    /// An anonymous object.
+    Object(ConstObject),
 }
 
 impl ConstValue {
@@ -32,12 +40,25 @@ impl ConstValue {
     pub fn type_info(&self) -> TypeInfo {
         match self {
             Self::Unit => TypeInfo::StaticType(crate::UNIT_TYPE),
+            Self::Byte(..) => TypeInfo::StaticType(crate::BYTE_TYPE),
+            Self::Char(..) => TypeInfo::StaticType(crate::CHAR_TYPE),
             Self::Bool(..) => TypeInfo::StaticType(crate::BOOL_TYPE),
             Self::String(..) => TypeInfo::StaticType(crate::STRING_TYPE),
+            Self::Bytes(..) => TypeInfo::StaticType(crate::BYTES_TYPE),
             Self::Integer(..) => TypeInfo::StaticType(crate::INTEGER_TYPE),
             Self::Float(..) => TypeInfo::StaticType(crate::FLOAT_TYPE),
             Self::Vec(..) => TypeInfo::StaticType(crate::VEC_TYPE),
             Self::Tuple(..) => TypeInfo::StaticType(crate::TUPLE_TYPE),
+            Self::Object(..) => TypeInfo::StaticType(crate::OBJECT_TYPE),
         }
     }
+}
+
+/// A constant object.
+#[derive(Debug, Clone)]
+pub struct ConstObject {
+    /// Keys.
+    pub keys: Box<[Box<str>]>,
+    /// Values.
+    pub values: Box<[ConstValue]>,
 }

--- a/crates/runestick/src/lib.rs
+++ b/crates/runestick/src/lib.rs
@@ -96,6 +96,7 @@ mod type_;
 mod type_info;
 mod type_of;
 mod unit;
+mod vec;
 mod vec_tuple;
 mod vm_call;
 mod vm_error;
@@ -117,7 +118,7 @@ pub use self::compile_meta::{
     CompileMeta, CompileMetaCapture, CompileMetaKind, CompileMetaStruct, CompileMetaTuple,
     CompileSource,
 };
-pub use self::const_value::ConstValue;
+pub use self::const_value::{ConstObject, ConstValue};
 pub use self::from_value::{FromValue, UnsafeFromValue};
 pub use self::generator::Generator;
 pub use self::generator_state::GeneratorState;
@@ -140,6 +141,7 @@ pub use self::to_value::{ToValue, UnsafeToValue};
 pub use self::tuple::Tuple;
 pub use self::type_::Type;
 pub use self::type_info::TypeInfo;
+pub use self::vec::Vec;
 pub use crate::access::{
     AccessError, BorrowMut, BorrowRef, NotAccessibleMut, NotAccessibleRef, RawExclusiveGuard,
     RawSharedGuard,

--- a/crates/runestick/src/modules/vec.rs
+++ b/crates/runestick/src/modules/vec.rs
@@ -1,22 +1,22 @@
 //! The `std::vec` module.
 
-use crate::{ContextError, Module, Value};
+use crate::{ContextError, Module, Value, Vec};
 use std::iter::Rev;
 
 /// Construct the `std::vec` module.
 pub fn module() -> Result<Module, ContextError> {
     let mut module = Module::new(&["std", "vec"]);
 
-    module.ty::<Vec<Value>>()?;
+    module.ty::<Vec>()?;
     module.ty::<Iter>()?;
     module.ty::<Rev<Iter>>()?;
 
-    module.function(&["Vec", "new"], Vec::<Value>::new)?;
+    module.function(&["Vec", "new"], Vec::new)?;
     module.inst_fn("iter", vec_iter)?;
-    module.inst_fn("len", Vec::<Value>::len)?;
-    module.inst_fn("push", Vec::<Value>::push)?;
-    module.inst_fn("clear", Vec::<Value>::clear)?;
-    module.inst_fn("pop", Vec::<Value>::pop)?;
+    module.inst_fn("len", Vec::len)?;
+    module.inst_fn("push", Vec::push)?;
+    module.inst_fn("clear", Vec::clear)?;
+    module.inst_fn("pop", Vec::pop)?;
 
     module.inst_fn(crate::INTO_ITER, vec_iter)?;
     module.inst_fn("next", Iter::next)?;

--- a/crates/runestick/src/named.rs
+++ b/crates/runestick/src/named.rs
@@ -1,4 +1,4 @@
-use crate::{RawStr, Value};
+use crate::RawStr;
 
 /// Something that is named.
 pub trait Named {
@@ -8,10 +8,6 @@ pub trait Named {
 
 impl Named for String {
     const NAME: RawStr = RawStr::from_str("String");
-}
-
-impl Named for Vec<Value> {
-    const NAME: RawStr = RawStr::from_str("Vec");
 }
 
 impl Named for i64 {

--- a/crates/runestick/src/serde.rs
+++ b/crates/runestick/src/serde.rs
@@ -1,6 +1,7 @@
-use crate::{Bytes, Object, Shared, Value};
+use crate::{Bytes, Object, Shared, Value, Vec};
 use serde::{de, ser};
 use std::fmt;
+use std::vec;
 
 /// Deserialize implementation for value pointers.
 impl<'de> de::Deserialize<'de> for Value {
@@ -123,7 +124,7 @@ impl<'de> de::Visitor<'de> for VmVisitor {
     }
 
     #[inline]
-    fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
+    fn visit_byte_buf<E>(self, v: vec::Vec<u8>) -> Result<Self::Value, E>
     where
         E: de::Error,
     {
@@ -239,13 +240,17 @@ impl<'de> de::Visitor<'de> for VmVisitor {
     where
         V: de::SeqAccess<'de>,
     {
-        let mut vec = Vec::new();
+        let mut vec = if let Some(hint) = visitor.size_hint() {
+            vec::Vec::with_capacity(hint)
+        } else {
+            vec::Vec::new()
+        };
 
         while let Some(elem) = visitor.next_element()? {
             vec.push(elem);
         }
 
-        Ok(Value::Vec(Shared::new(vec)))
+        Ok(Value::Vec(Shared::new(Vec::from(vec))))
     }
 
     #[inline]

--- a/crates/runestick/src/static_type.rs
+++ b/crates/runestick/src/static_type.rs
@@ -2,6 +2,7 @@ use crate::Hash;
 use crate::RawStr;
 use std::cmp;
 use std::hash;
+use std::vec;
 
 /// Static type information.
 #[derive(Debug)]
@@ -108,7 +109,8 @@ pub static VEC_TYPE: &StaticType = &StaticType {
     hash: Hash::new(0x6c129752545b4223),
 };
 
-impl_static_type!(impl<T> Vec<T> => VEC_TYPE);
+impl_static_type!(crate::Vec => VEC_TYPE);
+impl_static_type!(impl<T> vec::Vec<T> => VEC_TYPE);
 impl_static_type!([crate::Value] => VEC_TYPE);
 impl_static_type!(impl<T> crate::VecTuple<T> => VEC_TYPE);
 

--- a/crates/runestick/src/to_value.rs
+++ b/crates/runestick/src/to_value.rs
@@ -111,23 +111,6 @@ where
     }
 }
 
-// Vec impls
-
-impl<T> ToValue for Vec<T>
-where
-    T: ToValue,
-{
-    fn to_value(self) -> Result<Value, VmError> {
-        let mut vec = Vec::with_capacity(self.len());
-
-        for value in self {
-            vec.push(value.to_value()?);
-        }
-
-        Ok(Value::from(Shared::new(vec)))
-    }
-}
-
 // number impls
 
 macro_rules! number_value_trait {

--- a/crates/runestick/src/unit.rs
+++ b/crates/runestick/src/unit.rs
@@ -87,12 +87,12 @@ impl Unit {
     }
 
     /// Iterate over all static object keys in the unit.
-    pub fn iter_static_object_keys(&self) -> impl Iterator<Item = (Hash, &[String])> + '_ {
-        let mut it = self.static_object_keys.iter();
+    pub fn iter_static_object_keys(&self) -> impl Iterator<Item = (usize, &[String])> + '_ {
+        let mut it = self.static_object_keys.iter().enumerate();
 
         std::iter::from_fn(move || {
-            let s = it.next()?;
-            Some((Hash::object_keys(&s[..]), &s[..]))
+            let (n, s) = it.next()?;
+            Some((n, &s[..]))
         })
     }
 

--- a/crates/runestick/src/value.rs
+++ b/crates/runestick/src/value.rs
@@ -1,11 +1,12 @@
 use crate::access::AccessKind;
 use crate::{
     Any, AnyObj, Bytes, Function, Future, Generator, GeneratorState, Hash, Item, Mut, Object,
-    RawMut, RawRef, Ref, Shared, StaticString, Stream, Tuple, Type, TypeInfo, VmError,
+    RawMut, RawRef, Ref, Shared, StaticString, Stream, Tuple, Type, TypeInfo, Vec, VmError,
 };
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::sync::Arc;
+use std::vec;
 
 /// A tuple with a well-defined type.
 pub struct TypedTuple {
@@ -199,7 +200,7 @@ pub enum Value {
     /// A byte string.
     Bytes(Shared<Bytes>),
     /// A vector containing any values.
-    Vec(Shared<Vec<Value>>),
+    Vec(Shared<Vec>),
     /// A tuple.
     Tuple(Shared<Tuple>),
     /// An object.
@@ -232,17 +233,17 @@ pub enum Value {
 
 impl Value {
     /// Construct a vector.
-    pub fn vec(vec: Vec<Value>) -> Self {
-        Self::Vec(Shared::new(vec))
+    pub fn vec(vec: vec::Vec<Value>) -> Self {
+        Self::Vec(Shared::new(Vec::from(vec)))
     }
 
     /// Construct a tuple.
-    pub fn tuple(vec: Vec<Value>) -> Self {
+    pub fn tuple(vec: vec::Vec<Value>) -> Self {
         Self::Tuple(Shared::new(Tuple::from(vec)))
     }
 
     /// Construct a typed tuple.
-    pub fn typed_tuple(rtti: Arc<Rtti>, vec: Vec<Value>) -> Self {
+    pub fn typed_tuple(rtti: Arc<Rtti>, vec: vec::Vec<Value>) -> Self {
         Self::TypedTuple(Shared::new(TypedTuple {
             rtti,
             tuple: Tuple::from(vec),
@@ -250,7 +251,7 @@ impl Value {
     }
 
     /// Construct a typed tuple.
-    pub fn variant_tuple(rtti: Arc<VariantRtti>, vec: Vec<Value>) -> Self {
+    pub fn variant_tuple(rtti: Arc<VariantRtti>, vec: vec::Vec<Value>) -> Self {
         Self::TupleVariant(Shared::new(TupleVariant {
             rtti,
             tuple: Tuple::from(vec),
@@ -396,10 +397,10 @@ impl Value {
 
     /// Try to coerce value into a vector.
     #[inline]
-    pub fn into_vec(self) -> Result<Shared<Vec<Value>>, VmError> {
+    pub fn into_vec(self) -> Result<Shared<Vec>, VmError> {
         match self {
             Self::Vec(vec) => Ok(vec),
-            actual => Err(VmError::expected::<Vec<Value>>(actual.type_info()?)),
+            actual => Err(VmError::expected::<Vec>(actual.type_info()?)),
         }
     }
 
@@ -780,7 +781,7 @@ macro_rules! impl_from_shared {
 
 impl_from_shared!(Shared<Bytes>, Bytes);
 impl_from_shared!(Shared<String>, String);
-impl_from!(Shared<Vec<Value>>, Vec);
+impl_from_shared!(Shared<Vec>, Vec);
 impl_from_shared!(Shared<Tuple>, Tuple);
 impl_from_shared!(Shared<Object>, Object);
 impl_from_shared!(Shared<Future>, Future);

--- a/crates/runestick/src/vec.rs
+++ b/crates/runestick/src/vec.rs
@@ -1,0 +1,276 @@
+use crate::{
+    FromValue, Mut, Named, RawMut, RawRef, RawStr, Ref, Shared, ToValue, UnsafeFromValue, Value,
+    VmError,
+};
+use std::fmt;
+use std::ops;
+use std::slice;
+use std::vec;
+
+/// Struct representing a dynamic vector.
+///
+/// # Examples
+///
+/// ```rust
+/// # fn main() -> runestick::Result<()> {
+/// let mut vec = runestick::Vec::new();
+/// assert!(vec.is_empty());
+///
+/// vec.push_value(42)?;
+/// vec.push_value(true)?;
+/// assert_eq!(2, vec.len());
+///
+/// assert_eq!(Some(42), vec.get_value(0)?);
+/// assert_eq!(Some(true), vec.get_value(1)?);
+/// assert_eq!(None::<bool>, vec.get_value(2)?);
+/// # Ok(()) }
+/// ```
+#[derive(Clone)]
+#[repr(transparent)]
+pub struct Vec {
+    inner: vec::Vec<Value>,
+}
+
+impl Vec {
+    /// Construct a new empty dynamic vector.
+    pub const fn new() -> Self {
+        Self {
+            inner: vec::Vec::new(),
+        }
+    }
+
+    /// Construct a new dynamic vector guaranteed to have at least the given
+    /// capacity.
+    pub fn with_capacity(cap: usize) -> Self {
+        Self {
+            inner: vec::Vec::with_capacity(cap),
+        }
+    }
+
+    /// Convert into inner std vector.
+    pub fn into_inner(self) -> vec::Vec<Value> {
+        self.inner
+    }
+
+    /// Returns `true` if the dynamic vector contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Returns the number of elements in the dynamic vector, also referred to
+    /// as its 'length'.
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Appends an element to the back of a dynamic vector.
+    pub fn push(&mut self, value: Value) {
+        self.inner.push(value);
+    }
+
+    /// Appends an element to the back of a dynamic vector, converting it as
+    /// necessary through the [`ToValue`] trait.
+    pub fn push_value<T>(&mut self, value: T) -> Result<(), VmError>
+    where
+        T: ToValue,
+    {
+        self.inner.push(value.to_value()?);
+        Ok(())
+    }
+
+    /// Get the value at the given index.
+    pub fn get(&self, index: usize) -> Option<&Value> {
+        self.inner.get(index)
+    }
+
+    /// Get the given value at the given index.
+    pub fn get_value<T>(&self, index: usize) -> Result<Option<T>, VmError>
+    where
+        T: FromValue,
+    {
+        let value = match self.inner.get(index) {
+            Some(value) => value.clone(),
+            None => return Ok(None),
+        };
+
+        Ok(Some(T::from_value(value)?))
+    }
+
+    /// Get the mutable value at the given index.
+    pub fn get_mut(&mut self, index: usize) -> Option<&mut Value> {
+        self.inner.get_mut(index)
+    }
+
+    /// Removes the last element from a dynamic vector and returns it, or
+    /// [`None`] if it is empty.
+    pub fn pop(&mut self) -> Option<Value> {
+        self.inner.pop()
+    }
+
+    /// Clears the vector, removing all values.
+    ///
+    /// Note that this method has no effect on the allocated capacity of the
+    /// vector.
+    pub fn clear(&mut self) {
+        self.inner.clear();
+    }
+}
+
+impl Named for Vec {
+    const NAME: RawStr = RawStr::from_str("Vec");
+}
+
+impl fmt::Debug for Vec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list().entries(&*self.inner).finish()
+    }
+}
+
+impl ops::Deref for Vec {
+    type Target = [Value];
+
+    fn deref(&self) -> &Self::Target {
+        &*self.inner
+    }
+}
+
+impl ops::DerefMut for Vec {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut *self.inner
+    }
+}
+
+impl IntoIterator for Vec {
+    type Item = Value;
+    type IntoIter = std::vec::IntoIter<Value>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a Vec {
+    type Item = &'a Value;
+    type IntoIter = slice::Iter<'a, Value>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut Vec {
+    type Item = &'a mut Value;
+    type IntoIter = slice::IterMut<'a, Value>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner.iter_mut()
+    }
+}
+
+impl From<vec::Vec<Value>> for Vec {
+    fn from(inner: vec::Vec<Value>) -> Self {
+        Self { inner }
+    }
+}
+
+impl From<Box<[Value]>> for Vec {
+    fn from(inner: Box<[Value]>) -> Self {
+        Self {
+            inner: inner.to_vec(),
+        }
+    }
+}
+
+impl FromValue for Mut<Vec> {
+    fn from_value(value: Value) -> Result<Self, VmError> {
+        Ok(value.into_vec()?.into_mut()?)
+    }
+}
+
+impl FromValue for Ref<Vec> {
+    fn from_value(value: Value) -> Result<Self, VmError> {
+        Ok(value.into_vec()?.into_ref()?)
+    }
+}
+
+impl FromValue for Vec {
+    fn from_value(value: Value) -> Result<Self, VmError> {
+        Ok(value.into_vec()?.take()?)
+    }
+}
+
+impl<T> FromValue for vec::Vec<T>
+where
+    T: FromValue,
+{
+    fn from_value(value: Value) -> Result<Self, VmError> {
+        let vec = value.into_vec()?;
+        let vec = vec.take()?;
+
+        let mut output = vec::Vec::with_capacity(vec.len());
+
+        for value in vec {
+            output.push(T::from_value(value)?);
+        }
+
+        Ok(output)
+    }
+}
+
+impl<'a> UnsafeFromValue for &'a [Value] {
+    type Output = *const [Value];
+    type Guard = RawRef;
+
+    unsafe fn unsafe_from_value(value: Value) -> Result<(Self::Output, Self::Guard), VmError> {
+        let vec = value.into_vec()?;
+        let (vec, guard) = Ref::into_raw(vec.into_ref()?);
+        Ok((&**vec, guard))
+    }
+
+    unsafe fn to_arg(output: Self::Output) -> Self {
+        &*output
+    }
+}
+
+impl<'a> UnsafeFromValue for &'a Vec {
+    type Output = *const Vec;
+    type Guard = RawRef;
+
+    unsafe fn unsafe_from_value(value: Value) -> Result<(Self::Output, Self::Guard), VmError> {
+        let vec = value.into_vec()?;
+        Ok(Ref::into_raw(vec.into_ref()?))
+    }
+
+    unsafe fn to_arg(output: Self::Output) -> Self {
+        &*output
+    }
+}
+
+impl<'a> UnsafeFromValue for &'a mut Vec {
+    type Output = *mut Vec;
+    type Guard = RawMut;
+
+    unsafe fn unsafe_from_value(value: Value) -> Result<(Self::Output, Self::Guard), VmError> {
+        let vec = value.into_vec()?;
+        Ok(Mut::into_raw(vec.into_mut()?))
+    }
+
+    unsafe fn to_arg(output: Self::Output) -> Self {
+        &mut *output
+    }
+}
+
+impl<T> ToValue for vec::Vec<T>
+where
+    T: ToValue,
+{
+    fn to_value(self) -> Result<Value, VmError> {
+        let mut vec = vec::Vec::with_capacity(self.len());
+
+        for value in self {
+            vec.push(value.to_value()?);
+        }
+
+        Ok(Value::from(Shared::new(Vec::from(vec))))
+    }
+}


### PR DESCRIPTION
This adds supports for anonymous objects and tuples, like these:
```rust
const OBJECT = #{a: 42};
const TUPLE = (1, 2, 3);
```

I've also introduced `runestick::Vec`, which is a type-erased variant of a dynamic vector, essentially equivalent to `Vec<Value>`, but performs no conversion of its inner values and is capable of holding some associated methods useful for decoding inner values, like `push_value` and `get_value`:

```rust
let mut vec = runestick::Vec::new();

vec.push_value(42)?;
vec.push_value(true)?;

assert_eq!(Some(42), vec.get_value::<i64>(0)?);
assert_eq!(Some(true), vec.get_value::<bool>(1)?);
assert_eq!(None, vec.get_value::<bool>(2)?);
```