### PR TITLE
Introduce opaque identifiers for indexed items

### DIFF
--- a/crates/rune-macros/src/internals.rs
+++ b/crates/rune-macros/src/internals.rs
@@ -6,6 +6,7 @@ use std::fmt;
 pub struct Symbol(&'static str);
 
 pub const RUNE: Symbol = Symbol("rune");
+pub const ID: Symbol = Symbol("id");
 pub const SKIP: Symbol = Symbol("skip");
 pub const ITER: Symbol = Symbol("iter");
 pub const OPTIONAL: Symbol = Symbol("optional");

--- a/crates/rune-macros/src/parse.rs
+++ b/crates/rune-macros/src/parse.rs
@@ -101,6 +101,13 @@ impl Expander {
 
         for (i, field) in named.named.iter().enumerate() {
             let attrs = self.ctx.parse_field_attributes(&field.attrs)?;
+            let ident = self.ctx.field_ident(&field)?;
+
+            if attrs.id.is_some() {
+                fields.push(quote_spanned! { field.span() => #ident: Default::default() });
+                continue;
+            }
+
             if attrs.attributes.is_some() {
                 if let Some((idx, attrs_field)) = &attrs_field {
                     let attrs_ident = self.ctx.field_ident(attrs_field)?;
@@ -123,7 +130,6 @@ impl Expander {
                 }
             }
 
-            let ident = self.ctx.field_ident(&field)?;
             fields.push(quote_spanned! { field.span() => #ident: parser.parse()? })
         }
 

--- a/crates/rune-macros/src/to_tokens.rs
+++ b/crates/rune-macros/src/to_tokens.rs
@@ -141,10 +141,11 @@ impl Expander {
             let ident = self.ctx.field_ident(&field)?;
             let attrs = self.ctx.parse_field_attributes(&field.attrs)?;
 
-            if attrs.skip.is_none() {
-                fields
-                    .push(quote_spanned! { field.span() => self.#ident.to_tokens(context, stream) })
+            if attrs.skip() {
+                continue;
             }
+
+            fields.push(quote_spanned! { field.span() => self.#ident.to_tokens(context, stream) })
         }
 
         let ident = &input.ident;
@@ -182,12 +183,13 @@ impl Expander {
         for field in &named.named {
             let ident = self.ctx.field_ident(&field)?;
             let attrs = self.ctx.parse_field_attributes(&field.attrs)?;
+            idents.push(ident);
 
-            if attrs.skip.is_none() {
-                fields.push(quote_spanned! { field.span() => #ident.to_tokens(context, stream) })
+            if attrs.skip() {
+                continue;
             }
 
-            idents.push(ident);
+            fields.push(quote_spanned! { field.span() => #ident.to_tokens(context, stream) })
         }
 
         let ident = &variant.ident;
@@ -210,14 +212,14 @@ impl Expander {
             let ident = syn::Ident::new(&format!("f{}", n), field.span());
             let attrs = self.ctx.parse_field_attributes(&field.attrs)?;
 
-            if attrs.skip.is_none() {
-                let ident = &ident;
+            idents.push(ident.clone());
 
-                field_into_tokens
-                    .push(quote_spanned! { field.span() => #ident.to_tokens(context, stream) })
+            if attrs.skip() {
+                continue;
             }
 
-            idents.push(ident);
+            field_into_tokens
+                .push(quote_spanned! { field.span() => #ident.to_tokens(context, stream) })
         }
 
         let ident = &variant.ident;

--- a/crates/rune/src/ast/block.rs
+++ b/crates/rune/src/ast/block.rs
@@ -1,15 +1,25 @@
 use crate::ast;
-use crate::{Parse, ParseError, Parser, Spanned, ToTokens};
+use crate::parsing::Opaque;
+use crate::{Id, Parse, ParseError, Parser, Spanned, ToTokens};
 
 /// A block of expressions.
 #[derive(Debug, Clone, PartialEq, Eq, ToTokens, Spanned)]
 pub struct Block {
+    /// The unique identifier for the block expression.
+    #[rune(id)]
+    pub id: Id,
     /// The close brace.
     pub open: ast::OpenBrace,
     /// Statements in the block.
     pub statements: Vec<ast::Stmt>,
     /// The close brace.
     pub close: ast::CloseBrace,
+}
+
+impl Opaque for Block {
+    fn id(&self) -> Id {
+        self.id
+    }
 }
 
 impl Block {
@@ -71,6 +81,7 @@ impl Parse for Block {
         let close = parser.parse()?;
 
         Ok(Block {
+            id: Default::default(),
             open,
             statements,
             close,

--- a/crates/rune/src/ast/expr_closure.rs
+++ b/crates/rune/src/ast/expr_closure.rs
@@ -1,10 +1,14 @@
 use crate::ast;
-use crate::{Parse, ParseError, Parser, Spanned, ToTokens};
+use crate::parsing::Opaque;
+use crate::{Id, Parse, ParseError, Parser, Spanned, ToTokens};
 use runestick::Span;
 
 /// A closure expression.
 #[derive(Debug, Clone, PartialEq, Eq, ToTokens, Spanned)]
 pub struct ExprClosure {
+    /// Opaque identifier for the closure.
+    #[rune(id)]
+    pub id: Id,
     /// The attributes for the async closure
     #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,
@@ -57,11 +61,18 @@ impl ExprClosure {
         };
 
         Ok(Self {
+            id: Default::default(),
             attributes,
             async_token,
             args,
             body: Box::new(parser.parse()?),
         })
+    }
+}
+
+impl Opaque for ExprClosure {
+    fn id(&self) -> Id {
+        self.id
     }
 }
 

--- a/crates/rune/src/ast/item_const.rs
+++ b/crates/rune/src/ast/item_const.rs
@@ -1,5 +1,5 @@
 use crate::ast;
-use crate::{Parse, ParseError, Parser, Spanned, ToTokens};
+use crate::{Id, Parse, ParseError, Parser, Spanned, ToTokens};
 
 /// A const declaration.
 ///
@@ -12,6 +12,9 @@ use crate::{Parse, ParseError, Parser, Spanned, ToTokens};
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Parse, ToTokens, Spanned)]
 pub struct ItemConst {
+    /// Opaque identifier for the constant.
+    #[rune(id)]
+    pub id: Id,
     /// The *inner* attributes that are applied to the const declaration.
     #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,
@@ -36,6 +39,7 @@ impl ItemConst {
         visibility: ast::Visibility,
     ) -> Result<Self, ParseError> {
         Ok(Self {
+            id: Default::default(),
             attributes,
             visibility,
             const_token: parser.parse()?,

--- a/crates/rune/src/ast/item_enum.rs
+++ b/crates/rune/src/ast/item_enum.rs
@@ -1,5 +1,5 @@
 use crate::ast;
-use crate::{OptionSpanned, Parse, ParseError, Parser, Spanned, ToTokens};
+use crate::{Id, OptionSpanned, Parse, ParseError, Parser, Spanned, ToTokens};
 
 /// An enum declaration.
 #[derive(Debug, Clone, PartialEq, Eq, ToTokens, Spanned)]
@@ -58,6 +58,9 @@ impl Parse for ItemEnum {
 /// An enum variant.
 #[derive(Debug, Clone, PartialEq, Eq, Parse, ToTokens, Spanned)]
 pub struct ItemVariant {
+    /// Opaque identifier of variant.
+    #[rune(id)]
+    pub id: Id,
     /// The attributes associated with the variant.
     #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,

--- a/crates/rune/src/ast/item_struct.rs
+++ b/crates/rune/src/ast/item_struct.rs
@@ -1,9 +1,12 @@
 use crate::ast;
-use crate::{OptionSpanned, Parse, ParseError, Parser, Spanned, ToTokens};
+use crate::{Id, OptionSpanned, Parse, ParseError, Parser, Spanned, ToTokens};
 
 /// A struct declaration.
 #[derive(Debug, Clone, PartialEq, Eq, ToTokens, Spanned)]
 pub struct ItemStruct {
+    /// Opaque identifier of the struct.
+    #[rune(id)]
+    pub id: Id,
     /// The attributes for the struct
     #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,
@@ -32,6 +35,7 @@ impl ItemStruct {
         visibility: ast::Visibility,
     ) -> Result<Self, ParseError> {
         Ok(Self {
+            id: Default::default(),
             attributes,
             visibility,
             struct_: parser.parse()?,

--- a/crates/rune/src/ast/lit_template.rs
+++ b/crates/rune/src/ast/lit_template.rs
@@ -1,16 +1,26 @@
 use crate::ast;
-use crate::{Parse, ParseError, ParseErrorKind, Parser, Resolve, Spanned, Storage, ToTokens};
+use crate::parsing::Opaque;
+use crate::{Id, Parse, ParseError, ParseErrorKind, Parser, Resolve, Spanned, Storage, ToTokens};
 use runestick::{Source, Span};
 use std::borrow::Cow;
 
 /// A string literal.
 #[derive(Debug, Clone, PartialEq, Eq, ToTokens, Spanned)]
 pub struct LitTemplate {
+    /// Opaque identifier for the template.
+    #[rune(id)]
+    pub id: Id,
     /// The token corresponding to the literal.
     token: ast::Token,
     /// The source string of the literal template.
     #[rune(skip)]
     source: ast::LitStrSource,
+}
+
+impl Opaque for LitTemplate {
+    fn id(&self) -> Id {
+        self.id
+    }
 }
 
 /// A single template component.
@@ -132,7 +142,11 @@ impl Parse for LitTemplate {
         let token = parser.token_next()?;
 
         match token.kind {
-            ast::Kind::LitTemplate(source) => Ok(LitTemplate { token, source }),
+            ast::Kind::LitTemplate(source) => Ok(LitTemplate {
+                id: Default::default(),
+                token,
+                source,
+            }),
             _ => Err(ParseError::expected(token, "template literal")),
         }
     }

--- a/crates/rune/src/ast/path.rs
+++ b/crates/rune/src/ast/path.rs
@@ -1,9 +1,13 @@
 use crate::ast;
-use crate::{Parse, ParseError, ParseErrorKind, Parser, Peek, Spanned, ToTokens};
+use crate::parsing::Opaque;
+use crate::{Id, Parse, ParseError, ParseErrorKind, Parser, Peek, Spanned, ToTokens};
 
 /// A path, where each element is separated by a `::`.
 #[derive(Debug, Clone, PartialEq, Eq, Parse, ToTokens, Spanned)]
 pub struct Path {
+    /// Opaque id associated with path.
+    #[rune(id)]
+    pub id: Id,
     /// The optional leading colon `::`
     #[rune(iter)]
     pub leading_colon: Option<ast::Scope>,
@@ -54,6 +58,12 @@ impl Path {
 
             Some(&it.next()?.1)
         })
+    }
+}
+
+impl Opaque for Path {
+    fn id(&self) -> Id {
+        self.id
     }
 }
 

--- a/crates/rune/src/compiling/compile/block.rs
+++ b/crates/rune/src/compiling/compile/block.rs
@@ -27,7 +27,6 @@ impl Compile<(&ast::Block, Needs)> for Compiler<'_> {
     fn compile(&mut self, (block, needs): (&ast::Block, Needs)) -> CompileResult<()> {
         let span = block.span();
         log::trace!("Block => {:?}", self.source.source(span));
-        let _guard = self.items.push_block();
 
         self.contexts.push(span);
         let scopes_count = self.scopes.push_child(span)?;

--- a/crates/rune/src/compiling/compile/expr_block.rs
+++ b/crates/rune/src/compiling/compile/expr_block.rs
@@ -10,15 +10,14 @@ impl Compile<(&ast::ExprBlock, Needs)> for Compiler<'_> {
             return Ok(self.compile((&expr_block.block, needs))?);
         }
 
-        let _guard = self.items.push_async_block();
-        let item = self.items.item();
+        let item = self.query.item_for(&expr_block.block)?.clone();
 
-        let meta = match self.lookup_meta(&item, span)? {
+        let meta = match self.lookup_exact_meta(&item, span)? {
             Some(meta) => meta,
             None => {
                 return Err(CompileError::new(
                     span,
-                    CompileErrorKind::MissingType { item },
+                    CompileErrorKind::MissingType { item: item.clone() },
                 ));
             }
         };

--- a/crates/rune/src/compiling/compile/expr_call.rs
+++ b/crates/rune/src/compiling/compile/expr_call.rs
@@ -66,7 +66,7 @@ impl Compile<(&ast::ExprCall, Needs)> for Compiler<'_> {
             self.scopes.decl_anon(span)?;
         }
 
-        let item = self.convert_path_to_item(path)?;
+        let (base, item) = self.convert_path_to_item(path)?;
 
         if let Some(name) = item.as_local() {
             if let Some(var) =
@@ -85,7 +85,7 @@ impl Compile<(&ast::ExprCall, Needs)> for Compiler<'_> {
             }
         }
 
-        let meta = match self.lookup_meta(&item, path.span())? {
+        let meta = match self.lookup_meta(&base, &item, path.span())? {
             Some(meta) => meta,
             None => {
                 return Err(CompileError::new(

--- a/crates/rune/src/compiling/compile/expr_closure.rs
+++ b/crates/rune/src/compiling/compile/expr_closure.rs
@@ -63,8 +63,7 @@ impl Compile<(&ast::ExprClosure, Needs)> for Compiler<'_> {
             return Ok(());
         }
 
-        let _guard = self.items.push_closure();
-        let item = self.items.item();
+        let item = self.query.item_for(expr_closure)?.clone();
         let hash = Hash::type_hash(&item);
 
         let meta = self.query.query_meta(&item)?.ok_or_else(|| {

--- a/crates/rune/src/compiling/compile/expr_path.rs
+++ b/crates/rune/src/compiling/compile/expr_path.rs
@@ -11,7 +11,7 @@ impl Compile<(&ast::Path, Needs)> for Compiler<'_> {
             self.warnings.not_used(self.source_id, span, self.context());
         }
 
-        let item = self.convert_path_to_item(path)?;
+        let (base, item) = self.convert_path_to_item(path)?;
 
         if let Needs::Value = needs {
             if let Some(local) = item.as_local() {
@@ -25,7 +25,7 @@ impl Compile<(&ast::Path, Needs)> for Compiler<'_> {
             }
         }
 
-        let meta = match self.lookup_meta(&item, span)? {
+        let meta = match self.lookup_meta(&base, &item, span)? {
             Some(meta) => meta,
             None => {
                 let error = match (needs, item.as_local()) {

--- a/crates/rune/src/compiling/compile/expr_select.rs
+++ b/crates/rune/src/compiling/compile/expr_select.rs
@@ -65,7 +65,7 @@ impl Compile<(&ast::ExprSelect, Needs)> for Compiler<'_> {
             loop {
                 match &branch.pat {
                     ast::Pat::PatPath(path) => {
-                        let item = self.convert_path_to_item(&path.path)?;
+                        let (_, item) = self.convert_path_to_item(&path.path)?;
 
                         if let Some(local) = item.as_local() {
                             self.scopes.decl_var(local, path.span())?;

--- a/crates/rune/src/compiling/compile/lit_object.rs
+++ b/crates/rune/src/compiling/compile/lit_object.rs
@@ -57,9 +57,9 @@ impl Compile<(&ast::LitObject, Needs)> for Compiler<'_> {
 
         match &lit_object.ident {
             ast::LitObjectIdent::Named(path) => {
-                let item = self.convert_path_to_item(path)?;
+                let (base, item) = self.convert_path_to_item(path)?;
 
-                let meta = match self.lookup_meta(&item, path.span())? {
+                let meta = match self.lookup_meta(&base, &item, path.span())? {
                     Some(meta) => meta,
                     None => {
                         return Err(CompileError::new(

--- a/crates/rune/src/compiling/compile/lit_template.rs
+++ b/crates/rune/src/compiling/compile/lit_template.rs
@@ -12,7 +12,7 @@ impl Compile<(&ast::LitTemplate, Needs)> for Compiler<'_> {
             return Ok(());
         }
 
-        let template = lit_template.resolve(&self.storage, &*self.source)?;
+        let template = self.query.template_for(lit_template)?.clone();
 
         if !template.has_expansions {
             self.warnings
@@ -21,7 +21,7 @@ impl Compile<(&ast::LitTemplate, Needs)> for Compiler<'_> {
 
         let expected = self.scopes.push_child(span)?;
 
-        for c in template.components.iter() {
+        for c in &template.components {
             match c {
                 ast::TemplateComponent::String(string) => {
                     let slot = self.unit.new_static_string(span, &string)?;

--- a/crates/rune/src/compiling/compile_error.rs
+++ b/crates/rune/src/compiling/compile_error.rs
@@ -120,8 +120,6 @@ pub enum CompileErrorKind {
         item: Item,
         existing: (SourceId, Span),
     },
-    #[error("found conflicting item `{existing}`")]
-    ItemConflict { existing: Item },
     #[error("variable `{name}` conflicts")]
     VariableConflict { name: String, existing_span: Span },
     #[error("missing macro `{item}`")]

--- a/crates/rune/src/compiling/mod.rs
+++ b/crates/rune/src/compiling/mod.rs
@@ -1,7 +1,7 @@
 use crate::ast;
 use crate::load::{FileSourceLoader, SourceLoader, Sources};
 use crate::query::{Build, BuildEntry, Query};
-use crate::shared::{Consts, Items};
+use crate::shared::Consts;
 use crate::worker::{LoadFileKind, Task, Worker};
 use crate::{Error, Errors, Options, Spanned as _, Storage, Warnings};
 use runestick::{Context, Item, Source, Span};
@@ -175,7 +175,6 @@ impl CompileBuildEntry<'_> {
             context: self.context,
             query: self.query,
             asm: &mut asm,
-            items: Items::new(item.as_vec()),
             unit: self.unit.clone(),
             scopes: Scopes::new(),
             contexts: vec![],
@@ -214,7 +213,7 @@ impl CompileBuildEntry<'_> {
                 let name = f.ast.name.resolve(self.storage, &*source)?;
 
                 let meta = compiler
-                    .lookup_meta(&f.impl_item, f.instance_span)?
+                    .lookup_exact_meta(&f.impl_item, f.instance_span)?
                     .ok_or_else(|| {
                         CompileError::new(
                             &f.instance_span,

--- a/crates/rune/src/ir/ir_compiler.rs
+++ b/crates/rune/src/ir/ir_compiler.rs
@@ -1,4 +1,5 @@
 use crate::ir::ir;
+use crate::query::Query;
 use crate::{Resolve, Spanned, Storage};
 use runestick::{ConstValue, Source};
 
@@ -7,6 +8,7 @@ use crate::CompileError;
 
 /// A compiler that compiles AST into Rune IR.
 pub(crate) struct IrCompiler<'a> {
+    pub(crate) query: &'a Query,
     pub(crate) storage: &'a Storage,
     pub(crate) source: &'a Source,
 }
@@ -370,15 +372,15 @@ impl IrCompile<&ast::LitTemplate> for IrCompiler<'_> {
         let span = lit_template.span();
         let mut components = Vec::new();
 
-        let template = self.resolve(lit_template)?;
+        let template = self.query.template_for(lit_template)?;
 
-        for c in template.components {
+        for c in &template.components {
             match c {
                 ast::TemplateComponent::String(string) => {
-                    components.push(ir::IrTemplateComponent::String(string.into()));
+                    components.push(ir::IrTemplateComponent::String(string.clone().into()));
                 }
                 ast::TemplateComponent::Expr(expr) => {
-                    let ir = self.compile(&*expr)?;
+                    let ir = self.compile(&**expr)?;
                     components.push(ir::IrTemplateComponent::Ir(ir));
                 }
             }

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -282,7 +282,7 @@ pub use self::load::{
 pub use self::load::{FileSourceLoader, SourceLoader, Sources};
 pub use self::macros::{MacroContext, Storage, ToTokens, TokenStream, TokenStreamIter};
 pub use self::options::Options;
-pub use self::parsing::{Lexer, Parse, ParseError, ParseErrorKind, Parser, Peek, Resolve};
+pub use self::parsing::{Id, Lexer, Parse, ParseError, ParseErrorKind, Parser, Peek, Resolve};
 pub use self::query::{QueryError, QueryErrorKind};
 pub use self::shared::{ScopeError, ScopeErrorKind};
 pub use self::spanned::{OptionSpanned, Spanned};

--- a/crates/rune/src/parsing/id.rs
+++ b/crates/rune/src/parsing/id.rs
@@ -1,0 +1,41 @@
+use std::fmt;
+use std::num::NonZeroUsize;
+use std::ops;
+
+/// An opaque identifier that is associated with AST items.
+///
+/// The default implementation for an identifier is empty, meaning it does not
+/// hold any value, and attempting to perform lookups over it will fail with an
+/// error indicating that it's empty with the string `Id(*)`.
+///
+/// This is used to store associated metadata to AST items through:
+/// * [Query::insert_item](crate::Query::insert_item)
+/// * [Query::insert_template](crate::Query::insert_template)
+#[derive(Default, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct Id(Option<NonZeroUsize>);
+
+impl Id {
+    /// Construct a new identifier.
+    pub(crate) fn new(index: usize) -> Id {
+        Id(NonZeroUsize::new(index + 1))
+    }
+}
+
+impl ops::Deref for Id {
+    type Target = Option<NonZeroUsize>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl fmt::Debug for Id {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(index) = self.0 {
+            write!(f, "Id({})", index.get())
+        } else {
+            write!(f, "Id(*)")
+        }
+    }
+}

--- a/crates/rune/src/parsing/mod.rs
+++ b/crates/rune/src/parsing/mod.rs
@@ -1,11 +1,15 @@
+mod id;
 mod lexer;
+mod opaque;
 mod parse;
 mod parse_error;
 mod parser;
 mod peek;
 mod resolve;
 
+pub use self::id::Id;
 pub use self::lexer::Lexer;
+pub(crate) use self::opaque::Opaque;
 pub use self::parse::Parse;
 pub use self::parse_error::{ParseError, ParseErrorKind};
 pub use self::parser::Parser;

--- a/crates/rune/src/parsing/opaque.rs
+++ b/crates/rune/src/parsing/opaque.rs
@@ -1,0 +1,27 @@
+use crate::parsing::Id;
+use runestick::Span;
+
+pub(crate) trait Opaque {
+    fn id(&self) -> Id;
+}
+
+impl Opaque for Id {
+    fn id(&self) -> Id {
+        *self
+    }
+}
+
+impl<T> Opaque for &T
+where
+    T: Opaque,
+{
+    fn id(&self) -> Id {
+        Opaque::id(*self)
+    }
+}
+
+impl Opaque for (Span, Id) {
+    fn id(&self) -> Id {
+        self.1
+    }
+}

--- a/crates/rune/src/spanned.rs
+++ b/crates/rune/src/spanned.rs
@@ -1,3 +1,4 @@
+use crate::parsing::Id;
 use runestick::Span;
 
 /// Types for which we can get a span.
@@ -46,6 +47,12 @@ where
 {
     fn span(&self) -> Span {
         Spanned::span(*self)
+    }
+}
+
+impl Spanned for (Span, Id) {
+    fn span(&self) -> Span {
+        self.0
     }
 }
 


### PR DESCRIPTION
This introduces opaque identifiers that can be associated with AST items, which can be used to store data about them in a lookaside table.

It is currently used to:
* Store resolved templates, and their associated (indexed) AST.
* Store the item associated to relevant AST, like `ast::Path` in which they are declared. Because this information determines modules that are being resolved.
* Store the associated item to inline compiled procedures like async blocks and closures (which have names like `foo::$block0::$closure0`.

This used to be handled by traversing the identical path at compile time using a separate [`Items` instance](https://github.com/rune-rs/rune/pull/118/files#diff-8615912abcb3b0654975e45b7284e23cL47). But this was extremely error prone and caused issues when it wasn't feasible to traverse the items in the same way at compile time. This is a big root cause for miscompilations, and could lead to severe issues where for example the wrong closure is used.

Opaque, and *unique* identifiers guarantee that the generated code object is associated with exactly one piece of AST. And prevents accidentally referencing other unrelated things.