### PR TITLE
Expand macros earlier so they include constants

### DIFF
--- a/crates/rune-modules/README.md
+++ b/crates/rune-modules/README.md
@@ -54,6 +54,7 @@ See each module for documentation:
 * [fs]
 * [process]
 * [signal]
+* [rand]
 
 ### Features
 
@@ -62,9 +63,10 @@ See each module for documentation:
 * `json` for the [json module][json]
 * `toml` for the [toml module][toml]
 * `time` for the [time module][time]
-* `fs` for the [fs module]][fs]
-* `process` for the [process module]][process]
-* `signal` for the [process module]][signal]
+* `fs` for the [fs module][fs]
+* `process` for the [process module][process]
+* `signal` for the [signal module][signal]
+* `rand` for the [rand module][rand]
 
 [http]: https://docs.rs/rune-modules/0/rune_modules/http/
 [json]: https://docs.rs/rune-modules/0/rune_modules/json/
@@ -73,3 +75,4 @@ See each module for documentation:
 [fs]: https://docs.rs/rune-modules/0/rune_modules/fs/
 [process]: https://docs.rs/rune-modules/0/rune_modules/process/
 [signal]: https://docs.rs/rune-modules/0/rune_modules/signal/
+[rand]: https://docs.rs/rune-modules/0/rune_modules/rand/

--- a/crates/rune/src/ast/expr_async.rs
+++ b/crates/rune/src/ast/expr_async.rs
@@ -10,15 +10,12 @@ use crate::{Parse, Spanned, ToTokens};
 ///
 /// let expr = testing::roundtrip::<ast::ExprAsync>("async {}");
 /// assert_eq!(expr.block.statements.len(), 0);
-/// assert!(expr.block.produces_nothing());
 ///
 /// let expr = testing::roundtrip::<ast::ExprAsync>("async { 42 }");
 /// assert_eq!(expr.block.statements.len(), 1);
-/// assert!(!expr.block.produces_nothing());
 ///
 /// let expr = testing::roundtrip::<ast::ExprAsync>("#[retry] async { 42 }");
 /// assert_eq!(expr.block.statements.len(), 1);
-/// assert!(!expr.block.produces_nothing());
 /// assert_eq!(expr.attributes.len(), 1);
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Parse, ToTokens, Spanned)]

--- a/crates/rune/src/ast/expr_binary.rs
+++ b/crates/rune/src/ast/expr_binary.rs
@@ -20,12 +20,6 @@ pub struct ExprBinary {
 }
 
 impl ExprBinary {
-    /// If the expression is empty.
-    pub fn produces_nothing(&self) -> bool {
-        // Assignments do not produce a value.
-        matches!(self.op, BinOp::Assign { .. })
-    }
-
     /// Get the span of the op.
     pub fn op_span(&self) -> Span {
         if let Some(t2) = self.t2 {

--- a/crates/rune/src/ast/expr_block.rs
+++ b/crates/rune/src/ast/expr_block.rs
@@ -10,10 +10,3 @@ pub struct ExprBlock {
     /// The close brace.
     pub block: ast::Block,
 }
-
-impl ExprBlock {
-    /// Test if the block expression doesn't produce a value.
-    pub fn produces_nothing(&self) -> bool {
-        self.block.produces_nothing()
-    }
-}

--- a/crates/rune/src/ast/expr_group.rs
+++ b/crates/rune/src/ast/expr_group.rs
@@ -11,10 +11,3 @@ pub struct ExprGroup {
     /// The close parenthesis.
     pub close: ast::CloseParen,
 }
-
-impl ExprGroup {
-    /// Check if expression is empty.
-    pub fn produces_nothing(&self) -> bool {
-        self.expr.produces_nothing()
-    }
-}

--- a/crates/rune/src/ast/expr_if.rs
+++ b/crates/rune/src/ast/expr_if.rs
@@ -34,11 +34,6 @@ pub struct ExprIf {
 }
 
 impl ExprIf {
-    /// An if statement evaluates to empty if it does not have an else branch.
-    pub fn produces_nothing(&self) -> bool {
-        self.expr_else.is_none()
-    }
-
     /// Parse an if statement attaching the given attributes
     pub fn parse_with_attributes(
         parser: &mut Parser,

--- a/crates/rune/src/ast/expr_is.rs
+++ b/crates/rune/src/ast/expr_is.rs
@@ -11,10 +11,3 @@ pub struct ExprIs {
     /// The right-hand side of a is operation.
     pub rhs: Box<ast::Expr>,
 }
-
-impl ExprIs {
-    /// If the expression is empty.
-    pub fn produces_nothing(&self) -> bool {
-        false
-    }
-}

--- a/crates/rune/src/ast/expr_is_not.rs
+++ b/crates/rune/src/ast/expr_is_not.rs
@@ -13,10 +13,3 @@ pub struct ExprIsNot {
     /// The right-hand side of a is operation.
     pub rhs: Box<ast::Expr>,
 }
-
-impl ExprIsNot {
-    /// If the expression is empty.
-    pub fn produces_nothing(&self) -> bool {
-        false
-    }
-}

--- a/crates/rune/src/ast/expr_match.rs
+++ b/crates/rune/src/ast/expr_match.rs
@@ -94,10 +94,3 @@ pub struct ExprMatchBranch {
     /// The body of the match.
     pub body: Box<ast::Expr>,
 }
-
-impl ExprMatchBranch {
-    /// Test if the branch produces nothing.
-    pub fn produces_nothing(&self) -> bool {
-        self.body.produces_nothing()
-    }
-}

--- a/crates/rune/src/ast/expr_unary.rs
+++ b/crates/rune/src/ast/expr_unary.rs
@@ -38,7 +38,7 @@ impl Parse for ExprUnary {
                 parser,
                 EagerBrace(true),
                 ExprChain(true),
-                vec![],
+                &mut vec![],
             )?),
         })
     }

--- a/crates/rune/src/ast/file.rs
+++ b/crates/rune/src/ast/file.rs
@@ -80,10 +80,11 @@ impl Parse for File {
 
         let mut item_attributes = parser.parse()?;
         let mut item_visibility = parser.parse()?;
+        let mut path = parser.parse::<Option<ast::Path>>()?;
 
-        while ast::Item::peek_as_stmt(parser)? {
+        while path.is_some() || ast::Item::peek_as_item(parser, path.as_ref())? {
             let item: ast::Item =
-                ast::Item::parse_with_meta(parser, item_attributes, item_visibility)?;
+                ast::Item::parse_with_meta(parser, item_attributes, item_visibility, path.take())?;
 
             let semi_colon = if item.needs_semi_colon() || parser.peek::<ast::SemiColon>()? {
                 Some(parser.parse::<ast::SemiColon>()?)
@@ -94,6 +95,7 @@ impl Parse for File {
             items.push((item, semi_colon));
             item_attributes = parser.parse()?;
             item_visibility = parser.parse()?;
+            path = parser.parse()?;
         }
 
         // meta without items. maybe use different error kind?

--- a/crates/rune/src/ast/grouped.rs
+++ b/crates/rune/src/ast/grouped.rs
@@ -34,6 +34,11 @@ macro_rules! grouped {
             pub fn iter(&self) -> std::slice::Iter<'_, (T, Option<S>)> {
                 self.$field.iter()
             }
+
+            /// Iterate mutably over elements.
+            pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, (T, Option<S>)> {
+                self.$field.iter_mut()
+            }
         }
 
         impl<'a, T, S> IntoIterator for &'a $name<T, S> {
@@ -42,6 +47,15 @@ macro_rules! grouped {
 
             fn into_iter(self) -> Self::IntoIter {
                 self.iter()
+            }
+        }
+
+        impl<'a, T, S> IntoIterator for &'a mut $name<T, S> {
+            type Item = &'a mut (T, Option<S>);
+            type IntoIter = std::slice::IterMut<'a, (T, Option<S>)>;
+
+            fn into_iter(self) -> Self::IntoIter {
+                self.iter_mut()
             }
         }
 

--- a/crates/rune/src/ast/item_const.rs
+++ b/crates/rune/src/ast/item_const.rs
@@ -8,7 +8,7 @@ use crate::{Parse, ParseError, Parser, Spanned, ToTokens};
 /// ```rust
 /// use rune::{testing, ast};
 ///
-/// testing::roundtrip::<ast::ItemConst>("const value = #{};");
+/// testing::roundtrip::<ast::ItemConst>("const value = #{}");
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Parse, ToTokens, Spanned)]
 pub struct ItemConst {
@@ -26,8 +26,6 @@ pub struct ItemConst {
     pub eq: ast::Eq,
     /// The optional body of the module declaration.
     pub expr: Box<ast::Expr>,
-    /// Terminating semicolon.
-    pub semi: ast::SemiColon,
 }
 
 impl ItemConst {
@@ -44,7 +42,6 @@ impl ItemConst {
             name: parser.parse()?,
             eq: parser.parse()?,
             expr: parser.parse()?,
-            semi: parser.parse()?,
         })
     }
 }

--- a/crates/rune/src/ast/item_use.rs
+++ b/crates/rune/src/ast/item_use.rs
@@ -18,9 +18,8 @@ pub struct ItemUse {
     /// First component in use.
     pub first: ast::PathSegment,
     /// The rest of the import.
+    #[rune(iter)]
     pub rest: Vec<(ast::Scope, ItemUseComponent)>,
-    /// Use items are always terminated by a semi-colon.
-    pub semi: ast::SemiColon,
 }
 
 impl ItemUse {
@@ -37,7 +36,6 @@ impl ItemUse {
             use_: parser.parse()?,
             first: parser.parse()?,
             rest: parser.parse()?,
-            semi: parser.parse()?,
         })
     }
 }
@@ -49,11 +47,11 @@ impl ItemUse {
 /// ```rust
 /// use rune::{testing, ast};
 ///
-/// testing::roundtrip::<ast::ItemUse>("use foo;");
-/// testing::roundtrip::<ast::ItemUse>("use foo::bar;");
-/// testing::roundtrip::<ast::ItemUse>("use foo::bar::baz;");
-/// testing::roundtrip::<ast::ItemUse>("#[macro_use] use foo::bar::baz;");
-/// testing::roundtrip::<ast::ItemUse>("#[macro_use] pub(crate) use foo::bar::baz;");
+/// testing::roundtrip::<ast::ItemUse>("use foo");
+/// testing::roundtrip::<ast::ItemUse>("use foo::bar");
+/// testing::roundtrip::<ast::ItemUse>("use foo::bar::baz");
+/// testing::roundtrip::<ast::ItemUse>("#[macro_use] use foo::bar::baz");
+/// testing::roundtrip::<ast::ItemUse>("#[macro_use] pub(crate) use foo::bar::baz");
 /// ```
 impl Parse for ItemUse {
     fn parse(parser: &mut Parser) -> Result<Self, ParseError> {

--- a/crates/rune/src/ast/path.rs
+++ b/crates/rune/src/ast/path.rs
@@ -30,6 +30,18 @@ impl Path {
         }
     }
 
+    /// Borrow as an identifier used for field access calls.
+    ///
+    /// This is only allowed if there are no other path components
+    /// and the PathSegment is not `Crate` or `Super`.
+    pub fn try_as_ident_mut(&mut self) -> Option<&mut ast::Ident> {
+        if self.rest.is_empty() && self.trailing.is_none() && self.leading_colon.is_none() {
+            self.first.try_as_ident_mut()
+        } else {
+            None
+        }
+    }
+
     /// Iterate over all components in path.
     pub fn into_components(&self) -> impl Iterator<Item = &'_ PathSegment> + '_ {
         let mut first = Some(&self.first);
@@ -69,6 +81,18 @@ impl PathSegment {
     /// This is only allowed if the PathSegment is `Ident(_)`
     /// and not `Crate` or `Super`.
     pub fn try_as_ident(&self) -> Option<&ast::Ident> {
+        if let PathSegment::Ident(ident) = self {
+            Some(ident)
+        } else {
+            None
+        }
+    }
+
+    /// Borrow as a mutable identifier.
+    ///
+    /// This is only allowed if the PathSegment is `Ident(_)`
+    /// and not `Crate` or `Super`.
+    pub fn try_as_ident_mut(&mut self) -> Option<&mut ast::Ident> {
         if let PathSegment::Ident(ident) = self {
             Some(ident)
         } else {

--- a/crates/rune/src/ast/stmt.rs
+++ b/crates/rune/src/ast/stmt.rs
@@ -1,13 +1,74 @@
 use crate::ast;
-use crate::{Spanned, ToTokens};
+use crate::{
+    OptionSpanned as _, Parse, ParseError, ParseErrorKind, Parser, Peek, Spanned, ToTokens,
+};
 
 /// A statement within a block.
 #[derive(Debug, Clone, PartialEq, Eq, ToTokens, Spanned)]
 pub enum Stmt {
     /// A declaration.
-    Item(ast::Item),
+    Item(ast::Item, #[rune(iter)] Option<ast::SemiColon>),
     /// An expression.
     Expr(ast::Expr),
     /// An expression followed by a semicolon.
     Semi(ast::Expr, ast::SemiColon),
+}
+
+impl Peek for Stmt {
+    fn peek(t1: Option<ast::Token>, t2: Option<ast::Token>) -> bool {
+        match peek!(t1).kind {
+            ast::Kind::Use => true,
+            ast::Kind::Enum => true,
+            ast::Kind::Struct => true,
+            ast::Kind::Impl => true,
+            ast::Kind::Async => matches!(peek!(t2).kind, ast::Kind::Fn),
+            ast::Kind::Fn => true,
+            ast::Kind::Mod => true,
+            ast::Kind::Const => true,
+            ast::Kind::Ident { .. } => true,
+            _ => ast::Expr::peek(t1, t2),
+        }
+    }
+}
+
+impl Parse for Stmt {
+    fn parse(parser: &mut Parser) -> Result<Self, ParseError> {
+        let mut attributes = parser.parse()?;
+        let visibility = parser.parse()?;
+        let path = parser.parse::<Option<ast::Path>>()?;
+
+        if ast::Item::peek_as_item(parser, path.as_ref())? {
+            let item: ast::Item = ast::Item::parse_with_meta(parser, attributes, visibility, path)?;
+
+            let semi = if item.needs_semi_colon() {
+                Some(parser.parse()?)
+            } else {
+                parser.parse()?
+            };
+
+            return Ok(ast::Stmt::Item(item, semi));
+        }
+
+        if let Some(span) = visibility.option_span() {
+            return Err(ParseError::new(
+                span,
+                ParseErrorKind::UnsupportedExprVisibility,
+            ));
+        }
+
+        let expr: ast::Expr = ast::Expr::parse_with_meta(parser, &mut attributes, path)?;
+
+        if let Some(span) = attributes.option_span() {
+            return Err(ParseError::new(
+                span,
+                ParseErrorKind::AttributesNotSupported,
+            ));
+        }
+
+        if parser.peek::<ast::SemiColon>()? {
+            Ok(ast::Stmt::Semi(expr, parser.parse()?))
+        } else {
+            Ok(ast::Stmt::Expr(expr))
+        }
+    }
 }

--- a/crates/rune/src/compiling/compile/expr.rs
+++ b/crates/rune/src/compiling/compile/expr.rs
@@ -121,16 +121,10 @@ impl Compile<(&ast::Expr, Needs)> for Compiler<'_> {
                 }
             },
             ast::Expr::MacroCall(expr_call_macro) => {
-                let _guard = self.items.push_macro();
-                let item = self.items.item();
-
-                if let Some(Expanded::Expr(expr)) = self.expanded.get(&item) {
-                    self.compile((expr, needs))?;
-                } else {
-                    let span = expr_call_macro.span();
-
-                    return Err(CompileError::internal(&span, "macro has not been expanded"));
-                }
+                return Err(CompileError::internal(
+                    expr_call_macro,
+                    "encountered unexpanded macro",
+                ));
             }
             // NB: declarations are not used in this compilation stage.
             // They have been separately indexed and will be built when queried

--- a/crates/rune/src/compiling/compile/prelude.rs
+++ b/crates/rune/src/compiling/compile/prelude.rs
@@ -1,6 +1,5 @@
 pub(crate) use crate::ast;
 pub(crate) use crate::compiling::{Compile, Compiler, Loop, Needs};
-pub(crate) use crate::worker::Expanded;
 pub(crate) use crate::{CompileError, CompileErrorKind, CompileResult, Resolve, Spanned};
 pub(crate) use runestick::{
     CompileMetaCapture, CompileMetaKind, ConstValue, Hash, Inst, InstOp, InstTarget, Item, Span,

--- a/crates/rune/src/compiling/compile_error.rs
+++ b/crates/rune/src/compiling/compile_error.rs
@@ -210,4 +210,10 @@ pub enum CompileErrorKind {
     BreakOutsideOfLoop,
     #[error("multiple `default` branches in select")]
     SelectMultipleDefaults,
+    /// Expected a block semicolon which is needed for the kind of expression.
+    #[error("expected expression to be terminated by a semicolon `;`")]
+    ExpectedBlockSemiColon {
+        /// The following expression.
+        followed_span: Span,
+    },
 }

--- a/crates/rune/src/compiling/compiler.rs
+++ b/crates/rune/src/compiling/compiler.rs
@@ -3,7 +3,6 @@ use crate::collections::HashMap;
 use crate::compiling::{Assembly, Compile as _, CompileVisitor, Loops, Scope, ScopeGuard, Scopes};
 use crate::query::Query;
 use crate::shared::Items;
-use crate::worker::Expanded;
 use crate::CompileResult;
 use crate::{
     CompileError, CompileErrorKind, Options, Resolve as _, Spanned as _, Storage, UnitBuilder,
@@ -40,8 +39,6 @@ pub(crate) struct Compiler<'a> {
     pub(crate) storage: &'a Storage,
     /// The context we are compiling for.
     pub(crate) context: &'a Context,
-    /// Items expanded by macros.
-    pub(crate) expanded: &'a HashMap<Item, Expanded>,
     /// Query system to compile required items.
     pub(crate) query: &'a mut Query,
     /// The assembly we are generating.

--- a/crates/rune/src/compiling/mod.rs
+++ b/crates/rune/src/compiling/mod.rs
@@ -1,9 +1,8 @@
 use crate::ast;
-use crate::collections::HashMap;
 use crate::load::{FileSourceLoader, SourceLoader, Sources};
 use crate::query::{Build, BuildEntry, Query};
 use crate::shared::{Consts, Items};
-use crate::worker::{Expanded, LoadFileKind, Task, Worker};
+use crate::worker::{LoadFileKind, Task, Worker};
 use crate::{Error, Errors, Options, Spanned as _, Storage, Warnings};
 use runestick::{Context, Item, Source, Span};
 use std::collections::VecDeque;
@@ -119,7 +118,6 @@ pub fn compile_with_options(
                 warnings: worker.warnings,
                 query: &mut worker.query,
                 entry,
-                expanded: &worker.expanded,
                 visitor: worker.visitor,
             };
 
@@ -154,7 +152,6 @@ struct CompileBuildEntry<'a> {
     warnings: &'a mut Warnings,
     query: &'a mut Query,
     entry: BuildEntry,
-    expanded: &'a HashMap<Item, Expanded>,
     visitor: &'a mut dyn CompileVisitor,
 }
 
@@ -185,7 +182,6 @@ impl CompileBuildEntry<'_> {
             loops: Loops::new(),
             options: self.options,
             warnings: self.warnings,
-            expanded: self.expanded,
             visitor: self.visitor,
         };
 

--- a/crates/rune/src/indexing/index_scopes.rs
+++ b/crates/rune/src/indexing/index_scopes.rs
@@ -150,13 +150,13 @@ enum IndexScopeLevel {
 
 /// An indexing scope.
 #[derive(Debug)]
-pub struct IndexScopes {
+pub(crate) struct IndexScopes {
     levels: Rc<RefCell<Vec<IndexScopeLevel>>>,
 }
 
 impl IndexScopes {
     /// Construct a new handler for indexing scopes.
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             levels: Rc::new(RefCell::new(vec![IndexScopeLevel::IndexScope(
                 IndexScope::new(),
@@ -164,15 +164,8 @@ impl IndexScopes {
         }
     }
 
-    /// Take a snapshot of the current scopes.
-    pub fn snapshot(&self) -> Self {
-        Self {
-            levels: Rc::new(RefCell::new(self.levels.borrow().clone())),
-        }
-    }
-
     /// Declare the given variable in the last scope.
-    pub fn declare(&mut self, var: &str, span: Span) -> Result<(), CompileError> {
+    pub(crate) fn declare(&mut self, var: &str, span: Span) -> Result<(), CompileError> {
         let mut levels = self.levels.borrow_mut();
 
         let level = levels
@@ -190,7 +183,7 @@ impl IndexScopes {
     }
 
     /// Mark that the given variable is used.
-    pub fn mark_use(&mut self, var: &str) {
+    pub(crate) fn mark_use(&mut self, var: &str) {
         let mut levels = self.levels.borrow_mut();
         let iter = levels.iter_mut().rev();
 
@@ -244,7 +237,7 @@ impl IndexScopes {
 
     /// Mark that a yield was used, meaning the encapsulating function is a
     /// generator.
-    pub fn mark_yield(&mut self, span: Span) -> Result<(), CompileError> {
+    pub(crate) fn mark_yield(&mut self, span: Span) -> Result<(), CompileError> {
         let mut levels = self.levels.borrow_mut();
         let iter = levels.iter_mut().rev();
 
@@ -270,7 +263,7 @@ impl IndexScopes {
 
     /// Mark that a yield was used, meaning the encapsulating function is a
     /// generator.
-    pub fn mark_await(&mut self, span: Span) -> Result<(), CompileError> {
+    pub(crate) fn mark_await(&mut self, span: Span) -> Result<(), CompileError> {
         let mut levels = self.levels.borrow_mut();
         let iter = levels.iter_mut().rev();
 
@@ -303,7 +296,7 @@ impl IndexScopes {
     }
 
     /// Push a function.
-    pub fn push_function(&mut self, is_async: bool) -> IndexScopeGuard {
+    pub(crate) fn push_function(&mut self, is_async: bool) -> IndexScopeGuard {
         self.levels
             .borrow_mut()
             .push(IndexScopeLevel::IndexFunction(IndexFunction::new(is_async)));
@@ -314,7 +307,7 @@ impl IndexScopes {
     }
 
     /// Push a closure boundary.
-    pub fn push_closure(&mut self, is_async: bool) -> IndexScopeGuard {
+    pub(crate) fn push_closure(&mut self, is_async: bool) -> IndexScopeGuard {
         self.levels
             .borrow_mut()
             .push(IndexScopeLevel::IndexClosure(IndexClosure::new(is_async)));
@@ -325,7 +318,7 @@ impl IndexScopes {
     }
 
     /// Push a new scope.
-    pub fn push_scope(&mut self) -> IndexScopeGuard {
+    pub(crate) fn push_scope(&mut self) -> IndexScopeGuard {
         self.levels
             .borrow_mut()
             .push(IndexScopeLevel::IndexScope(IndexScope::new()));

--- a/crates/rune/src/load/sources.rs
+++ b/crates/rune/src/load/sources.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 /// A collection of source files, and a queue of things to compile.
 #[derive(Debug, Default)]
 pub struct Sources {
+    /// Sources associated.
     sources: Vec<Arc<Source>>,
 }
 

--- a/crates/rune/src/macros/macro_compiler.rs
+++ b/crates/rune/src/macros/macro_compiler.rs
@@ -21,11 +21,11 @@ pub(crate) struct MacroCompiler<'a> {
 
 impl MacroCompiler<'_> {
     /// Compile the given macro into the given output type.
-    pub(crate) fn eval_macro<T>(&mut self, expr_call_macro: ast::MacroCall) -> CompileResult<T>
+    pub(crate) fn eval_macro<T>(&mut self, macro_call: &ast::MacroCall) -> CompileResult<T>
     where
         T: Parse,
     {
-        let span = expr_call_macro.span();
+        let span = macro_call.span();
 
         if !self.options.macros {
             return Err(CompileError::experimental(
@@ -34,12 +34,10 @@ impl MacroCompiler<'_> {
             ));
         }
 
-        let item = self.unit.convert_path(
-            &self.item,
-            &expr_call_macro.path,
-            &self.storage,
-            &*self.source,
-        )?;
+        let item =
+            self.unit
+                .convert_path(&self.item, &macro_call.path, &self.storage, &*self.source)?;
+
         let hash = Hash::type_hash(&item);
 
         let handler = match self.context.lookup_macro(hash) {
@@ -52,7 +50,7 @@ impl MacroCompiler<'_> {
             }
         };
 
-        let input_stream = &expr_call_macro.stream;
+        let input_stream = &macro_call.stream;
 
         self.macro_context.default_span = span;
         self.macro_context.end = Span::point(span.end);

--- a/crates/rune/src/parsing/parse_error.rs
+++ b/crates/rune/src/parsing/parse_error.rs
@@ -32,6 +32,7 @@ impl ParseError {
 
 /// Error when parsing.
 #[derive(Debug, Clone, Copy, Error)]
+#[allow(missing_docs)]
 pub enum ParseErrorKind {
     /// Error raised when we expect and end-of-file but it didn't happen.
     #[error("expected end-of-file, but got token `{actual}`")]
@@ -166,16 +167,12 @@ pub enum ParseErrorKind {
         /// The delimiter we saw.
         actual: ast::Kind,
     },
-    /// Expected a block semicolon which is needed for the kind of expression.
-    #[error("expected expression to be terminated by a semicolon `;`")]
-    ExpectedBlockSemiColon {
-        /// The following expression.
-        followed_span: Span,
-    },
     /// Encountered a position with attributes for which it is not supported.
     #[error("attributes not supported in this position")]
     AttributesNotSupported,
     /// Encountered when we expect inner attributes.
     #[error("expected inner attribute")]
     ExpectedInnerAttribute,
+    #[error("item needs to be terminated by a semi-colon `;`")]
+    ItemNeedsSemi,
 }

--- a/crates/rune/src/query.rs
+++ b/crates/rune/src/query.rs
@@ -660,10 +660,8 @@ impl Query {
         source: &Source,
     ) -> Result<CompileMetaKind, QueryError> {
         Ok(match body {
-            ast::ItemStructBody::UnitBody(_) => self.unit_body_meta(item, enum_item),
-            ast::ItemStructBody::TupleBody(tuple, _) => {
-                self.tuple_body_meta(item, enum_item, tuple)
-            }
+            ast::ItemStructBody::UnitBody => self.unit_body_meta(item, enum_item),
+            ast::ItemStructBody::TupleBody(tuple) => self.tuple_body_meta(item, enum_item, tuple),
             ast::ItemStructBody::StructBody(st) => {
                 self.struct_body_meta(item, enum_item, source, st)?
             }

--- a/crates/rune/src/shared/items.rs
+++ b/crates/rune/src/shared/items.rs
@@ -51,13 +51,6 @@ impl Items {
         }
     }
 
-    /// Take a snapshot of the existing items.
-    pub(crate) fn snapshot(&self) -> Self {
-        Self {
-            path: Rc::new(RefCell::new(self.path.borrow().clone())),
-        }
-    }
-
     /// Check if the current path is empty.
     pub(crate) fn is_empty(&self) -> bool {
         self.path.borrow().is_empty()
@@ -125,28 +118,9 @@ impl Items {
         }
     }
 
-    /// Push a component and return a guard to it.
-    pub(crate) fn push_macro(&mut self) -> Guard {
-        let index = self.next_child();
-
-        self.path
-            .borrow_mut()
-            .push(Node::from(Component::Macro(index)));
-
-        Guard {
-            path: self.path.clone(),
-        }
-    }
-
     /// Get the item for the current state of the path.
     pub(crate) fn item(&self) -> Item {
         let path = self.path.borrow();
         Item::of(path.iter().map(|n| &n.component))
-    }
-
-    /// Pop the last component.
-    pub(crate) fn pop(&self) -> Option<Component> {
-        let mut path = self.path.borrow_mut();
-        Some(path.pop()?.component)
     }
 }

--- a/crates/rune/src/spanned.rs
+++ b/crates/rune/src/spanned.rs
@@ -40,6 +40,15 @@ where
     }
 }
 
+impl<T> Spanned for &mut T
+where
+    T: Spanned,
+{
+    fn span(&self) -> Span {
+        Spanned::span(*self)
+    }
+}
+
 /// Types for which we can optionally get a span.
 pub trait OptionSpanned {
     /// Get the optional span of the type.

--- a/crates/rune/src/worker.rs
+++ b/crates/rune/src/worker.rs
@@ -3,15 +3,14 @@
 use crate::ast;
 use crate::collections::HashMap;
 use crate::indexing::{Index as _, IndexScopes, Indexer};
-use crate::macros::MacroCompiler;
 use crate::query::Query;
 use crate::shared::{Consts, Items};
 use crate::CompileResult;
 use crate::{
-    CompileError, CompileErrorKind, CompileVisitor, Error, Errors, MacroContext, Options,
-    Resolve as _, SourceLoader, Sources, Spanned as _, Storage, UnitBuilder, Warnings,
+    CompileError, CompileErrorKind, CompileVisitor, Error, Errors, Options, Resolve as _,
+    SourceLoader, Sources, Spanned as _, Storage, UnitBuilder, Warnings,
 };
-use runestick::{Component, Context, Item, Source, SourceId, Span};
+use runestick::{Context, Item, Source, SourceId, Span};
 use std::collections::VecDeque;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -28,12 +27,6 @@ pub(crate) enum Task {
         /// The source id of the item being loaded.
         source_id: SourceId,
     },
-    /// An indexing task, which will index the specified item.
-    Index(Index),
-    /// Task to process an import.
-    Import(Import),
-    /// Task to expand a macro. This might produce additional indexing tasks.
-    ExpandMacro(Macro),
 }
 
 /// The kind of the loaded module.
@@ -44,16 +37,6 @@ pub(crate) enum LoadFileKind {
     /// A loaded module, which inherits its root from the file it was loaded
     /// from.
     Module { root: Option<PathBuf> },
-}
-
-#[derive(Debug)]
-pub(crate) enum IndexAst {
-    /// Index the root of a file with the given item.
-    File(ast::File),
-    /// Index an item.
-    Item(ast::Item),
-    /// Index a new expression.
-    Expr(ast::Expr),
 }
 
 pub(crate) struct Worker<'a> {
@@ -67,7 +50,6 @@ pub(crate) struct Worker<'a> {
     pub(crate) source_loader: &'a mut dyn SourceLoader,
     pub(crate) query: Query,
     pub(crate) loaded: HashMap<Item, (SourceId, Span)>,
-    pub(crate) expanded: HashMap<Item, Expanded>,
 }
 
 impl<'a> Worker<'a> {
@@ -96,7 +78,6 @@ impl<'a> Worker<'a> {
             source_loader,
             query: Query::new(storage, unit, consts),
             loaded: HashMap::new(),
-            expanded: HashMap::new(),
         }
     }
 
@@ -121,7 +102,7 @@ impl<'a> Worker<'a> {
                         }
                     };
 
-                    let file = match crate::parse_all::<ast::File>(source.as_str()) {
+                    let mut file = match crate::parse_all::<ast::File>(source.as_str()) {
                         Ok(file) => file,
                         Err(error) => {
                             self.errors.push(Error::new(source_id, error));
@@ -137,29 +118,6 @@ impl<'a> Worker<'a> {
 
                     let items = Items::new(item.clone().into_vec());
 
-                    self.queue.push_back(Task::Index(Index {
-                        root,
-                        item,
-                        items,
-                        source_id,
-                        source,
-                        scopes: IndexScopes::new(),
-                        impl_items: Default::default(),
-                        ast: IndexAst::File(file),
-                    }));
-                }
-                Task::Index(index) => {
-                    let Index {
-                        root,
-                        item,
-                        items,
-                        source_id,
-                        source,
-                        scopes,
-                        impl_items,
-                        ast,
-                    } = index;
-
                     log::trace!("index: {}", item);
 
                     let mut indexer = Indexer {
@@ -169,172 +127,26 @@ impl<'a> Worker<'a> {
                         query: &mut self.query,
                         queue: &mut self.queue,
                         sources: self.sources,
+                        context: self.context,
+                        options: self.options,
                         source_id,
                         source,
                         warnings: self.warnings,
                         items,
-                        scopes,
-                        impl_items,
+                        scopes: IndexScopes::new(),
+                        impl_items: Default::default(),
                         visitor: self.visitor,
                         source_loader: self.source_loader,
                     };
 
-                    let result = match ast {
-                        IndexAst::File(ast) => match indexer.index(&ast) {
-                            Ok(()) => Ok(None),
-                            Err(error) => Err(error),
-                        },
-                        IndexAst::Item(ast) => match indexer.index(&ast) {
-                            Ok(()) => Ok(None),
-                            Err(error) => Err(error),
-                        },
-                        IndexAst::Expr(ast) => match indexer.index(&ast) {
-                            Ok(()) => Ok(Some(Expanded::Expr(ast))),
-                            Err(error) => Err(error),
-                        },
-                    };
-
-                    match result {
-                        Ok(expanded) => {
-                            if let Some(expanded) = expanded {
-                                self.expanded.insert(item, expanded);
-                            }
-                        }
-                        Err(error) => {
-                            self.errors.push(Error::new(source_id, error));
-                        }
-                    }
-                }
-                Task::Import(import) => {
-                    log::trace!("import: {}", import.item);
-
-                    let source_id = import.source_id;
-
-                    let result =
-                        import.process(self.context, &self.query.storage, &self.query.unit);
-
-                    if let Err(error) = result {
+                    if let Err(error) = indexer.index(&mut file) {
                         self.errors.push(Error::new(source_id, error));
+                        continue;
                     }
-                }
-                Task::ExpandMacro(m) => {
-                    let Macro {
-                        kind,
-                        root,
-                        items,
-                        ast,
-                        source,
-                        source_id,
-                        scopes,
-                        impl_items,
-                    } = m;
-
-                    let item = items.item();
-                    let span = ast.span();
-
-                    log::trace!("expand macro: {} => {:?}", item, source.source(ast.span()));
-
-                    match kind {
-                        MacroKind::Expr => (),
-                        MacroKind::Item => {
-                            // NB: item macros are not expanded into the second
-                            // compiler phase (only indexed), so we need to
-                            // restore their item position so that indexing is
-                            // done on the correct item.
-                            match items.pop() {
-                                Some(Component::Macro(..)) => (),
-                                _ => {
-                                    self.errors.push(
-                                        Error::new(source_id, CompileError::internal(
-                                            &span,
-                                            "expected macro item as last component of macro expansion",
-                                        ))
-                                    );
-
-                                    continue;
-                                }
-                            }
-                        }
-                    }
-
-                    let mut macro_context =
-                        MacroContext::new(self.query.storage.clone(), source.clone());
-
-                    let mut compiler = MacroCompiler {
-                        storage: self.query.storage.clone(),
-                        item: item.clone(),
-                        macro_context: &mut macro_context,
-                        options: self.options,
-                        context: self.context,
-                        unit: self.query.unit.clone(),
-                        source: source.clone(),
-                    };
-
-                    let ast = match kind {
-                        MacroKind::Expr => {
-                            let ast = match compiler.eval_macro::<ast::Expr>(ast) {
-                                Ok(ast) => ast,
-                                Err(error) => {
-                                    self.errors.push(Error::new(source_id, error));
-
-                                    continue;
-                                }
-                            };
-
-                            IndexAst::Expr(ast)
-                        }
-                        MacroKind::Item => {
-                            let ast = match compiler.eval_macro::<ast::Item>(ast) {
-                                Ok(ast) => ast,
-                                Err(error) => {
-                                    self.errors.push(Error::new(source_id, error));
-
-                                    continue;
-                                }
-                            };
-
-                            IndexAst::Item(ast)
-                        }
-                    };
-
-                    self.queue.push_back(Task::Index(Index {
-                        root,
-                        item,
-                        items,
-                        source_id,
-                        source,
-                        scopes,
-                        impl_items,
-                        ast,
-                    }));
                 }
             }
         }
     }
-}
-
-/// An item that has been expanded by a macro.
-pub(crate) enum Expanded {
-    /// The expansion resulted in an expression.
-    Expr(ast::Expr),
-}
-
-/// Indexing to process.
-#[derive(Debug)]
-pub(crate) struct Index {
-    /// The root URL of the file which caused this item to be indexed.
-    root: Option<PathBuf>,
-    /// Item being built.
-    item: Item,
-    /// Path to index.
-    items: Items,
-    /// The source id where the item came from.
-    source_id: SourceId,
-    /// The source where the item came from.
-    source: Arc<Source>,
-    scopes: IndexScopes,
-    impl_items: Vec<Item>,
-    ast: IndexAst,
 }
 
 /// Import to process.
@@ -429,30 +241,4 @@ impl Import {
 
         Ok(())
     }
-}
-
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum MacroKind {
-    Expr,
-    Item,
-}
-
-#[derive(Debug)]
-pub(crate) struct Macro {
-    /// The kind of the macro.
-    pub(crate) kind: MacroKind,
-    /// The URL root at which the macro is being expanded.
-    pub(crate) root: Option<PathBuf>,
-    /// The item path where the macro is being expanded.
-    pub(crate) items: Items,
-    /// The AST of the macro call causing the expansion.
-    pub(crate) ast: ast::MacroCall,
-    /// The source where the macro is being expanded.
-    pub(crate) source: Arc<Source>,
-    /// The source id where the macro is being expanded.
-    pub(crate) source_id: usize,
-    /// Snapshot of index scopes when the macro was being expanded.
-    pub(crate) scopes: IndexScopes,
-    /// Snapshot of impl_items when the macro was being expanded.
-    pub(crate) impl_items: Vec<Item>,
 }


### PR DESCRIPTION
This also simplifies macro expansion significantly, having it operate in-place.