### PR TITLE
Fix issue with constant expression

### DIFF
--- a/crates/rune/src/ir/eval/ir_scope.rs
+++ b/crates/rune/src/ir/eval/ir_scope.rs
@@ -7,8 +7,8 @@ impl Eval<&ir::IrScope> for IrInterpreter<'_> {
         self.budget.take(ir_scope)?;
         let guard = self.scopes.push();
 
-        for im in &ir_scope.instructions {
-            let _ = self.eval(im, used)?;
+        for ir in &ir_scope.instructions {
+            let _ = self.eval(ir, used)?;
         }
 
         let value = if let Some(last) = &ir_scope.last {

--- a/crates/rune/src/ir/ir_compiler.rs
+++ b/crates/rune/src/ir/ir_compiler.rs
@@ -77,6 +77,7 @@ impl IrCompile<&ast::Expr> for IrCompiler<'_> {
         Ok(match expr {
             ast::Expr::ExprGroup(expr_group) => self.compile(&*expr_group.expr)?,
             ast::Expr::ExprBinary(expr_binary) => self.compile(expr_binary)?,
+            ast::Expr::ExprAssign(expr_assign) => self.compile(expr_assign)?,
             ast::Expr::ExprIf(expr_if) => ir::Ir::new(expr.span(), self.compile(expr_if)?),
             ast::Expr::ExprLoop(expr_loop) => ir::Ir::new(expr.span(), self.compile(expr_loop)?),
             ast::Expr::ExprWhile(expr_while) => ir::Ir::new(expr.span(), self.compile(expr_while)?),

--- a/crates/rune/src/ir/ir_interpreter.rs
+++ b/crates/rune/src/ir/ir_interpreter.rs
@@ -179,11 +179,7 @@ impl IrScopes {
     ) -> Result<(), IrError> {
         match &ir_target.kind {
             ir::IrTargetKind::Name(name) => {
-                let scope = self
-                    .last_mut()
-                    .ok_or_else(|| IrError::custom(ir_target, "no scopes"))?;
-
-                scope.insert(name.as_ref().to_owned(), value);
+                *self.get_name_mut(name.as_ref(), ir_target)? = value;
                 Ok(())
             }
             ir::IrTargetKind::Field(target, field) => {
@@ -241,14 +237,7 @@ impl IrScopes {
     ) -> Result<(), IrError> {
         match &ir_target.kind {
             ir::IrTargetKind::Name(name) => {
-                let scope = self
-                    .last_mut()
-                    .ok_or_else(|| IrError::custom(ir_target, "no scopes"))?;
-
-                let value = scope
-                    .get_mut(name.as_ref())
-                    .ok_or_else(|| IrError::custom(ir_target, "not such variable"))?;
-
+                let value = self.get_name_mut(name.as_ref(), ir_target)?;
                 op(value)
             }
             ir::IrTargetKind::Field(target, field) => {

--- a/crates/rune/src/shared/scopes.rs
+++ b/crates/rune/src/shared/scopes.rs
@@ -48,13 +48,34 @@ impl<T> Scopes<T> {
         Ok(())
     }
 
-    /// Get the given variable as mutable.
+    /// Get the given variable.
     pub(crate) fn get_name<'a, S>(&'a self, name: &str, spanned: S) -> Result<&'a T, ScopeError>
     where
         S: Spanned,
     {
         for scope in self.scopes.iter().rev() {
             if let Some(current) = scope.locals.get(name) {
+                return Ok(current);
+            }
+        }
+
+        Err(ScopeError::new(
+            spanned,
+            ScopeErrorKind::MissingLocal { name: name.into() },
+        ))
+    }
+
+    /// Get the given variable as mutable.
+    pub(crate) fn get_name_mut<'a, S>(
+        &'a mut self,
+        name: &str,
+        spanned: S,
+    ) -> Result<&'a mut T, ScopeError>
+    where
+        S: Spanned,
+    {
+        for scope in self.scopes.iter_mut().rev() {
+            if let Some(current) = scope.locals.get_mut(name) {
                 return Ok(current);
             }
         }
@@ -109,18 +130,6 @@ pub(crate) struct ScopeGuard {
 pub(crate) struct Scope<T> {
     /// Locals in the current scope.
     locals: HashMap<String, T>,
-}
-
-impl<T> Scope<T> {
-    /// Insert the given local.
-    pub(crate) fn insert(&mut self, name: String, local: T) -> Option<T> {
-        self.locals.insert(name, local)
-    }
-
-    /// Get the given name mutably from the scope.
-    pub(crate) fn get_mut(&mut self, name: &str) -> Option<&mut T> {
-        self.locals.get_mut(name)
-    }
 }
 
 impl<T> Default for Scope<T> {

--- a/crates/rune/src/tests/vm_const_exprs.rs
+++ b/crates/rune/src/tests/vm_const_exprs.rs
@@ -112,3 +112,45 @@ fn test_const_collections() {
         vec.get_value::<String>(0).unwrap().as_deref()
     );
 }
+
+#[test]
+fn test_more_complexity() {
+    let result = rune!(i64 => r#"
+    const BASE = 10;
+    const LIMIT = 0b1 << 10;
+
+    const VALUE = {
+        let timeout = BASE;
+
+        while timeout < LIMIT {
+            timeout *= 2;
+        }
+
+        timeout
+    };
+
+    fn main() { VALUE }
+    "#);
+    assert_eq!(result, 1280);
+}
+
+#[test]
+fn test_if_else() {
+    let result = rune!(i64 => r#"
+    const VALUE = { if true { 1 } else if true { 2 } else { 3 } };
+    fn main() { VALUE }
+    "#);
+    assert_eq!(result, 1);
+
+    let result = rune!(i64 => r#"
+    const VALUE = { if false { 1 } else if true { 2 } else { 3 } };
+    fn main() { VALUE }
+    "#);
+    assert_eq!(result, 2);
+
+    let result = rune!(i64 => r#"
+    const VALUE = { if false { 1 } else if false { 2 } else { 3 } };
+    fn main() { VALUE }
+    "#);
+    assert_eq!(result, 3);
+}


### PR DESCRIPTION
Turns out constant expressions are not using their scope correctly when referencing local variables. This leads to declaring a new variable, instead of mutating an old one, causing the example script to run out of budget.