### PR TITLE
Support parsing label and async prefixes to expressions for better diagnostics

### DIFF
--- a/crates/rune/src/ast/expr_async.rs
+++ b/crates/rune/src/ast/expr_async.rs
@@ -24,7 +24,7 @@ pub struct ExprAsync {
     #[rune(iter, attributes)]
     pub attributes: Vec<ast::Attribute>,
     /// The `async` keyword.
-    pub async_: ast::Async,
+    pub async_token: ast::Async,
     /// The close brace.
     pub block: ast::Block,
 }

--- a/crates/rune/src/ast/expr_binary.rs
+++ b/crates/rune/src/ast/expr_binary.rs
@@ -153,6 +153,12 @@ impl BinOp {
             Self::Sub => true,
             Self::Or => true,
             Self::And => true,
+            Self::Rem => true,
+            Self::Shl => true,
+            Self::Shr => true,
+            Self::BitAnd => true,
+            Self::BitOr => true,
+            Self::BitXor => true,
             _ => false,
         }
     }

--- a/crates/rune/src/ast/expr_for.rs
+++ b/crates/rune/src/ast/expr_for.rs
@@ -50,24 +50,12 @@ impl ExprFor {
             body: Box::new(parser.parse()?),
         })
     }
-
-    /// Parse the `for` loop with the given attributes
-    pub fn parse_with_attributes(
-        parser: &mut Parser<'_>,
-        attributes: Vec<ast::Attribute>,
-    ) -> Result<Self, ParseError> {
-        let label = if parser.peek::<ast::Label>()? {
-            Some((parser.parse()?, parser.parse()?))
-        } else {
-            None
-        };
-        Self::parse_with_attributes_and_label(parser, attributes, label)
-    }
 }
 
 impl Parse for ExprFor {
     fn parse(parser: &mut Parser<'_>) -> Result<Self, ParseError> {
         let attributes = parser.parse()?;
-        Self::parse_with_attributes(parser, attributes)
+        let label = parser.parse()?;
+        Self::parse_with_attributes_and_label(parser, attributes, label)
     }
 }

--- a/crates/rune/src/ast/expr_loop.rs
+++ b/crates/rune/src/ast/expr_loop.rs
@@ -41,20 +41,12 @@ impl ExprLoop {
             body: Box::new(parser.parse()?),
         })
     }
-
-    /// Parse the `loop` with the given attributes.
-    pub fn parse_with_attributes(
-        parser: &mut Parser<'_>,
-        attributes: Vec<ast::Attribute>,
-    ) -> Result<Self, ParseError> {
-        let label = parser.parse()?;
-        Self::parse_with_attributes_and_label(parser, attributes, label)
-    }
 }
 
 impl Parse for ExprLoop {
     fn parse(parser: &mut Parser<'_>) -> Result<Self, ParseError> {
         let attributes = parser.parse()?;
-        Self::parse_with_attributes(parser, attributes)
+        let label = parser.parse()?;
+        Self::parse_with_attributes_and_label(parser, attributes, label)
     }
 }

--- a/crates/rune/src/ast/expr_unary.rs
+++ b/crates/rune/src/ast/expr_unary.rs
@@ -1,5 +1,4 @@
 use crate::ast;
-use crate::ast::expr::{EagerBrace, ExprChain};
 use crate::{Parse, ParseError, Parser, Spanned, ToTokens};
 use std::fmt;
 
@@ -30,16 +29,12 @@ impl Parse for ExprUnary {
     fn parse(parser: &mut Parser) -> Result<Self, ParseError> {
         let token = parser.token_next()?;
         let op = UnaryOp::from_token(token)?;
+        let path = parser.parse::<Option<ast::Path>>()?;
 
         Ok(Self {
             op,
             token,
-            expr: Box::new(ast::Expr::parse_primary(
-                parser,
-                EagerBrace(true),
-                ExprChain(true),
-                &mut vec![],
-            )?),
+            expr: Box::new(ast::Expr::parse_with_meta(parser, &mut vec![], path)?),
         })
     }
 }

--- a/crates/rune/src/ast/expr_while.rs
+++ b/crates/rune/src/ast/expr_while.rs
@@ -43,20 +43,12 @@ impl ExprWhile {
             body: Box::new(parser.parse()?),
         })
     }
-
-    /// Parse the `while` with the given attributes.
-    pub fn parse_with_attributes(
-        parser: &mut Parser<'_>,
-        attributes: Vec<ast::Attribute>,
-    ) -> Result<Self, ParseError> {
-        let label = parser.parse()?;
-        Self::parse_with_attributes_and_label(parser, attributes, label)
-    }
 }
 
 impl Parse for ExprWhile {
     fn parse(parser: &mut Parser<'_>) -> Result<Self, ParseError> {
         let attributes = parser.parse()?;
-        Self::parse_with_attributes(parser, attributes)
+        let label = parser.parse()?;
+        Self::parse_with_attributes_and_label(parser, attributes, label)
     }
 }

--- a/crates/rune/src/ast/file.rs
+++ b/crates/rune/src/ast/file.rs
@@ -83,8 +83,12 @@ impl Parse for File {
         let mut path = parser.parse::<Option<ast::Path>>()?;
 
         while path.is_some() || ast::Item::peek_as_item(parser, path.as_ref())? {
-            let item: ast::Item =
-                ast::Item::parse_with_meta(parser, item_attributes, item_visibility, path.take())?;
+            let item: ast::Item = ast::Item::parse_with_meta_path(
+                parser,
+                item_attributes,
+                item_visibility,
+                path.take(),
+            )?;
 
             let semi_colon = if item.needs_semi_colon() || parser.peek::<ast::SemiColon>()? {
                 Some(parser.parse::<ast::SemiColon>()?)

--- a/crates/rune/src/ast/macro_call.rs
+++ b/crates/rune/src/ast/macro_call.rs
@@ -5,6 +5,9 @@ use runestick::Span;
 /// A function call `<expr>!(<args>)`.
 #[derive(Debug, Clone, PartialEq, Eq, ToTokens, Spanned)]
 pub struct MacroCall {
+    /// Attributes associated with macro call.
+    #[rune(iter)]
+    pub attributes: Vec<ast::Attribute>,
     /// The expression being called over.
     pub path: ast::Path,
     /// Bang operator `!`.
@@ -19,7 +22,11 @@ pub struct MacroCall {
 
 impl MacroCall {
     /// Parse with an expression.
-    pub fn parse_with_path(parser: &mut Parser, path: ast::Path) -> Result<Self, ParseError> {
+    pub fn parse_with_meta_path(
+        parser: &mut Parser,
+        attributes: Vec<ast::Attribute>,
+        path: ast::Path,
+    ) -> Result<Self, ParseError> {
         let bang = parser.parse()?;
 
         let mut level = 1;
@@ -71,6 +78,7 @@ impl MacroCall {
         }
 
         Ok(Self {
+            attributes,
             bang,
             path,
             open,
@@ -82,7 +90,8 @@ impl MacroCall {
 
 impl Parse for MacroCall {
     fn parse(parser: &mut Parser) -> Result<Self, ParseError> {
+        let attributes = parser.parse()?;
         let path = parser.parse()?;
-        Self::parse_with_path(parser, path)
+        Self::parse_with_meta_path(parser, attributes, path)
     }
 }

--- a/crates/rune/src/ast/stmt.rs
+++ b/crates/rune/src/ast/stmt.rs
@@ -38,7 +38,8 @@ impl Parse for Stmt {
         let path = parser.parse::<Option<ast::Path>>()?;
 
         if ast::Item::peek_as_item(parser, path.as_ref())? {
-            let item: ast::Item = ast::Item::parse_with_meta(parser, attributes, visibility, path)?;
+            let item: ast::Item =
+                ast::Item::parse_with_meta_path(parser, attributes, visibility, path)?;
 
             let semi = if item.needs_semi_colon() {
                 Some(parser.parse()?)

--- a/crates/rune/src/indexing/index.rs
+++ b/crates/rune/src/indexing/index.rs
@@ -1039,7 +1039,7 @@ impl Index<ast::ExprClosure> for Indexer<'_> {
         log::trace!("ExprClosure => {:?}", self.source.source(span));
 
         let _guard = self.items.push_closure();
-        let guard = self.scopes.push_closure(expr_closure.async_.is_some());
+        let guard = self.scopes.push_closure(expr_closure.async_token.is_some());
         let span = expr_closure.span();
 
         for (arg, _) in expr_closure.args.as_slice() {

--- a/crates/rune/src/parsing/parse_error.rs
+++ b/crates/rune/src/parsing/parse_error.rs
@@ -175,4 +175,8 @@ pub enum ParseErrorKind {
     ExpectedInnerAttribute,
     #[error("item needs to be terminated by a semi-colon `;`")]
     ItemNeedsSemi,
+    #[error("expected `while`, `for`, `loop` after a label")]
+    UnsupportedLabel,
+    #[error("expected block or closure after `async`")]
+    UnsupportedAsync,
 }

--- a/crates/rune/src/spanned.rs
+++ b/crates/rune/src/spanned.rs
@@ -84,3 +84,12 @@ where
         }
     }
 }
+
+impl<T> OptionSpanned for Option<T>
+where
+    T: Spanned,
+{
+    fn option_span(&self) -> Option<Span> {
+        self.as_ref().map(Spanned::span)
+    }
+}


### PR DESCRIPTION
This parses the label and async prefixes and generates custom errors in case they are not consumed, leading to better diagnostics and in the future quick fixes for the language server.