### PR TITLE
Various internal improvements to performance and safety

### DIFF
--- a/crates/rune/src/ast/block.rs
+++ b/crates/rune/src/ast/block.rs
@@ -21,7 +21,7 @@ use crate::{Id, Parse, ParseError, Parser, Spanned, ToTokens};
 pub struct Block {
     /// The unique identifier for the block expression.
     #[rune(id)]
-    pub id: Id,
+    pub id: Option<Id>,
     /// The close brace.
     pub open: ast::OpenBrace,
     /// Statements in the block.
@@ -31,7 +31,7 @@ pub struct Block {
 }
 
 impl Opaque for Block {
-    fn id(&self) -> Id {
+    fn id(&self) -> Option<Id> {
         self.id
     }
 }

--- a/crates/rune/src/ast/expr_call.rs
+++ b/crates/rune/src/ast/expr_call.rs
@@ -15,7 +15,7 @@ use crate::{Id, Spanned, ToTokens};
 pub struct ExprCall {
     /// Opaque identifier related with call.
     #[rune(id)]
-    pub id: Id,
+    pub id: Option<Id>,
     /// Attributes associated with expression.
     #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,
@@ -28,7 +28,7 @@ pub struct ExprCall {
 expr_parse!(ExprCall, "call expression");
 
 impl Opaque for ExprCall {
-    fn id(&self) -> Id {
+    fn id(&self) -> Option<Id> {
         self.id
     }
 }

--- a/crates/rune/src/ast/expr_closure.rs
+++ b/crates/rune/src/ast/expr_closure.rs
@@ -24,7 +24,7 @@ use runestick::Span;
 pub struct ExprClosure {
     /// Opaque identifier for the closure.
     #[rune(id)]
-    pub id: Id,
+    pub id: Option<Id>,
     /// The attributes for the async closure
     #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,
@@ -87,7 +87,7 @@ impl ExprClosure {
 }
 
 impl Opaque for ExprClosure {
-    fn id(&self) -> Id {
+    fn id(&self) -> Option<Id> {
         self.id
     }
 }

--- a/crates/rune/src/ast/item_const.rs
+++ b/crates/rune/src/ast/item_const.rs
@@ -14,7 +14,7 @@ use crate::{Id, ParseError, Parser, Spanned, ToTokens};
 pub struct ItemConst {
     /// Opaque identifier for the constant.
     #[rune(id)]
-    pub id: Id,
+    pub id: Option<Id>,
     /// The *inner* attributes that are applied to the const declaration.
     #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,

--- a/crates/rune/src/ast/item_enum.rs
+++ b/crates/rune/src/ast/item_enum.rs
@@ -53,7 +53,7 @@ item_parse!(ItemEnum, "enum item");
 pub struct ItemVariant {
     /// Opaque identifier of variant.
     #[rune(id)]
-    pub id: Id,
+    pub id: Option<Id>,
     /// The attributes associated with the variant.
     #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,

--- a/crates/rune/src/ast/item_fn.rs
+++ b/crates/rune/src/ast/item_fn.rs
@@ -42,7 +42,7 @@ use runestick::Span;
 pub struct ItemFn {
     /// Opaque identifier for fn item.
     #[rune(id)]
-    pub id: Id,
+    pub id: Option<Id>,
     /// The attributes for the fn
     #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,

--- a/crates/rune/src/ast/item_struct.rs
+++ b/crates/rune/src/ast/item_struct.rs
@@ -18,7 +18,7 @@ use crate::{Id, OptionSpanned, Parse, ParseError, Parser, Spanned, ToTokens};
 pub struct ItemStruct {
     /// Opaque identifier of the struct.
     #[rune(id)]
-    pub id: Id,
+    pub id: Option<Id>,
     /// The attributes for the struct
     #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,

--- a/crates/rune/src/ast/lit_template.rs
+++ b/crates/rune/src/ast/lit_template.rs
@@ -9,7 +9,7 @@ use std::borrow::Cow;
 pub struct LitTemplate {
     /// Opaque identifier for the template.
     #[rune(id)]
-    pub id: Id,
+    pub id: Option<Id>,
     /// The token corresponding to the literal.
     token: ast::Token,
     /// The source string of the literal template.
@@ -18,7 +18,7 @@ pub struct LitTemplate {
 }
 
 impl Opaque for LitTemplate {
-    fn id(&self) -> Id {
+    fn id(&self) -> Option<Id> {
         self.id
     }
 }

--- a/crates/rune/src/ast/path.rs
+++ b/crates/rune/src/ast/path.rs
@@ -7,7 +7,7 @@ use crate::{Id, Parse, ParseError, ParseErrorKind, Parser, Peek, Spanned, ToToke
 pub struct Path {
     /// Opaque id associated with path.
     #[rune(id)]
-    pub id: Id,
+    pub id: Option<Id>,
     /// The optional leading colon `::`
     #[rune(iter)]
     pub leading_colon: Option<ast::Scope>,
@@ -62,7 +62,7 @@ impl Path {
 }
 
 impl Opaque for Path {
-    fn id(&self) -> Id {
+    fn id(&self) -> Option<Id> {
         self.id
     }
 }

--- a/crates/rune/src/compiling/unit_builder.rs
+++ b/crates/rune/src/compiling/unit_builder.rs
@@ -421,7 +421,7 @@ impl UnitBuilder {
         let mut inner = self.inner.borrow_mut();
 
         if let Some(last) = path.last() {
-            let key = ImportKey::new(at, last.clone());
+            let key = ImportKey::new(at, last.into_component());
 
             let entry = ImportEntry {
                 item: path.clone(),

--- a/crates/rune/src/load/source_loader.rs
+++ b/crates/rune/src/load/source_loader.rs
@@ -1,5 +1,5 @@
 use crate::{CompileError, CompileErrorKind};
-use runestick::{Component, Item, Source, Span};
+use runestick::{ComponentRef, Item, Source, Span};
 use std::path::Path;
 
 /// A source loader.
@@ -32,8 +32,8 @@ impl SourceLoader for FileSourceLoader {
         }
 
         for c in item {
-            if let Component::String(string) = c {
-                base.push(string.as_ref());
+            if let ComponentRef::String(string) = c {
+                base.push(string);
             } else {
                 return Err(CompileError::new(
                     span,

--- a/crates/rune/src/macros/macro_compiler.rs
+++ b/crates/rune/src/macros/macro_compiler.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 pub(crate) struct MacroCompiler<'a> {
     pub(crate) storage: Storage,
-    pub(crate) item: Item,
+    pub(crate) item: &'a Item,
     pub(crate) macro_context: &'a mut MacroContext,
     pub(crate) options: &'a Options,
     pub(crate) context: &'a Context,

--- a/crates/rune/src/parsing/opaque.rs
+++ b/crates/rune/src/parsing/opaque.rs
@@ -2,11 +2,11 @@ use crate::Id;
 use runestick::Span;
 
 pub(crate) trait Opaque {
-    fn id(&self) -> Id;
+    fn id(&self) -> Option<Id>;
 }
 
-impl Opaque for Id {
-    fn id(&self) -> Id {
+impl Opaque for Option<Id> {
+    fn id(&self) -> Option<Id> {
         *self
     }
 }
@@ -15,13 +15,13 @@ impl<T> Opaque for &T
 where
     T: Opaque,
 {
-    fn id(&self) -> Id {
+    fn id(&self) -> Option<Id> {
         Opaque::id(*self)
     }
 }
 
-impl Opaque for (Span, Id) {
-    fn id(&self) -> Id {
+impl Opaque for (Span, Option<Id>) {
+    fn id(&self) -> Option<Id> {
         self.1
     }
 }

--- a/crates/rune/src/query.rs
+++ b/crates/rune/src/query.rs
@@ -251,14 +251,14 @@ impl Query {
     }
 
     /// Insert an item and return its Id.
-    pub(crate) fn insert_item(&mut self, item: Item) -> Option<Id> {
+    pub(crate) fn insert_item(&mut self, item: &Item) -> Option<Id> {
         if let Some(id) = self.items_rev.get(&item) {
             return Some(*id);
         }
 
         let id = self.next_id.next()?;
         self.items_rev.insert(item.clone(), id);
-        self.items.insert(id, item);
+        self.items.insert(id, item.clone());
         Some(id)
     }
 

--- a/crates/rune/src/query.rs
+++ b/crates/rune/src/query.rs
@@ -227,6 +227,8 @@ pub(crate) struct Query {
     /// These items are associated with AST elements, and encodoes the item path
     /// that the AST element was indexed.
     pub(crate) items: HashMap<Id, Item>,
+    /// Reverse lookup for items to reduce the number of items used.
+    pub(crate) items_rev: HashMap<Item, Id>,
     /// Compiled constant functions.
     pub(crate) const_fns: HashMap<Id, Rc<ir::IrFn>>,
 }
@@ -243,13 +245,19 @@ impl Query {
             indexed: HashMap::new(),
             templates: HashMap::new(),
             items: HashMap::new(),
+            items_rev: HashMap::new(),
             const_fns: HashMap::new(),
         }
     }
 
     /// Insert an item and return its Id.
     pub(crate) fn insert_item(&mut self, item: Item) -> Option<Id> {
+        if let Some(id) = self.items_rev.get(&item) {
+            return Some(*id);
+        }
+
         let id = self.next_id.next()?;
+        self.items_rev.insert(item.clone(), id);
         self.items.insert(id, item);
         Some(id)
     }

--- a/crates/rune/src/spanned.rs
+++ b/crates/rune/src/spanned.rs
@@ -50,7 +50,7 @@ where
     }
 }
 
-impl Spanned for (Span, Id) {
+impl Spanned for (Span, Option<Id>) {
     fn span(&self) -> Span {
         self.0
     }

--- a/crates/rune/src/worker.rs
+++ b/crates/rune/src/worker.rs
@@ -119,9 +119,8 @@ impl<'a> Worker<'a> {
                         LoadFileKind::Module { root } => root,
                     };
 
-                    let items = Items::new(item.clone().into_vec());
-
                     log::trace!("index: {}", item);
+                    let items = Items::new(item.clone());
 
                     let mut indexer = Indexer {
                         root,

--- a/crates/runestick/src/compile_meta.rs
+++ b/crates/runestick/src/compile_meta.rs
@@ -212,7 +212,7 @@ pub enum CompileMetaKind {
     /// A constant function.
     ConstFn {
         /// Opaque identifier for the constant function.
-        id: Id,
+        id: Option<Id>,
         /// The item of the constant function.
         item: Item,
     },

--- a/crates/runestick/src/lib.rs
+++ b/crates/runestick/src/lib.rs
@@ -160,7 +160,7 @@ pub use crate::function::Function;
 pub use crate::future::Future;
 pub use crate::hash::{Hash, IntoTypeHash};
 pub use crate::inst::{Inst, InstOp, InstTarget, InstValue, PanicReason, TypeCheck};
-pub use crate::item::{Component, IntoComponent, Item};
+pub use crate::item::{Component, ComponentRef, IntoComponent, Item};
 pub use crate::names::Names;
 pub use crate::object::Object;
 pub use crate::panic::Panic;

--- a/crates/runestick/src/names.rs
+++ b/crates/runestick/src/names.rs
@@ -125,7 +125,7 @@ impl Names {
         let mut current = &self.root;
 
         for c in iter {
-            let c = c.into_component();
+            let c = c.as_component_ref().into_component();
             current = current.children.get(&c)?;
         }
 


### PR DESCRIPTION
This introduces a patch which makes the opaque identifier used to indirectly reference more compiler metadata locally unique over the entire compile phase. Previously it was allocated in a manner which meant that the identifiers conflicted over the different kinds of data stored in `Query`, like const fns and items. Now instead, the identifier is generated using [a global counter](https://github.com/rune-rs/rune/pull/127/files#diff-a7a441d34213eeea97100238a1eb797dR212). So identifiers used for different kinds of data are now distinct, increasing the likelihood of raising an error on compiler bugs.

I've also introduced many by-reference operations for `Item` and its associated `Component`. Previously a `Component` has to be strictly owned when operating over `item`, i.e. iterating over it, or inspecting the last component would return a copy of the slice of data making up the component. Now I've introduce [`ComponentRef`](https://github.com/rune-rs/rune/pull/127/files#diff-e303a4353a37e4fee561d914fab5a1a7R344), which can reference a slice out of the component instead of having to copy it.

`Items` has been slimmed down to only be a wrapper around an `Item`, and add utility things like guards. This means that `Items::item` which previously returned a constructed copy of the item being built now can return [a guarded reference over the inner item](https://github.com/rune-rs/rune/pull/127/files#diff-4df8fb6cf7c4dd13d0350877580a68acR103), reducing the need to copy and increasing memory locality.

Finally, the [internal encoding of an `Item`](https://github.com/rune-rs/rune/pull/127/files#diff-e303a4353a37e4fee561d914fab5a1a7R32) has been slimmed down significantly. A simple component `Block`, `Closure`, ... has been reduced to only take up two bytes (the tag). While strings take up the string length + 4 bytes. One tag at the beginning and end of the string to enable seeking backwards.