### PR TITLE
Clean up macro spans and introduce format! macro

### DIFF
--- a/crates/rune-modules/Cargo.toml
+++ b/crates/rune-modules/Cargo.toml
@@ -15,8 +15,8 @@ Native modules for Rune, an embeddable dynamic programming language for Rust.
 """
 
 [features]
-default = ["test", "core", "io"]
-full = ["time", "http", "json", "toml", "fs", "process", "signal", "rand"]
+default = ["test", "core", "io", "fmt"]
+full = ["time", "http", "json", "toml", "fs", "process", "signal", "rand", "io", "fmt"]
 time = ["tokio", "tokio/time"]
 fs = ["tokio", "tokio/fs"]
 http = ["reqwest"]
@@ -28,6 +28,7 @@ experiments = []
 test = []
 core = []
 io = []
+fmt = []
 
 [dependencies]
 reqwest = {version = "0.10.7", optional = true, default-features = false, features = ["rustls-tls", "gzip", "json"]}

--- a/crates/rune-modules/src/fmt.rs
+++ b/crates/rune-modules/src/fmt.rs
@@ -1,4 +1,4 @@
-//! `std::io` module for the [Rune Language].
+//! `std::fmt` module for the [Rune Language].
 //!
 //! [Rune Language]: https://rune-rs.github.io
 //!
@@ -7,7 +7,7 @@
 //! Add the following to your `Cargo.toml`:
 //!
 //! ```toml
-//! rune-modules = {version = "0.6.16", features = ["io"]}
+//! rune-modules = {version = "0.6.16", features = ["fmt"]}
 //! ```
 //!
 //! Install it into your context:
@@ -15,26 +15,26 @@
 //! ```rust
 //! # fn main() -> runestick::Result<()> {
 //! let mut context = runestick::Context::with_default_modules()?;
-//! context.install(&rune_modules::io::module(true)?)?;
+//! context.install(&rune_modules::fmt::module(true)?)?;
 //! # Ok(())
 //! # }
 //! ```
 
 use rune::macros;
-use rune::{quote, Parser, TokenStream};
+use rune::{Parser, TokenStream};
 
 /// Construct the supplemental `std::io` module.
 pub fn module(_stdio: bool) -> Result<runestick::Module, runestick::ContextError> {
-    let mut module = runestick::Module::new(&["std", "io"]);
-    module.macro_(&["println"], println_macro)?;
+    let mut module = runestick::Module::new(&["std", "fmt"]);
+    module.macro_(&["format"], format_macro)?;
     Ok(module)
 }
 
-/// Implementation for the `println!` macro.
-pub(crate) fn println_macro(stream: &TokenStream) -> runestick::Result<TokenStream> {
+/// Implementation for the `format!` macro.
+pub(crate) fn format_macro(stream: &TokenStream) -> runestick::Result<TokenStream> {
     let mut p = Parser::from_token_stream(stream);
     let args = p.parse::<macros::FormatArgs>()?;
     p.eof()?;
     let expanded = args.expand()?;
-    Ok(quote!(std::io::println(#expanded)).into_token_stream())
+    Ok(expanded.into_token_stream())
 }

--- a/crates/rune-modules/src/lib.rs
+++ b/crates/rune-modules/src/lib.rs
@@ -46,6 +46,8 @@
 //!
 //! See each module for documentation:
 //! * [core]
+//! * [experiments]
+//! * [fmt]
 //! * [fs]
 //! * [http]
 //! * [io]
@@ -61,6 +63,7 @@
 //!
 //! * `core` for the [core module][toml]
 //! * `experiments` for the [experiments module][experiments]
+//! * `fmt` for the [fmt module][fmt]
 //! * `fs` for the [fs module][fs]
 //! * `full` includes all modules.
 //! * `http` for the [http module][http]
@@ -75,6 +78,7 @@
 //!
 //! [core]: https://docs.rs/rune-modules/0/rune_modules/core/
 //! [experiments]: https://docs.rs/rune-modules/0/rune_modules/experiments/
+//! [fmt]: https://docs.rs/rune-modules/0/rune_modules/fmt/
 //! [fs]: https://docs.rs/rune-modules/0/rune_modules/fs/
 //! [http]: https://docs.rs/rune-modules/0/rune_modules/http/
 //! [io]: https://docs.rs/rune-modules/0/rune_modules/io/
@@ -121,15 +125,16 @@ macro_rules! modules {
 }
 
 modules! {
+    core, "core",
+    fmt, "fmt",
     fs, "fs",
     http, "http",
+    io, "io",
     json, "json",
     process, "process",
     rand, "rand",
     signal, "signal",
+    test, "test",
     time, "time",
     toml, "toml",
-    test, "test",
-    core, "core",
-    io, "io",
 }

--- a/crates/rune/src/ast/generated.rs
+++ b/crates/rune/src/ast/generated.rs
@@ -4263,7 +4263,7 @@ impl macros::ToTokens for Kind {
     fn to_tokens(&self, context: &macros::MacroContext, stream: &mut macros::TokenStream) {
         stream.push(ast::Token {
             kind: *self,
-            span: context.span(),
+            span: context.macro_span(),
         });
     }
 }

--- a/crates/rune/src/compiling/unit_builder.rs
+++ b/crates/rune/src/compiling/unit_builder.rs
@@ -47,6 +47,8 @@ impl UnitBuilder {
         this.prelude
             .insert("println".into(), Item::of(&["std", "io", "println"]));
         this.prelude
+            .insert("format".into(), Item::of(&["std", "fmt", "format"]));
+        this.prelude
             .insert("unit".into(), Item::of(&["std", "core", "unit"]));
         this.prelude
             .insert("bool".into(), Item::of(&["std", "core", "bool"]));

--- a/crates/rune/src/macros/macro_compiler.rs
+++ b/crates/rune/src/macros/macro_compiler.rs
@@ -57,7 +57,8 @@ impl MacroCompiler<'_> {
         let input_stream = &macro_call.stream;
 
         let macro_context = MacroContext {
-            span: macro_call.stream_span(),
+            macro_span: macro_call.span(),
+            stream_span: macro_call.stream_span(),
             source: self.source.clone(),
             storage: self.storage.clone(),
             eval_context: Some(EvaluationContext {

--- a/crates/rune/src/macros/mod.rs
+++ b/crates/rune/src/macros/mod.rs
@@ -17,4 +17,4 @@ pub use self::storage::Storage;
 pub use self::token_stream::{ToTokens, TokenStream, TokenStreamIter};
 
 pub(crate) use self::macro_compiler::MacroCompiler;
-pub(crate) use self::macro_context::{current_context, current_span};
+pub(crate) use self::macro_context::{current_context, current_stream_span};

--- a/crates/rune/src/parsing/parser.rs
+++ b/crates/rune/src/parsing/parser.rs
@@ -41,7 +41,7 @@ impl<'a> Parser<'a> {
 
     /// Construct a new parser with a source.
     fn with_source(source: Source<'a>) -> Self {
-        let span = source.span().or_else(crate::macros::current_span);
+        let span = source.span().or_else(crate::macros::current_stream_span);
 
         Self {
             peeker: Peeker {

--- a/crates/rune/tests/test_all/core_macros.rs
+++ b/crates/rune/tests/test_all/core_macros.rs
@@ -9,3 +9,22 @@ fn test_stringify() {
     let out: String = rune!(String => fn main() { stringify!(assert_eq!(1 + 1, 2)) });
     assert_eq!("assert_eq ! ( 1 + 1 , 2 )", out);
 }
+
+#[test]
+fn test_format() {
+    let out: String = rune!(String => fn main() { format!("Hello, World") });
+    assert_eq!("Hello, World", out);
+
+    let out: String = rune!(String => fn main() { format!("Hello, {name}", name = "John Doe") });
+    assert_eq!("Hello, John Doe", out);
+
+    let out: String = rune!(String => fn main() { format!("Hello, {1} {0}", "John", "Doe") });
+    assert_eq!("Hello, Doe John", out);
+
+    let out: String = rune!(String => fn main() { format!("Hello, {} {0} {}", "John", "Doe") });
+    assert_eq!("Hello, John John Doe", out);
+
+    let out: String =
+        rune!(String => fn main() { format!("Hello, {}" + " {0} {}", "John", "Doe") });
+    assert_eq!("Hello, John John Doe", out);
+}

--- a/tools/generate/src/main.rs
+++ b/tools/generate/src/main.rs
@@ -172,18 +172,36 @@ fn main() -> Result<()> {
             #("/// Helper macro to reference a specific token.")
             #[macro_export]
             macro_rules! T {
-                (()) => { $crate::ast::LitUnit };
-                ('(') => { $crate::ast::OpenParen };
-                (')') => { $crate::ast::CloseParen };
-                ('[') => { $crate::ast::OpenBracket };
-                (']') => { $crate::ast::CloseBracket };
-                ('{') => { $crate::ast::OpenBrace };
-                ('}') => { $crate::ast::CloseBrace };
+                (()) => {
+                    $crate::ast::LitUnit
+                };
+                ('(') => {
+                    $crate::ast::OpenParen
+                };
+                (')') => {
+                    $crate::ast::CloseParen
+                };
+                ('[') => {
+                    $crate::ast::OpenBracket
+                };
+                (']') => {
+                    $crate::ast::CloseBracket 
+                };
+                ('{') => {
+                    $crate::ast::OpenBrace
+                };
+                ('}') => {
+                    $crate::ast::CloseBrace
+                };
                 #(for k in &keywords join(#<push>) =>
-                    (#(&k.keyword)) => { $crate::ast::generated::#(&k.variant) };
+                    (#(&k.keyword)) => {
+                        $crate::ast::generated::#(&k.variant)
+                    };
                 )
                 #(for k in &punctuations join(#<push>) =>
-                    (#(&k.punct)) => { $crate::ast::generated::#(&k.variant) };
+                    (#(&k.punct)) => {
+                        $crate::ast::generated::#(&k.variant)
+                    };
                 )
             }
 
@@ -293,7 +311,7 @@ fn main() -> Result<()> {
                 fn to_tokens(&self, context: &#macro_context, stream: &mut #token_stream) {
                     stream.push(#token {
                         kind: *self,
-                        span: context.span(),
+                        span: context.macro_span(),
                     });
                 }
             }


### PR DESCRIPTION
This adjusts the spans of tokens generated by macros to match the macro itself, to fix errors like these:
![image](https://user-images.githubusercontent.com/111092/95530459-361a1200-09de-11eb-8470-fe4db988ba78.png)

Are now instead correctly reported like this:
![image](https://user-images.githubusercontent.com/111092/95530498-4d58ff80-09de-11eb-8a00-1bd3c1bcf7a3.png)

Also introduces the `format!` macro and using it as groundwork for testing format specifications.