### PR TITLE
Change syntax of template strings to be same as EcmaScript

### DIFF
--- a/book/src/template_strings.md
+++ b/book/src/template_strings.md
@@ -1,7 +1,7 @@
 # Template strings
 
 If you've been paying attention on previous sections you might have seen odd
-looking strings like `` `Hello {name}` ``. These are called *template strings*,
+looking strings like `` `Hello ${name}` ``. These are called *template strings*,
 and allow you to conveniently build strings using variables from the
 environment.
 
@@ -59,6 +59,6 @@ $> cargo run --bin rune -- scripts/book/template_strings/not_a_template.rn
 error: virtual machine error
   ┌─ scripts/book/template_strings/not_a_template.rn:3:13
   │
-3 │     println(`{vec}`);
-  │             ^^^^^^^ `vector` does not implement the `string_display` protocol
+3 │     println(`${vec}`);
+  │             ^^^^^^^^ `Vec` does not implement the `string_display` protocol
 ```

--- a/crates/rune/src/ast/lit_char.rs
+++ b/crates/rune/src/ast/lit_char.rs
@@ -88,7 +88,7 @@ impl<'a> Resolve<'a> for LitChar {
             '\\' => {
                 let c = match ast::utils::parse_char_escape(
                     &mut it,
-                    ast::utils::WithBrace(false),
+                    ast::utils::WithTemplate(false),
                     ast::utils::WithLineCont(false),
                 ) {
                     Ok(c) => c,

--- a/crates/rune/src/ast/lit_str.rs
+++ b/crates/rune/src/ast/lit_str.rs
@@ -22,7 +22,7 @@ impl LitStr {
         storage: &Storage,
         source: &'a Source,
     ) -> Result<Cow<'a, str>, ParseError> {
-        self.resolve_string(storage, source, ast::utils::WithBrace(true))
+        self.resolve_string(storage, source, ast::utils::WithTemplate(true))
     }
 
     /// Resolve the given string with the specified configuration.
@@ -30,7 +30,7 @@ impl LitStr {
         &self,
         storage: &Storage,
         source: &'a Source,
-        with_brace: ast::utils::WithBrace,
+        with_template: ast::utils::WithTemplate,
     ) -> Result<Cow<'a, str>, ParseError> {
         let span = self.token.span();
 
@@ -52,7 +52,7 @@ impl LitStr {
             .ok_or_else(|| ParseError::new(span, ParseErrorKind::BadSlice))?;
 
         Ok(if text.escaped {
-            Cow::Owned(Self::parse_escaped(span, string, with_brace)?)
+            Cow::Owned(Self::parse_escaped(span, string, with_template)?)
         } else {
             Cow::Borrowed(string)
         })
@@ -61,7 +61,7 @@ impl LitStr {
     fn parse_escaped(
         span: Span,
         source: &str,
-        with_brace: ast::utils::WithBrace,
+        with_template: ast::utils::WithTemplate,
     ) -> Result<String, ParseError> {
         let mut buffer = String::with_capacity(source.len());
 
@@ -76,7 +76,7 @@ impl LitStr {
             buffer.extend(match c {
                 '\\' => match ast::utils::parse_char_escape(
                     &mut it,
-                    with_brace,
+                    with_template,
                     ast::utils::WithLineCont(true),
                 ) {
                     Ok(c) => c,
@@ -121,7 +121,7 @@ impl<'a> Resolve<'a> for LitStr {
     type Output = Cow<'a, str>;
 
     fn resolve(&self, storage: &Storage, source: &'a Source) -> Result<Cow<'a, str>, ParseError> {
-        self.resolve_string(storage, source, ast::utils::WithBrace(false))
+        self.resolve_string(storage, source, ast::utils::WithTemplate(false))
     }
 }
 

--- a/crates/rune/src/ast/utils.rs
+++ b/crates/rune/src/ast/utils.rs
@@ -3,11 +3,11 @@ use crate::ParseErrorKind;
 use std::iter::Peekable;
 use std::ops;
 
-/// Indicates if we are parsing braces.
+/// Indicates if we are parsing template escapes.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct WithBrace(pub(super) bool);
+pub(crate) struct WithTemplate(pub(super) bool);
 
-impl ops::Deref for WithBrace {
+impl ops::Deref for WithTemplate {
     type Target = bool;
 
     fn deref(&self) -> &Self::Target {
@@ -74,7 +74,7 @@ pub(super) fn parse_byte_escape(
 /// Parse a byte escape sequence.
 pub(super) fn parse_char_escape(
     it: &mut Peekable<impl Iterator<Item = (usize, char)>>,
-    with_brace: WithBrace,
+    with_template: WithTemplate,
     with_line_cont: WithLineCont,
 ) -> Result<Option<char>, ParseErrorKind> {
     let (_, c) = it.next().ok_or_else(|| ParseErrorKind::BadEscapeSequence)?;
@@ -91,8 +91,8 @@ pub(super) fn parse_char_escape(
 
             return Ok(None);
         }
-        '{' if *with_brace => '{',
-        '}' if *with_brace => '}',
+        '$' if *with_template => '$',
+        '`' if *with_template => '`',
         '\'' => '\'',
         '\"' => '\"',
         'n' => '\n',

--- a/crates/rune/src/diagnostics.rs
+++ b/crates/rune/src/diagnostics.rs
@@ -107,7 +107,7 @@ impl EmitDiagnostics for Warnings {
                 WarningKind::TemplateWithoutExpansions { span, context } => {
                     labels.push(
                         Label::primary(w.source_id, span.range())
-                            .with_message("template string without expansions like `{1 + 2}`"),
+                            .with_message("template string without expansions like `${1 + 2}`"),
                     );
 
                     *context

--- a/crates/rune/src/parsing/parse_error.rs
+++ b/crates/rune/src/parsing/parse_error.rs
@@ -123,8 +123,6 @@ pub enum ParseErrorKind {
     BadHexEscapeByte,
     #[error("bad byte escape")]
     BadByteEscape,
-    #[error("closing braces must be escaped inside of templates with `\\}}`")]
-    BadCloseBrace,
     #[error("unsupported field access")]
     BadFieldAccess,
     #[error("expected close delimiter `{expected}`, but got `{actual}`")]

--- a/crates/rune/tests/test_all/compiler_general.rs
+++ b/crates/rune/tests/test_all/compiler_general.rs
@@ -32,14 +32,8 @@ fn test_pointers() {
 
 #[test]
 fn test_template_strings() {
-    assert_parse!(r#"fn main() { `hello \}` }"#);
-
-    assert_parse_error! {
-        r#"fn main() { `hello }` }"#,
-        span, BadCloseBrace {} => {
-            assert_eq!(span, Span::new(19, 20));
-        }
-    };
+    assert_parse!(r#"fn main() { `hello \`` }"#);
+    assert_parse!(r#"fn main() { `hello \$` }"#);
 }
 
 #[test]

--- a/crates/rune/tests/test_all/vm_const_exprs.rs
+++ b/crates/rune/tests/test_all/vm_const_exprs.rs
@@ -26,7 +26,7 @@ fn test_const_values() {
     assert_eq!(
         "Hello World 1 1.0 true",
         rune_s!(String => r#"
-            const VALUE = `Hello {WORLD} {A} {B} {C}`;
+            const VALUE = `Hello ${WORLD} ${A} ${B} ${C}`;
             const WORLD = "World";
             const A = 1;
             const B = 1.0;
@@ -171,11 +171,11 @@ fn test_const_fn() {
     const VALUE = "baz";
 
     const fn foo(n) {
-        `foo {n}`
+        `foo ${n}`
     }
     
     fn main() {
-        foo(`bar {VALUE}`)
+        foo(`bar ${VALUE}`)
     }
     "#};
 
@@ -185,7 +185,7 @@ fn test_const_fn() {
         const VALUE = foo("bar", "baz");
 
         const fn foo(a, b) {
-            `foo {a} {b} {bar("biz")}`
+            `foo ${a} ${b} ${bar("biz")}`
         }
         
         const fn bar(c) {

--- a/crates/rune/tests/test_all/vm_general.rs
+++ b/crates/rune/tests/test_all/vm_general.rs
@@ -602,7 +602,7 @@ fn test_template_string() {
         rune_s! { String => r#"
             fn main() {
                 let name = "John Doe";
-                `Hello {name}, I am {1 - 10} years old!`
+                `Hello ${name}, I am ${1 - 10} years old!`
             }
         "#},
         "Hello John Doe, I am -9 years old!",
@@ -616,7 +616,7 @@ fn test_template_string() {
             fn main() {
                 let name = "John Doe";
 
-                `Hello {name}, I am {{
+                `Hello ${name}, I am ${{
                     let a = 20;
                     a += 2;
                     a

--- a/crates/rune/tests/test_all/vm_tuples.rs
+++ b/crates/rune/tests/test_all/vm_tuples.rs
@@ -6,7 +6,7 @@ fn test_mutate_tuples() {
                 let m = ("Now", "You", "See", "Me");
                 m.2 = "Don't";
                 m.3 = "!";
-                `{m.0} {m.1} {m.2} {m.3}`
+                `${m.0} ${m.1} ${m.2} ${m.3}`
             }
         "#},
         "Now You Don't !",

--- a/scripts/book/template_strings/basic_template.rn
+++ b/scripts/book/template_strings/basic_template.rn
@@ -1,4 +1,4 @@
 fn main() {
     let age = 30;
-    println(`I am {age} years old!`);
+    println(`I am ${age} years old!`);
 }

--- a/scripts/book/template_strings/not_a_template.rn
+++ b/scripts/book/template_strings/not_a_template.rn
@@ -1,4 +1,4 @@
 fn main() {
     let vec = [1, 2, 3];
-    println(`{vec}`);
+    println(`${vec}`);
 }


### PR DESCRIPTION
This changes template strings to be this:
```js
let name = "World";
dbg(`Hello {name}`)
```
To this:
```js
let name = "World";
dbg(`Hello ${name}`)
```
Which is the same approach to [template literals as EcmaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals), hopefully reducing the weirdness budget a bit.

This means the only extra supported escape sequences for templates are:
* `\$` for the dollar sign.
* `` \` `` for the backtick punctuation.