### PR TITLE
Refcounting in the IR interpreter used for constant evaluation

### DIFF
--- a/crates/rune/src/compile/const_value.rs
+++ b/crates/rune/src/compile/const_value.rs
@@ -48,14 +48,14 @@ impl Compile<(&ConstValue, Span)> for Compiler<'_> {
                 let mut entries = object.iter().collect::<Vec<_>>();
                 entries.sort_by_key(|k| k.0);
 
+                for (_, value) in &entries {
+                    self.compile((*value, span))?;
+                }
+
                 let slot = self
                     .unit
                     .borrow_mut()
                     .new_static_object_keys(entries.iter().map(|e| e.0))?;
-
-                for (_, value) in entries {
-                    self.compile((value, span))?;
-                }
 
                 self.asm.push(Inst::Object { slot }, span);
             }

--- a/crates/rune/src/compile_error.rs
+++ b/crates/rune/src/compile_error.rs
@@ -1,7 +1,8 @@
 use crate::ast;
+use crate::ir_value::IrValue;
 use crate::unit_builder::UnitBuilderError;
 use crate::{ParseError, ParseErrorKind, Spanned};
-use runestick::{AccessError, CompileMeta, ConstValue, Item, SourceId, Span, TypeInfo, TypeOf};
+use runestick::{AccessError, CompileMeta, Item, SourceId, Span, TypeInfo, TypeOf};
 use std::error;
 use std::fmt;
 use std::io;
@@ -75,7 +76,7 @@ impl CompileError {
     }
 
     /// An error raised when we expect a certain constant value but get another.
-    pub fn const_expected<S, E>(spanned: S, actual: &ConstValue) -> Self
+    pub fn const_expected<S, E>(spanned: S, actual: &IrValue) -> Self
     where
         S: Spanned,
         E: TypeOf,

--- a/crates/rune/src/eval/ir.rs
+++ b/crates/rune/src/eval/ir.rs
@@ -2,7 +2,7 @@ use crate::eval::prelude::*;
 
 /// Eval the interior expression.
 impl Eval<&Ir> for IrInterpreter<'_> {
-    fn eval(&mut self, ir: &Ir, used: Used) -> Result<ConstValue, EvalOutcome> {
+    fn eval(&mut self, ir: &Ir, used: Used) -> Result<IrValue, EvalOutcome> {
         self.budget.take(ir)?;
 
         match &ir.kind {
@@ -12,8 +12,8 @@ impl Eval<&Ir> for IrInterpreter<'_> {
             IrKind::Set(ir_set) => self.eval(ir_set, used),
             IrKind::Template(ir_template) => self.eval(ir_template, used),
             IrKind::Name(name) => Ok(self.resolve_var(name.as_ref(), ir.span(), used)?),
-            IrKind::Target(ir_target) => Ok(self.scopes.get_target_mut(ir_target)?.clone()),
-            IrKind::Value(const_value) => Ok(const_value.clone()),
+            IrKind::Target(ir_target) => Ok(self.scopes.get_target(ir_target)?),
+            IrKind::Value(const_value) => Ok(IrValue::from_const(const_value.clone())),
             IrKind::Branches(branches) => self.eval(branches, used),
             IrKind::Loop(ir_loop) => self.eval(ir_loop, used),
             IrKind::Break(ir_break) => self.eval(ir_break, used),

--- a/crates/rune/src/eval/ir_binary.rs
+++ b/crates/rune/src/eval/ir_binary.rs
@@ -1,7 +1,7 @@
 use crate::eval::prelude::*;
 
 impl Eval<&IrBinary> for IrInterpreter<'_> {
-    fn eval(&mut self, ir_binary: &IrBinary, used: Used) -> Result<ConstValue, EvalOutcome> {
+    fn eval(&mut self, ir_binary: &IrBinary, used: Used) -> Result<IrValue, EvalOutcome> {
         let span = ir_binary.span();
         self.budget.take(span)?;
 
@@ -9,7 +9,7 @@ impl Eval<&IrBinary> for IrInterpreter<'_> {
         let b = self.eval(&*ir_binary.rhs, used)?;
 
         match (a, b) {
-            (ConstValue::Integer(a), ConstValue::Integer(b)) => match ir_binary.op {
+            (IrValue::Integer(a), IrValue::Integer(b)) => match ir_binary.op {
                 IrBinaryOp::Add => {
                     return Ok(checked_int(
                         a,
@@ -58,7 +58,7 @@ impl Eval<&IrBinary> for IrInterpreter<'_> {
                         .checked_shl(b)
                         .ok_or_else(|| CompileError::const_error(span, "integer shift overflow"))?;
 
-                    return Ok(ConstValue::Integer(n));
+                    return Ok(IrValue::Integer(n));
                 }
                 IrBinaryOp::Shr => {
                     let b = u32::try_from(b).map_err(|_| {
@@ -72,25 +72,25 @@ impl Eval<&IrBinary> for IrInterpreter<'_> {
                         CompileError::const_error(span, "integer shift underflow")
                     })?;
 
-                    return Ok(ConstValue::Integer(n));
+                    return Ok(IrValue::Integer(n));
                 }
-                IrBinaryOp::Lt => return Ok(ConstValue::Bool(a < b)),
-                IrBinaryOp::Lte => return Ok(ConstValue::Bool(a <= b)),
-                IrBinaryOp::Eq => return Ok(ConstValue::Bool(a == b)),
-                IrBinaryOp::Gt => return Ok(ConstValue::Bool(a > b)),
-                IrBinaryOp::Gte => return Ok(ConstValue::Bool(a >= b)),
+                IrBinaryOp::Lt => return Ok(IrValue::Bool(a < b)),
+                IrBinaryOp::Lte => return Ok(IrValue::Bool(a <= b)),
+                IrBinaryOp::Eq => return Ok(IrValue::Bool(a == b)),
+                IrBinaryOp::Gt => return Ok(IrValue::Bool(a > b)),
+                IrBinaryOp::Gte => return Ok(IrValue::Bool(a >= b)),
             },
-            (ConstValue::Float(a), ConstValue::Float(b)) => {
+            (IrValue::Float(a), IrValue::Float(b)) => {
                 match ir_binary.op {
-                    IrBinaryOp::Add => return Ok(ConstValue::Float(a + b)),
-                    IrBinaryOp::Sub => return Ok(ConstValue::Float(a - b)),
-                    IrBinaryOp::Mul => return Ok(ConstValue::Float(a * b)),
-                    IrBinaryOp::Div => return Ok(ConstValue::Float(a / b)),
-                    IrBinaryOp::Lt => return Ok(ConstValue::Bool(a < b)),
-                    IrBinaryOp::Lte => return Ok(ConstValue::Bool(a <= b)),
-                    IrBinaryOp::Eq => return Ok(ConstValue::Bool(a == b)),
-                    IrBinaryOp::Gt => return Ok(ConstValue::Bool(a > b)),
-                    IrBinaryOp::Gte => return Ok(ConstValue::Bool(a >= b)),
+                    IrBinaryOp::Add => return Ok(IrValue::Float(a + b)),
+                    IrBinaryOp::Sub => return Ok(IrValue::Float(a - b)),
+                    IrBinaryOp::Mul => return Ok(IrValue::Float(a * b)),
+                    IrBinaryOp::Div => return Ok(IrValue::Float(a / b)),
+                    IrBinaryOp::Lt => return Ok(IrValue::Bool(a < b)),
+                    IrBinaryOp::Lte => return Ok(IrValue::Bool(a <= b)),
+                    IrBinaryOp::Eq => return Ok(IrValue::Bool(a == b)),
+                    IrBinaryOp::Gt => return Ok(IrValue::Bool(a > b)),
+                    IrBinaryOp::Gte => return Ok(IrValue::Bool(a >= b)),
                     _ => (),
                 };
             }
@@ -107,7 +107,7 @@ fn checked_int(
     op: impl FnOnce(i64, i64) -> Option<i64>,
     msg: &'static str,
     span: Span,
-) -> Result<ConstValue, CompileError> {
+) -> Result<IrValue, CompileError> {
     let n = op(a, b).ok_or_else(|| CompileError::const_error(span, msg))?;
-    Ok(ConstValue::Integer(n))
+    Ok(IrValue::Integer(n))
 }

--- a/crates/rune/src/eval/ir_branches.rs
+++ b/crates/rune/src/eval/ir_branches.rs
@@ -1,7 +1,7 @@
 use crate::eval::prelude::*;
 
 impl Eval<&IrBranches> for IrInterpreter<'_> {
-    fn eval(&mut self, ir_branches: &IrBranches, used: Used) -> Result<ConstValue, EvalOutcome> {
+    fn eval(&mut self, ir_branches: &IrBranches, used: Used) -> Result<IrValue, EvalOutcome> {
         for (ir, branch) in &ir_branches.branches {
             if ir.as_bool(self, used)? {
                 return self.eval(branch, used);
@@ -12,6 +12,6 @@ impl Eval<&IrBranches> for IrInterpreter<'_> {
             return self.eval(branch, used);
         }
 
-        Ok(ConstValue::Unit)
+        Ok(IrValue::Unit)
     }
 }

--- a/crates/rune/src/eval/ir_break.rs
+++ b/crates/rune/src/eval/ir_break.rs
@@ -1,7 +1,7 @@
 use crate::eval::prelude::*;
 
 impl Eval<&IrBreak> for IrInterpreter<'_> {
-    fn eval(&mut self, ir_break: &IrBreak, used: Used) -> Result<ConstValue, EvalOutcome> {
+    fn eval(&mut self, ir_break: &IrBreak, used: Used) -> Result<IrValue, EvalOutcome> {
         let span = ir_break.span();
         self.budget.take(span)?;
 

--- a/crates/rune/src/eval/ir_decl.rs
+++ b/crates/rune/src/eval/ir_decl.rs
@@ -1,10 +1,10 @@
 use crate::eval::prelude::*;
 
 impl Eval<&IrDecl> for IrInterpreter<'_> {
-    fn eval(&mut self, im_decl: &IrDecl, used: Used) -> Result<ConstValue, EvalOutcome> {
+    fn eval(&mut self, im_decl: &IrDecl, used: Used) -> Result<IrValue, EvalOutcome> {
         self.budget.take(im_decl)?;
         let value = self.eval(&*im_decl.value, used)?;
         self.scopes.decl(&im_decl.name, value, im_decl)?;
-        Ok(ConstValue::Unit)
+        Ok(IrValue::Unit)
     }
 }

--- a/crates/rune/src/eval/ir_loop.rs
+++ b/crates/rune/src/eval/ir_loop.rs
@@ -1,7 +1,7 @@
 use crate::eval::prelude::*;
 
 impl Eval<&IrLoop> for IrInterpreter<'_> {
-    fn eval(&mut self, ir_loop: &IrLoop, used: Used) -> Result<ConstValue, EvalOutcome> {
+    fn eval(&mut self, ir_loop: &IrLoop, used: Used) -> Result<IrValue, EvalOutcome> {
         let span = ir_loop.span();
         self.budget.take(span)?;
 
@@ -40,6 +40,6 @@ impl Eval<&IrLoop> for IrInterpreter<'_> {
             };
         }
 
-        Ok(ConstValue::Unit)
+        Ok(IrValue::Unit)
     }
 }

--- a/crates/rune/src/eval/ir_object.rs
+++ b/crates/rune/src/eval/ir_object.rs
@@ -2,13 +2,13 @@ use crate::collections::HashMap;
 use crate::eval::prelude::*;
 
 impl Eval<&IrObject> for IrInterpreter<'_> {
-    fn eval(&mut self, ir_object: &IrObject, used: Used) -> Result<ConstValue, EvalOutcome> {
+    fn eval(&mut self, ir_object: &IrObject, used: Used) -> Result<IrValue, EvalOutcome> {
         let mut object = HashMap::with_capacity(ir_object.assignments.len());
 
         for (key, value) in ir_object.assignments.iter() {
             object.insert(key.as_ref().to_owned(), self.eval(value, used)?);
         }
 
-        Ok(ConstValue::Object(object))
+        Ok(IrValue::Object(Shared::new(object)))
     }
 }

--- a/crates/rune/src/eval/ir_scope.rs
+++ b/crates/rune/src/eval/ir_scope.rs
@@ -1,7 +1,7 @@
 use crate::eval::prelude::*;
 
 impl Eval<&IrScope> for IrInterpreter<'_> {
-    fn eval(&mut self, ir_scope: &IrScope, used: Used) -> Result<ConstValue, EvalOutcome> {
+    fn eval(&mut self, ir_scope: &IrScope, used: Used) -> Result<IrValue, EvalOutcome> {
         self.budget.take(ir_scope)?;
         let guard = self.scopes.push();
 
@@ -12,7 +12,7 @@ impl Eval<&IrScope> for IrInterpreter<'_> {
         let value = if let Some(last) = &ir_scope.last {
             self.eval(&**last, used)?
         } else {
-            ConstValue::Unit
+            IrValue::Unit
         };
 
         self.scopes.pop(ir_scope, guard)?;

--- a/crates/rune/src/eval/ir_set.rs
+++ b/crates/rune/src/eval/ir_set.rs
@@ -1,10 +1,10 @@
 use crate::eval::prelude::*;
 
 impl Eval<&IrSet> for IrInterpreter<'_> {
-    fn eval(&mut self, ir_set: &IrSet, used: Used) -> Result<ConstValue, EvalOutcome> {
+    fn eval(&mut self, ir_set: &IrSet, used: Used) -> Result<IrValue, EvalOutcome> {
         self.budget.take(ir_set)?;
         let value = self.eval(&*ir_set.value, used)?;
         self.scopes.set_target(&ir_set.target, value)?;
-        Ok(ConstValue::Unit)
+        Ok(IrValue::Unit)
     }
 }

--- a/crates/rune/src/eval/ir_tuple.rs
+++ b/crates/rune/src/eval/ir_tuple.rs
@@ -1,13 +1,13 @@
 use crate::eval::prelude::*;
 
 impl Eval<&IrTuple> for IrInterpreter<'_> {
-    fn eval(&mut self, ir_tuple: &IrTuple, used: Used) -> Result<ConstValue, EvalOutcome> {
+    fn eval(&mut self, ir_tuple: &IrTuple, used: Used) -> Result<IrValue, EvalOutcome> {
         let mut items = Vec::with_capacity(ir_tuple.items.len());
 
         for item in ir_tuple.items.iter() {
             items.push(self.eval(item, used)?);
         }
 
-        Ok(ConstValue::Tuple(items.into_boxed_slice()))
+        Ok(IrValue::Tuple(Shared::new(items.into_boxed_slice())))
     }
 }

--- a/crates/rune/src/eval/ir_vec.rs
+++ b/crates/rune/src/eval/ir_vec.rs
@@ -1,13 +1,13 @@
 use crate::eval::prelude::*;
 
 impl Eval<&IrVec> for IrInterpreter<'_> {
-    fn eval(&mut self, ir_vec: &IrVec, used: Used) -> Result<ConstValue, EvalOutcome> {
+    fn eval(&mut self, ir_vec: &IrVec, used: Used) -> Result<IrValue, EvalOutcome> {
         let mut vec = Vec::with_capacity(ir_vec.items.len());
 
         for item in ir_vec.items.iter() {
             vec.push(self.eval(item, used)?);
         }
 
-        Ok(ConstValue::Vec(vec))
+        Ok(IrValue::Vec(Shared::new(vec)))
     }
 }

--- a/crates/rune/src/eval/mod.rs
+++ b/crates/rune/src/eval/mod.rs
@@ -1,6 +1,7 @@
 use crate::ir_interpreter::IrInterpreter;
+use crate::ir_value::IrValue;
 use crate::{CompileError, ParseError, Spanned};
-use runestick::{ConstValue, Span};
+use runestick::Span;
 
 mod ir;
 mod ir_binary;
@@ -34,7 +35,7 @@ impl Used {
 
 pub(crate) trait Eval<T> {
     /// Evaluate the given type.
-    fn eval(&mut self, value: T, used: Used) -> Result<ConstValue, EvalOutcome>;
+    fn eval(&mut self, value: T, used: Used) -> Result<IrValue, EvalOutcome>;
 }
 
 pub(crate) trait ConstAs {
@@ -95,7 +96,7 @@ pub(crate) enum EvalBreak {
     /// Break the next nested loop.
     Inherent,
     /// The break had a value.
-    Value(ConstValue),
+    Value(IrValue),
     /// The break had a label.
     Label(Box<str>),
 }

--- a/crates/rune/src/eval/prelude.rs
+++ b/crates/rune/src/eval/prelude.rs
@@ -3,7 +3,8 @@
 pub(crate) use crate::eval::{ConstAs, Eval, EvalBreak, EvalOutcome, Used};
 pub(crate) use crate::ir::*;
 pub(crate) use crate::ir_interpreter::IrInterpreter;
+pub(crate) use crate::ir_value::IrValue;
 pub(crate) use crate::CompileError;
 pub(crate) use crate::Spanned;
-pub(crate) use runestick::{ConstValue, Span};
+pub(crate) use runestick::{Shared, Span};
 pub(crate) use std::convert::TryFrom;

--- a/crates/rune/src/ir_value.rs
+++ b/crates/rune/src/ir_value.rs
@@ -1,0 +1,152 @@
+use crate::collections::HashMap;
+use crate::{CompileError, Spanned};
+use runestick::{ConstValue, Shared, TypeInfo};
+
+/// A constant value.
+#[derive(Debug, Clone)]
+pub enum IrValue {
+    /// A constant unit.
+    Unit,
+    /// A byte.
+    Byte(u8),
+    /// A character.
+    Char(char),
+    /// A boolean constant value.
+    Bool(bool),
+    /// An integer constant.
+    Integer(i64),
+    /// An float constant.
+    Float(f64),
+    /// A string constant designated by its slot.
+    String(Shared<String>),
+    /// A byte string.
+    Bytes(Shared<Vec<u8>>),
+    /// A vector of values.
+    Vec(Shared<Vec<IrValue>>),
+    /// An anonymous tuple.
+    Tuple(Shared<Box<[IrValue]>>),
+    /// An anonymous object.
+    Object(Shared<HashMap<String, IrValue>>),
+}
+
+impl IrValue {
+    pub fn from_const(value: ConstValue) -> Self {
+        match value {
+            ConstValue::Unit => Self::Unit,
+            ConstValue::Byte(b) => Self::Byte(b),
+            ConstValue::Char(c) => Self::Char(c),
+            ConstValue::Bool(b) => Self::Bool(b),
+            ConstValue::Integer(n) => Self::Integer(n),
+            ConstValue::Float(n) => Self::Float(n),
+            ConstValue::String(s) => Self::String(Shared::new(s)),
+            ConstValue::Bytes(b) => Self::Bytes(Shared::new(b)),
+            ConstValue::Vec(vec) => {
+                let mut ir_vec = Vec::with_capacity(vec.len());
+
+                for value in vec {
+                    ir_vec.push(Self::from_const(value));
+                }
+
+                Self::Vec(Shared::new(ir_vec))
+            }
+            ConstValue::Tuple(tuple) => {
+                let mut ir_tuple = Vec::with_capacity(tuple.len());
+
+                for value in Vec::from(tuple) {
+                    ir_tuple.push(Self::from_const(value));
+                }
+
+                Self::Tuple(Shared::new(ir_tuple.into_boxed_slice()))
+            }
+            ConstValue::Object(object) => {
+                let mut ir_object = HashMap::with_capacity(object.len());
+
+                for (key, value) in object {
+                    ir_object.insert(key, Self::from_const(value));
+                }
+
+                Self::Object(Shared::new(ir_object))
+            }
+        }
+    }
+
+    /// Convert into constant value.
+    pub fn into_const<S>(self, spanned: S) -> Result<ConstValue, CompileError>
+    where
+        S: Copy + Spanned,
+    {
+        Ok(match self {
+            IrValue::Unit => ConstValue::Unit,
+            IrValue::Byte(b) => ConstValue::Byte(b),
+            IrValue::Char(c) => ConstValue::Char(c),
+            IrValue::Bool(b) => ConstValue::Bool(b),
+            IrValue::Integer(n) => ConstValue::Integer(n),
+            IrValue::Float(f) => ConstValue::Float(f),
+            IrValue::String(s) => {
+                let s = s.take().map_err(|e| CompileError::access(spanned, e))?;
+                ConstValue::String(s)
+            }
+            IrValue::Bytes(b) => {
+                let b = b.take().map_err(|e| CompileError::access(spanned, e))?;
+                ConstValue::Bytes(b)
+            }
+            IrValue::Vec(vec) => {
+                let vec = vec.take().map_err(|e| CompileError::access(spanned, e))?;
+                let mut const_vec = Vec::with_capacity(vec.len());
+
+                for value in vec {
+                    const_vec.push(value.into_const(spanned)?);
+                }
+
+                ConstValue::Vec(const_vec)
+            }
+            IrValue::Tuple(tuple) => {
+                let tuple = tuple.take().map_err(|e| CompileError::access(spanned, e))?;
+                let mut const_tuple = Vec::with_capacity(tuple.len());
+
+                for value in Vec::from(tuple) {
+                    const_tuple.push(value.into_const(spanned)?);
+                }
+
+                ConstValue::Tuple(const_tuple.into_boxed_slice())
+            }
+            IrValue::Object(object) => {
+                let object = object
+                    .take()
+                    .map_err(|e| CompileError::access(spanned, e))?;
+                let mut const_object = HashMap::with_capacity(object.len());
+
+                for (key, value) in object {
+                    const_object.insert(key, value.into_const(spanned)?);
+                }
+
+                ConstValue::Object(const_object)
+            }
+        })
+    }
+
+    /// Try to coerce into boolean.
+    pub fn into_bool(self) -> Result<bool, Self> {
+        match self {
+            Self::Bool(value) => Ok(value),
+            value => Err(value),
+        }
+    }
+
+    /// Get the type information of the value.
+    pub fn type_info(&self) -> TypeInfo {
+        match self {
+            Self::Unit => TypeInfo::StaticType(runestick::UNIT_TYPE),
+            Self::Byte(..) => TypeInfo::StaticType(runestick::BYTE_TYPE),
+            Self::Char(..) => TypeInfo::StaticType(runestick::CHAR_TYPE),
+            Self::Bool(..) => TypeInfo::StaticType(runestick::BOOL_TYPE),
+            Self::String(..) => TypeInfo::StaticType(runestick::STRING_TYPE),
+            Self::Bytes(..) => TypeInfo::StaticType(runestick::BYTES_TYPE),
+            Self::Integer(..) => TypeInfo::StaticType(runestick::INTEGER_TYPE),
+            Self::Float(..) => TypeInfo::StaticType(runestick::FLOAT_TYPE),
+            Self::Vec(..) => TypeInfo::StaticType(runestick::VEC_TYPE),
+            Self::Tuple(..) => TypeInfo::StaticType(runestick::TUPLE_TYPE),
+            Self::Object(..) => TypeInfo::StaticType(runestick::OBJECT_TYPE),
+        }
+    }
+}

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -187,6 +187,7 @@ mod index_scopes;
 mod ir;
 mod ir_compiler;
 mod ir_interpreter;
+mod ir_value;
 mod items;
 mod lexer;
 mod load;


### PR DESCRIPTION
This will unlock implementing more complex things, and eventually the whole language if we so wish. However, constant evaluations will still be limited to things which have no side effects.