### PR TITLE
Merge import and indexing systems

### DIFF
--- a/crates/rune/src/compiling/compile_error.rs
+++ b/crates/rune/src/compiling/compile_error.rs
@@ -194,8 +194,14 @@ pub enum CompileErrorKind {
         expected: usize,
         actual: usize,
     },
-    #[error("expression not supported here")]
-    UnsupportedPattern,
+    #[error("{meta} is not supported here")]
+    UnsupportedPattern { meta: CompileMeta },
+    #[error("undefined types cannot be used as patterns")]
+    UnsupportedPatternNoMeta,
+    #[error("`..` is not supported in this location")]
+    UnsupportedPatternRest,
+    #[error("this kind of expression is not supported as a pattern")]
+    UnsupportedPatternExpr,
     #[error("not a valid binding")]
     UnsupportedBinding,
     #[error("floating point numbers cannot be used in patterns")]

--- a/crates/rune/src/compiling/compiler.rs
+++ b/crates/rune/src/compiling/compiler.rs
@@ -359,7 +359,7 @@ impl<'a> Compiler<'a> {
                 None => {
                     return Err(CompileError::new(
                         span,
-                        CompileErrorKind::UnsupportedPattern,
+                        CompileErrorKind::UnsupportedPatternNoMeta,
                     ));
                 }
             };
@@ -485,7 +485,7 @@ impl<'a> Compiler<'a> {
                         None => {
                             return Err(CompileError::new(
                                 span,
-                                CompileErrorKind::UnsupportedPattern,
+                                CompileErrorKind::UnsupportedPatternExpr,
                             ));
                         }
                     };
@@ -498,7 +498,7 @@ impl<'a> Compiler<'a> {
                 _ => {
                     return Err(CompileError::new(
                         span,
-                        CompileErrorKind::UnsupportedPattern,
+                        CompileErrorKind::UnsupportedPatternExpr,
                     ));
                 }
             };
@@ -748,7 +748,10 @@ impl<'a> Compiler<'a> {
                 self.compile_pat_object(object, false_label, &load)?;
                 Ok(true)
             }
-            pat => Err(CompileError::new(pat, CompileErrorKind::UnsupportedPattern)),
+            pat => Err(CompileError::new(
+                pat,
+                CompileErrorKind::UnsupportedPatternExpr,
+            )),
         }
     }
 
@@ -823,7 +826,7 @@ impl<'a> Compiler<'a> {
 
             return Err(CompileError::new(
                 pat_lit,
-                CompileErrorKind::UnsupportedPattern,
+                CompileErrorKind::UnsupportedPatternExpr,
             ));
         }
 
@@ -937,7 +940,7 @@ where
         if let ast::Pat::PatRest(rest) = pat {
             return Err(CompileError::new(
                 rest,
-                CompileErrorKind::UnsupportedPattern,
+                CompileErrorKind::UnsupportedPatternRest,
             ));
         }
 

--- a/crates/rune/src/compiling/unit_builder.rs
+++ b/crates/rune/src/compiling/unit_builder.rs
@@ -519,6 +519,24 @@ impl UnitBuilder {
         Ok(())
     }
 
+    /// Insert meta without registering peripherals under the assumption that it
+    /// already has been registered.
+    pub(crate) fn insert_meta_without_peripherals(
+        &self,
+        meta: CompileMeta,
+    ) -> Result<(), InsertMetaError> {
+        let mut inner = self.inner.borrow_mut();
+
+        if let Some(existing) = inner.meta.insert(meta.item.clone(), meta.clone()) {
+            return Err(InsertMetaError::MetaConflict {
+                current: meta,
+                existing,
+            });
+        }
+
+        Ok(())
+    }
+
     /// Construct a new empty assembly associated with the current unit.
     pub(crate) fn new_assembly(&self, location: Location) -> Assembly {
         let label_count = self.inner.borrow().label_count;

--- a/crates/rune/src/diagnostics.rs
+++ b/crates/rune/src/diagnostics.rs
@@ -422,15 +422,6 @@ impl EmitDiagnostics for Error {
                             .with_message("previously defined here"),
                     );
                 }
-                QueryErrorKind::ImportConflict {
-                    other: Location { source_id, span },
-                    ..
-                } => {
-                    labels.push(
-                        Label::secondary(*source_id, span.start..span.end)
-                            .with_message("previous import here"),
-                    );
-                }
                 QueryErrorKind::NotVisible {
                     chain,
                     location: Location { source_id, span },

--- a/crates/rune/src/query/imports.rs
+++ b/crates/rune/src/query/imports.rs
@@ -10,11 +10,6 @@ use std::rc::Rc;
 pub(crate) struct Imports {
     /// Prelude from the prelude.
     pub(super) prelude: HashMap<Box<str>, Item>,
-    /// All imports in the current unit.
-    ///
-    /// Only used to link against the current environment to make sure all
-    /// required units are present.
-    pub(super) imports: HashMap<Item, Rc<ImportEntry>>,
     /// All available names in the context.
     pub(super) names: Names<(NameKind, Location)>,
     /// Associated between `id` and `Item`. Use to look up items through
@@ -104,6 +99,7 @@ pub struct ImportEntry {
 
 #[derive(Debug)]
 pub(crate) enum NameKind {
+    Wildcard,
     Use,
     Other,
 }

--- a/crates/rune/src/query/query_error.rs
+++ b/crates/rune/src/query/query_error.rs
@@ -51,7 +51,7 @@ pub enum QueryErrorKind {
     },
     #[error("missing {what} for id {id:?}")]
     MissingId { what: &'static str, id: Option<Id> },
-    #[error("conflicting item `{item}`")]
+    #[error("cannot define conflicting item `{item}`")]
     ItemConflict { item: Item, other: Location },
     #[error("item `{item}` with {visibility} visibility, is not accessible from here")]
     NotVisible {
@@ -76,8 +76,6 @@ pub enum QueryErrorKind {
     MissingMod { item: Item },
     #[error("cycle in import")]
     ImportCycle { path: Vec<ImportEntryStep> },
-    #[error("already imported `{item}`")]
-    ImportConflict { item: Item, other: Location },
     #[error("missing last use component")]
     LastUseComponent,
     #[error("found indexed entry for `{item}`, but was not an import")]

--- a/crates/rune/src/tests/compiler_paths.rs
+++ b/crates/rune/src/tests/compiler_paths.rs
@@ -79,7 +79,7 @@ fn test_import_conflict() {
         r#"use std::{option, option};"#,
         span, QueryError { error, .. } => {
             assert_eq!(span, Span::new(18, 24));
-            assert_matches!(&*error, ImportConflict { .. });
+            assert_matches!(&*error, ItemConflict { .. });
         }
     };
 }

--- a/crates/rune/src/tests/compiler_use.rs
+++ b/crates/rune/src/tests/compiler_use.rs
@@ -48,13 +48,11 @@ fn test_import_cycle() {
                 other => panic!("unexpected query error: {:?}", other),
             };
 
-            assert_eq!(3, path.len());
+            assert_eq!(2, path.len());
             assert_eq!(Span::new(107, 120), path[0].location.span);
             assert_eq!(Span::new(37, 50), path[1].location.span);
-            assert_eq!(Span::new(107, 120), path[2].location.span);
         }
     };
-    
 }
 
 #[test]

--- a/crates/runestick/src/compile_meta.rs
+++ b/crates/runestick/src/compile_meta.rs
@@ -194,7 +194,10 @@ pub enum CompileMetaKind {
     /// A macro.
     Macro,
     /// Purely an import.
-    Import,
+    Import {
+        /// The imported target.
+        imported: Item,
+    },
 }
 
 /// The metadata about a type.

--- a/crates/runestick/src/item.rs
+++ b/crates/runestick/src/item.rs
@@ -67,19 +67,6 @@ impl Item {
         }
     }
 
-    /// Indicate if this item is supposed to be unique or not.
-    pub fn is_unique(&self) -> bool {
-        let c = match self.last() {
-            Some(c) => c,
-            None => return true,
-        };
-
-        match c {
-            ComponentRef::Block(..) => false,
-            _ => true,
-        }
-    }
-
     /// Construct a new item path.
     pub fn of<I>(iter: I) -> Self
     where


### PR DESCRIPTION
This gets rid of the import system as a system on the sideline and merges it with the existing indexing system.

Also fixes the `is_unique` workaround that was introduced to handle reverse lookup of items for import purposes by pre-emptively indexing all items and using separate method for looking up the current item metadata when needed.