### PR TITLE
Better macro support

### DIFF
--- a/crates/rune-modules/src/experiments/mod.rs
+++ b/crates/rune-modules/src/experiments/mod.rs
@@ -37,7 +37,7 @@ fn make_function(stream: &TokenStream) -> runestick::Result<TokenStream> {
     let ident = parser.parse::<ast::Ident>()?;
     let _ = parser.parse::<ast::Rocket>()?;
     let output = parser.parse::<ast::ExprBlock>()?;
-    parser.parse_eof()?;
+    parser.eof()?;
 
     Ok(rune::quote!(fn #ident() { #output }))
 }

--- a/crates/rune-modules/src/experiments/stringy_math_macro.rs
+++ b/crates/rune-modules/src/experiments/stringy_math_macro.rs
@@ -26,6 +26,6 @@ pub(crate) fn stringy_math(stream: &TokenStream) -> runestick::Result<TokenStrea
         }
     }
 
-    parser.parse_eof()?;
+    parser.eof()?;
     Ok(output)
 }

--- a/crates/rune-modules/src/test.rs
+++ b/crates/rune-modules/src/test.rs
@@ -60,7 +60,7 @@ pub(crate) fn assert_macro(
         })
     };
 
-    parser.parse_eof()?;
+    parser.eof()?;
     Ok(output)
 }
 
@@ -96,6 +96,6 @@ pub(crate) fn assert_eq_macro(
         })
     };
 
-    parser.parse_eof()?;
+    parser.eof()?;
     Ok(output)
 }

--- a/crates/rune/src/ast/expr.rs
+++ b/crates/rune/src/ast/expr.rs
@@ -614,7 +614,7 @@ impl Peek for Expr {
             ast::Kind::LitByte { .. } => true,
             ast::Kind::LitStr { .. } => true,
             ast::Kind::LitByteStr { .. } => true,
-            ast::Kind::LitTemplate { .. } => true,
+            ast::Kind::Template { .. } => true,
             ast::Kind::Open(ast::Delimiter::Parenthesis) => true,
             ast::Kind::Open(ast::Delimiter::Bracket) => true,
             ast::Kind::Open(ast::Delimiter::Brace) => true,

--- a/crates/rune/src/ast/lit.rs
+++ b/crates/rune/src/ast/lit.rs
@@ -64,7 +64,7 @@ impl Lit {
             ast::Kind::LitChar(_) => true,
             ast::Kind::LitStr(_) => true,
             ast::Kind::LitByteStr(_) => true,
-            ast::Kind::LitTemplate(_) => true,
+            ast::Kind::Template => true,
             ast::Kind::Open(ast::Delimiter::Bracket) => true,
             ast::Kind::Pound => match parser.token_peek2()?.map(|t| t.kind) {
                 Some(ast::Kind::Open(ast::Delimiter::Brace)) => true,
@@ -109,7 +109,7 @@ impl Parse for Lit {
                 ast::Kind::LitChar(_) => Lit::Char(parser.parse()?),
                 ast::Kind::LitStr(_) => Lit::Str(parser.parse()?),
                 ast::Kind::LitByteStr(_) => Lit::ByteStr(parser.parse()?),
-                ast::Kind::LitTemplate(_) => Lit::Template(parser.parse()?),
+                ast::Kind::Template => Lit::Template(parser.parse()?),
                 ast::Kind::Open(ast::Delimiter::Parenthesis) => {
                     match parser.token_peek2_eof()?.kind {
                         ast::Kind::Close(ast::Delimiter::Parenthesis) => Lit::Unit(parser.parse()?),

--- a/crates/rune/src/ast/mod.rs
+++ b/crates/rune/src/ast/mod.rs
@@ -158,7 +158,7 @@ pub use self::lit_object::{
     AnonymousLitObject, LitObject, LitObjectFieldAssign, LitObjectIdent, LitObjectKey,
 };
 pub use self::lit_str::LitStr;
-pub use self::lit_template::{LitTemplate, Template, TemplateComponent};
+pub use self::lit_template::LitTemplate;
 pub use self::lit_tuple::LitTuple;
 pub use self::lit_unit::LitUnit;
 pub use self::lit_vec::LitVec;
@@ -273,6 +273,7 @@ decl_tokens! {
     (SemiColon, "A semicolon `;`.", Kind::SemiColon),
     (Struct, "The `struct` keyword.", Kind::Struct),
     (Super, "The `super` keyword.", Kind::Super),
+    (Template, "The `template` keyword.", Kind::Template),
     (Try, "The `?` operator.", Kind::QuestionMark),
     (Underscore, "The underscore `_`.", Kind::Underscore),
     (Use, "The `use` keyword.", Kind::Use),

--- a/crates/rune/src/ast/utils.rs
+++ b/crates/rune/src/ast/utils.rs
@@ -1,12 +1,11 @@
 use crate::ast;
-use crate::{ParseError, ParseErrorKind};
-use runestick::Span;
+use crate::ParseErrorKind;
 use std::iter::Peekable;
 use std::ops;
 
 /// Indicates if we are parsing braces.
 #[derive(Debug, Clone, Copy)]
-pub(super) struct WithBrace(pub(super) bool);
+pub(crate) struct WithBrace(pub(super) bool);
 
 impl ops::Deref for WithBrace {
     type Target = bool;
@@ -29,20 +28,11 @@ impl ops::Deref for WithLineCont {
 }
 
 /// Parse a byte escape sequence.
-pub(super) fn parse_byte_escape<I>(
-    span: Span,
-    it: &mut Peekable<I>,
+pub(super) fn parse_byte_escape(
+    it: &mut Peekable<impl Iterator<Item = (usize, char)>>,
     with_line_cont: WithLineCont,
-) -> Result<Option<u8>, ParseError>
-where
-    I: Iterator<Item = (usize, char)>,
-{
-    let (n, c) = match it.next() {
-        Some(c) => c,
-        None => {
-            return Err(ParseError::new(span, ParseErrorKind::BadEscapeSequence));
-        }
-    };
+) -> Result<Option<u8>, ParseErrorKind> {
+    let (_, c) = it.next().ok_or_else(|| ParseErrorKind::BadEscapeSequence)?;
 
     Ok(Some(match c {
         '\n' | '\r' if *with_line_cont => {
@@ -64,43 +54,30 @@ where
         '\\' => b'\\',
         '0' => b'\0',
         'x' => {
-            let (result, span) = parse_hex_escape(span, it)?;
+            let result = parse_hex_escape(it)?;
 
             if result > 0xff {
-                return Err(ParseError::new(span, ParseErrorKind::UnsupportedByteEscape));
+                return Err(ParseErrorKind::UnsupportedByteEscape);
             }
 
             result as u8
         }
         'u' => {
-            return Err(ParseError::new(
-                span,
-                ParseErrorKind::UnicodeEscapeNotSupported,
-            ));
+            return Err(ParseErrorKind::UnicodeEscapeNotSupported);
         }
         _ => {
-            let span = span.with_end(n);
-            return Err(ParseError::new(span, ParseErrorKind::BadEscapeSequence));
+            return Err(ParseErrorKind::BadEscapeSequence);
         }
     }))
 }
 
 /// Parse a byte escape sequence.
-pub(super) fn parse_char_escape<I>(
-    span: Span,
-    it: &mut Peekable<I>,
+pub(super) fn parse_char_escape(
+    it: &mut Peekable<impl Iterator<Item = (usize, char)>>,
     with_brace: WithBrace,
     with_line_cont: WithLineCont,
-) -> Result<Option<char>, ParseError>
-where
-    I: Iterator<Item = (usize, char)>,
-{
-    let (n, c) = match it.next() {
-        Some(c) => c,
-        None => {
-            return Err(ParseError::new(span, ParseErrorKind::BadEscapeSequence));
-        }
-    };
+) -> Result<Option<char>, ParseErrorKind> {
+    let (_, c) = it.next().ok_or_else(|| ParseErrorKind::BadEscapeSequence)?;
 
     Ok(Some(match c {
         '\n' | '\r' if *with_line_cont => {
@@ -124,140 +101,95 @@ where
         '\\' => '\\',
         '0' => '\0',
         'x' => {
-            let (result, span) = parse_hex_escape(span, it)?;
+            let result = parse_hex_escape(it)?;
 
             if result > 0x7f {
-                return Err(ParseError::new(
-                    span,
-                    ParseErrorKind::UnsupportedUnicodeByteEscape,
-                ));
+                return Err(ParseErrorKind::UnsupportedUnicodeByteEscape);
             }
 
             if let Some(c) = std::char::from_u32(result) {
                 c
             } else {
-                return Err(ParseError::new(span, ParseErrorKind::BadByteEscape));
+                return Err(ParseErrorKind::BadByteEscape);
             }
         }
-        'u' => parse_unicode_escape(span, it)?,
+        'u' => parse_unicode_escape(it)?,
         _ => {
-            let span = span.with_end(n);
-            return Err(ParseError::new(span, ParseErrorKind::BadEscapeSequence));
+            return Err(ParseErrorKind::BadEscapeSequence);
         }
     }))
 }
 
 /// Parse a hex escape.
-fn parse_hex_escape<I>(span: Span, it: &mut Peekable<I>) -> Result<(u32, Span), ParseError>
-where
-    I: Iterator<Item = (usize, char)>,
-{
+fn parse_hex_escape(
+    it: &mut Peekable<impl Iterator<Item = (usize, char)>>,
+) -> Result<u32, ParseErrorKind> {
     let mut result = 0u32;
 
     for _ in 0..2 {
-        let (_, c) = it
-            .next()
-            .ok_or_else(|| ParseError::new(span, ParseErrorKind::BadByteEscape))?;
-
-        let span = it.peek().map(|(n, _)| span.with_end(*n)).unwrap_or(span);
+        let (_, c) = it.next().ok_or_else(|| ParseErrorKind::BadByteEscape)?;
 
         result = result
             .checked_shl(4)
-            .ok_or_else(|| ParseError::new(span, ParseErrorKind::BadByteEscape))?;
+            .ok_or_else(|| ParseErrorKind::BadByteEscape)?;
 
         result += match c {
             '0'..='9' => c as u32 - '0' as u32,
             'a'..='f' => c as u32 - 'a' as u32 + 10,
             'A'..='F' => c as u32 - 'A' as u32 + 10,
-            _ => return Err(ParseError::new(span, ParseErrorKind::BadByteEscape)),
+            _ => return Err(ParseErrorKind::BadByteEscape),
         };
     }
 
-    let span = it.peek().map(|(n, _)| span.with_end(*n)).unwrap_or(span);
-    Ok((result, span))
+    Ok(result)
 }
 
 /// Parse a unicode escape.
-pub(super) fn parse_unicode_escape<I>(span: Span, it: &mut Peekable<I>) -> Result<char, ParseError>
-where
-    I: Iterator<Item = (usize, char)>,
-{
+pub(super) fn parse_unicode_escape(
+    it: &mut Peekable<impl Iterator<Item = (usize, char)>>,
+) -> Result<char, ParseErrorKind> {
     match it.next() {
         Some((_, '{')) => (),
-        _ => return Err(ParseError::new(span, ParseErrorKind::BadUnicodeEscape)),
+        _ => return Err(ParseErrorKind::BadUnicodeEscape),
     };
 
     let mut first = true;
     let mut result = 0u32;
 
     loop {
-        let (_, c) = it
-            .next()
-            .ok_or_else(|| ParseError::new(span, ParseErrorKind::BadUnicodeEscape))?;
-
-        let span = it.peek().map(|(n, _)| span.with_end(*n)).unwrap_or(span);
+        let (_, c) = it.next().ok_or_else(|| ParseErrorKind::BadUnicodeEscape)?;
 
         match c {
             '}' => {
                 if first {
-                    return Err(ParseError::new(span, ParseErrorKind::BadUnicodeEscape));
+                    return Err(ParseErrorKind::BadUnicodeEscape);
                 }
 
                 if let Some(c) = std::char::from_u32(result) {
                     return Ok(c);
                 }
 
-                return Err(ParseError::new(span, ParseErrorKind::BadUnicodeEscape));
+                return Err(ParseErrorKind::BadUnicodeEscape);
             }
             c => {
                 first = false;
 
-                result = result
-                    .checked_shl(4)
-                    .ok_or_else(|| ParseError::new(span, ParseErrorKind::BadUnicodeEscape))?;
+                result = match result.checked_shl(4) {
+                    Some(result) => result,
+                    None => {
+                        return Err(ParseErrorKind::BadUnicodeEscape);
+                    }
+                };
 
                 result += match c {
                     '0'..='9' => c as u32 - '0' as u32,
                     'a'..='f' => c as u32 - 'a' as u32 + 10,
                     'A'..='F' => c as u32 - 'A' as u32 + 10,
                     _ => {
-                        return Err(ParseError::new(span, ParseErrorKind::BadUnicodeEscape));
+                        return Err(ParseErrorKind::BadUnicodeEscape);
                     }
                 };
             }
-        }
-    }
-}
-
-/// Find the span of an expression inside of a balanced collection of braces.
-///
-/// This is expected to start parsing immediately after an opening brace `{`.
-pub(crate) fn template_expr<I>(span: Span, it: &mut I) -> Result<Span, ParseError>
-where
-    I: Iterator<Item = (usize, char)>,
-{
-    let mut start = None;
-    let mut level = 1;
-
-    loop {
-        let (n, c) = it
-            .next()
-            .ok_or_else(|| ParseError::new(span, ParseErrorKind::InvalidTemplateLiteral))?;
-
-        if start.is_none() {
-            start = Some(n);
-        }
-
-        match c {
-            '{' => level += 1,
-            '}' => level -= 1,
-            _ => (),
-        }
-
-        if level == 0 {
-            let start = start
-                .ok_or_else(|| ParseError::new(span, ParseErrorKind::InvalidTemplateLiteral))?;
-            return Ok(Span::new(start, n));
         }
     }
 }
@@ -281,7 +213,6 @@ pub(crate) fn is_block_end(expr: &ast::Expr, comma: Option<&ast::Comma>) -> bool
 #[cfg(test)]
 mod tests {
     use super::{parse_hex_escape, parse_unicode_escape};
-    use runestick::Span;
 
     macro_rules! input {
         ($string:expr) => {
@@ -291,20 +222,20 @@ mod tests {
 
     #[test]
     fn test_parse_hex_escape() {
-        assert!(parse_hex_escape(Span::empty(), input!("a")).is_err());
+        assert!(parse_hex_escape(input!("a")).is_err());
 
-        let (c, _) = parse_hex_escape(Span::empty(), input!("7f")).unwrap();
+        let c = parse_hex_escape(input!("7f")).unwrap();
         assert_eq!(c, 0x7f);
     }
 
     #[test]
     fn test_parse_unicode_escape() {
-        parse_unicode_escape(Span::empty(), input!("{0}")).unwrap();
+        parse_unicode_escape(input!("{0}")).unwrap();
 
-        let c = parse_unicode_escape(Span::empty(), input!("{1F4AF}")).unwrap();
+        let c = parse_unicode_escape(input!("{1F4AF}")).unwrap();
         assert_eq!(c, '💯');
 
-        let c = parse_unicode_escape(Span::empty(), input!("{1f4af}")).unwrap();
+        let c = parse_unicode_escape(input!("{1f4af}")).unwrap();
         assert_eq!(c, '💯');
     }
 }

--- a/crates/rune/src/compiling/compile_error.rs
+++ b/crates/rune/src/compiling/compile_error.rs
@@ -105,13 +105,13 @@ impl From<Internal> for CompileError {
 pub enum CompileErrorKind {
     #[error("internal compiler error: {message}")]
     Internal { message: &'static str },
-    #[error("ir error: {error}")]
+    #[error("{error}")]
     IrError {
         #[source]
         #[from]
         error: Box<IrErrorKind>,
     },
-    #[error("query error: {error}")]
+    #[error("{error}")]
     QueryError {
         #[source]
         #[from]

--- a/crates/rune/src/compiling/compiler.rs
+++ b/crates/rune/src/compiling/compiler.rs
@@ -885,12 +885,9 @@ impl<'a> Compiler<'a> {
             ));
         }
 
-        let mut ir_query = self.query.as_ir_query();
-
         let mut compiler = IrCompiler {
             storage: self.storage.clone(),
             source: self.source.clone(),
-            query: &mut *ir_query,
         };
 
         let mut compiled = Vec::new();
@@ -899,6 +896,8 @@ impl<'a> Compiler<'a> {
         for ((a, _), name) in args.iter().zip(&query_const_fn.ir_fn.args) {
             compiled.push((compiler.compile(a)?, name));
         }
+
+        let mut ir_query = self.query.as_ir_query();
 
         let mut interpreter = IrInterpreter {
             budget: IrBudget::new(1_000_000),

--- a/crates/rune/src/compiling/compiler.rs
+++ b/crates/rune/src/compiling/compiler.rs
@@ -874,8 +874,6 @@ impl<'a> Compiler<'a> {
     where
         S: Copy + Spanned,
     {
-        use crate::ir::IrCompile;
-
         if query_const_fn.ir_fn.args.len() != args.len() {
             return Err(CompileError::new(
                 spanned,

--- a/crates/rune/src/compiling/mod.rs
+++ b/crates/rune/src/compiling/mod.rs
@@ -112,7 +112,7 @@ pub fn compile_with_options(
     }
 
     loop {
-        while let Some(entry) = worker.query.queue.pop_front() {
+        while let Some(entry) = worker.query.next_build_entry() {
             let source_id = entry.location.source_id;
 
             let task = CompileBuildEntry {
@@ -121,6 +121,7 @@ pub fn compile_with_options(
                 storage: &storage,
                 unit,
                 warnings: worker.warnings,
+                consts: &worker.consts,
                 query: &mut worker.query,
                 entry,
                 visitor: worker.visitor,
@@ -155,6 +156,7 @@ struct CompileBuildEntry<'a> {
     storage: &'a Storage,
     unit: &'a UnitBuilder,
     warnings: &'a mut Warnings,
+    consts: &'a Consts,
     query: &'a mut Query,
     entry: BuildEntry,
     visitor: &'a mut dyn CompileVisitor,
@@ -177,6 +179,7 @@ impl CompileBuildEntry<'_> {
             source_id: location.source_id,
             source: source.clone(),
             context: self.context,
+            consts: self.consts,
             query: self.query,
             asm: &mut asm,
             unit: self.unit.clone(),

--- a/crates/rune/src/indexing/index.rs
+++ b/crates/rune/src/indexing/index.rs
@@ -1384,18 +1384,10 @@ impl Index<ast::LitTemplate> for Indexer<'_> {
         let span = lit_template.span();
         log::trace!("LitTemplate => {:?}", self.source.source(span));
 
-        let mut template = lit_template.resolve(&self.storage, &*self.source)?;
-
-        for c in &mut template.components {
-            match c {
-                ast::TemplateComponent::Expr(expr) => {
-                    self.index(&mut **expr)?;
-                }
-                ast::TemplateComponent::String(..) => (),
-            }
+        for (expr, _) in &mut lit_template.args {
+            self.index(expr)?;
         }
 
-        lit_template.id = Some(self.query.insert_template(template));
         Ok(())
     }
 }

--- a/crates/rune/src/ir/eval/ir_assign.rs
+++ b/crates/rune/src/ir/eval/ir_assign.rs
@@ -1,15 +1,19 @@
 use crate::ir::eval::prelude::*;
 
-impl Eval<&ir::IrAssign> for IrInterpreter<'_> {
+impl IrEval for ir::IrAssign {
     type Output = IrValue;
 
-    fn eval(&mut self, ir_assign: &ir::IrAssign, used: Used) -> Result<Self::Output, EvalOutcome> {
-        self.budget.take(ir_assign)?;
-        let value = self.eval(&*ir_assign.value, used)?;
+    fn eval(
+        &self,
+        interp: &mut IrInterpreter<'_>,
+        used: Used,
+    ) -> Result<Self::Output, IrEvalOutcome> {
+        interp.budget.take(self)?;
+        let value = self.value.eval(interp, used)?;
 
-        self.scopes.mut_target(&ir_assign.target, move |t| {
-            ir_assign.op.assign(ir_assign, t, value)
-        })?;
+        interp
+            .scopes
+            .mut_target(&self.target, move |t| self.op.assign(self, t, value))?;
 
         Ok(IrValue::Unit)
     }

--- a/crates/rune/src/ir/eval/ir_break.rs
+++ b/crates/rune/src/ir/eval/ir_break.rs
@@ -1,21 +1,22 @@
 use crate::ir::eval::prelude::*;
 
-impl Eval<&ir::IrBreak> for IrInterpreter<'_> {
+impl IrEval for ir::IrBreak {
     type Output = ();
 
-    fn eval(&mut self, ir_break: &ir::IrBreak, used: Used) -> Result<(), EvalOutcome> {
-        let span = ir_break.span();
-        self.budget.take(span)?;
+    fn eval(&self, interp: &mut IrInterpreter<'_>, used: Used) -> Result<(), IrEvalOutcome> {
+        let span = self.span();
+        interp.budget.take(span)?;
 
-        match &ir_break.kind {
+        match &self.kind {
             ir::IrBreakKind::Ir(ir) => {
-                let value = self.eval(&**ir, used)?;
-                Err(EvalOutcome::Break(span, EvalBreak::Value(value)))
+                let value = ir.eval(interp, used)?;
+                Err(IrEvalOutcome::Break(span, IrEvalBreak::Value(value)))
             }
-            ir::IrBreakKind::Label(label) => {
-                Err(EvalOutcome::Break(span, EvalBreak::Label(label.clone())))
-            }
-            ir::IrBreakKind::Inherent => Err(EvalOutcome::Break(span, EvalBreak::Inherent)),
+            ir::IrBreakKind::Label(label) => Err(IrEvalOutcome::Break(
+                span,
+                IrEvalBreak::Label(label.clone()),
+            )),
+            ir::IrBreakKind::Inherent => Err(IrEvalOutcome::Break(span, IrEvalBreak::Inherent)),
         }
     }
 }

--- a/crates/rune/src/ir/eval/ir_call.rs
+++ b/crates/rune/src/ir/eval/ir_call.rs
@@ -1,15 +1,19 @@
 use crate::ir::eval::prelude::*;
 
-impl Eval<&ir::IrCall> for IrInterpreter<'_> {
+impl IrEval for ir::IrCall {
     type Output = IrValue;
 
-    fn eval(&mut self, ir_call: &ir::IrCall, used: Used) -> Result<Self::Output, EvalOutcome> {
+    fn eval(
+        &self,
+        interp: &mut IrInterpreter<'_>,
+        used: Used,
+    ) -> Result<Self::Output, IrEvalOutcome> {
         let mut args = Vec::new();
 
-        for arg in &ir_call.args {
-            args.push(self.eval(arg, used)?);
+        for arg in &self.args {
+            args.push(arg.eval(interp, used)?);
         }
 
-        Ok(self.call_const_fn(ir_call, &*ir_call.target, args, used)?)
+        Ok(interp.call_const_fn(self, &self.target, args, used)?)
     }
 }

--- a/crates/rune/src/ir/eval/ir_condition.rs
+++ b/crates/rune/src/ir/eval/ir_condition.rs
@@ -1,18 +1,18 @@
 use crate::ir::eval::prelude::*;
 
-impl Eval<&ir::IrCondition> for IrInterpreter<'_> {
+impl IrEval for ir::IrCondition {
     type Output = bool;
 
     fn eval(
-        &mut self,
-        ir_condition: &ir::IrCondition,
+        &self,
+        interp: &mut IrInterpreter<'_>,
         used: Used,
-    ) -> Result<Self::Output, EvalOutcome> {
-        match ir_condition {
-            ir::IrCondition::Ir(ir) => Ok(ir.as_bool(self, used)?),
+    ) -> Result<Self::Output, IrEvalOutcome> {
+        match self {
+            ir::IrCondition::Ir(ir) => Ok(ir.as_bool(interp, used)?),
             ir::IrCondition::Let(ir_let) => {
-                let value = self.eval(&ir_let.ir, used)?;
-                Ok(ir_let.pat.matches(self, value, used, ir_condition)?)
+                let value = ir_let.ir.eval(interp, used)?;
+                Ok(ir_let.pat.matches(interp, value, used, self)?)
             }
         }
     }

--- a/crates/rune/src/ir/eval/ir_decl.rs
+++ b/crates/rune/src/ir/eval/ir_decl.rs
@@ -1,12 +1,16 @@
 use crate::ir::eval::prelude::*;
 
-impl Eval<&ir::IrDecl> for IrInterpreter<'_> {
+impl IrEval for ir::IrDecl {
     type Output = IrValue;
 
-    fn eval(&mut self, im_decl: &ir::IrDecl, used: Used) -> Result<Self::Output, EvalOutcome> {
-        self.budget.take(im_decl)?;
-        let value = self.eval(&*im_decl.value, used)?;
-        self.scopes.decl(&im_decl.name, value, im_decl)?;
+    fn eval(
+        &self,
+        interp: &mut IrInterpreter<'_>,
+        used: Used,
+    ) -> Result<Self::Output, IrEvalOutcome> {
+        interp.budget.take(self)?;
+        let value = self.value.eval(interp, used)?;
+        interp.scopes.decl(&self.name, value, self)?;
         Ok(IrValue::Unit)
     }
 }

--- a/crates/rune/src/ir/eval/ir_object.rs
+++ b/crates/rune/src/ir/eval/ir_object.rs
@@ -1,14 +1,18 @@
 use crate::collections::HashMap;
 use crate::ir::eval::prelude::*;
 
-impl Eval<&ir::IrObject> for IrInterpreter<'_> {
+impl IrEval for ir::IrObject {
     type Output = IrValue;
 
-    fn eval(&mut self, ir_object: &ir::IrObject, used: Used) -> Result<Self::Output, EvalOutcome> {
-        let mut object = HashMap::with_capacity(ir_object.assignments.len());
+    fn eval(
+        &self,
+        interp: &mut IrInterpreter<'_>,
+        used: Used,
+    ) -> Result<Self::Output, IrEvalOutcome> {
+        let mut object = HashMap::with_capacity(self.assignments.len());
 
-        for (key, value) in ir_object.assignments.iter() {
-            object.insert(key.as_ref().to_owned(), self.eval(value, used)?);
+        for (key, value) in self.assignments.iter() {
+            object.insert(key.as_ref().to_owned(), value.eval(interp, used)?);
         }
 
         Ok(IrValue::Object(Shared::new(object)))

--- a/crates/rune/src/ir/eval/ir_set.rs
+++ b/crates/rune/src/ir/eval/ir_set.rs
@@ -1,12 +1,16 @@
 use crate::ir::eval::prelude::*;
 
-impl Eval<&ir::IrSet> for IrInterpreter<'_> {
+impl IrEval for ir::IrSet {
     type Output = IrValue;
 
-    fn eval(&mut self, ir_set: &ir::IrSet, used: Used) -> Result<Self::Output, EvalOutcome> {
-        self.budget.take(ir_set)?;
-        let value = self.eval(&*ir_set.value, used)?;
-        self.scopes.set_target(&ir_set.target, value)?;
+    fn eval(
+        &self,
+        interp: &mut IrInterpreter<'_>,
+        used: Used,
+    ) -> Result<Self::Output, IrEvalOutcome> {
+        interp.budget.take(self)?;
+        let value = self.value.eval(interp, used)?;
+        interp.scopes.set_target(&self.target, value)?;
         Ok(IrValue::Unit)
     }
 }

--- a/crates/rune/src/ir/eval/ir_tuple.rs
+++ b/crates/rune/src/ir/eval/ir_tuple.rs
@@ -1,13 +1,17 @@
 use crate::ir::eval::prelude::*;
 
-impl Eval<&ir::IrTuple> for IrInterpreter<'_> {
+impl IrEval for &ir::IrTuple {
     type Output = IrValue;
 
-    fn eval(&mut self, ir_tuple: &ir::IrTuple, used: Used) -> Result<Self::Output, EvalOutcome> {
-        let mut items = Vec::with_capacity(ir_tuple.items.len());
+    fn eval(
+        &self,
+        interp: &mut IrInterpreter<'_>,
+        used: Used,
+    ) -> Result<Self::Output, IrEvalOutcome> {
+        let mut items = Vec::with_capacity(self.items.len());
 
-        for item in ir_tuple.items.iter() {
-            items.push(self.eval(item, used)?);
+        for item in self.items.iter() {
+            items.push(item.eval(interp, used)?);
         }
 
         Ok(IrValue::Tuple(Shared::new(items.into_boxed_slice())))

--- a/crates/rune/src/ir/eval/ir_vec.rs
+++ b/crates/rune/src/ir/eval/ir_vec.rs
@@ -1,13 +1,17 @@
 use crate::ir::eval::prelude::*;
 
-impl Eval<&ir::IrVec> for IrInterpreter<'_> {
+impl IrEval for ir::IrVec {
     type Output = IrValue;
 
-    fn eval(&mut self, ir_vec: &ir::IrVec, used: Used) -> Result<Self::Output, EvalOutcome> {
-        let mut vec = Vec::with_capacity(ir_vec.items.len());
+    fn eval(
+        &self,
+        interp: &mut IrInterpreter<'_>,
+        used: Used,
+    ) -> Result<Self::Output, IrEvalOutcome> {
+        let mut vec = Vec::with_capacity(self.items.len());
 
-        for item in ir_vec.items.iter() {
-            vec.push(self.eval(item, used)?);
+        for item in self.items.iter() {
+            vec.push(item.eval(interp, used)?);
         }
 
         Ok(IrValue::Vec(Shared::new(vec)))

--- a/crates/rune/src/ir/eval/prelude.rs
+++ b/crates/rune/src/ir/eval/prelude.rs
@@ -1,10 +1,10 @@
 //! prelude that can should be used for eval implementations.
 
-pub(crate) use crate::ir::eval::{ConstAs, Eval, EvalBreak, EvalOutcome, Matches};
+pub(crate) use crate::ir::eval::{ConstAs, IrEval, IrEvalBreak, IrEvalOutcome, Matches};
 pub(crate) use crate::ir::ir;
 pub(crate) use crate::ir::IrInterpreter;
 pub(crate) use crate::ir::IrValue;
 pub(crate) use crate::query::Used;
 pub(crate) use crate::{IrError, Spanned};
-pub(crate) use runestick::Shared;
+pub(crate) use runestick::{Shared, Span};
 pub(crate) use std::convert::TryFrom;

--- a/crates/rune/src/ir/ir.rs
+++ b/crates/rune/src/ir/ir.rs
@@ -11,12 +11,12 @@ use runestick::{ConstValue, Span};
 macro_rules! decl_kind {
     (
         $(#[$meta:meta])*
-        pub(crate) enum $name:ident {
+        $vis:vis enum $name:ident {
             $($(#[$field_meta:meta])* $variant:ident($ty:ty)),* $(,)?
         }
     ) => {
         $(#[$meta])*
-        pub(crate) enum $name {
+        $vis enum $name {
             $($(#[$field_meta])* $variant($ty),)*
         }
 
@@ -32,7 +32,7 @@ macro_rules! decl_kind {
 
 /// A single operation in the Rune intermediate language.
 #[derive(Debug, Clone, Spanned)]
-pub(crate) struct Ir {
+pub struct Ir {
     #[rune(span)]
     pub(crate) span: Span,
     pub(crate) kind: IrKind,
@@ -54,7 +54,7 @@ impl Ir {
 
 /// The target of a set operation.
 #[derive(Debug, Clone, Spanned)]
-pub(crate) struct IrTarget {
+pub struct IrTarget {
     /// Span of the target.
     #[rune(span)]
     pub(crate) span: Span,
@@ -64,7 +64,7 @@ pub(crate) struct IrTarget {
 
 /// The kind of the target.
 #[derive(Debug, Clone)]
-pub(crate) enum IrTargetKind {
+pub enum IrTargetKind {
     /// A variable.
     Name(Box<str>),
     /// A field target.
@@ -76,7 +76,7 @@ pub(crate) enum IrTargetKind {
 decl_kind! {
     /// The kind of an intermediate operation.
     #[derive(Debug, Clone)]
-    pub(crate) enum IrKind {
+    pub enum IrKind {
         /// Push a scope with the given instructions.
         Scope(IrScope),
         /// A binary operation.
@@ -115,7 +115,7 @@ decl_kind! {
 
 /// An interpeted function.
 #[derive(Debug, Clone, Spanned)]
-pub(crate) struct IrFn {
+pub struct IrFn {
     /// The span of the function.
     #[rune(span)]
     pub(crate) span: Span,
@@ -127,7 +127,7 @@ pub(crate) struct IrFn {
 
 /// Definition of a new variable scope.
 #[derive(Debug, Clone, Spanned)]
-pub(crate) struct IrScope {
+pub struct IrScope {
     /// The span of the scope.
     #[rune(span)]
     pub(crate) span: Span,
@@ -139,7 +139,7 @@ pub(crate) struct IrScope {
 
 /// A binary operation.
 #[derive(Debug, Clone, Spanned)]
-pub(crate) struct IrBinary {
+pub struct IrBinary {
     /// The span of the binary op.
     #[rune(span)]
     pub(crate) span: Span,
@@ -153,7 +153,7 @@ pub(crate) struct IrBinary {
 
 /// A local variable declaration.
 #[derive(Debug, Clone, Spanned)]
-pub(crate) struct IrDecl {
+pub struct IrDecl {
     /// The span of the declaration.
     #[rune(span)]
     pub(crate) span: Span,
@@ -165,7 +165,7 @@ pub(crate) struct IrDecl {
 
 /// Set a target.
 #[derive(Debug, Clone, Spanned)]
-pub(crate) struct IrSet {
+pub struct IrSet {
     /// The span of the set operation.
     #[rune(span)]
     pub(crate) span: Span,
@@ -177,7 +177,7 @@ pub(crate) struct IrSet {
 
 /// Assign a target.
 #[derive(Debug, Clone, Spanned)]
-pub(crate) struct IrAssign {
+pub struct IrAssign {
     /// The span of the set operation.
     #[rune(span)]
     pub(crate) span: Span,
@@ -191,7 +191,7 @@ pub(crate) struct IrAssign {
 
 /// A string template.
 #[derive(Debug, Clone, Spanned)]
-pub(crate) struct IrTemplate {
+pub struct IrTemplate {
     /// The span of the template.
     #[rune(span)]
     pub(crate) span: Span,
@@ -201,7 +201,7 @@ pub(crate) struct IrTemplate {
 
 /// A string template.
 #[derive(Debug, Clone)]
-pub(crate) enum IrTemplateComponent {
+pub enum IrTemplateComponent {
     /// An ir expression.
     Ir(Ir),
     /// A literal string.
@@ -210,7 +210,7 @@ pub(crate) enum IrTemplateComponent {
 
 /// Branch conditions in intermediate representation.
 #[derive(Debug, Clone)]
-pub(crate) struct IrBranches {
+pub struct IrBranches {
     /// branches and their associated conditions.
     pub(crate) branches: Vec<(IrCondition, IrScope)>,
     /// The default fallback branch.
@@ -219,7 +219,7 @@ pub(crate) struct IrBranches {
 
 /// The condition for a branch.
 #[derive(Debug, Clone, Spanned)]
-pub(crate) enum IrCondition {
+pub enum IrCondition {
     /// A simple conditiona ir expression.
     Ir(Ir),
     /// A pattern match.
@@ -228,7 +228,7 @@ pub(crate) enum IrCondition {
 
 /// A pattern match.
 #[derive(Debug, Clone, Spanned)]
-pub(crate) struct IrLet {
+pub struct IrLet {
     /// The span of the let condition.
     #[rune(span)]
     pub(crate) span: Span,
@@ -240,7 +240,7 @@ pub(crate) struct IrLet {
 
 /// A pattern.
 #[derive(Debug, Clone)]
-pub(crate) enum IrPat {
+pub enum IrPat {
     /// An ignore pattern `_`.
     Ignore,
     /// A named binding.
@@ -249,7 +249,7 @@ pub(crate) enum IrPat {
 
 /// A loop with an optional condition.
 #[derive(Debug, Clone, Spanned)]
-pub(crate) struct IrLoop {
+pub struct IrLoop {
     /// The span of the loop.
     #[rune(span)]
     pub(crate) span: Span,
@@ -263,7 +263,7 @@ pub(crate) struct IrLoop {
 
 /// A break operation.
 #[derive(Debug, Clone, Spanned)]
-pub(crate) struct IrBreak {
+pub struct IrBreak {
     /// The span of the break.
     #[rune(span)]
     pub(crate) span: Span,
@@ -273,7 +273,7 @@ pub(crate) struct IrBreak {
 
 /// The kind of a break expression.
 #[derive(Debug, Clone)]
-pub(crate) enum IrBreakKind {
+pub enum IrBreakKind {
     /// Break to the next loop.
     Inherent,
     /// Break to the given label.
@@ -284,7 +284,7 @@ pub(crate) enum IrBreakKind {
 
 /// Tuple expression.
 #[derive(Debug, Clone, Spanned)]
-pub(crate) struct IrTuple {
+pub struct IrTuple {
     /// Span of the tuple.
     #[rune(span)]
     pub(crate) span: Span,
@@ -294,7 +294,7 @@ pub(crate) struct IrTuple {
 
 /// Object expression.
 #[derive(Debug, Clone, Spanned)]
-pub(crate) struct IrObject {
+pub struct IrObject {
     /// Span of the object.
     #[rune(span)]
     pub(crate) span: Span,
@@ -304,7 +304,7 @@ pub(crate) struct IrObject {
 
 /// Call expressions.
 #[derive(Debug, Clone, Spanned)]
-pub(crate) struct IrCall {
+pub struct IrCall {
     /// Span of the call.
     #[rune(span)]
     pub(crate) span: Span,
@@ -316,7 +316,7 @@ pub(crate) struct IrCall {
 
 /// Vector expression.
 #[derive(Debug, Clone, Spanned)]
-pub(crate) struct IrVec {
+pub struct IrVec {
     /// Span of the vector.
     #[rune(span)]
     pub(crate) span: Span,
@@ -326,7 +326,7 @@ pub(crate) struct IrVec {
 
 /// A binary operation.
 #[derive(Debug, Clone, Copy)]
-pub(crate) enum IrBinaryOp {
+pub enum IrBinaryOp {
     /// Add `+`.
     Add,
     /// Subtract `-`.
@@ -353,7 +353,7 @@ pub(crate) enum IrBinaryOp {
 
 /// An assign operation.
 #[derive(Debug, Clone, Copy)]
-pub(crate) enum IrAssignOp {
+pub enum IrAssignOp {
     /// `+=`.
     Add,
     /// `-=`.

--- a/crates/rune/src/ir/ir_error.rs
+++ b/crates/rune/src/ir/ir_error.rs
@@ -89,7 +89,7 @@ pub enum IrErrorKind {
         error: AccessError,
     },
     /// An access error raised during queries.
-    #[error("query error: {error}")]
+    #[error("{error}")]
     QueryError {
         /// The source error.
         #[source]
@@ -98,7 +98,7 @@ pub enum IrErrorKind {
     },
     /// Encountered an expression that is not supported as a constant
     /// expression.
-    #[error("not a constant expression")]
+    #[error("expected a constant expression")]
     NotConst,
     /// Trying to process a cycle of constants.
     #[error("constant cycle detected")]
@@ -154,4 +154,6 @@ pub enum IrErrorKind {
     FnNotFound,
     #[error("argument count mismatch, got {actual} but expected {expected}")]
     ArgumentCountMismatch { actual: usize, expected: usize },
+    #[error("can't perform constant evaluation in this context")]
+    MissingMacroQuery,
 }

--- a/crates/rune/src/ir/ir_query.rs
+++ b/crates/rune/src/ir/ir_query.rs
@@ -1,4 +1,3 @@
-use crate::ast;
 use crate::parsing::Id;
 use crate::query::{QueryConstFn, QueryError, Used};
 use runestick::{CompileMeta, Item, Span};
@@ -13,9 +12,6 @@ pub(crate) trait IrQuery {
         item: &Item,
         used: Used,
     ) -> Result<Option<CompileMeta>, QueryError>;
-
-    /// Get the template associated with the AST.
-    fn template_for(&self, spanned: Span, id: Option<Id>) -> Result<Rc<ast::Template>, QueryError>;
 
     /// Query for the constant function related to the given id.
     fn const_fn_for(&self, spanned: Span, id: Option<Id>) -> Result<Rc<QueryConstFn>, QueryError>;

--- a/crates/rune/src/ir/ir_query.rs
+++ b/crates/rune/src/ir/ir_query.rs
@@ -1,0 +1,22 @@
+use crate::ast;
+use crate::parsing::Id;
+use crate::query::{QueryConstFn, QueryError, Used};
+use runestick::{CompileMeta, Item, Span};
+use std::rc::Rc;
+
+/// Query interface for the interpreter.
+pub(crate) trait IrQuery {
+    /// Query for the given meta.
+    fn query_meta(
+        &mut self,
+        spanned: Span,
+        item: &Item,
+        used: Used,
+    ) -> Result<Option<CompileMeta>, QueryError>;
+
+    /// Get the template associated with the AST.
+    fn template_for(&self, spanned: Span, id: Option<Id>) -> Result<Rc<ast::Template>, QueryError>;
+
+    /// Query for the constant function related to the given id.
+    fn const_fn_for(&self, spanned: Span, id: Option<Id>) -> Result<Rc<QueryConstFn>, QueryError>;
+}

--- a/crates/rune/src/ir/mod.rs
+++ b/crates/rune/src/ir/mod.rs
@@ -3,10 +3,12 @@ pub(crate) mod ir;
 mod ir_compiler;
 mod ir_error;
 mod ir_interpreter;
+mod ir_query;
 mod ir_value;
 
 pub use self::ir_error::{IrError, IrErrorKind};
 
 pub(crate) use self::ir_compiler::{IrCompile, IrCompiler};
 pub(crate) use self::ir_interpreter::{IrBudget, IrInterpreter};
+pub(crate) use self::ir_query::IrQuery;
 pub(crate) use self::ir_value::IrValue;

--- a/crates/rune/src/ir/mod.rs
+++ b/crates/rune/src/ir/mod.rs
@@ -1,14 +1,16 @@
 mod eval;
-pub(crate) mod ir;
+pub mod ir;
 mod ir_compiler;
 mod ir_error;
 mod ir_interpreter;
 mod ir_query;
 mod ir_value;
 
+pub use self::eval::{IrEval, IrEvalBreak, IrEvalOutcome};
+pub use self::ir_compiler::{IrCompile, IrCompiler};
 pub use self::ir_error::{IrError, IrErrorKind};
+pub use self::ir_interpreter::IrInterpreter;
+pub use self::ir_value::IrValue;
 
-pub(crate) use self::ir_compiler::{IrCompile, IrCompiler};
-pub(crate) use self::ir_interpreter::{IrBudget, IrInterpreter};
+pub(crate) use self::ir_interpreter::IrBudget;
 pub(crate) use self::ir_query::IrQuery;
-pub(crate) use self::ir_value::IrValue;

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -283,7 +283,7 @@ pub use self::options::Options;
 pub use self::parsing::{
     Id, Lexer, Parse, ParseError, ParseErrorKind, Parser, Peek, Resolve, ResolveOwned,
 };
-pub use self::query::{QueryError, QueryErrorKind};
+pub use self::query::{QueryError, QueryErrorKind, Used};
 pub use self::shared::{Location, ScopeError, ScopeErrorKind};
 pub use self::spanned::{OptionSpanned, Spanned};
 pub use compiling::compile;
@@ -301,6 +301,6 @@ where
 {
     let mut parser = Parser::new(source);
     let ast = parser.parse::<T>()?;
-    parser.parse_eof()?;
+    parser.eof()?;
     Ok(ast)
 }

--- a/crates/rune/src/macros/functions.rs
+++ b/crates/rune/src/macros/functions.rs
@@ -1,5 +1,17 @@
+use crate::compiling::CompileError;
+use crate::ir::{IrCompile, IrEval};
 use crate::macros::{current_context, ToTokens, TokenStream};
 use crate::parsing::{ParseError, ResolveOwned};
+use crate::Spanned;
+
+/// Evaluate the given target as a constant expression.
+pub fn eval<T>(target: &T) -> Result<<T::Output as IrEval>::Output, CompileError>
+where
+    T: Spanned + IrCompile,
+    T::Output: IrEval,
+{
+    current_context(|ctx| ctx.eval(target))
+}
 
 /// Resolve the value of a token.
 ///

--- a/crates/rune/src/macros/macro_compiler.rs
+++ b/crates/rune/src/macros/macro_compiler.rs
@@ -14,7 +14,7 @@ pub(crate) struct MacroCompiler<'a> {
     pub(crate) options: &'a Options,
     pub(crate) context: &'a Context,
     pub(crate) source: Arc<Source>,
-    pub(crate) query: &'a mut Query,
+    pub(crate) query: Query,
 }
 
 impl MacroCompiler<'_> {

--- a/crates/rune/src/macros/macro_context.rs
+++ b/crates/rune/src/macros/macro_context.rs
@@ -133,7 +133,6 @@ impl MacroContext {
         let mut ir_compiler = IrCompiler {
             storage: self.storage.clone(),
             source: self.source.clone(),
-            query: &mut *ir_query,
         };
 
         let output = ir_compiler.compile(target)?;
@@ -218,17 +217,6 @@ impl MacroContext {
         ast::Token {
             span: self.span,
             kind: ast::Kind::Label(ast::StringSource::Synthetic(id)),
-        }
-    }
-
-    /// Construct a new template string. This should be specified without the ``
-    /// ` `` delimiters, so `"foo"` instead of ``"`foo`" ``.
-    pub fn template_string(&self, string: &str) -> ast::Token {
-        let id = self.storage.insert_str(string);
-
-        ast::Token {
-            span: self.span,
-            kind: ast::Kind::LitTemplate(ast::LitStrSource::Synthetic(id)),
         }
     }
 }

--- a/crates/rune/src/macros/mod.rs
+++ b/crates/rune/src/macros/mod.rs
@@ -7,7 +7,8 @@ mod quote;
 mod storage;
 mod token_stream;
 
-pub use self::functions::{resolve, stringify, to_tokens};
+pub use self::functions::{eval, resolve, stringify, to_tokens};
+pub(crate) use self::macro_context::EvaluationContext;
 pub use self::macro_context::{with_context, IntoLit, MacroContext};
 pub use self::storage::Storage;
 pub use self::token_stream::{ToTokens, TokenStream, TokenStreamIter};

--- a/crates/rune/src/parsing/lexer.rs
+++ b/crates/rune/src/parsing/lexer.rs
@@ -1,13 +1,18 @@
 use crate::ast;
-use crate::ast::utils;
 use crate::{ParseError, ParseErrorKind};
 use runestick::Span;
+use std::collections::VecDeque;
+use std::fmt;
 
 /// Lexer for the rune language.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Lexer<'a> {
-    cursor: usize,
-    source: &'a str,
+    /// Source iterator.
+    iter: SourceIter<'a>,
+    /// Current lexer mode.
+    modes: LexerModes,
+    /// Buffered tokens.
+    buffer: VecDeque<ast::Token>,
 }
 
 impl<'a> Lexer<'a> {
@@ -37,75 +42,40 @@ impl<'a> Lexer<'a> {
     /// };
     /// ```
     pub fn new(source: &'a str) -> Self {
-        Self { cursor: 0, source }
-    }
-
-    /// Construct a new lexer with the given start.
-    pub fn new_with_start(source: &'a str, start: usize) -> Self {
         Self {
-            cursor: start,
-            source,
+            iter: SourceIter::new(source),
+            modes: LexerModes::default(),
+            buffer: VecDeque::new(),
         }
     }
 
     /// Access the span of the lexer.
     pub fn span(&self) -> Span {
-        Span::new(0, self.source.len())
+        self.iter.end_span(0)
     }
 
-    /// Calculate the end span by peeking the next token.
-    fn end_span<I, T>(&self, it: &I) -> usize
-    where
-        I: Iterator<Item = (usize, T)> + Clone,
-    {
-        it.clone()
-            .next()
-            .map(|(n, _)| self.cursor + n)
-            .unwrap_or_else(|| self.source.len())
-    }
+    fn next_ident(&mut self, start: usize) -> Result<Option<ast::Token>, ParseError> {
+        while let Some(c) = self.iter.peek() {
+            if !matches!(c, 'a'..='z' | 'A'..='Z' | '_' | '0'..='9') {
+                break;
+            }
 
-    fn next_ident<I>(&mut self, it: &mut I, start: usize) -> Result<Option<ast::Token>, ParseError>
-    where
-        I: Clone + Iterator<Item = (usize, char)>,
-    {
-        self.cursor = loop {
-            break match it.clone().next() {
-                Some((n, c)) => match c {
-                    'a'..='z' | 'A'..='Z' | '_' | '0'..='9' => {
-                        it.next();
-                        continue;
-                    }
-                    _ => self.cursor + n,
-                },
-                None => self.source.len(),
-            };
-        };
+            self.iter.next();
+        }
 
-        let ident = &self.source[start..self.cursor];
-
-        let span = Span {
-            start,
-            end: self.cursor,
-        };
-
+        let (ident, span) = self.iter.source_from(start);
         let kind =
             ast::Kind::from_keyword(ident).unwrap_or(ast::Kind::Ident(ast::StringSource::Text));
         Ok(Some(ast::Token { kind, span }))
     }
 
     /// Consume a number literal.
-    fn next_number_literal<I>(
+    fn next_number_literal(
         &mut self,
-        it: &mut I,
         c: char,
         start: usize,
-    ) -> Result<Option<ast::Token>, ParseError>
-    where
-        I: Clone + Iterator<Item = (usize, char)>,
-    {
-        let mut is_fractional = false;
-
-        let base = if let ('0', Some((_, m))) = (c, it.clone().next()) {
+    ) -> Result<Option<ast::Token>, ParseError> {
+        let base = if let ('0', Some(m)) = (c, self.iter.peek()) {
             // This loop is useful.
             #[allow(clippy::never_loop)]
             loop {
@@ -116,205 +86,160 @@ impl<'a> Lexer<'a> {
                     _ => break ast::NumberBase::Decimal,
                 };
 
-                // consume character.
-                it.next();
+                self.iter.next();
                 break number;
             }
         } else {
             ast::NumberBase::Decimal
         };
 
-        self.cursor = loop {
-            let (n, c) = match it.next() {
-                Some((n, c)) => (n, c),
-                None => break self.source.len(),
-            };
+        let mut is_fractional = false;
 
+        while let Some(c) = self.iter.peek() {
             match c {
-                c if char::is_alphanumeric(c) => (),
+                c if char::is_alphanumeric(c) => {
+                    self.iter.next();
+                }
                 '.' if !is_fractional => {
+                    self.iter.next();
                     is_fractional = true;
 
                     // char immediately following a dot should be numerical.
-                    if !it.next().map(|(_, c)| c.is_numeric()).unwrap_or_default() {
-                        break self.cursor + n;
+                    if !self.iter.peek().map(char::is_numeric).unwrap_or_default() {
+                        break;
                     }
                 }
-                _ => break self.cursor + n,
+                _ => break,
             }
-        };
+        }
 
         Ok(Some(ast::Token {
             kind: ast::Kind::LitNumber(ast::NumberSource::Text(ast::NumberSourceText {
                 is_fractional,
                 base,
             })),
-            span: Span {
-                start,
-                end: self.cursor,
-            },
+            span: self.iter.span_from(start),
         }))
     }
 
     /// Consume a string literal.
-    fn next_char_or_label<I>(
-        &mut self,
-        it: &mut I,
-        start: usize,
-    ) -> Result<Option<ast::Token>, ParseError>
-    where
-        I: Clone + Iterator<Item = (usize, char)>,
-    {
+    fn next_char_or_label(&mut self, start: usize) -> Result<Option<ast::Token>, ParseError> {
         let mut is_label = true;
         let mut char_count = 0;
 
-        self.cursor = loop {
-            let (n, c) = match it.clone().next() {
+        loop {
+            let c = match self.iter.peek() {
                 Some(c) => c,
                 None => {
                     if is_label {
-                        let span = Span {
-                            start,
-                            end: self.source.len(),
-                        };
-
+                        let span = self.iter.end_span(start);
                         return Err(ParseError::new(span, ParseErrorKind::ExpectedCharClose));
                     }
 
-                    break self.source.len();
+                    break;
                 }
             };
 
             match c {
                 '\\' => {
                     is_label = false;
-                    it.next();
-                    it.next();
+                    self.iter.next();
+                    self.iter.next();
                     char_count += 1;
                 }
                 '\'' => {
                     is_label = false;
-                    it.next();
-                    break self.end_span(it);
+                    self.iter.next();
+                    break;
                 }
                 // components of labels.
                 '0'..='9' | 'a'..='z' => {
-                    it.next();
+                    self.iter.next();
                     char_count += 1;
                 }
                 c if c.is_control() => {
-                    let span = Span {
-                        start,
-                        end: self.cursor + n,
-                    };
-
+                    let span = self.iter.span_from(start);
                     return Err(ParseError::new(span, ParseErrorKind::UnterminatedCharLit));
                 }
                 _ if is_label && char_count > 0 => {
-                    break self.cursor + n;
+                    break;
                 }
                 _ => {
                     is_label = false;
-                    it.next();
+                    self.iter.next();
                     char_count += 1;
                 }
             }
-        };
+        }
 
         if is_label {
             Ok(Some(ast::Token {
                 kind: ast::Kind::Label(ast::StringSource::Text),
-                span: Span {
-                    start,
-                    end: self.cursor,
-                },
+                span: self.iter.span_from(start),
             }))
         } else {
             Ok(Some(ast::Token {
                 kind: ast::Kind::LitChar(ast::CopySource::Text),
-                span: Span {
-                    start,
-                    end: self.cursor,
-                },
+                span: self.iter.span_from(start),
             }))
         }
     }
 
     /// Consume a string literal.
-    fn next_lit_byte<I>(
-        &mut self,
-        it: &mut I,
-        start: usize,
-    ) -> Result<Option<ast::Token>, ParseError>
-    where
-        I: Clone + Iterator<Item = (usize, char)>,
-    {
-        self.cursor = loop {
-            let (n, c) = match it.clone().next() {
+    fn next_lit_byte(&mut self, start: usize) -> Result<Option<ast::Token>, ParseError> {
+        loop {
+            let c = match self.iter.next() {
                 Some(c) => c,
                 None => {
-                    let span = Span {
-                        start,
-                        end: self.source.len(),
-                    };
-
-                    return Err(ParseError::new(span, ParseErrorKind::ExpectedByteClose));
+                    return Err(ParseError::new(
+                        self.iter.span_from(start),
+                        ParseErrorKind::ExpectedByteClose,
+                    ));
                 }
             };
 
             match c {
                 '\\' => {
-                    it.next();
-                    it.next();
+                    self.iter.next();
                 }
                 '\'' => {
-                    it.next();
-                    break self.end_span(it);
+                    break;
                 }
                 c if c.is_control() => {
-                    let span = Span {
-                        start,
-                        end: self.cursor + n,
-                    };
-
+                    let span = self.iter.span_from(start);
                     return Err(ParseError::new(span, ParseErrorKind::UnterminatedByteLit));
                 }
-                _ => {
-                    it.next();
-                }
+                _ => (),
             }
-        };
+        }
 
         Ok(Some(ast::Token {
             kind: ast::Kind::LitByte(ast::CopySource::Text),
-            span: Span {
-                start,
-                end: self.cursor,
-            },
+            span: self.iter.span_from(start),
         }))
     }
 
     /// Consume a string literal.
     fn next_str(
         &mut self,
-        it: &mut (impl Iterator<Item = (usize, char)> + Clone),
         start: usize,
         error_kind: impl FnOnce() -> ParseErrorKind + Copy,
         kind: impl FnOnce(ast::LitStrSource) -> ast::Kind,
     ) -> Result<Option<ast::Token>, ParseError> {
         let mut escaped = false;
 
-        self.cursor = loop {
-            let (_, c) = it.next().ok_or_else(|| {
-                ParseError::new(Span::new(start, self.source.len()), error_kind())
-            })?;
+        loop {
+            let c = self
+                .iter
+                .next()
+                .ok_or_else(|| ParseError::new(self.iter.span_from(start), error_kind()))?;
 
             match c {
-                '"' => break self.end_span(it),
+                '"' => break,
                 '\\' => {
-                    if it.next().is_none() {
+                    if self.iter.peek().is_none() {
                         return Err(ParseError::new(
-                            Span::new(start, self.source.len()),
+                            self.iter.end_span(start),
                             ParseErrorKind::ExpectedEscape,
                         ));
                     } else {
@@ -323,95 +248,167 @@ impl<'a> Lexer<'a> {
                 }
                 _ => (),
             }
-        };
+        }
 
         Ok(Some(ast::Token {
-            kind: kind(ast::LitStrSource::Text(ast::LitStrSourceText { escaped })),
-            span: Span::new(start, self.cursor),
-        }))
-    }
-
-    /// Consume a string literal.
-    fn next_template<I>(
-        &mut self,
-        it: &mut I,
-        start: usize,
-    ) -> Result<Option<ast::Token>, ParseError>
-    where
-        I: Clone + Iterator<Item = (usize, char)>,
-    {
-        let mut escaped = false;
-
-        self.cursor = loop {
-            break match it.next() {
-                Some((n, c)) => match c {
-                    '`' => self.end_span(it),
-                    '{' => {
-                        let span = Span::new(start, n);
-                        utils::template_expr(span, it)?;
-                        continue;
-                    }
-                    '\\' => match it.next() {
-                        Some(_) => {
-                            escaped = true;
-                            continue;
-                        }
-                        None => {
-                            let span = Span {
-                                start,
-                                end: self.source.len(),
-                            };
-
-                            return Err(ParseError::new(
-                                span,
-                                ParseErrorKind::ExpectedTemplateClose,
-                            ));
-                        }
-                    },
-                    _ => continue,
-                },
-                None => {
-                    let span = Span {
-                        start,
-                        end: self.source.len(),
-                    };
-
-                    return Err(ParseError::new(span, ParseErrorKind::ExpectedTemplateClose));
-                }
-            };
-        };
-
-        Ok(Some(ast::Token {
-            kind: ast::Kind::LitTemplate(ast::LitStrSource::Text(ast::LitStrSourceText {
+            kind: kind(ast::LitStrSource::Text(ast::LitStrSourceText {
                 escaped,
+                wrapped: true,
             })),
-            span: Span {
-                start,
-                end: self.cursor,
-            },
+            span: self.iter.span_from(start),
         }))
     }
 
     /// Consume the entire line.
-    fn consume_line<I>(&mut self, it: &mut I)
-    where
-        I: Clone + Iterator<Item = (usize, char)>,
-    {
-        loop {
-            match it.next() {
-                Some((_, '\n')) | None => break,
-                _ => (),
+    fn consume_line(&mut self) {
+        while !matches!(self.iter.next(), Some('\n') | None) {}
+    }
+
+    fn template_next(&mut self) -> Result<(), ParseError> {
+        use std::mem::take;
+
+        let start = self.iter.pos();
+        let mut escaped = false;
+
+        while let Some(c) = self.iter.peek() {
+            match c {
+                '{' => {
+                    let expressions = self.modes.expression_count(&self.iter, start)?;
+
+                    let span = self.iter.span_from(start);
+                    let had_string = start != self.iter.pos();
+                    let start = self.iter.pos();
+                    self.iter.next();
+
+                    if had_string {
+                        if *expressions > 0 {
+                            self.buffer.push_back(ast::Token {
+                                kind: ast::Kind::Comma,
+                                span,
+                            });
+                        }
+
+                        self.buffer.push_back(ast::Token {
+                            kind: ast::Kind::LitStr(ast::LitStrSource::Text(
+                                ast::LitStrSourceText {
+                                    escaped: take(&mut escaped),
+                                    wrapped: false,
+                                },
+                            )),
+                            span,
+                        });
+
+                        *expressions += 1;
+                    }
+
+                    if *expressions > 0 {
+                        self.buffer.push_back(ast::Token {
+                            kind: ast::Kind::Comma,
+                            span: self.iter.span_from(start),
+                        });
+                    }
+
+                    self.modes.push(LexerMode::Default(1));
+                    return Ok(());
+                }
+                '}' => {
+                    let start = self.iter.pos();
+                    self.iter.next();
+
+                    return Err(ParseError::new(
+                        self.iter.span_from(start),
+                        ParseErrorKind::UnexpectedCloseBrace,
+                    ));
+                }
+                '\\' => {
+                    self.iter.next();
+
+                    if self.iter.next().is_none() {
+                        return Err(ParseError::new(
+                            self.iter.end_span(start),
+                            ParseErrorKind::ExpectedEscape,
+                        ));
+                    } else {
+                        escaped = true;
+                    }
+                }
+                '`' => {
+                    let span = self.iter.span_from(start);
+                    let had_string = start != self.iter.pos();
+                    let start = self.iter.pos();
+                    self.iter.next();
+
+                    let expressions = self.modes.expression_count(&self.iter, start)?;
+
+                    if had_string {
+                        if *expressions > 0 {
+                            self.buffer.push_back(ast::Token {
+                                kind: ast::Kind::Comma,
+                                span,
+                            });
+                        }
+
+                        self.buffer.push_back(ast::Token {
+                            kind: ast::Kind::LitStr(ast::LitStrSource::Text(
+                                ast::LitStrSourceText {
+                                    escaped: take(&mut escaped),
+                                    wrapped: false,
+                                },
+                            )),
+                            span,
+                        });
+
+                        *expressions += 1;
+                    }
+
+                    self.buffer.push_back(ast::Token {
+                        kind: ast::Kind::Close(ast::Delimiter::Brace),
+                        span: self.iter.span_from(start),
+                    });
+
+                    let expressions = *expressions;
+                    self.modes
+                        .pop(&self.iter, LexerMode::Template(expressions))?;
+
+                    return Ok(());
+                }
+                _ => {
+                    self.iter.next();
+                }
             }
         }
+
+        Err(ParseError::new(
+            self.iter.point_span(),
+            ParseErrorKind::UnexpectedEof,
+        ))
     }
 
     /// Consume the next token from the lexer.
     #[allow(clippy::should_implement_trait)]
     pub fn next(&mut self) -> Result<Option<ast::Token>, ParseError> {
-        let mut it = self.source[self.cursor..].char_indices();
+        'outer: loop {
+            if let Some(token) = self.buffer.pop_front() {
+                return Ok(Some(token));
+            }
 
-        'outer: while let Some((start, c)) = it.next() {
-            let start = self.cursor + start;
+            let mode = self.modes.last();
+
+            let level = match mode {
+                LexerMode::Template(..) => {
+                    self.template_next()?;
+                    continue;
+                }
+                LexerMode::Default(level) => (level),
+            };
+
+            let (start, c) = match self.iter.next_with_pos() {
+                Some(next) => next,
+                None => {
+                    self.modes.pop(&self.iter, LexerMode::Default(0))?;
+                    return Ok(None);
+                }
+            };
 
             if char::is_whitespace(c) {
                 continue;
@@ -420,113 +417,112 @@ impl<'a> Lexer<'a> {
             // This loop is useful, at least until it's rewritten.
             #[allow(clippy::never_loop)]
             let kind = loop {
-                if let Some(c2) = it.clone().next().map(|(_, c)| c) {
+                if let Some(c2) = self.iter.peek() {
                     match (c, c2) {
                         ('+', '=') => {
-                            it.next();
+                            self.iter.next();
                             break ast::Kind::PlusEq;
                         }
                         ('-', '=') => {
-                            it.next();
+                            self.iter.next();
                             break ast::Kind::DashEq;
                         }
                         ('*', '=') => {
-                            it.next();
+                            self.iter.next();
                             break ast::Kind::StarEq;
                         }
                         ('/', '=') => {
-                            it.next();
+                            self.iter.next();
                             break ast::Kind::SlashEq;
                         }
                         ('%', '=') => {
-                            it.next();
+                            self.iter.next();
                             break ast::Kind::PercEq;
                         }
                         ('&', '=') => {
-                            it.next();
+                            self.iter.next();
                             break ast::Kind::AmpEq;
                         }
                         ('^', '=') => {
-                            it.next();
+                            self.iter.next();
                             break ast::Kind::CaretEq;
                         }
                         ('|', '=') => {
-                            it.next();
+                            self.iter.next();
                             break ast::Kind::PipeEq;
                         }
                         ('/', '/') => {
-                            self.consume_line(&mut it);
+                            self.consume_line();
                             continue 'outer;
                         }
                         (':', ':') => {
-                            it.next();
+                            self.iter.next();
                             break ast::Kind::ColonColon;
                         }
                         ('<', '=') => {
-                            it.next();
+                            self.iter.next();
                             break ast::Kind::LtEq;
                         }
                         ('>', '=') => {
-                            it.next();
+                            self.iter.next();
                             break ast::Kind::GtEq;
                         }
                         ('=', '=') => {
-                            it.next();
+                            self.iter.next();
                             break ast::Kind::EqEq;
                         }
                         ('!', '=') => {
-                            it.next();
+                            self.iter.next();
                             break ast::Kind::BangEq;
                         }
                         ('&', '&') => {
-                            it.next();
+                            self.iter.next();
                             break ast::Kind::AmpAmp;
                         }
                         ('|', '|') => {
-                            it.next();
+                            self.iter.next();
                             break ast::Kind::PipePipe;
                         }
                         ('<', '<') => {
-                            it.next();
+                            self.iter.next();
 
-                            break if matches!(it.next(), Some((_, '='))) {
-                                it.next();
+                            break if matches!(self.iter.peek(), Some('=')) {
+                                self.iter.next();
                                 ast::Kind::LtLtEq
                             } else {
                                 ast::Kind::LtLt
                             };
                         }
                         ('>', '>') => {
-                            it.next();
+                            self.iter.next();
 
-                            break if matches!(it.next(), Some((_, '='))) {
-                                it.next();
+                            break if matches!(self.iter.peek(), Some('=')) {
+                                self.iter.next();
                                 ast::Kind::GtGtEq
                             } else {
                                 ast::Kind::GtGt
                             };
                         }
                         ('.', '.') => {
-                            it.next();
+                            self.iter.next();
                             break ast::Kind::DotDot;
                         }
                         ('=', '>') => {
-                            it.next();
+                            self.iter.next();
                             break ast::Kind::Rocket;
                         }
                         ('-', '>') => {
-                            it.next();
+                            self.iter.next();
                             break ast::Kind::Arrow;
                         }
                         ('b', '\'') => {
-                            it.next();
-                            it.next();
-                            return self.next_lit_byte(&mut it, start);
+                            self.iter.next();
+                            self.iter.next();
+                            return self.next_lit_byte(start);
                         }
                         ('b', '"') => {
-                            it.next();
+                            self.iter.next();
                             return self.next_str(
-                                &mut it,
                                 start,
                                 || ParseErrorKind::UnterminatedByteStrLit,
                                 ast::Kind::LitByteStr,
@@ -539,8 +535,27 @@ impl<'a> Lexer<'a> {
                 break match c {
                     '(' => ast::Kind::Open(ast::Delimiter::Parenthesis),
                     ')' => ast::Kind::Close(ast::Delimiter::Parenthesis),
-                    '{' => ast::Kind::Open(ast::Delimiter::Brace),
-                    '}' => ast::Kind::Close(ast::Delimiter::Brace),
+                    '{' => {
+                        if level > 0 {
+                            self.modes.push(LexerMode::Default(level + 1));
+                        }
+
+                        ast::Kind::Open(ast::Delimiter::Brace)
+                    }
+                    '}' => {
+                        if level > 0 {
+                            self.modes.pop(&self.iter, LexerMode::Default(level))?;
+
+                            // NB: end of expression in template.
+                            if level == 1 {
+                                let expressions = self.modes.expression_count(&self.iter, start)?;
+                                *expressions += 1;
+                                continue 'outer;
+                            }
+                        }
+
+                        ast::Kind::Close(ast::Delimiter::Brace)
+                    }
                     '[' => ast::Kind::Open(ast::Delimiter::Bracket),
                     ']' => ast::Kind::Close(ast::Delimiter::Bracket),
                     '_' => ast::Kind::Underscore,
@@ -566,49 +581,203 @@ impl<'a> Lexer<'a> {
                     '$' => ast::Kind::Dollar,
                     '~' => ast::Kind::Tilde,
                     'a'..='z' | 'A'..='Z' => {
-                        return self.next_ident(&mut it, start);
+                        return self.next_ident(start);
                     }
                     '0'..='9' => {
-                        return self.next_number_literal(&mut it, c, start);
+                        return self.next_number_literal(c, start);
                     }
                     '"' => {
                         return self.next_str(
-                            &mut it,
                             start,
                             || ParseErrorKind::UnterminatedStrLit,
                             ast::Kind::LitStr,
                         );
                     }
                     '`' => {
-                        return self.next_template(&mut it, start);
+                        let span = self.iter.span_from(start);
+
+                        self.buffer.push_back(ast::Token {
+                            kind: ast::Kind::Template,
+                            span,
+                        });
+
+                        self.buffer.push_back(ast::Token {
+                            kind: ast::Kind::Open(ast::Delimiter::Brace),
+                            span,
+                        });
+
+                        self.modes.push(LexerMode::Template(0));
+                        continue 'outer;
                     }
                     '\'' => {
-                        return self.next_char_or_label(&mut it, start);
+                        return self.next_char_or_label(start);
                     }
                     _ => {
-                        let span = Span {
-                            start,
-                            end: self.end_span(&it),
-                        };
-
+                        let span = self.iter.end_span(start);
                         return Err(ParseError::new(span, ParseErrorKind::UnexpectedChar { c }));
                     }
                 };
             };
 
-            self.cursor = self.end_span(&it);
-
             return Ok(Some(ast::Token {
                 kind,
-                span: Span {
-                    start,
-                    end: self.cursor,
-                },
+                span: self.iter.span_from(start),
             }));
         }
+    }
+}
 
-        self.cursor = self.source.len();
-        Ok(None)
+#[derive(Debug, Clone)]
+struct SourceIter<'a> {
+    source: &'a str,
+    chars: std::str::Chars<'a>,
+}
+
+impl<'a> SourceIter<'a> {
+    fn new(source: &'a str) -> Self {
+        Self {
+            source,
+            chars: source.chars(),
+        }
+    }
+
+    /// Get the current character position of the iterator.
+    fn pos(&self) -> usize {
+        self.source.len() - self.chars.as_str().len()
+    }
+
+    /// Get the source from the given start, to the current position.
+    fn source_from(&self, start: usize) -> (&'a str, Span) {
+        let span = self.span_from(start);
+        (&self.source[start..span.end], span)
+    }
+
+    /// Get the current point span.
+    fn point_span(&self) -> Span {
+        Span::point(self.pos())
+    }
+
+    /// Get the span from the given start, to the current position.
+    fn span_from(&self, start: usize) -> Span {
+        Span::new(start, self.pos())
+    }
+
+    /// Get the end span from the given start to the end of the source.
+    fn end_span(&self, start: usize) -> Span {
+        Span::new(start, self.source.len())
+    }
+
+    /// Peek the next cursor.
+    fn peek(&self) -> Option<char> {
+        self.chars.clone().next()
+    }
+
+    /// Next with position.
+    fn next_with_pos(&mut self) -> Option<(usize, char)> {
+        let p = self.pos();
+        let c = self.next()?;
+        Some((p, c))
+    }
+}
+
+impl Iterator for SourceIter<'_> {
+    type Item = char;
+
+    /// Consume the next character.
+    fn next(&mut self) -> Option<Self::Item> {
+        self.chars.next()
+    }
+}
+
+struct WithCharIndex<'s, 'a> {
+    iter: &'s mut SourceIter<'a>,
+}
+
+impl Iterator for WithCharIndex<'_, '_> {
+    type Item = (usize, char);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let pos = self.iter.pos();
+        Some((pos, self.iter.next()?))
+    }
+}
+
+#[derive(Debug, Default)]
+struct LexerModes {
+    modes: Vec<LexerMode>,
+}
+
+impl LexerModes {
+    /// Get the last mode.
+    fn last(&self) -> LexerMode {
+        self.modes.last().copied().unwrap_or_default()
+    }
+
+    /// Push the given lexer mode.
+    fn push(&mut self, mode: LexerMode) {
+        self.modes.push(mode);
+    }
+
+    /// Pop the expected lexer mode.
+    fn pop(&mut self, iter: &SourceIter<'_>, expected: LexerMode) -> Result<(), ParseError> {
+        let mode = self.modes.pop().unwrap_or_default();
+
+        if mode != expected {
+            return Err(ParseError::new(
+                iter.point_span(),
+                ParseErrorKind::BadLexerMode { mode, expected },
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Get the expression count.
+    fn expression_count<'a>(
+        &'a mut self,
+        iter: &SourceIter<'_>,
+        start: usize,
+    ) -> Result<&'a mut usize, ParseError> {
+        match self.modes.last_mut() {
+            Some(LexerMode::Template(expression)) => Ok(expression),
+            _ => {
+                let span = iter.span_from(start);
+                return Err(ParseError::new(span, ParseErrorKind::ExpectedTemplateMode));
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LexerMode {
+    /// Default mode, boolean indicating if we are inside a template or not.
+    Default(usize),
+    /// We are parsing a template string.
+    Template(usize),
+}
+
+impl Default for LexerMode {
+    fn default() -> Self {
+        Self::Default(0)
+    }
+}
+
+impl fmt::Display for LexerMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LexerMode::Default(level) => {
+                if *level > 0 {
+                    write!(f, "default in template ({})", level)?;
+                } else {
+                    write!(f, "default")?;
+                }
+            }
+            LexerMode::Template(expressions) => {
+                write!(f, "template {}", expressions)?;
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -618,12 +787,74 @@ mod tests {
     use crate::ast;
     use runestick::Span;
 
+    macro_rules! span {
+        ($start:expr, $end:expr) => {
+            Span {
+                start: $start,
+                end: $end,
+            }
+        };
+    }
+
     macro_rules! test_lexer {
-        ($source:expr $(, $pat:expr)* $(,)?) => {{
+        ($source:expr $(, $pat:pat)* $(,)?) => {{
             let mut it = Lexer::new($source);
-            $(assert_eq!(it.next().unwrap(), Some($pat));)*
+
+            #[allow(never_used)]
+            #[allow(unused_assignments)]
+            {
+                let mut n = 0;
+
+                $(
+                    match it.next().unwrap().expect("expected token") {
+                        $pat => (),
+                        #[allow(unreachable_patterns)]
+                        other => {
+                            panic!("\nGot bad token #{}.\nExpected: `{}`\nBut got: {:?}", n, stringify!($pat), other);
+                        }
+                    }
+
+                    n += 1;
+                )*
+            }
+
             assert_eq!(it.next().unwrap(), None);
         }}
+    }
+
+    #[test]
+    fn test_number_literals() {
+        test_lexer! {
+            "(10)",
+            ast::Token {
+                span: span!(0, 1),
+                kind: ast::Kind::Open(ast::Delimiter::Parenthesis),
+            },
+            ast::Token {
+                span: span!(1, 3),
+                kind: ast::Kind::LitNumber(ast::NumberSource::Text(ast::NumberSourceText {
+                    is_fractional: false,
+                    base: ast::NumberBase::Decimal,
+                })),
+            },
+            ast::Token {
+                span: span!(3, 4),
+                kind: ast::Kind::Close(ast::Delimiter::Parenthesis),
+            },
+        };
+
+        test_lexer! {
+            "(10.)",
+            _,
+            ast::Token {
+                span: span!(1, 4),
+                kind: ast::Kind::LitNumber(ast::NumberSource::Text(ast::NumberSourceText {
+                    is_fractional: true,
+                    base: ast::NumberBase::Decimal,
+                })),
+            },
+            _,
+        };
     }
 
     #[test]
@@ -631,7 +862,7 @@ mod tests {
         test_lexer! {
             "'a'",
             ast::Token {
-                span: Span::new(0, 3),
+                span: span!(0, 3),
                 kind: ast::Kind::LitChar(ast::CopySource::Text),
             }
         };
@@ -639,7 +870,7 @@ mod tests {
         test_lexer! {
             "'\\u{abcd}'",
             ast::Token {
-                span: Span::new(0, 10),
+                span: span!(0, 10),
                 kind: ast::Kind::LitChar(ast::CopySource::Text),
             }
         };
@@ -650,16 +881,16 @@ mod tests {
         test_lexer! {
             "'asdf 'a' \"foo bar\"",
             ast::Token {
-                span: Span::new(0, 5),
+                span: span!(0, 5),
                 kind: ast::Kind::Label(ast::StringSource::Text),
             },
             ast::Token {
-                span: Span::new(6, 9),
+                span: span!(6, 9),
                 kind: ast::Kind::LitChar(ast::CopySource::Text),
             },
             ast::Token {
-                span: Span::new(10, 19),
-                kind: ast::Kind::LitStr(ast::LitStrSource::Text(ast::LitStrSourceText { escaped: false })),
+                span: span!(10, 19),
+                kind: ast::Kind::LitStr(ast::LitStrSource::Text(ast::LitStrSourceText { escaped: false, wrapped: true })),
             }
         };
     }
@@ -669,35 +900,35 @@ mod tests {
         test_lexer! {
             "+ += - -= * *= / /=",
             ast::Token {
-                span: Span::new(0, 1),
+                span: span!(0, 1),
                 kind: ast::Kind::Plus,
             },
             ast::Token {
-                span: Span::new(2, 4),
+                span: span!(2, 4),
                 kind: ast::Kind::PlusEq,
             },
             ast::Token {
-                span: Span::new(5, 6),
+                span: span!(5, 6),
                 kind: ast::Kind::Dash,
             },
             ast::Token {
-                span: Span::new(7, 9),
+                span: span!(7, 9),
                 kind: ast::Kind::DashEq,
             },
             ast::Token {
-                span: Span::new(10, 11),
+                span: span!(10, 11),
                 kind: ast::Kind::Star,
             },
             ast::Token {
-                span: Span::new(12, 14),
+                span: span!(12, 14),
                 kind: ast::Kind::StarEq,
             },
             ast::Token {
-                span: Span::new(15, 16),
+                span: span!(15, 16),
                 kind: ast::Kind::Div,
             },
             ast::Token {
-                span: Span::new(17, 19),
+                span: span!(17, 19),
                 kind: ast::Kind::SlashEq,
             }
         };
@@ -708,30 +939,30 @@ mod tests {
         test_lexer! {
             "a.checked_div(10)",
             ast::Token {
-                span: Span::new(0, 1),
+                span: span!(0, 1),
                 kind: ast::Kind::Ident(ast::StringSource::Text),
             },
             ast::Token {
-                span: Span::new(1, 2),
+                span: span!(1, 2),
                 kind: ast::Kind::Dot,
             },
             ast::Token {
-                span: Span::new(2, 13),
+                span: span!(2, 13),
                 kind: ast::Kind::Ident(ast::StringSource::Text),
             },
             ast::Token {
-                span: Span::new(13, 14),
+                span: span!(13, 14),
                 kind: ast::Kind::Open(ast::Delimiter::Parenthesis),
             },
             ast::Token {
-                span: Span::new(14, 16),
+                span: span!(14, 16),
                 kind: ast::Kind::LitNumber(ast::NumberSource::Text(ast::NumberSourceText {
                     is_fractional: false,
                     base: ast::NumberBase::Decimal,
                 })),
             },
             ast::Token {
-                span: Span::new(16, 17),
+                span: span!(16, 17),
                 kind: ast::Kind::Close(ast::Delimiter::Parenthesis),
             },
         };
@@ -742,8 +973,95 @@ mod tests {
         test_lexer! {
             "`foo {bar} \\` baz`",
             ast::Token {
-                span: Span::new(0, 18),
-                kind: ast::Kind::LitTemplate(ast::LitStrSource::Text(ast::LitStrSourceText { escaped: true })),
+                kind: ast::Kind::Template,
+                span: span!(0, 1),
+            },
+            ast::Token {
+                kind: ast::Kind::Open(ast::Delimiter::Brace),
+                span: span!(0, 1),
+            },
+            ast::Token {
+                kind: ast::Kind::LitStr(ast::LitStrSource::Text(ast::LitStrSourceText {
+                    escaped: false,
+                    wrapped: false,
+                })),
+                span: span!(1, 5),
+            },
+            ast::Token {
+                kind: ast::Kind::Comma,
+                span: span!(5, 6),
+            },
+            ast::Token {
+                kind: ast::Kind::Ident(ast::StringSource::Text),
+                span: span!(6, 9),
+            },
+            ast::Token {
+                kind: ast::Kind::Comma,
+                span: span!(10, 17),
+            },
+            ast::Token {
+                kind: ast::Kind::LitStr(ast::LitStrSource::Text(ast::LitStrSourceText {
+                    escaped: true,
+                    wrapped: false,
+                })),
+                span: span!(10, 17),
+            },
+            ast::Token {
+                kind: ast::Kind::Close(ast::Delimiter::Brace),
+                span: span!(17, 18),
+            },
+        };
+    }
+
+    #[test]
+    fn test_template_literals_multi() {
+        test_lexer! {
+            "`foo {bar} {baz}`",
+            ast::Token {
+                kind: ast::Kind::Template,
+                span: span!(0, 1),
+            },
+            ast::Token {
+                kind: ast::Kind::Open(ast::Delimiter::Brace),
+                span: span!(0, 1),
+            },
+            ast::Token {
+                kind: ast::Kind::LitStr(ast::LitStrSource::Text(ast::LitStrSourceText {
+                    escaped: false,
+                    wrapped: false,
+                })),
+                span: span!(1, 5),
+            },
+            ast::Token {
+                kind: ast::Kind::Comma,
+                span: span!(5, 6),
+            },
+            ast::Token {
+                kind: ast::Kind::Ident(ast::StringSource::Text),
+                span: span!(6, 9),
+            },
+            ast::Token {
+                kind: ast::Kind::Comma,
+                span: span!(10, 11),
+            },
+            ast::Token {
+                kind: ast::Kind::LitStr(ast::LitStrSource::Text(ast::LitStrSourceText {
+                    escaped: false,
+                    wrapped: false,
+                })),
+                span: span!(10, 11),
+            },
+            ast::Token {
+                kind: ast::Kind::Comma,
+                span: span!(11, 12),
+            },
+            ast::Token {
+                kind: ast::Kind::Ident(ast::StringSource::Text),
+                span: span!(12, 15),
+            },
+            ast::Token {
+                kind: ast::Kind::Close(ast::Delimiter::Brace),
+                span: span!(16, 17),
             },
         };
     }
@@ -753,9 +1071,10 @@ mod tests {
         test_lexer! {
             r#"b"""#,
             ast::Token {
-                span: Span::new(0, 3),
+                span: span!(0, 3),
                 kind: ast::Kind::LitByteStr(ast::LitStrSource::Text(ast::LitStrSourceText {
                     escaped: false,
+                    wrapped: true,
                 })),
             },
         };
@@ -763,9 +1082,10 @@ mod tests {
         test_lexer! {
             r#"b"hello world""#,
             ast::Token {
-                span: Span::new(0, 14),
+                span: span!(0, 14),
                 kind: ast::Kind::LitByteStr(ast::LitStrSource::Text(ast::LitStrSourceText {
                     escaped: false,
+                    wrapped: true,
                 })),
             },
         };
@@ -773,7 +1093,7 @@ mod tests {
         test_lexer! {
             "b'\\\\''",
             ast::Token {
-                span: Span::new(0, 6),
+                span: span!(0, 6),
                 kind: ast::Kind::LitByte(ast::CopySource::Text),
             },
         };
@@ -781,15 +1101,15 @@ mod tests {
         test_lexer! {
             "'label 'a' b'a'",
             ast::Token {
-                span: Span::new(0, 6),
+                span: span!(0, 6),
                 kind: ast::Kind::Label(ast::StringSource::Text),
             },
             ast::Token {
-                span: Span::new(7, 10),
+                span: span!(7, 10),
                 kind: ast::Kind::LitChar(ast::CopySource::Text),
             },
             ast::Token {
-                span: Span::new(11, 15),
+                span: span!(11, 15),
                 kind: ast::Kind::LitByte(ast::CopySource::Text),
             },
         };
@@ -797,7 +1117,7 @@ mod tests {
         test_lexer! {
             "b'a'",
             ast::Token {
-                span: Span::new(0, 4),
+                span: span!(0, 4),
                 kind: ast::Kind::LitByte(ast::CopySource::Text),
             },
         };
@@ -805,7 +1125,7 @@ mod tests {
         test_lexer! {
             "b'\\n'",
             ast::Token {
-                span: Span::new(0, 5),
+                span: span!(0, 5),
                 kind: ast::Kind::LitByte(ast::CopySource::Text),
             },
         };

--- a/crates/rune/src/parsing/mod.rs
+++ b/crates/rune/src/parsing/mod.rs
@@ -6,7 +6,7 @@ mod parser;
 mod peek;
 mod resolve;
 
-pub use self::lexer::Lexer;
+pub use self::lexer::{Lexer, LexerMode};
 pub(crate) use self::opaque::Opaque;
 pub use self::parse::Parse;
 pub use self::parse_error::{ParseError, ParseErrorKind};

--- a/crates/rune/src/parsing/parse_error.rs
+++ b/crates/rune/src/parsing/parse_error.rs
@@ -1,4 +1,5 @@
 use crate::ast;
+use crate::parsing::LexerMode;
 use crate::shared::Description;
 use crate::Spanned;
 use runestick::Span;
@@ -43,6 +44,11 @@ pub enum ParseErrorKind {
     /// Error raised when we encounter end-of-file but we didn't expect it.
     #[error("unexpected end-of-file")]
     UnexpectedEof,
+    #[error("bad lexer mode `{mode}`, expected `{expected}`")]
+    BadLexerMode {
+        mode: LexerMode,
+        expected: LexerMode,
+    },
     /// An expectation error.
     #[error("expected {expected}, but got `{actual}`")]
     Expected {
@@ -148,8 +154,8 @@ pub enum ParseErrorKind {
     #[error("bad byte escape")]
     BadByteEscape,
     /// When we encounter an invalid template literal.
-    #[error("invalid template literal")]
-    InvalidTemplateLiteral,
+    #[error("template expression unexpectedly ended")]
+    UnexpectedExprEnd,
     /// When we encounter an unescaped closing brace `}`.
     #[error("closing braces must be escaped inside of templates with `\\}}`")]
     UnexpectedCloseBrace,
@@ -185,4 +191,6 @@ pub enum ParseErrorKind {
     BadNumber,
     #[error("expected identifier for object key")]
     ExpectedObjectIdent,
+    #[error("expected template lexer mode")]
+    ExpectedTemplateMode,
 }

--- a/crates/rune/src/parsing/parse_error.rs
+++ b/crates/rune/src/parsing/parse_error.rs
@@ -85,6 +85,8 @@ pub enum ParseErrorKind {
     /// Expected a character to be closed.
     #[error("expected character literal to be closed")]
     ExpectedCharClose,
+    #[error("expected label or character")]
+    ExpectedCharOrLabel,
     /// Expected a byte to be closed.
     #[error("expected byte literal to be closed")]
     ExpectedByteClose,

--- a/crates/rune/src/parsing/parser.rs
+++ b/crates/rune/src/parsing/parser.rs
@@ -149,7 +149,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Assert that the parser has reached its end-of-file.
-    pub fn parse_eof(&mut self) -> Result<(), ParseError> {
+    pub fn eof(&mut self) -> Result<(), ParseError> {
         if let Some(token) = self.p1? {
             return Err(ParseError::new(
                 token,

--- a/crates/rune/src/parsing/parser.rs
+++ b/crates/rune/src/parsing/parser.rs
@@ -27,20 +27,15 @@ pub struct Parser<'a> {
 impl<'a> Parser<'a> {
     /// Construct a new parser around the given source.
     pub fn new(source: &'a str) -> Self {
-        Self::new_with_start(source, 0)
+        Self::with_source(Source {
+            inner: SourceInner::Lexer(Lexer::new(source)),
+        })
     }
 
     /// Construct a parser from a token stream.
     pub fn from_token_stream(token_stream: &'a TokenStream) -> Self {
         Self::with_source(Source {
             inner: SourceInner::TokenStream(token_stream.iter()),
-        })
-    }
-
-    /// Construct a new parser around the given source.
-    pub(crate) fn new_with_start(source: &'a str, start: usize) -> Self {
-        Self::with_source(Source {
-            inner: SourceInner::Lexer(Lexer::new_with_start(source, start)),
         })
     }
 

--- a/crates/rune/src/query/mod.rs
+++ b/crates/rune/src/query/mod.rs
@@ -847,7 +847,6 @@ impl QueryInner {
             // std::option::Option::None
             // ```
             if entry.imported == current {
-                println!("SUPERFLOUS IMPORT");
                 break;
             }
 

--- a/crates/rune/src/query/query_error.rs
+++ b/crates/rune/src/query/query_error.rs
@@ -82,4 +82,12 @@ pub enum QueryErrorKind {
     NotIndexedImport { item: Item },
     #[error("{meta} can't be used as an import")]
     UnsupportedImportMeta { meta: CompileMeta },
+    /// Tried to add an item that already exists.
+    #[error("trying to insert `{current}` but conflicting meta `{existing}` already exists")]
+    MetaConflict {
+        /// The meta we tried to insert.
+        current: CompileMeta,
+        /// The existing item.
+        existing: CompileMeta,
+    },
 }

--- a/crates/rune/src/query/query_error.rs
+++ b/crates/rune/src/query/query_error.rs
@@ -31,19 +31,19 @@ pub enum QueryErrorKind {
         #[from]
         error: InsertMetaError,
     },
-    #[error("interpreter error: {error}")]
+    #[error("{error}")]
     IrError {
         #[source]
         #[from]
         error: Box<IrErrorKind>,
     },
-    #[error("compile error: {error}")]
+    #[error("{error}")]
     CompileError {
         #[source]
         #[from]
         error: Box<CompileErrorKind>,
     },
-    #[error("parse error: {error}")]
+    #[error("{error}")]
     ParseError {
         #[source]
         #[from]

--- a/crates/rune/src/shared/consts.rs
+++ b/crates/rune/src/shared/consts.rs
@@ -9,7 +9,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 /// State for constants processing.
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub(crate) struct Consts {
     inner: Rc<RefCell<Inner>>,
 }

--- a/crates/rune/src/testing.rs
+++ b/crates/rune/src/testing.rs
@@ -198,7 +198,7 @@ where
 {
     let mut parser = crate::parsing::Parser::new(source);
     let ast = parser.parse::<T>().expect("first parse");
-    parser.parse_eof().expect("first parse eof");
+    parser.eof().expect("first parse eof");
 
     let mut ctx = crate::macros::MacroContext::empty();
     let mut token_stream = crate::macros::TokenStream::empty();
@@ -206,7 +206,7 @@ where
     ast.to_tokens(&mut ctx, &mut token_stream);
     let mut parser = crate::parsing::Parser::from_token_stream(&token_stream);
     let ast2 = parser.parse::<T>().expect("second parse");
-    parser.parse_eof().expect("second parse eof");
+    parser.eof().expect("second parse eof");
 
     assert_eq!(ast, ast2);
     ast

--- a/crates/rune/src/worker.rs
+++ b/crates/rune/src/worker.rs
@@ -132,6 +132,7 @@ impl<'a> Worker<'a> {
                         root,
                         storage: self.query.storage(),
                         loaded: &mut self.loaded,
+                        consts: self.consts.clone(),
                         query: self.query.clone(),
                         queue: &mut self.queue,
                         sources: self.sources,

--- a/crates/rune/tests/test_all/compiler_general.rs
+++ b/crates/rune/tests/test_all/compiler_general.rs
@@ -34,10 +34,10 @@ fn test_pointers() {
 fn test_template_strings() {
     assert_parse!(r#"fn main() { `hello \}` }"#);
 
-    assert_compile_error! {
+    assert_parse_error! {
         r#"fn main() { `hello }` }"#,
-        span, CompileErrorKind::ParseError { error: UnexpectedCloseBrace {} } => {
-            assert_eq!(span, Span::new(13, 20));
+        span, UnexpectedCloseBrace {} => {
+            assert_eq!(span, Span::new(19, 20));
         }
     };
 }

--- a/crates/runestick/src/span.rs
+++ b/crates/runestick/src/span.rs
@@ -12,23 +12,15 @@ pub struct Span {
 
 impl Span {
     /// Construct a new span.
-    pub fn new(start: usize, end: usize) -> Self {
+    pub const fn new(start: usize, end: usize) -> Self {
         Self { start, end }
     }
 
-    /// Return a span with a modified start position.
-    pub fn with_start(self, start: usize) -> Self {
+    /// Adjust the span with the given positive offset.
+    pub fn adjust(self, diff: usize) -> Self {
         Self {
-            start,
-            end: self.end,
-        }
-    }
-
-    /// Return a span with a modified end position.
-    pub fn with_end(self, end: usize) -> Self {
-        Self {
-            start: self.start,
-            end,
+            start: self.start.saturating_add(diff),
+            end: self.end.saturating_add(diff),
         }
     }
 

--- a/site/content/posts/2020-10-01-tmir1.md
+++ b/site/content/posts/2020-10-01-tmir1.md
@@ -116,7 +116,7 @@ pub(crate) fn stringy_math(stream: &TokenStream) -> runestick::Result<TokenStrea
         }
     }
 
-    parser.parse_eof()?;
+    parser.eof()?;
     Ok(output)
 }
 ```


### PR DESCRIPTION
This reworks the `Query` system so that it can be passed around statically, and adds support for performing constant evaluation in macros. That means that the following (or any constantly evaled expressions) will work without issues:

```rust
const FORMAT_STRING = build_format_string("Hello");

const fn build_format_string(prefix) {
    `{prefix} \{\}`
}

fn main() {
    println!(FORMAT_STRING, "World"); // -> will produce "Hello World"
}
```

Note that the current state of the `println!` macro is still only a skeleton, i.e. arg parsing hasn't been implemented yet. But right now it can receive a constant value as the first argument.

I've also reworked template strings so that they solely are lexer sugaring over a different kind of expression which uses a new reserved keyword `template`. That means that this:

```text
`Hello {world}`
```
Desugars to this during lexing:
```rust
template { "Hello ", world }
```
This makes it vastly easier to work with template string in macros, since the desugared version uses syntax which works well with Rust and the `quote!` macro.