### PR TITLE
Implement Args for Vec

### DIFF
--- a/crates/rune/examples/vec_args.rs
+++ b/crates/rune/examples/vec_args.rs
@@ -1,0 +1,42 @@
+use std::sync::Arc;
+
+use rune::{Errors, Options, Sources, Warnings};
+use runestick::{Context, Module, Source, Value, Vm, VmError};
+
+fn main() -> runestick::Result<()> {
+    let mut my_module = Module::new(&["mymodule"]);
+    my_module.function(
+        &["pass_along"],
+        |func: runestick::Function, args: Vec<Value>| -> Result<Value, VmError> { func.call(args) },
+    )?;
+
+    let mut context = Context::with_default_modules()?;
+    context.install(&my_module)?;
+
+    let options = Options::default();
+
+    let mut sources = Sources::new();
+    sources.insert(Source::new(
+        "test",
+        r#"
+        fn main() {
+            let value = mymodule::pass_along(add, [5, 9]);
+            println(`${value}`);
+        }
+
+        fn add(a, b) {
+            a + b
+        }
+        "#,
+    ));
+
+    let mut errors = Errors::new();
+    let mut warnings = Warnings::disabled();
+
+    let unit = rune::load_sources(&context, &options, &mut sources, &mut errors, &mut warnings)?;
+
+    let vm = Vm::new(Arc::new(context), Arc::new(unit));
+    let _ = vm.execute(&["main"], ())?.complete()?;
+
+    Ok(())
+}

--- a/crates/runestick/src/args.rs
+++ b/crates/runestick/src/args.rs
@@ -1,3 +1,5 @@
+use crate::{Stack, Value, VmError};
+
 /// Trait for converting arguments onto the stack.
 pub trait Args {
     /// Encode arguments onto a stack.
@@ -47,3 +49,20 @@ macro_rules! impl_into_args {
 }
 
 repeat_macro!(impl_into_args);
+
+impl Args for Vec<Value> {
+    fn into_stack(self, stack: &mut Stack) -> Result<(), VmError> {
+        for value in self {
+            stack.push(value);
+        }
+        Ok(())
+    }
+
+    fn into_vec(self) -> Result<Vec<Value>, VmError> {
+        Ok(self)
+    }
+
+    fn count(&self) -> usize {
+        self.len()
+    }
+}

--- a/crates/runestick/src/args.rs
+++ b/crates/runestick/src/args.rs
@@ -7,7 +7,7 @@ pub trait Args {
     fn into_vec(self) -> Result<Vec<crate::Value>, crate::VmError>;
 
     /// The number of arguments.
-    fn count() -> usize;
+    fn count(&self) -> usize;
 }
 
 macro_rules! impl_into_args {
@@ -39,7 +39,7 @@ macro_rules! impl_into_args {
                 Ok(vec![$($value,)*])
             }
 
-            fn count() -> usize {
+            fn count(&self) -> usize {
                 $count
             }
         }

--- a/crates/runestick/src/function.rs
+++ b/crates/runestick/src/function.rs
@@ -21,9 +21,10 @@ impl Function {
     {
         let value = match &self.inner {
             Inner::FnHandler(handler) => {
-                let mut stack = Stack::with_capacity(A::count());
+                let arg_count = args.count();
+                let mut stack = Stack::with_capacity(arg_count);
                 args.into_stack(&mut stack)?;
-                (handler.handler)(&mut stack, A::count())?;
+                (handler.handler)(&mut stack, arg_count)?;
                 stack.pop()?
             }
             Inner::FnOffset(fn_offset) => fn_offset.call(args, ())?,
@@ -31,19 +32,19 @@ impl Function {
                 .fn_offset
                 .call(args, (closure.environment.clone(),))?,
             Inner::FnUnitStruct(empty) => {
-                Self::check_args(A::count(), 0)?;
+                Self::check_args(args.count(), 0)?;
                 Value::unit_struct(empty.rtti.clone())
             }
             Inner::FnTupleStruct(tuple) => {
-                Self::check_args(A::count(), tuple.args)?;
+                Self::check_args(args.count(), tuple.args)?;
                 Value::tuple_struct(tuple.rtti.clone(), args.into_vec()?)
             }
             Inner::FnUnitVariant(empty) => {
-                Self::check_args(A::count(), 0)?;
+                Self::check_args(args.count(), 0)?;
                 Value::empty_variant(empty.rtti.clone())
             }
             Inner::FnTupleVariant(tuple) => {
-                Self::check_args(A::count(), tuple.args)?;
+                Self::check_args(args.count(), tuple.args)?;
                 Value::tuple_variant(tuple.rtti.clone(), args.into_vec()?)
             }
         };
@@ -293,7 +294,7 @@ impl FnOffset {
         A: Args,
         E: Args,
     {
-        Function::check_args(A::count(), self.args)?;
+        Function::check_args(args.count(), self.args)?;
 
         let mut vm = Vm::new(self.context.clone(), self.unit.clone());
 

--- a/crates/runestick/src/vm.rs
+++ b/crates/runestick/src/vm.rs
@@ -195,7 +195,7 @@ impl Vm {
         N: IntoTypeHash,
         A: Args,
     {
-        self.set_entrypoint(name, A::count())?;
+        self.set_entrypoint(name, args.count())?;
         args.into_stack(&mut self.stack)?;
         Ok(VmExecution::new(self))
     }
@@ -349,7 +349,7 @@ impl Vm {
         H: IntoTypeHash,
         A: Args,
     {
-        let count = A::count() + 1;
+        let count = args.count() + 1;
         let hash = Hash::instance_function(target.type_of()?, hash.into_type_hash());
 
         if let Some(UnitFn::Offset {
@@ -383,7 +383,7 @@ impl Vm {
         H: IntoTypeHash,
         A: Args,
     {
-        let count = A::count() + 1;
+        let count = args.count() + 1;
         let hash = Hash::getter(target.type_of()?, hash.into_type_hash());
 
         let handler = match self.context.lookup(hash) {


### PR DESCRIPTION
The first commit changes the `Args::count` method to take a self parameter, as the size for a Vector can not be known at  compile-time like the size of tuples. Hopefully, such a change won't cause worse optimization for tuples as all `Args` are used as generic parameters and so are known what they are compile-time.  
  
The second commit implements Args for a `Vec<runestick::Value>`, as well as adding an example of it being used. The use-case for this is when you want to pass parameters of an unknown amount into a rune function.  
This could be changed to be more generic instead, such as implementing `Args` for `Vec<T> where T: ToValue`. That would include `Value`, and other Vectors of types which could be transformed into values. If you'd prefer, I could change the pr to implement it for `T: ToValue`.