### PR TITLE
Support grouped imports

### DIFF
--- a/crates/rune/src/ast/item_use.rs
+++ b/crates/rune/src/ast/item_use.rs
@@ -26,12 +26,9 @@ pub struct ItemUse {
     #[rune(iter)]
     pub leading_colon: Option<ast::Scope>,
     /// The use token.
-    pub use_: ast::Use,
-    /// First component in use.
-    pub first: ast::PathSegment,
-    /// The rest of the import.
-    #[rune(iter)]
-    pub rest: Vec<(ast::Scope, ItemUseComponent)>,
+    pub use_token: ast::Use,
+    /// Item path.
+    pub path: ItemUsePath,
 }
 
 impl ItemUse {
@@ -45,39 +42,86 @@ impl ItemUse {
             attributes,
             visibility,
             leading_colon: parser.parse()?,
-            use_: parser.parse()?,
-            first: parser.parse()?,
-            rest: parser.parse()?,
+            use_token: parser.parse()?,
+            path: parser.parse()?,
         })
     }
 }
 
 item_parse!(ItemUse, "use item");
 
+/// A single use declaration path, like `foo::bar::{baz::*, biz}`.
+///
+/// # Examples
+///
+/// ```rust
+/// use rune::{testing, ast};
+///
+/// testing::roundtrip::<ast::ItemUsePath>("crate::foo");
+/// testing::roundtrip::<ast::ItemUsePath>("foo::bar");
+/// testing::roundtrip::<ast::ItemUsePath>("foo::bar::{baz::*, biz}");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, ToTokens, Spanned)]
+pub struct ItemUsePath {
+    /// First component in use.
+    pub first: ast::PathSegment,
+    /// The middle part of the import.
+    #[rune(iter)]
+    pub middle: Vec<(ast::Scope, ast::PathSegment)>,
+    /// The optional last group component.
+    #[rune(iter)]
+    pub last: Option<(ast::Scope, ItemUseComponent)>,
+}
+
+impl Parse for ItemUsePath {
+    fn parse(parser: &mut Parser) -> Result<Self, ParseError> {
+        let first = parser.parse()?;
+        let mut middle = Vec::new();
+        let mut last = None;
+
+        while parser.peek::<ast::Scope>()? {
+            let scope = parser.parse::<ast::Scope>()?;
+
+            if parser.peek::<ast::PathSegment>()? {
+                middle.push((scope, parser.parse()?));
+            } else {
+                last = Some((scope, parser.parse()?));
+                break;
+            }
+        }
+
+        Ok(Self {
+            first,
+            middle,
+            last,
+        })
+    }
+}
+
 /// A use component.
 #[derive(Debug, Clone, PartialEq, Eq, ToTokens, Spanned)]
 pub enum ItemUseComponent {
-    /// An identifier import.
-    PathSegment(ast::PathSegment),
     /// A wildcard import.
     Wildcard(ast::Mul),
+    /// A grouped import.
+    Group(ast::Braced<ast::ItemUsePath, ast::Comma>),
+}
+
+impl Peek for ItemUseComponent {
+    fn peek(t1: Option<ast::Token>, _: Option<ast::Token>) -> bool {
+        matches!(
+            peek!(t1).kind,
+            ast::Kind::Star | ast::Kind::Open(ast::Delimiter::Brace)
+        )
+    }
 }
 
 impl Parse for ItemUseComponent {
     fn parse(parser: &mut Parser) -> Result<Self, ParseError> {
-        if parser.peek::<ast::PathSegment>()? {
-            Ok(Self::PathSegment(parser.parse()?))
-        } else if parser.peek::<ast::Mul>()? {
-            Ok(Self::Wildcard(parser.parse()?))
+        Ok(if parser.peek::<ast::Mul>()? {
+            Self::Wildcard(parser.parse()?)
         } else {
-            let token = parser.token_peek_eof()?;
-            Err(ParseError::expected(token, "import component"))
-        }
-    }
-}
-
-impl Peek for ItemUseComponent {
-    fn peek(t1: Option<ast::Token>, t2: Option<ast::Token>) -> bool {
-        ast::PathSegment::peek(t1, t2) || ast::Mul::peek(t1, t2)
+            Self::Group(parser.parse()?)
+        })
     }
 }

--- a/crates/rune/src/ast/mod.rs
+++ b/crates/rune/src/ast/mod.rs
@@ -151,7 +151,7 @@ pub use self::item_fn::ItemFn;
 pub use self::item_impl::ItemImpl;
 pub use self::item_mod::{ItemMod, ItemModBody};
 pub use self::item_struct::{Field, ItemStruct, ItemStructBody};
-pub use self::item_use::{ItemUse, ItemUseComponent};
+pub use self::item_use::{ItemUse, ItemUseComponent, ItemUsePath};
 pub use self::label::Label;
 pub use self::lit::Lit;
 pub use self::lit_bool::LitBool;

--- a/crates/rune/src/compiling/unit_builder.rs
+++ b/crates/rune/src/compiling/unit_builder.rs
@@ -411,30 +411,24 @@ impl UnitBuilder {
     }
 
     /// Declare a new import.
-    pub(crate) fn new_import<I>(
+    pub(crate) fn new_import(
         &self,
-        item: Item,
-        path: I,
+        at: Item,
+        path: Item,
         span: Span,
         source_id: usize,
-    ) -> Result<(), UnitBuilderError>
-    where
-        I: Copy + IntoIterator,
-        I::Item: IntoComponent,
-    {
+    ) -> Result<(), UnitBuilderError> {
         let mut inner = self.inner.borrow_mut();
 
-        let path = Item::of(path);
-
         if let Some(last) = path.last() {
+            let key = ImportKey::new(at, last.clone());
+
             let entry = ImportEntry {
                 item: path.clone(),
                 span: Some((span, source_id)),
             };
 
-            inner
-                .imports
-                .insert(ImportKey::new(item, last.clone()), entry);
+            inner.imports.insert(key, entry);
         }
 
         Ok(())

--- a/crates/rune/src/tests/mod.rs
+++ b/crates/rune/src/tests/mod.rs
@@ -28,6 +28,7 @@ mod vm_result;
 mod vm_streams;
 mod vm_test_external_fn_ptr;
 mod vm_test_from_value_derive;
+mod vm_test_imports;
 mod vm_test_instance_fns;
 mod vm_test_linked_list;
 mod vm_test_mod;

--- a/crates/rune/src/tests/vm_test_imports.rs
+++ b/crates/rune/src/tests/vm_test_imports.rs
@@ -1,0 +1,25 @@
+#[test]
+fn test_grouped_imports() {
+    assert_eq! {
+        rune! {
+            (i64, bool, bool) => r#"
+            use a::{b::*, b::Foo::Baz, c};
+
+            mod a {
+                mod b {
+                    enum Foo { Bar, Baz, }
+                }
+            
+                mod c {
+                    const VALUE = 2;
+                }
+            }
+
+            fn main() {
+                (c::VALUE, Foo::Bar is a::b::Foo, Baz is a::b::Foo)
+            }                     
+            "#
+        },
+        (2, true, true),
+    };
+}


### PR DESCRIPTION
CC: @dillonhicks - since you're touching these systems as well.

This adds support for specifying imports group, like so:

```rust
use std::{result, option, iter::range};

// ...
```

Note about macros:

Macros are currently only allowed in contexts, so wildcard imports for these are handled separately, while wildcard imports for units are deferred with the `ExpandUnitWildcard` task until after indexing. This should have not practical implications for now, but it's clear that the system has to be reworked once we introduce re-exports.