### PR TITLE
Add more tests and impl Drop for Access guard

### DIFF
--- a/crates/rune/src/compiling/compile/lit_object.rs
+++ b/crates/rune/src/compiling/compile/lit_object.rs
@@ -36,20 +36,12 @@ impl Compile<(&ast::LitObject, Needs)> for Compiler<'_> {
 
             if let Some((_, expr)) = &assign.assign {
                 self.compile((expr, Needs::Value))?;
-
-                // Evaluate the expressions one by one, then pop them to cause any
-                // side effects (without creating an object).
-                if !needs.value() {
-                    self.asm.push(Inst::Pop, span);
-                }
             } else {
                 let key = assign.key.resolve(&self.storage, &*self.source)?;
                 let var = self
                     .scopes
                     .get_var(&*key, self.source_id, self.visitor, span)?;
-                if needs.value() {
-                    var.copy(&mut self.asm, span, format!("name `{}`", key));
-                }
+                var.copy(&mut self.asm, span, format!("name `{}`", key));
             }
         }
 

--- a/crates/rune/src/tests/mod.rs
+++ b/crates/rune/src/tests/mod.rs
@@ -20,6 +20,7 @@ mod vm_is;
 mod vm_lazy_and_or;
 mod vm_literals;
 mod vm_match;
+mod vm_not_used;
 mod vm_option;
 mod vm_pat;
 mod vm_result;

--- a/crates/rune/src/tests/vm_general.rs
+++ b/crates/rune/src/tests/vm_general.rs
@@ -654,14 +654,6 @@ fn test_break_label() {
 }
 
 #[test]
-fn test_literal() {
-    assert_eq! {
-        rune!(char => r#"fn main() { '\u{1F4AF}' }"#),
-        '💯',
-    };
-}
-
-#[test]
 fn test_string_concat() {
     assert_eq! {
         rune! {
@@ -728,53 +720,6 @@ fn test_variants_as_functions() {
 
                 match foo {
                     Foo::B(a, b) => a + b,
-                    _ => 0,
-                }
-            }
-            "#
-        },
-        3,
-    };
-}
-
-#[test]
-fn test_struct_matching() {
-    assert_eq! {
-        rune! {
-            i64 => r#"
-            struct Foo { a, b }
-
-            fn main() {
-                let foo = Foo {
-                    a: 1,
-                    b: 2,
-                };
-
-                match foo {
-                    Foo { a, b } => a + b,
-                    _ => 0,
-                }
-            }
-            "#
-        },
-        3,
-    };
-
-    assert_eq! {
-        rune! {
-            i64 => r#"
-            struct Foo { a, b }
-
-            fn main() {
-                let b = 2;
-
-                let foo = Foo {
-                    a: 1,
-                    b,
-                };
-
-                match foo {
-                    Foo { a, b } => a + b,
                     _ => 0,
                 }
             }

--- a/crates/rune/src/tests/vm_literals.rs
+++ b/crates/rune/src/tests/vm_literals.rs
@@ -1,38 +1,27 @@
 #[test]
-fn test_hex() {
-    assert_eq! {
-        rune!(i64 => r#"fn main() { 0xff }"#),
-        255,
-    };
+fn test_literals() {
+    assert_eq!(
+        rune!(String => r#"fn main() { "Hello World" }"#),
+        "Hello World"
+    );
+    assert_eq!(
+        rune!(runestick::Bytes => r#"fn main() { b"Hello World" }"#),
+        b"Hello World"[..]
+    );
 
-    assert_eq! {
-        rune!(i64 => r#"fn main() { -0xff }"#),
-        -255,
-    };
-}
+    assert_eq!(rune!(i64 => r#"fn main() { 0xff }"#), 0xff);
+    assert_eq!(rune!(i64 => r#"fn main() { -0xff }"#), -0xff);
 
-#[test]
-fn test_binary() {
-    assert_eq! {
-        rune!(i64 => r#"fn main() { 0b10010001 }"#),
-        145,
-    };
+    assert_eq!(rune!(i64 => r#"fn main() { 0b10010001 }"#), 0b10010001);
+    assert_eq!(rune!(i64 => r#"fn main() { -0b10010001 }"#), -0b10010001);
 
-    assert_eq! {
-        rune!(i64 => r#"fn main() { -0b10010001 }"#),
-        -145,
-    };
-}
+    assert_eq!(rune!(i64 => r#"fn main() { 0o77 }"#), 0o77);
+    assert_eq!(rune!(i64 => r#"fn main() { -0o77 }"#), -0o77);
 
-#[test]
-fn test_octal() {
-    assert_eq! {
-        rune!(i64 => r#"fn main() { 0o77 }"#),
-        63,
-    };
+    assert_eq!(rune!(u8 => r#"fn main() { b'0' }"#), b'0');
+    assert_eq!(rune!(u8 => r#"fn main() { b'\xaf' }"#), b'\xaf');
 
-    assert_eq! {
-        rune!(i64 => r#"fn main() { -0o77 }"#),
-        -63,
-    };
+    assert_eq!(rune!(char => r#"fn main() { '\x60' }"#), '\x60');
+    assert_eq!(rune!(char => r#"fn main() { '\u{1F4AF}' }"#), '\u{1F4AF}');
+    assert_eq!(rune!(char => r#"fn main() { '💯' }"#), '💯');
 }

--- a/crates/rune/src/tests/vm_match.rs
+++ b/crates/rune/src/tests/vm_match.rs
@@ -62,3 +62,50 @@ fn test_path_type_match() {
         true,
     };
 }
+
+#[test]
+fn test_struct_matching() {
+    assert_eq! {
+        rune! {
+            i64 => r#"
+            struct Foo { a, b }
+
+            fn main() {
+                let foo = Foo {
+                    a: 1,
+                    b: 2,
+                };
+
+                match foo {
+                    Foo { a, b } => a + b,
+                    _ => 0,
+                }
+            }
+            "#
+        },
+        3,
+    };
+
+    assert_eq! {
+        rune! {
+            i64 => r#"
+            struct Foo { a, b }
+
+            fn main() {
+                let b = 2;
+
+                let foo = Foo {
+                    a: 1,
+                    b,
+                };
+
+                match foo {
+                    Foo { a, b } => a + b,
+                    _ => 0,
+                }
+            }
+            "#
+        },
+        3,
+    };
+}

--- a/crates/rune/src/tests/vm_not_used.rs
+++ b/crates/rune/src/tests/vm_not_used.rs
@@ -1,0 +1,21 @@
+#[test]
+fn test_not_used() {
+    assert_eq! {
+        rune! {
+            () => r#"
+            fn main() {
+                0;
+                4.1;
+                'a';
+                b'a';
+                "Hello World";
+                b"Hello World";
+                [1, 2, 3];
+                (1, 2, 3, 4);
+                #{"foo": 42, "bar": [1, 2, 3, 4]};
+            }
+            "#
+        },
+        (),
+    };
+}

--- a/crates/runestick/src/vm.rs
+++ b/crates/runestick/src/vm.rs
@@ -2457,8 +2457,8 @@ impl Vm {
         I: FnOnce(i64, i64) -> Option<i64>,
         F: FnOnce(f64, f64) -> f64,
     {
-        let mut guard;
         let lhs;
+        let mut guard;
 
         let (lhs, rhs) = target_value!(self, target, guard, lhs);
 
@@ -2573,8 +2573,8 @@ impl Vm {
         H: IntoTypeHash,
         I: FnOnce(&mut i64, i64),
     {
-        let mut guard;
         let lhs;
+        let mut guard;
 
         let (lhs, rhs) = target_value!(self, target, guard, lhs);
 
@@ -2645,8 +2645,8 @@ impl Vm {
         E: FnOnce() -> VmError,
         I: FnOnce(i64, i64) -> Option<i64>,
     {
-        let mut guard;
         let lhs;
+        let mut guard;
 
         let (lhs, rhs) = target_value!(self, target, guard, lhs);
 


### PR DESCRIPTION
This implements `Drop` for the public access guards so that they are correctly drop checked, preventing the `Shared<T>` they are associated with from being dropped before it!

This was discovered thanks to a debug assertion related to `Shared<T>`, which checks that access is exclusive once it is being de-allocated.