### PR TITLE
Replace import iteration with dead code elimination during imports

### DIFF
--- a/crates/rune/src/compiling/unit_builder.rs
+++ b/crates/rune/src/compiling/unit_builder.rs
@@ -506,6 +506,7 @@ impl UnitBuilder {
             CompileMetaKind::Macro { .. } => (),
             CompileMetaKind::Const { .. } => (),
             CompileMetaKind::ConstFn { .. } => (),
+            CompileMetaKind::Import { .. } => (),
         }
 
         if let Some(existing) = inner.meta.insert(meta.item.clone(), meta.clone()) {

--- a/crates/rune/src/diagnostics.rs
+++ b/crates/rune/src/diagnostics.rs
@@ -82,8 +82,7 @@ impl EmitDiagnostics for Warnings {
             let context = match &w.kind {
                 WarningKind::NotUsed { span, context } => {
                     labels.push(
-                        Label::primary(w.source_id, span.start..span.end)
-                            .with_message("value not used"),
+                        Label::primary(w.source_id, span.start..span.end).with_message("not used"),
                     );
 
                     *context
@@ -322,14 +321,14 @@ impl EmitDiagnostics for Error {
         fn format_compile_error(
             this: &Error,
             sources: &Sources,
-            span: Span,
+            error_span: Span,
             kind: &CompileErrorKind,
             labels: &mut Vec<Label<SourceId>>,
             notes: &mut Vec<String>,
         ) -> fmt::Result {
             match kind {
                 CompileErrorKind::QueryError { error } => {
-                    format_query_error(this, sources, span, error, labels, notes)?;
+                    format_query_error(this, sources, error_span, error, labels, notes)?;
                 }
                 CompileErrorKind::DuplicateObjectKey { existing, object } => {
                     labels.push(
@@ -361,7 +360,7 @@ impl EmitDiagnostics for Error {
 
                     let binding = sources
                         .source_at(this.source_id())
-                        .and_then(|s| s.source(span));
+                        .and_then(|s| s.source(error_span));
 
                     if let Some(binding) = binding {
                         let mut note = String::new();
@@ -378,17 +377,17 @@ impl EmitDiagnostics for Error {
         fn format_query_error(
             this: &Error,
             sources: &Sources,
-            span: Span,
+            error_span: Span,
             kind: &QueryErrorKind,
             labels: &mut Vec<Label<SourceId>>,
             notes: &mut Vec<String>,
         ) -> fmt::Result {
             match kind {
                 QueryErrorKind::CompileError { error } => {
-                    format_compile_error(this, sources, span, error, labels, notes)?;
+                    format_compile_error(this, sources, error_span, error, labels, notes)?;
                 }
                 QueryErrorKind::IrError { error } => {
-                    format_ir_error(this, sources, span, error, labels, notes)?;
+                    format_ir_error(this, sources, error_span, error, labels, notes)?;
                 }
                 QueryErrorKind::ImportCycle { path } => {
                     let mut it = path.into_iter();
@@ -475,14 +474,14 @@ impl EmitDiagnostics for Error {
         fn format_ir_error(
             this: &Error,
             sources: &Sources,
-            span: Span,
+            error_span: Span,
             kind: &IrErrorKind,
             labels: &mut Vec<Label<SourceId>>,
             notes: &mut Vec<String>,
         ) -> fmt::Result {
             match kind {
                 IrErrorKind::QueryError { error } => {
-                    format_query_error(this, sources, span, error, labels, notes)?;
+                    format_query_error(this, sources, error_span, error, labels, notes)?;
                 }
                 _ => (),
             }

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -271,8 +271,8 @@ mod collections {
 }
 
 pub use self::compiling::{
-    CompileError, CompileErrorKind, CompileResult, CompileVisitor, LinkerError, NoopCompileVisitor,
-    UnitBuilder, Var,
+    CompileError, CompileErrorKind, CompileResult, CompileVisitor, ImportEntryStep, LinkerError,
+    NoopCompileVisitor, UnitBuilder, Var,
 };
 pub use self::ir::{IrError, IrErrorKind};
 pub use self::load::{

--- a/crates/rune/src/query/query_error.rs
+++ b/crates/rune/src/query/query_error.rs
@@ -4,7 +4,7 @@ use crate::shared::Location;
 use crate::{
     CompileError, CompileErrorKind, Id, IrError, IrErrorKind, ParseError, ParseErrorKind, Spanned,
 };
-use runestick::{Item, Span};
+use runestick::{CompileMeta, Item, Span};
 use thiserror::Error;
 
 error! {
@@ -51,7 +51,7 @@ pub enum QueryErrorKind {
     },
     #[error("missing {what} for id {id:?}")]
     MissingId { what: &'static str, id: Option<Id> },
-    #[error("tried to insert conflicting item `{item}`")]
+    #[error("conflicting item `{item}`")]
     ItemConflict { item: Item, other: Location },
     #[error("item `{item}` with {visibility} visibility, is not accessible from here")]
     NotVisible {
@@ -80,4 +80,8 @@ pub enum QueryErrorKind {
     ImportConflict { item: Item, other: Location },
     #[error("missing last use component")]
     LastUseComponent,
+    #[error("found indexed entry for `{item}`, but was not an import")]
+    NotIndexedImport { item: Item },
+    #[error("{meta} can't be used as an import")]
+    UnsupportedImportMeta { meta: CompileMeta },
 }

--- a/crates/rune/src/worker.rs
+++ b/crates/rune/src/worker.rs
@@ -14,6 +14,7 @@ use runestick::{Context, Item, Source, SourceId, Span};
 use std::collections::VecDeque;
 use std::path::PathBuf;
 use std::rc::Rc;
+use std::sync::Arc;
 
 /// A single task that can be fed to the worker.
 #[derive(Debug)]
@@ -163,7 +164,7 @@ impl<'a> Worker<'a> {
 pub(crate) struct Import<'a> {
     pub(crate) visibility: Visibility,
     pub(crate) item: &'a Item,
-    pub(crate) source: &'a Source,
+    pub(crate) source: &'a Arc<Source>,
     pub(crate) source_id: usize,
     pub(crate) ast: ast::ItemUse,
 }
@@ -257,6 +258,7 @@ impl Import<'_> {
                                 query.insert_import(
                                     self.source_id,
                                     span,
+                                    &self.source,
                                     mod_item,
                                     self.visibility,
                                     self.item.clone(),
@@ -277,6 +279,7 @@ impl Import<'_> {
                             name: name.clone(),
                             span,
                             source_id: self.source_id,
+                            source: self.source.clone(),
                             was_in_context,
                             mod_item: mod_item.clone(),
                         };
@@ -319,6 +322,7 @@ impl Import<'_> {
                 query.insert_import(
                     self.source_id,
                     span,
+                    &self.source,
                     mod_item,
                     self.visibility,
                     self.item.clone(),
@@ -339,6 +343,7 @@ pub(crate) struct ExpandUnitWildcard {
     from: Item,
     name: Item,
     source_id: SourceId,
+    source: Arc<Source>,
     span: Span,
     /// Indicates if any wildcards were expanded from context.
     was_in_context: bool,
@@ -359,6 +364,7 @@ impl ExpandUnitWildcard {
                 query.insert_import(
                     self.source_id,
                     self.span,
+                    &self.source,
                     &self.mod_item,
                     self.visibility,
                     self.from.clone(),

--- a/crates/runestick/src/compile_meta.rs
+++ b/crates/runestick/src/compile_meta.rs
@@ -50,6 +50,7 @@ impl CompileMeta {
             CompileMetaKind::Macro { .. } => None,
             CompileMetaKind::Const { .. } => None,
             CompileMetaKind::ConstFn { .. } => None,
+            CompileMetaKind::Import { .. } => None,
         }
     }
 }
@@ -95,6 +96,9 @@ impl fmt::Display for CompileMeta {
             }
             CompileMetaKind::ConstFn { .. } => {
                 write!(fmt, "const fn {}", self.item)?;
+            }
+            CompileMetaKind::Import { .. } => {
+                write!(fmt, "import {}", self.item)?;
             }
         }
 
@@ -189,6 +193,8 @@ pub enum CompileMetaKind {
     },
     /// A macro.
     Macro,
+    /// Purely an import.
+    Import,
 }
 
 /// The metadata about a type.

--- a/crates/runestick/src/item.rs
+++ b/crates/runestick/src/item.rs
@@ -67,6 +67,19 @@ impl Item {
         }
     }
 
+    /// Indicate if this item is supposed to be unique or not.
+    pub fn is_unique(&self) -> bool {
+        let c = match self.last() {
+            Some(c) => c,
+            None => return true,
+        };
+
+        match c {
+            ComponentRef::Block(..) => false,
+            _ => true,
+        }
+    }
+
     /// Construct a new item path.
     pub fn of<I>(iter: I) -> Self
     where


### PR DESCRIPTION
This removes the `verify_imports` stage of compilation by integrating imports into the indexing/build system.

It's still kinda iffily integrated, in that the `get_imports` handling is done separately from `query_meta`. This is because imports can have cycles, and `query_meta` just doesn't have the necessary plumbing to deal with it. There's also a fair amount of metadata that would have to be awkwardly propagated (like import chains used for diagnostics), so it might not be worth it.

This is what cyclic import checking looks like right now:
![image](https://user-images.githubusercontent.com/111092/94960606-79164a00-04f3-11eb-9ac0-125b2f66d899.png)
