### PR TITLE
Only export items marked as `pub` in the root module

### DIFF
--- a/book/src/template_strings.md
+++ b/book/src/template_strings.md
@@ -11,7 +11,7 @@ environment.
 
 ```text
 $> cargo run --bin rune -- scripts/book/template_strings/basic_template.rn
-I am 30 years old!
+"I am 30 years old!"
 == () (4.5678ms)
 ```
 
@@ -56,9 +56,10 @@ types which do not implement this protocol will fail to run.
 
 ```text
 $> cargo run --bin rune -- scripts/book/template_strings/not_a_template.rn
+== ! (`Vec` does not implement the `string_display` protocol (at 5)) (77.7µs)
 error: virtual machine error
-  ┌─ scripts/book/template_strings/not_a_template.rn:3:13
+  ┌─ scripts/book/template_strings/not_a_template.rn:3:9
   │
-3 │     println(`${vec}`);
-  │             ^^^^^^^^ `Vec` does not implement the `string_display` protocol
+3 │     dbg(`${vec}`);
+  │         ^^^^^^^^ `Vec` does not implement the `string_display` protocol
 ```

--- a/book/src/types.md
+++ b/book/src/types.md
@@ -25,11 +25,12 @@ of that type.
 
 ```text
 $> cargo run --bin rune -- scripts/book/types/bad_type_check.rn
+== ! (panicked `assertion failed: vectors should be strings` (at 12)) (133.3µs)
 error: virtual machine error
-  ┌─ scripts/book/types/bad_type_check.rn:4:5
+  ┌─ scripts/book/types/bad_type_check.rn:2:5
   │
-4 │     assert(["hello", "world"] is String, "vectors should be strings");
-  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ panicked `assertion failed `vectors should be strings``
+2 │     assert!(["hello", "world"] is String, "vectors should be strings");
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ panicked `assertion failed: vectors should be strings`
 ```
 
 This gives us insight at runtime which type is which, and allows Rune scripts to

--- a/book/src/variables.md
+++ b/book/src/variables.md
@@ -56,11 +56,12 @@ raised in the virtual machine.
 ```text
 $> cargo run --bin rune -- scripts/book/variables/take_argument.rn
 field: 1
+== ! (failed to access value: cannot read, value is moved (at 14)) (469µs)
 error: virtual machine error
-  ┌─ scripts/book/variables/take_argument.rn:6:22
+  ┌─ scripts/book/variables/take_argument.rn:6:27
   │
-6 │     println(`field: {object.field}`);
-  │                      ^^^^^^^^^^^^ failed to access value: cannot read, value is moved
+6 │     println!("field: {}", object.field);
+  │                           ^^^^^^^^^^^^ failed to access value: cannot read, value is moved
 ```
 
 If you need to, you can test if a variable is still accessible for reading with

--- a/book/src/vectors.md
+++ b/book/src/vectors.md
@@ -9,9 +9,9 @@ vector isn't typed, and can store *any* Rune values.
 
 ```text
 $> cargo run --bin rune -- scripts/book/vectors/vectors.rn
-"Hello"
+Hello
 42
-"Hello"
+Hello
 42
 == () (5.0674ms)
 ```
@@ -27,7 +27,7 @@ protocol. It is also possible to create and use an iterator manually using
 ```text
 $> cargo run --bin rune -- scripts/book/vectors/vectors_rev.rn
 42
-"Hello"
+Hello
 == () (2.9116ms)
 ```
 

--- a/crates/rune-languageserver/src/state.rs
+++ b/crates/rune-languageserver/src/state.rs
@@ -198,6 +198,12 @@ impl State {
                             let range = lsp::Range::default();
                             diagnostics.push(display_to_error(range, message));
                         }
+                        rune::ErrorKind::BuildError(error) => {
+                            let diagnostics = by_url.entry(url.clone()).or_default();
+
+                            let range = lsp::Range::default();
+                            diagnostics.push(display_to_error(range, error));
+                        }
                     }
                 }
             }

--- a/crates/rune-wasm/src/lib.rs
+++ b/crates/rune-wasm/src/lib.rs
@@ -312,6 +312,7 @@ async fn inner_compile(input: String, config: JsValue) -> Result<CompileResult, 
                             }
                         },
                         rune::ErrorKind::Internal(_) => {}
+                        rune::ErrorKind::BuildError(_) => {}
                     }
                 }
             }

--- a/crates/rune/src/compiling/compile_error.rs
+++ b/crates/rune/src/compiling/compile_error.rs
@@ -220,6 +220,8 @@ pub enum CompileErrorKind {
     UseAliasNotSupported,
     #[error("conflicting function signature already exists `{existing}`")]
     FunctionConflict { existing: DebugSignature },
+    #[error("conflicting function hash already exists `{hash}`")]
+    FunctionReExportConflict { hash: Hash },
     #[error("conflicting constant registered for `{item}` on hash `{hash}`")]
     ConstantConflict { item: Item, hash: Hash },
     #[error("unsupported meta type for item `{existing}`")]

--- a/crates/rune/src/diagnostics.rs
+++ b/crates/rune/src/diagnostics.rs
@@ -246,6 +246,10 @@ impl EmitDiagnostics for Error {
                 writeln!(out, "internal error: {}", message)?;
                 return Ok(());
             }
+            ErrorKind::BuildError(error) => {
+                writeln!(out, "build error: {}", error)?;
+                return Ok(());
+            }
             ErrorKind::LinkError(error) => {
                 match error {
                     LinkerError::MissingFunction { hash, spans } => {

--- a/crates/rune/src/indexing/index.rs
+++ b/crates/rune/src/indexing/index.rs
@@ -659,7 +659,7 @@ impl Index for ast::ItemFn {
             };
 
             idx.query.insert_meta(span, meta)?;
-        } else if is_toplevel {
+        } else if is_toplevel && item.visibility.is_public() {
             // NB: immediately compile all toplevel functions.
             idx.query.push_build_entry(BuildEntry {
                 location: Location::new(idx.source_id, fun.ast.item_span()),

--- a/crates/rune/src/indexing/visibility.rs
+++ b/crates/rune/src/indexing/visibility.rs
@@ -19,6 +19,11 @@ pub enum Visibility {
 }
 
 impl Visibility {
+    /// Test if visibility is public.
+    pub(crate) fn is_public(self) -> bool {
+        matches!(self, Self::Public)
+    }
+
     /// Construct visibility from ast.
     pub(crate) fn from_ast(vis: &ast::Visibility) -> Result<Self, CompileError> {
         let span = match vis {

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -207,8 +207,8 @@ mod collections {
 }
 
 pub use self::compiling::{
-    CompileError, CompileErrorKind, CompileResult, CompileVisitor, ImportEntryStep, LinkerError,
-    NoopCompileVisitor, UnitBuilder, Var,
+    BuildError, CompileError, CompileErrorKind, CompileResult, CompileVisitor, ImportEntryStep,
+    LinkerError, NoopCompileVisitor, UnitBuilder, Var,
 };
 pub use self::ir::{IrError, IrErrorKind, IrValue};
 pub use self::load::{

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -113,7 +113,7 @@
 //!     sources.insert(Source::new(
 //!         "script",
 //!         r#"
-//!         fn calculate(a, b) {
+//!         pub fn calculate(a, b) {
 //!             println("Hello World");
 //!             a + b
 //!         }

--- a/crates/rune/src/load/error.rs
+++ b/crates/rune/src/load/error.rs
@@ -1,5 +1,5 @@
 use crate::compiling::LinkerError;
-use crate::{CompileError, ParseError, QueryError};
+use crate::{BuildError, CompileError, ParseError, QueryError};
 use runestick::SourceId;
 use std::error;
 use std::fmt;
@@ -30,7 +30,7 @@ impl Error {
     ///
     /// This should be used for programming invariants of the compiler which are
     /// broken for some reason.
-    pub fn internal(source_id: SourceId, message: &'static str) -> Self {
+    pub(crate) fn internal(source_id: SourceId, message: &'static str) -> Self {
         Self {
             source_id,
             kind: Box::new(ErrorKind::Internal(message)),
@@ -65,36 +65,38 @@ impl error::Error for Error {
     }
 }
 
-/// The kind of the load error.
+#[allow(missing_docs)]
 #[derive(Debug, Error)]
 pub enum ErrorKind {
-    /// Parse error.
     #[error("parse error")]
     ParseError(
         #[from]
         #[source]
         ParseError,
     ),
-    /// Compiler error.
     #[error("compile error")]
     CompileError(
         #[from]
         #[source]
         CompileError,
     ),
-    /// Query error.
     #[error("query error")]
     QueryError(
         #[from]
         #[source]
         QueryError,
     ),
-    /// A linker error occured.
     #[error("linker error")]
     LinkError(
         #[from]
         #[source]
         LinkerError,
+    ),
+    #[error("builder error: {0}")]
+    BuildError(
+        #[from]
+        #[source]
+        BuildError,
     ),
     /// An internal error.
     #[error("internal error: {0}")]

--- a/crates/rune/src/load/mod.rs
+++ b/crates/rune/src/load/mod.rs
@@ -47,7 +47,7 @@ pub struct LoadSourcesError;
 /// let mut options = rune::Options::default();
 /// let mut sources = rune::Sources::new();
 /// sources.insert(Source::new("entry", r#"
-/// fn main() {
+/// pub fn main() {
 ///     println("Hello World");
 /// }
 /// "#));

--- a/crates/rune/src/load/mod.rs
+++ b/crates/rune/src/load/mod.rs
@@ -135,9 +135,9 @@ pub fn load_sources_with_visitor(
     }
 
     match unit.build() {
-        Some(unit) => Ok(unit),
-        None => {
-            errors.push(Error::internal(0, "unit builder is not exclusively held"));
+        Ok(unit) => Ok(unit),
+        Err(error) => {
+            errors.push(Error::new(0, error));
             Err(LoadSourcesError)
         }
     }

--- a/crates/rune/src/testing.rs
+++ b/crates/rune/src/testing.rs
@@ -45,9 +45,9 @@ pub fn compile_source(
     }
 
     let unit = match unit.build() {
-        Some(unit) => unit,
-        None => {
-            errors.push(Error::internal(0, "unit builder is not exclusively held"));
+        Ok(unit) => unit,
+        Err(error) => {
+            errors.push(Error::new(0, error));
             return Err(errors);
         }
     };

--- a/crates/rune/src/testing.rs
+++ b/crates/rune/src/testing.rs
@@ -147,7 +147,7 @@ pub fn build(
 ///
 /// # fn main() {
 /// assert_eq! {
-///     rune::rune_s!(bool => "fn main() { true || false }"),
+///     rune::rune_s!(bool => "pub fn main() { true || false }"),
 ///     true,
 /// };
 /// # }
@@ -173,7 +173,7 @@ macro_rules! rune_s {
 ///
 /// # fn main() {
 /// assert_eq! {
-///     rune::rune!(bool => fn main() { true || false }),
+///     rune::rune!(bool => pub fn main() { true || false }),
 ///     true,
 /// };
 /// # }

--- a/crates/rune/tests/test_all/compiler_attributes.rs
+++ b/crates/rune/tests/test_all/compiler_attributes.rs
@@ -3,10 +3,10 @@ use rune::testing::*;
 #[test]
 fn test_bad_attributes() {
     assert_compile_error! {
-        r#"fn main() { #[foo] #[bar] let x = 1; }"#,
+        r#"pub fn main() { #[foo] #[bar] let x = 1; }"#,
         span, CompileErrorKind::Custom { message } => {
             assert_eq!(message, "attributes are not supported");
-            assert_eq!(span, Span::new(12, 25));
+            assert_eq!(span, Span::new(16, 29));
         }
     };
 }

--- a/crates/rune/tests/test_all/compiler_expr_assign.rs
+++ b/crates/rune/tests/test_all/compiler_expr_assign.rs
@@ -2,12 +2,12 @@ use rune::testing::*;
 
 #[test]
 fn test_assign_exprs() {
-    assert_parse!(r#"fn main() { let var = 1; var = 42; }"#);
+    assert_parse!(r#"pub fn main() { let var = 1; var = 42; }"#);
 
     assert_compile_error! {
-        r#"fn main() { 1 = 42; }"#,
+        r#"pub fn main() { 1 = 42; }"#,
         span, UnsupportedAssignExpr => {
-            assert_eq!(span, Span::new(12, 18));
+            assert_eq!(span, Span::new(16, 22));
         }
     };
 }

--- a/crates/rune/tests/test_all/compiler_expr_binary.rs
+++ b/crates/rune/tests/test_all/compiler_expr_binary.rs
@@ -3,16 +3,16 @@ use rune::testing::*;
 #[test]
 fn test_binary_exprs() {
     assert_parse_error! {
-        r#"fn main() { 0 < 10 >= 10 }"#,
+        r#"pub fn main() { 0 < 10 >= 10 }"#,
         span, PrecedenceGroupRequired => {
-            assert_eq!(span, Span::new(12, 18));
+            assert_eq!(span, Span::new(16, 22));
         }
     };
 
     // Test solving precedence with groups.
-    assert_parse!(r#"fn main() { (0 < 10) >= 10 }"#);
-    assert_parse!(r#"fn main() { 0 < (10 >= 10) }"#);
-    assert_parse!(r#"fn main() { 0 < 10 && 10 > 0 }"#);
-    assert_parse!(r#"fn main() { 0 < 10 && 10 > 0 || true }"#);
-    assert_parse!(r#"fn main() { false || return }"#);
+    assert_parse!(r#"pub fn main() { (0 < 10) >= 10 }"#);
+    assert_parse!(r#"pub fn main() { 0 < (10 >= 10) }"#);
+    assert_parse!(r#"pub fn main() { 0 < 10 && 10 > 0 }"#);
+    assert_parse!(r#"pub fn main() { 0 < 10 && 10 > 0 || true }"#);
+    assert_parse!(r#"pub fn main() { false || return }"#);
 }

--- a/crates/rune/tests/test_all/compiler_fn.rs
+++ b/crates/rune/tests/test_all/compiler_fn.rs
@@ -3,16 +3,16 @@ use rune::testing::*;
 #[test]
 fn test_fn_const_async() {
     assert_compile_error! {
-        r#"const async fn main() {}"#,
+        r#"pub const async fn main() {}"#,
         span, FnConstAsyncConflict => {
-            assert_eq!(span, Span::new(0, 11));
+            assert_eq!(span, Span::new(4, 15));
         }
     };
 
     assert_compile_error! {
-        r#"const fn main() { yield true }"#,
+        r#"pub const fn main() { yield true }"#,
         span, FnConstNotGenerator => {
-            assert_eq!(span, Span::new(0, 30));
+            assert_eq!(span, Span::new(0, 34));
         }
     };
 }

--- a/crates/rune/tests/test_all/compiler_general.rs
+++ b/crates/rune/tests/test_all/compiler_general.rs
@@ -3,9 +3,9 @@ use rune::testing::*;
 #[test]
 fn test_use_variant_as_type() {
     assert_compile_error! {
-        r#"fn main() { Err(0) is Err }"#,
+        r#"pub fn main() { Err(0) is Err }"#,
         span, ExpectedMeta { meta: CompileMeta { kind: CompileMetaKind::TupleVariant { .. }, .. }, .. } => {
-            assert_eq!(span, Span::new(22, 25));
+            assert_eq!(span, Span::new(26, 29));
         }
     };
 }
@@ -13,9 +13,9 @@ fn test_use_variant_as_type() {
 #[test]
 fn break_outside_of_loop() {
     assert_compile_error! {
-        r#"fn main() { break; }"#,
+        r#"pub fn main() { break; }"#,
         span, BreakOutsideOfLoop => {
-            assert_eq!(span, Span::new(12, 17));
+            assert_eq!(span, Span::new(16, 21));
         }
     };
 }
@@ -23,34 +23,34 @@ fn break_outside_of_loop() {
 #[test]
 fn test_pointers() {
     assert_compile_error! {
-        r#"fn main() { let n = 0; foo(&n); } fn foo(n) {}"#,
+        r#"pub fn main() { let n = 0; foo(&n); } fn foo(n) {}"#,
         span, UnsupportedRef => {
-            assert_eq!(span, Span::new(27, 29));
+            assert_eq!(span, Span::new(31, 33));
         }
     };
 }
 
 #[test]
 fn test_template_strings() {
-    assert_parse!(r#"fn main() { `hello \`` }"#);
-    assert_parse!(r#"fn main() { `hello \$` }"#);
+    assert_parse!(r#"pub fn main() { `hello \`` }"#);
+    assert_parse!(r#"pub fn main() { `hello \$` }"#);
 }
 
 #[test]
 fn test_wrong_arguments() {
     assert_compile_error! {
-        r#"fn main() { Some(1, 2) }"#,
+        r#"pub fn main() { Some(1, 2) }"#,
         span, UnsupportedArgumentCount { expected, actual, .. } => {
-            assert_eq!(span, Span::new(12, 22));
+            assert_eq!(span, Span::new(16, 26));
             assert_eq!(expected, 1);
             assert_eq!(actual, 2);
         }
     };
 
     assert_compile_error! {
-        r#"fn main() { None(1) }"#,
+        r#"pub fn main() { None(1) }"#,
         span, UnsupportedArgumentCount { expected, actual, .. } => {
-            assert_eq!(span, Span::new(12, 19));
+            assert_eq!(span, Span::new(16, 23));
             assert_eq!(expected, 0);
             assert_eq!(actual, 1);
         }
@@ -60,25 +60,25 @@ fn test_wrong_arguments() {
 #[test]
 fn test_bad_struct_declaration() {
     assert_compile_error! {
-        r#"struct Foo { a, b } fn main() { Foo { a: 12 } }"#,
+        r#"struct Foo { a, b } pub fn main() { Foo { a: 12 } }"#,
         span, LitObjectMissingField { field, .. } => {
-            assert_eq!(span, Span::new(32, 45));
+            assert_eq!(span, Span::new(36, 49));
             assert_eq!(field.as_ref(), "b");
         }
     };
 
     assert_compile_error! {
-        r#"struct Foo { a, b } fn main() { Foo { not_field: 12 } }"#,
+        r#"struct Foo { a, b } pub fn main() { Foo { not_field: 12 } }"#,
         span, LitObjectNotField { field, .. } => {
-            assert_eq!(span, Span::new(38, 47));
+            assert_eq!(span, Span::new(42, 51));
             assert_eq!(field.as_ref(), "not_field");
         }
     };
 
     assert_compile_error! {
-        r#"fn main() { None(1) }"#,
+        r#"pub fn main() { None(1) }"#,
         span, UnsupportedArgumentCount { expected, actual, .. } => {
-            assert_eq!(span, Span::new(12, 19));
+            assert_eq!(span, Span::new(16, 23));
             assert_eq!(expected, 0);
             assert_eq!(actual, 1);
         }

--- a/crates/rune/tests/test_all/compiler_literals.rs
+++ b/crates/rune/tests/test_all/compiler_literals.rs
@@ -2,40 +2,40 @@ use rune::testing::*;
 
 #[test]
 fn test_number_literals() {
-    assert_parse!(r#"fn main() { -9223372036854775808 }"#);
+    assert_parse!(r#"pub fn main() { -9223372036854775808 }"#);
     assert_parse!(
-        r#"fn main() { -0b1000000000000000000000000000000000000000000000000000000000000000 }"#
+        r#"pub fn main() { -0b1000000000000000000000000000000000000000000000000000000000000000 }"#
     );
     assert_parse!(
-        r#"fn main() { 0b0111111111111111111111111111111111111111111111111111111111111111 }"#
+        r#"pub fn main() { 0b0111111111111111111111111111111111111111111111111111111111111111 }"#
     );
 
     assert_compile_error! {
-        r#"fn main() { -0aardvark }"#,
+        r#"pub fn main() { -0aardvark }"#,
         span, CompileErrorKind::ResolveError { error: BadNumberLiteral { .. } } => {
-            assert_eq!(span, Span::new(13, 22));
+            assert_eq!(span, Span::new(17, 26));
         }
     };
 
     assert_compile_error! {
-        r#"fn main() { -9223372036854775809 }"#,
+        r#"pub fn main() { -9223372036854775809 }"#,
         span, CompileErrorKind::ParseError { error: BadNumberOutOfBounds { .. }} => {
-            assert_eq!(span, Span::new(12, 32));
+            assert_eq!(span, Span::new(16, 36));
         }
     };
 
-    assert_parse!(r#"fn main() { 9223372036854775807 }"#);
+    assert_parse!(r#"pub fn main() { 9223372036854775807 }"#);
     assert_compile_error! {
-        r#"fn main() { 9223372036854775808 }"#,
+        r#"pub fn main() { 9223372036854775808 }"#,
         span, CompileErrorKind::ParseError { error: BadNumberOutOfBounds { .. }} => {
-            assert_eq!(span, Span::new(12, 31));
+            assert_eq!(span, Span::new(16, 35));
         }
     };
 
     assert_compile_error! {
-        r#"fn main() { 0b1000000000000000000000000000000000000000000000000000000000000000 }"#,
+        r#"pub fn main() { 0b1000000000000000000000000000000000000000000000000000000000000000 }"#,
         span, CompileErrorKind::ParseError { error: BadNumberOutOfBounds { .. }} => {
-            assert_eq!(span, Span::new(12, 78));
+            assert_eq!(span, Span::new(16, 82));
         }
     };
 }

--- a/crates/rune/tests/test_all/compiler_paths.rs
+++ b/crates/rune/tests/test_all/compiler_paths.rs
@@ -26,7 +26,7 @@ fn test_super_self_crate_mod() {
 
             fn root() { 0b1 }
 
-            fn main() { Foo::foo() }
+            pub fn main() { Foo::foo() }
         },
         0b111111,
     };
@@ -50,7 +50,7 @@ fn test_super_use() {
 
             const VALUE = 1;
 
-            fn main() { x::y::foo() }
+            pub fn main() { x::y::foo() }
         },
         3,
     };

--- a/crates/rune/tests/test_all/compiler_use.rs
+++ b/crates/rune/tests/test_all/compiler_use.rs
@@ -12,12 +12,12 @@ fn test_import_cycle() {
 
         use self::a::Foo;
 
-        fn main() {
+        pub fn main() {
             Foo
         }             
         "#,
         span, QueryError { error: ImportCycle { .. } } => {
-            assert_eq!(span, Span::new(240, 243));
+            assert_eq!(span, Span::new(244, 247));
         }
     };
 
@@ -31,12 +31,12 @@ fn test_import_cycle() {
             pub use super::b::Foo;
         }
         
-        fn main() {
+        pub fn main() {
             a::Foo
         }           
         "#,
         span, QueryError { error: ImportCycle { path, .. } } => {
-            assert_eq!(span, Span::new(173, 179));
+            assert_eq!(span, Span::new(177, 183));
             assert_eq!(2, path.len());
             assert_eq!(Span::new(107, 120), path[0].location.span);
             assert_eq!(Span::new(37, 50), path[1].location.span);
@@ -55,7 +55,7 @@ fn test_recursive_import() {
 
         use self::a::Foo;
 
-        fn main() {
+        pub fn main() {
             Foo is a::c::Baz
         }
     };
@@ -74,7 +74,7 @@ fn test_recursive_context_import() {
 
         use self::a::Foo;
 
-        fn main() {
+        pub fn main() {
             Foo::None is Option
         }
     };
@@ -93,7 +93,7 @@ fn test_recusive_wildcard() {
 
         use self::a::*;
 
-        fn main() {
+        pub fn main() {
             (Foo::None is Option, Foo2::Some(2) is Option)
         }
     };
@@ -113,7 +113,7 @@ fn test_reexport_fn() {
 
         mod b { pub use crate::{a::b::out, a}; }
 
-        fn main() {
+        pub fn main() {
             b::out(2) + b::a::b::out(4)
         }
     };

--- a/crates/rune/tests/test_all/compiler_visibility.rs
+++ b/crates/rune/tests/test_all/compiler_visibility.rs
@@ -13,7 +13,7 @@ fn test_working_visibility() {
             pub fn visible() { b::hidden() }
         }
 
-        fn main() {
+        pub fn main() {
             a::visible()
         }
     };
@@ -35,12 +35,12 @@ fn test_access_hidden() {
             pub fn visible() { b::hidden() }
         }
 
-        fn main() {
+        pub fn main() {
             a::b::hidden()
         }        
         "#,
         span, QueryError { error: NotVisibleMod { .. } } => {
-            assert_eq!(span, Span::new(215, 227));
+            assert_eq!(span, Span::new(219, 231));
         }
     };
 }
@@ -64,7 +64,7 @@ fn test_indirect_access() {
             }
         }
 
-        fn main() {
+        pub fn main() {
             d::e::test().0
         }
     };
@@ -100,7 +100,7 @@ fn test_rust_example() {
             }
         }
 
-        fn main() {
+        pub fn main() {
             submodule::my_method();
         }
     };

--- a/crates/rune/tests/test_all/compiler_warnings.rs
+++ b/crates/rune/tests/test_all/compiler_warnings.rs
@@ -3,9 +3,9 @@ use rune::testing::*;
 #[test]
 fn test_let_pattern_might_panic() {
     assert_warnings! {
-        r#"fn main() { let [0, 1, 3] = []; }"#,
+        r#"pub fn main() { let [0, 1, 3] = []; }"#,
         LetPatternMightPanic { span, .. } => {
-            assert_eq!(span, Span::new(12, 31));
+            assert_eq!(span, Span::new(16, 35));
         }
     };
 }
@@ -13,9 +13,9 @@ fn test_let_pattern_might_panic() {
 #[test]
 fn test_template_without_variables() {
     assert_warnings! {
-        r#"fn main() { `Hello World` }"#,
+        r#"pub fn main() { `Hello World` }"#,
         TemplateWithoutExpansions { span, .. } => {
-            assert_eq!(span, Span::new(12, 25));
+            assert_eq!(span, Span::new(16, 29));
         }
     };
 }
@@ -23,9 +23,9 @@ fn test_template_without_variables() {
 #[test]
 fn test_remove_variant_parens() {
     assert_warnings! {
-        r#"fn main() { None() }"#,
+        r#"pub fn main() { None() }"#,
         RemoveTupleCallParams { span, .. } => {
-            assert_eq!(span, Span::new(12, 18));
+            assert_eq!(span, Span::new(16, 22));
         }
     };
 }

--- a/crates/rune/tests/test_all/core_macros.rs
+++ b/crates/rune/tests/test_all/core_macros.rs
@@ -1,19 +1,19 @@
 macro_rules! test_case {
     ($($tt:tt)*) => {
-        let out: String = rune!(String => fn main() { format!($($tt)*) });
+        let out: String = rune!(String => pub fn main() { format!($($tt)*) });
         assert_eq!(format!($($tt)*), out);
     }
 }
 
 #[test]
 fn test_asserts() {
-    rune!(() => fn main() { assert!(true) });
-    rune!(() => fn main() { assert_eq!(1 + 1, 2) });
+    rune!(() => pub fn main() { assert!(true) });
+    rune!(() => pub fn main() { assert_eq!(1 + 1, 2) });
 }
 
 #[test]
 fn test_stringify() {
-    let out: String = rune!(String => fn main() { stringify!(assert_eq!(1 + 1, 2)) });
+    let out: String = rune!(String => pub fn main() { stringify!(assert_eq!(1 + 1, 2)) });
     assert_eq!("assert_eq ! ( 1 + 1 , 2 )", out);
 }
 
@@ -33,7 +33,7 @@ fn test_format() {
     test_case!("Hello, {} {0} {}", "John", "Doe");
 
     let out: String =
-        rune!(String => fn main() { format!("Hello, {}" + " {0} {}", "John", "Doe") });
+        rune!(String => pub fn main() { format!("Hello, {}" + " {0} {}", "John", "Doe") });
     assert_eq!(format!("Hello, {} {0} {}", "John", "Doe"), out);
 }
 

--- a/crates/rune/tests/test_all/vm_arithmetic.rs
+++ b/crates/rune/tests/test_all/vm_arithmetic.rs
@@ -3,13 +3,13 @@ use rune::testing::*;
 macro_rules! op_tests {
     ($lhs:literal $op:tt $rhs:literal = $out:expr) => {
         assert_eq! {
-            rune!(i64 => fn main() { let a = $lhs; let b = $rhs; a $op b}),
+            rune!(i64 => pub fn main() { let a = $lhs; let b = $rhs; a $op b}),
             $out,
         };
 
         assert_eq! {
             rune_s!(i64 => &format!(
-                r#"fn main() {{ let a = {lhs}; let b = {rhs}; a {op}= b; a }}"#,
+                r#"pub fn main() {{ let a = {lhs}; let b = {rhs}; a {op}= b; a }}"#,
                 lhs = $lhs, rhs = $rhs, op = stringify!($op),
             )),
             $out,
@@ -17,7 +17,7 @@ macro_rules! op_tests {
 
         assert_eq! {
             rune_s!(i64 => &format!(
-                r#"struct Foo {{ padding, field }}; fn main() {{ let a = Foo{{ padding: 0, field: {lhs} }}; let b = {rhs}; a.field {op}= b; a.field }}"#,
+                r#"struct Foo {{ padding, field }}; pub fn main() {{ let a = Foo{{ padding: 0, field: {lhs} }}; let b = {rhs}; a.field {op}= b; a.field }}"#,
                 lhs = $lhs, rhs = $rhs, op = stringify!($op),
             )),
             $out,
@@ -25,7 +25,7 @@ macro_rules! op_tests {
 
         assert_eq! {
             rune_s!(i64 => &format!(
-                r#"enum Enum {{ Foo {{ padding, field }} }}; fn main() {{ let a = Enum::Foo {{ padding: 0, field: {lhs} }}; let b = {rhs}; a.field {op}= b; a.field }}"#,
+                r#"enum Enum {{ Foo {{ padding, field }} }}; pub fn main() {{ let a = Enum::Foo {{ padding: 0, field: {lhs} }}; let b = {rhs}; a.field {op}= b; a.field }}"#,
                 lhs = $lhs, rhs = $rhs, op = stringify!($op),
             )),
             $out,
@@ -33,7 +33,7 @@ macro_rules! op_tests {
 
         assert_eq! {
             rune_s!(i64 => &format!(
-                r#"fn main() {{ let a = #{{ padding: 0, field: {lhs} }}; let b = {rhs}; a.field {op}= b; a.field }}"#,
+                r#"pub fn main() {{ let a = #{{ padding: 0, field: {lhs} }}; let b = {rhs}; a.field {op}= b; a.field }}"#,
                 lhs = $lhs, rhs = $rhs, op = stringify!($op),
             )),
             $out,
@@ -41,7 +41,7 @@ macro_rules! op_tests {
 
         assert_eq! {
             rune_s!(i64 => &format!(
-                r#"fn main() {{ let a = (0, {lhs}); let b = {rhs}; a.1 {op}= b; a.1 }}"#,
+                r#"pub fn main() {{ let a = (0, {lhs}); let b = {rhs}; a.1 {op}= b; a.1 }}"#,
                 lhs = $lhs, rhs = $rhs, op = stringify!($op),
             )),
             $out,
@@ -49,7 +49,7 @@ macro_rules! op_tests {
 
         assert_eq! {
             rune_s!(i64 => &format!(
-                r#"struct Foo(padding, a); fn main() {{ let a = Foo(0, {lhs}); let b = {rhs}; a.1 {op}= b; a.1 }}"#,
+                r#"struct Foo(padding, a); pub fn main() {{ let a = Foo(0, {lhs}); let b = {rhs}; a.1 {op}= b; a.1 }}"#,
                 lhs = $lhs, rhs = $rhs, op = stringify!($op),
             )),
             $out,
@@ -57,7 +57,7 @@ macro_rules! op_tests {
 
         assert_eq! {
             rune_s!(i64 => &format!(
-                r#"enum Enum {{ Foo(padding, a) }}; fn main() {{ let a = Enum::Foo(0, {lhs}); let b = {rhs}; a.1 {op}= b; a.1 }}"#,
+                r#"enum Enum {{ Foo(padding, a) }}; pub fn main() {{ let a = Enum::Foo(0, {lhs}); let b = {rhs}; a.1 {op}= b; a.1 }}"#,
                 lhs = $lhs, rhs = $rhs, op = stringify!($op),
             )),
             $out,
@@ -65,7 +65,7 @@ macro_rules! op_tests {
 
         assert_eq! {
             rune_s!(i64 => &format!(
-                r#"fn main() {{ let a = Ok({lhs}); let b = {rhs}; a.0 {op}= b; a.0 }}"#,
+                r#"pub fn main() {{ let a = Ok({lhs}); let b = {rhs}; a.0 {op}= b; a.0 }}"#,
                 lhs = $lhs, rhs = $rhs, op = stringify!($op),
             )),
             $out,
@@ -73,7 +73,7 @@ macro_rules! op_tests {
 
         assert_eq! {
             rune_s!(i64 => &format!(
-                r#"fn main() {{ let a = Some({lhs}); let b = {rhs}; a.0 {op}= b; a.0 }}"#,
+                r#"pub fn main() {{ let a = Some({lhs}); let b = {rhs}; a.0 {op}= b; a.0 }}"#,
                 lhs = $lhs, rhs = $rhs, op = stringify!($op),
             )),
             $out,
@@ -85,7 +85,7 @@ macro_rules! error_test {
     ($lhs:literal $op:tt $rhs:literal = $error:ident) => {
         assert_vm_error!(
             &format!(
-                r#"fn main() {{ let a = {lhs}; let b = {rhs}; a {op} b; }}"#,
+                r#"pub fn main() {{ let a = {lhs}; let b = {rhs}; a {op} b; }}"#,
                 lhs = $lhs, rhs = $rhs, op = stringify!($op),
             ),
             $error => {}
@@ -93,7 +93,7 @@ macro_rules! error_test {
 
         assert_vm_error!(
             &format!(
-                r#"fn main() {{ let a = {lhs}; let b = {rhs}; a {op}= b; }}"#,
+                r#"pub fn main() {{ let a = {lhs}; let b = {rhs}; a {op}= b; }}"#,
                 lhs = $lhs, rhs = $rhs, op = stringify!($op),
             ),
             $error => {}
@@ -101,7 +101,7 @@ macro_rules! error_test {
 
         assert_vm_error!(
             &format!(
-                r#"fn main() {{ let a = #{{ padding: 0, field: {lhs} }}; let b = {rhs}; a.field {op}= b; }}"#,
+                r#"pub fn main() {{ let a = #{{ padding: 0, field: {lhs} }}; let b = {rhs}; a.field {op}= b; }}"#,
                 lhs = $lhs, rhs = $rhs, op = stringify!($op),
             ),
             $error => {}
@@ -109,7 +109,7 @@ macro_rules! error_test {
 
         assert_vm_error!(
             &format!(
-                r#"fn main() {{ let a = (0, {lhs}); let b = {rhs}; a.1 {op}= b; }}"#,
+                r#"pub fn main() {{ let a = (0, {lhs}); let b = {rhs}; a.1 {op}= b; }}"#,
                 lhs = $lhs, rhs = $rhs, op = stringify!($op),
             ),
             $error => {}
@@ -161,7 +161,7 @@ fn test_bit_ops() {
 fn test_bitwise_not() {
     assert_eq! {
         rune! { i64 =>
-            fn main() { let a = 0b10100; !a }
+            pub fn main() { let a = 0b10100; !a }
         },
         !0b10100,
     };

--- a/crates/rune/tests/test_all/vm_assign_exprs.rs
+++ b/crates/rune/tests/test_all/vm_assign_exprs.rs
@@ -3,7 +3,7 @@ fn test_basic_assign() {
     assert_eq! {
         42,
         rune! { i64 =>
-            fn main() { let a = 0; a = 42; a }
+            pub fn main() { let a = 0; a = 42; a }
         }
     };
 }
@@ -13,7 +13,7 @@ fn test_assign_anon_object() {
     assert_eq! {
         42,
         rune! { i64 =>
-            fn main() { let a = #{}; a.foo = #{}; a.foo.bar = 42; a.foo.bar }
+            pub fn main() { let a = #{}; a.foo = #{}; a.foo.bar = 42; a.foo.bar }
         }
     };
 }
@@ -23,7 +23,7 @@ fn test_assign_anon_tuple() {
     assert_eq! {
         42,
         rune! { i64 =>
-            fn main() { let a = ((0,),); (a.0).0 = 42; (a.0).0 }
+            pub fn main() { let a = ((0,),); (a.0).0 = 42; (a.0).0 }
         }
     };
 }
@@ -36,7 +36,7 @@ fn test_assign_struct() {
             struct Bar { padding, baz };
             struct Foo { bar, padding };
 
-            fn main() {
+            pub fn main() {
                 let foo = Foo { bar: (), padding: () };
                 foo.bar = Bar { padding: (), baz: () };
                 foo.bar.baz = 42;
@@ -54,7 +54,7 @@ fn test_assign_tuple() {
             struct Bar(baz, padding);
             struct Foo(padding, bar);
 
-            fn main() {
+            pub fn main() {
                 let foo = Foo((), ());
                 foo.1 = Bar((), ());
                 (foo.1).0 = 42;
@@ -70,7 +70,7 @@ fn test_assign_assign_exprs() {
         (4, (), ()),
         rune_s! {
             (i64, (), ()) => r#"
-            fn main() {
+            pub fn main() {
                 let a = #{b: #{c: #{d: 1}}};
                 let b = 2;
                 let c = 3;

--- a/crates/rune/tests/test_all/vm_async_block.rs
+++ b/crates/rune/tests/test_all/vm_async_block.rs
@@ -8,7 +8,7 @@ fn test_async_block() {
                 output
             }
 
-            async fn main() {
+            pub async fn main() {
                 let value = 42;
                 foo(async { value }).await / foo(async { 2 }).await
             }

--- a/crates/rune/tests/test_all/vm_blocks.rs
+++ b/crates/rune/tests/test_all/vm_blocks.rs
@@ -3,7 +3,7 @@ fn test_anonymous_type_precedence() {
     assert_eq! {
         3,
         rune! { i64 =>
-            fn main() {
+            pub fn main() {
                 fn a() { 1 }
                 fn b() { return a(); fn a() { 2 } }
                 a() + b()

--- a/crates/rune/tests/test_all/vm_closures.rs
+++ b/crates/rune/tests/test_all/vm_closures.rs
@@ -5,7 +5,7 @@ fn test_nested_closures() {
     assert_eq! {
         4,
         rune! { i64 =>
-            fn main() {
+            pub fn main() {
                 let var = 1;
 
                 let a = |i| {
@@ -27,7 +27,7 @@ fn test_closure_in_loop_iter() {
     assert_eq! {
         10,
         rune! { i64 =>
-            fn main() {
+            pub fn main() {
                 let out = 1;
 
                 for var in {
@@ -49,7 +49,7 @@ fn test_capture_match() {
     assert_eq! {
         3,
         rune! { i64 =>
-            fn main() {
+            pub fn main() {
                 let n = 1;
 
                 let a = match { let out = || Some(n + 1); out() } {
@@ -69,7 +69,7 @@ fn test_capture_fn_arg() {
         3,
         rune! { i64 =>
             fn foo(n) { |a| n + a }
-            fn main() { foo(1)(2) }
+            pub fn main() { foo(1)(2) }
         }
     };
 
@@ -77,21 +77,21 @@ fn test_capture_fn_arg() {
         4,
         rune! { i64 =>
             fn test(a, b) { b / a + 1 }
-            fn main() { {let a = || test; a()}({let b = || 2; b()}, {let c = || 6; c()}) }
+            pub fn main() {{let a = || test; a()}({let b = || 2; b()}, {let c = || 6; c()}) }
         }
     };
 
     assert_eq! {
         (2, 6),
         rune! { (i64, i64) =>
-            fn main() { ({let b = || 2; b()}, {let c = || 6; c()}) }
+            pub fn main() { ({let b = || 2; b()}, {let c = || 6; c()}) }
         }
     };
 
     assert_eq! {
         vec![2, 6],
         rune! { Vec<i64> =>
-            fn main() { [{let b = || 2; b()}, {let c = || 6; c()}] }
+            pub fn main() { [{let b = || 2; b()}, {let c = || 6; c()}] }
         }
     };
 }
@@ -105,7 +105,7 @@ fn test_capture_and_environ() {
                 cb(1).await
             }
 
-            async fn main() {
+            pub async fn main() {
                 let value = 12;
                 foo(async |n| n + value).await
             }
@@ -118,7 +118,7 @@ fn test_immediate_call() {
     assert_eq! {
         11,
         rune! { i64 =>
-            async fn main() {
+            pub async fn main() {
                 let future = (async || {
                     11
                 })();
@@ -146,7 +146,7 @@ fn test_nested_async_closure() {
                 }
             }
 
-            async fn main() {
+            pub async fn main() {
                 let requests = send_requests([
                     "https://google.com",
                     "https://amazon.com",
@@ -167,7 +167,7 @@ fn test_nested_async_closure() {
 #[test]
 fn test_closure_in_lit_vec() -> runestick::Result<()> {
     let ret = rune_s! {
-        VecTuple<(i64, Function, Function, i64)> => r#"fn main() { let a = 4; [0, || 2, || 4, 3] }"#
+        VecTuple<(i64, Function, Function, i64)> => r#"pub fn main() { let a = 4; [0, || 2, || 4, 3] }"#
     };
 
     let (start, first, second, end) = ret.0;
@@ -181,7 +181,7 @@ fn test_closure_in_lit_vec() -> runestick::Result<()> {
 #[test]
 fn test_closure_in_lit_tuple() -> runestick::Result<()> {
     let ret = rune_s! {
-        (i64, Function, Function, i64) => r#"fn main() { let a = 4; (0, || 2, || a, 3) }"#
+        (i64, Function, Function, i64) => r#"pub fn main() { let a = 4; (0, || 2, || a, 3) }"#
     };
 
     let (start, first, second, end) = ret;
@@ -203,7 +203,7 @@ fn test_closure_in_lit_object() -> runestick::Result<()> {
     }
 
     let proxy = rune_s! {
-        Proxy => r#"fn main() { let a = 4; #{a: 0, b: || 2, c: || a, d: 3} }"#
+        Proxy => r#"pub fn main() { let a = 4; #{a: 0, b: || 2, c: || a, d: 3} }"#
     };
 
     assert_eq!(0, proxy.a);

--- a/crates/rune/tests/test_all/vm_const_exprs.rs
+++ b/crates/rune/tests/test_all/vm_const_exprs.rs
@@ -1,7 +1,7 @@
 macro_rules! test_op {
     ($ty:ty => $lhs:literal $op:tt $rhs:literal = $result:literal) => {{
         let program = format!(
-            r#"const A = {lhs}; const B = {rhs}; const VALUE = A {op} B; fn main() {{ VALUE }}"#,
+            r#"const A = {lhs}; const B = {rhs}; const VALUE = A {op} B; pub fn main() {{ VALUE }}"#,
             lhs = $lhs, rhs = $rhs, op = stringify!($op),
         );
 
@@ -16,11 +16,14 @@ macro_rules! test_op {
 
 #[test]
 fn test_const_values() {
-    assert_eq!(true, rune!(bool => const VALUE = true; fn main() { VALUE }));
+    assert_eq!(
+        true,
+        rune!(bool => const VALUE = true; pub fn main() { VALUE })
+    );
 
     assert_eq!(
         "Hello World",
-        rune!(String => const VALUE = "Hello World"; fn main() { VALUE })
+        rune!(String => const VALUE = "Hello World"; pub fn main() { VALUE })
     );
 
     assert_eq!(
@@ -31,7 +34,7 @@ fn test_const_values() {
             const A = 1;
             const B = 1.0;
             const C = true;
-            fn main() { VALUE }
+            pub fn main() { VALUE }
         "#)
     );
 }
@@ -57,7 +60,7 @@ fn test_integer_ops() {
 macro_rules! test_float_op {
     ($ty:ty => $lhs:literal $op:tt $rhs:literal = $result:literal) => {{
         let program = format!(
-            r#"const A = {lhs}.0; const B = {rhs}.0; const VALUE = A {op} B; fn main() {{ VALUE }}"#,
+            r#"const A = {lhs}.0; const B = {rhs}.0; const VALUE = A {op} B; pub fn main() {{ VALUE }}"#,
             lhs = $lhs, rhs = $rhs, op = stringify!($op),
         );
 
@@ -88,22 +91,22 @@ fn test_float_ops() {
 
 #[test]
 fn test_const_collections() {
-    let object = rune!(runestick::Object => fn main() { VALUE } const VALUE = #{};);
+    let object = rune!(runestick::Object => pub fn main() { VALUE } const VALUE = #{};);
     assert!(object.is_empty());
 
-    let tuple = rune!(runestick::Tuple => fn main() { VALUE } const VALUE = (););
+    let tuple = rune!(runestick::Tuple => pub fn main() { VALUE } const VALUE = (););
     assert!(tuple.is_empty());
 
-    let tuple = rune!(runestick::Tuple => fn main() { VALUE } const VALUE = ("Hello World",););
+    let tuple = rune!(runestick::Tuple => pub fn main() { VALUE } const VALUE = ("Hello World",););
     assert_eq!(
         Some("Hello World"),
         tuple.get_value::<String>(0).unwrap().as_deref()
     );
 
-    let vec = rune!(runestick::Vec => fn main() { VALUE } const VALUE = [];);
+    let vec = rune!(runestick::Vec => pub fn main() { VALUE } const VALUE = [];);
     assert!(vec.is_empty());
 
-    let vec = rune!(runestick::Vec => fn main() { VALUE } const VALUE = ["Hello World"];);
+    let vec = rune!(runestick::Vec => pub fn main() { VALUE } const VALUE = ["Hello World"];);
     assert_eq!(
         Some("Hello World"),
         vec.get_value::<String>(0).unwrap().as_deref()
@@ -126,7 +129,7 @@ fn test_more_complexity() {
             timeout
         };
 
-        fn main() { VALUE }
+        pub fn main() { VALUE }
     };
 
     assert_eq!(result, 1280);
@@ -136,19 +139,19 @@ fn test_more_complexity() {
 fn test_if_else() {
     let result = rune! { i64 =>
         const VALUE = { if true { 1 } else if true { 2 } else { 3 } };
-        fn main() { VALUE }
+        pub fn main() { VALUE }
     };
     assert_eq!(result, 1);
 
     let result = rune! { i64 =>
         const VALUE = { if false { 1 } else if true { 2 } else { 3 } };
-        fn main() { VALUE }
+        pub fn main() { VALUE }
     };
     assert_eq!(result, 2);
 
     let result = rune! { i64 =>
         const VALUE = { if false { 1 } else if false { 2 } else { 3 } };
-        fn main() { VALUE }
+        pub fn main() { VALUE }
     };
     assert_eq!(result, 3);
 }
@@ -159,7 +162,7 @@ fn test_const_fn() {
         const VALUE = 2;
         const fn foo(n) { n + VALUE }
 
-        fn main() {
+        pub fn main() {
             const VALUE = 1;
             foo(1 + 4 / 2 - VALUE) + foo(VALUE - 1)
         }
@@ -174,7 +177,7 @@ fn test_const_fn() {
         `foo ${n}`
     }
     
-    fn main() {
+    pub fn main() {
         foo(`bar ${VALUE}`)
     }
     "#};
@@ -192,7 +195,7 @@ fn test_const_fn() {
             c
         }
         
-        fn main() {
+        pub fn main() {
             VALUE
         }    
     "#};
@@ -221,7 +224,7 @@ fn test_const_fn_visibility() {
             const B = 2;
         }
 
-        fn main() {
+        pub fn main() {
             b::out()
         }
     };

--- a/crates/rune/tests/test_all/vm_early_termination.rs
+++ b/crates/rune/tests/test_all/vm_early_termination.rs
@@ -1,42 +1,42 @@
 macro_rules! test_case {
     (($($k:tt)*), $field:tt, $index:tt, $($extra:tt)*) => {
         assert_eq! {
-            rune!(bool => fn main() { let m = $($k)*; m[return true]; false } $($extra)*),
+            rune!(bool => pub fn main() { let m = $($k)*; m[return true]; false } $($extra)*),
             true,
         };
 
         assert_eq! {
-            rune!(bool => fn main() { let m = $($k)*; m[return true] = 0; false } $($extra)*),
+            rune!(bool => pub fn main() { let m = $($k)*; m[return true] = 0; false } $($extra)*),
             true,
         };
 
         assert_eq! {
-            rune!(bool => fn main() { let m = $($k)*; m[$index] = return true; false } $($extra)*),
+            rune!(bool => pub fn main() { let m = $($k)*; m[$index] = return true; false } $($extra)*),
             true,
         };
 
         assert_eq! {
-            rune!(bool => fn main() { let m = $($k)*; m.$field = return true; false } $($extra)*),
+            rune!(bool => pub fn main() { let m = $($k)*; m.$field = return true; false } $($extra)*),
             true,
         };
 
         assert_eq! {
-            rune!(bool => fn main() { $($k)*[return true]; false } $($extra)*),
+            rune!(bool => pub fn main() { $($k)*[return true]; false } $($extra)*),
             true,
         };
 
         assert_eq! {
-            rune!(bool => fn main() { $($k)*[return true] = 0; false } $($extra)*),
+            rune!(bool => pub fn main() { $($k)*[return true] = 0; false } $($extra)*),
             true,
         };
 
         assert_eq! {
-            rune!(bool => fn main() { $($k)*[$index] = return true; false } $($extra)*),
+            rune!(bool => pub fn main() { $($k)*[$index] = return true; false } $($extra)*),
             true,
         };
 
         assert_eq! {
-            rune!(bool => fn main() { $($k)*.$field = return true; false } $($extra)*),
+            rune!(bool => pub fn main() { $($k)*.$field = return true; false } $($extra)*),
             true,
         };
     };

--- a/crates/rune/tests/test_all/vm_function.rs
+++ b/crates/rune/tests/test_all/vm_function.rs
@@ -9,14 +9,14 @@ fn test_function() {
     let function = rune! { Function =>
         fn foo(a, b) { a + b }
 
-        fn main() { foo }
+        pub fn main() { foo }
     };
 
     assert_eq!(function.call::<_, i64>((1i64, 3i64)).unwrap(), 4i64);
     assert!(function.call::<_, i64>((1i64,)).is_err());
 
     // ptr to native function
-    let function = rune!(Function => fn main() { Vec::new });
+    let function = rune!(Function => pub fn main() { Vec::new });
 
     let value: Vec<Value> = function.call(()).unwrap();
     assert_eq!(value.len(), 0);
@@ -24,7 +24,7 @@ fn test_function() {
     // ptr to dynamic function.
     let function = rune! { Function =>
         enum Custom { A(a) }
-        fn main() { Custom::A }
+        pub fn main() { Custom::A }
     };
 
     assert!(function.call::<_, Value>(()).is_err());
@@ -34,7 +34,7 @@ fn test_function() {
     // ptr to dynamic function.
     let function = rune! { Function =>
         struct Custom(a);
-        fn main() { Custom }
+        pub fn main() { Custom }
     };
 
     assert!(function.call::<_, Value>(()).is_err());
@@ -43,7 +43,7 @@ fn test_function() {
 
     // non-capturing closure == free function
     let function = rune! { Function =>
-        fn main() { |a, b| a + b }
+        pub fn main() { |a, b| a + b }
     };
 
     assert!(function.call::<_, Value>((1i64,)).is_err());
@@ -55,7 +55,7 @@ fn test_function() {
         &context,
         &["main"],
         (1i64, 2i64),
-        r#"fn main(a, b) { || a + b }"#,
+        r#"pub fn main(a, b) { || a + b }"#,
     )
     .unwrap();
 

--- a/crates/rune/tests/test_all/vm_general.rs
+++ b/crates/rune/tests/test_all/vm_general.rs
@@ -4,12 +4,12 @@ use rune::testing::*;
 
 #[test]
 fn test_small_programs() {
-    assert_eq!(rune!(u64 => fn main() { 42 }), 42u64);
-    assert_eq!(rune!(() => fn main() {}), ());
+    assert_eq!(rune!(u64 => pub fn main() { 42 }), 42u64);
+    assert_eq!(rune!(() => pub fn main() {}), ());
 
     assert_eq! {
         rune! { i64 =>
-            fn main() {
+            pub fn main() {
                 let a = 1;
                 let b = 2;
                 let c = a + b;
@@ -25,42 +25,42 @@ fn test_small_programs() {
 #[test]
 fn test_boolean_ops() {
     assert_eq! {
-        rune!(bool => fn main() { true && true }),
+        rune!(bool => pub fn main() { true && true }),
         true,
     };
 
     assert_eq! {
-        rune!(bool => fn main() { true && false }),
+        rune!(bool => pub fn main() { true && false }),
         false,
     };
 
     assert_eq! {
-        rune!(bool => fn main() { false && true }),
+        rune!(bool => pub fn main() { false && true }),
         false,
     };
 
     assert_eq! {
-        rune!(bool => fn main() { false && false }),
+        rune!(bool => pub fn main() { false && false }),
         false,
     };
 
     assert_eq! {
-        rune!(bool => fn main() { true || true }),
+        rune!(bool => pub fn main() { true || true }),
         true,
     };
 
     assert_eq! {
-        rune!(bool => fn main() { true || false }),
+        rune!(bool => pub fn main() { true || false }),
         true,
     };
 
     assert_eq! {
-        rune!(bool => fn main() { false || true }),
+        rune!(bool => pub fn main() { false || true }),
         true,
     };
 
     assert_eq! {
-        rune!(bool => fn main() { false || false }),
+        rune!(bool => pub fn main() { false || false }),
         false,
     };
 }
@@ -69,7 +69,7 @@ fn test_boolean_ops() {
 fn test_if() {
     assert_eq! {
         rune! { i64 =>
-            fn main() {
+            pub fn main() {
                 let n = 2;
 
                 if n > 5 {
@@ -84,7 +84,7 @@ fn test_if() {
 
     assert_eq! {
         rune!{ i64 =>
-            fn main() {
+            pub fn main() {
                 let n = 6;
 
                 if n > 5 {
@@ -102,7 +102,7 @@ fn test_if() {
 fn test_block() {
     assert_eq! {
         rune! { i64 =>
-            fn main() {
+            pub fn main() {
                 let b = 10;
 
                 let n = {
@@ -121,7 +121,7 @@ fn test_block() {
 fn test_shadowing() {
     assert_eq! {
         rune! { i64 =>
-            fn main() {
+            pub fn main() {
                 let a = 10;
                 let a = a;
                 a
@@ -134,7 +134,7 @@ fn test_shadowing() {
 #[test]
 fn test_vectors() {
     assert_eq! {
-        rune!(() => fn main() { let v = [1, 2, 3, 4, 5]; }),
+        rune!(() => pub fn main() { let v = [1, 2, 3, 4, 5]; }),
         (),
     };
 }
@@ -143,7 +143,7 @@ fn test_vectors() {
 fn test_while() {
     assert_eq! {
         rune!{ i64 =>
-            fn main() {
+            pub fn main() {
                 let a = 0;
 
                 while a < 10 {
@@ -158,7 +158,7 @@ fn test_while() {
 
     assert_eq! {
         rune! { i64 =>
-            fn main() {
+            pub fn main() {
                 let a = 0;
 
                 let a = while a >= 0 {
@@ -181,7 +181,7 @@ fn test_loop() {
     assert_eq! {
         rune! {
             runestick::VecTuple<(i64, bool)> =>
-            fn main() {
+            pub fn main() {
                 let a = 0;
 
                 let value = loop {
@@ -200,7 +200,7 @@ fn test_loop() {
 
     assert_eq! {
         rune! { i64 =>
-            fn main() {
+            pub fn main() {
                 let n = 0;
 
                 let n = loop {
@@ -224,7 +224,7 @@ fn test_for() {
         rune! { i64 =>
             use std::iter::range;
 
-            fn main() {
+            pub fn main() {
                 let a = 0;
                 let it = range(0, 10);
 
@@ -242,7 +242,7 @@ fn test_for() {
         rune! { i64 =>
             use std::iter::range;
 
-            fn main() {
+            pub fn main() {
                 let a = 0;
                 let it = range(0, 100);
 
@@ -264,7 +264,7 @@ fn test_for() {
         rune! { bool =>
             use std::iter::range;
 
-            fn main() {
+            pub fn main() {
                 let a = 0;
                 let it = range(0, 100);
 
@@ -289,7 +289,7 @@ fn test_return() {
         rune! { i64 =>
             use std::iter::range;
 
-            fn main() {
+            pub fn main() {
                 for v in range(0, 20) {
                     if v == 10 {
                         return v;
@@ -307,55 +307,55 @@ fn test_return() {
 fn test_is() {
     assert_eq! {
         rune! { bool =>
-            fn main() {
+            pub fn main() {
                 {} is Object
             }
         },
         false,
     };
 
-    assert!(rune!(bool => fn main() { #{} is Object }));
-    assert!(rune!(bool => fn main() { () is unit }));
-    assert!(rune!(bool => fn foo() {} fn main() { foo() is unit }));
-    assert!(rune!(bool => fn main() { {} is unit }));
-    assert!(rune!(bool => fn main() { true is bool }));
-    assert!(rune!(bool => fn main() { 'a' is char }));
-    assert!(rune!(bool => fn main() { 42 is int }));
-    assert!(rune!(bool => fn main() { 42.1 is float }));
-    assert!(rune!(bool => fn main() { "hello" is String }));
-    assert!(rune!(bool => fn main() { #{"hello": "world"} is Object }));
-    assert!(rune!(bool => fn main() { ["hello", "world"] is Vec }));
+    assert!(rune!(bool => pub fn main() { #{} is Object }));
+    assert!(rune!(bool => pub fn main() { () is unit }));
+    assert!(rune!(bool => fn foo() {} pub fn main() { foo() is unit }));
+    assert!(rune!(bool => pub fn main() {{} is unit }));
+    assert!(rune!(bool => pub fn main() { true is bool }));
+    assert!(rune!(bool => pub fn main() { 'a' is char }));
+    assert!(rune!(bool => pub fn main() { 42 is int }));
+    assert!(rune!(bool => pub fn main() { 42.1 is float }));
+    assert!(rune!(bool => pub fn main() { "hello" is String }));
+    assert!(rune!(bool => pub fn main() { #{"hello": "world"} is Object }));
+    assert!(rune!(bool => pub fn main() { ["hello", "world"] is Vec }));
 }
 
 #[test]
 fn test_match() {
     assert_eq! {
-        rune!(i64 => fn main() { match 1 { _ => 10 } }),
+        rune!(i64 => pub fn main() { match 1 { _ => 10 } }),
         10,
     };
 
     assert_eq! {
-        rune!(i64 => fn main() { match 10 { n => 10 } }),
+        rune!(i64 => pub fn main() { match 10 { n => 10 } }),
         10,
     };
 
     assert_eq! {
-        rune!(char => fn main() { match 'a' { 'a' => 'b', n => n } }),
+        rune!(char => pub fn main() { match 'a' { 'a' => 'b', n => n } }),
         'b',
     };
 
     assert_eq! {
-        rune!(i64 => fn main() { match 10 { n => n } }),
+        rune!(i64 => pub fn main() { match 10 { n => n } }),
         10,
     };
 
     assert_eq! {
-        rune!(i64 => fn main() { match 10 { 10 => 5, n => n } }),
+        rune!(i64 => pub fn main() { match 10 { 10 => 5, n => n } }),
         5,
     };
 
     assert_eq! {
-        rune!(String => fn main() { match "hello world" { "hello world" => "hello john", n => n } }),
+        rune!(String => pub fn main() { match "hello world" { "hello world" => "hello john", n => n } }),
         "hello john",
     };
 }
@@ -363,72 +363,72 @@ fn test_match() {
 #[test]
 fn test_vec_match() {
     assert_eq! {
-        rune!(bool => fn main() { match [] { [..] => true } }),
+        rune!(bool => pub fn main() { match [] { [..] => true } }),
         true,
     };
 
     assert_eq! {
-        rune!(bool => fn main() { match [] { [..] => true, _ => false } }),
+        rune!(bool => pub fn main() { match [] { [..] => true, _ => false } }),
         true,
     };
 
     assert_eq! {
-        rune!(bool => fn main() { match [1, 2] { [a, b] => a + 1 == b } }),
+        rune!(bool => pub fn main() { match [1, 2] { [a, b] => a + 1 == b } }),
         true,
     };
 
     assert_eq! {
-        rune!(() => fn main() { match [] { [a, b] => a + 1 == b } }),
+        rune!(() => pub fn main() { match [] { [a, b] => a + 1 == b } }),
         (),
     };
 
     assert_eq! {
-        rune!(bool => fn main() { match [1, 2] { [a, b] => a + 1 == b, _ => false } }),
+        rune!(bool => pub fn main() { match [1, 2] { [a, b] => a + 1 == b, _ => false } }),
         true,
     };
 
     assert_eq! {
-        rune!(bool => fn main() { match [1, 2] { [a, b, ..] => a + 1 == b, _ => false } }),
+        rune!(bool => pub fn main() { match [1, 2] { [a, b, ..] => a + 1 == b, _ => false } }),
         true,
     };
 
     assert_eq! {
-        rune!(bool => fn main() { match [1, 2] { [1, ..] => true, _ => false } }),
+        rune!(bool => pub fn main() { match [1, 2] { [1, ..] => true, _ => false } }),
         true,
     };
 
     assert_eq! {
-        rune!(bool => fn main() { match [1, 2] { [] => true, _ => false } }),
+        rune!(bool => pub fn main() { match [1, 2] { [] => true, _ => false } }),
         false,
     };
 
     assert_eq! {
-        rune!(bool => fn main() { match [1, 2] { [1, 2] => true, _ => false } }),
+        rune!(bool => pub fn main() { match [1, 2] { [1, 2] => true, _ => false } }),
         true,
     };
 
     assert_eq! {
-        rune!(bool => fn main() { match [1, 2] { [1] => true, _ => false } }),
+        rune!(bool => pub fn main() { match [1, 2] { [1] => true, _ => false } }),
         false,
     };
 
     assert_eq! {
-        rune!(bool => fn main() { match [1, [2, 3]] { [1, [2, ..]] => true, _ => false } }),
+        rune!(bool => pub fn main() { match [1, [2, 3]] { [1, [2, ..]] => true, _ => false } }),
         true,
     };
 
     assert_eq! {
-        rune!(bool => fn main() { match [1, []] { [1, [2, ..]] => true, _ => false } }),
+        rune!(bool => pub fn main() { match [1, []] { [1, [2, ..]] => true, _ => false } }),
         false,
     };
 
     assert_eq! {
-        rune!(bool => fn main() { match [1, [2, 3]] { [1, [2, 3]] => true, _ => false } }),
+        rune!(bool => pub fn main() { match [1, [2, 3]] { [1, [2, 3]] => true, _ => false } }),
         true,
     };
 
     assert_eq! {
-        rune!(bool => fn main() { match [1, [2, 4]] { [1, [2, 3]] => true, _ => false } }),
+        rune!(bool => pub fn main() { match [1, [2, 4]] { [1, [2, 3]] => true, _ => false } }),
         false,
     };
 }
@@ -436,37 +436,37 @@ fn test_vec_match() {
 #[test]
 fn test_object_match() {
     assert_eq! {
-        rune!(bool => fn main() { match #{} { #{..} => true } }),
+        rune!(bool => pub fn main() { match #{} { #{..} => true } }),
         true,
     };
 
     assert_eq! {
-        rune!(bool => fn main() { match #{foo: true} { #{foo} => foo, _ => false } }),
+        rune!(bool => pub fn main() { match #{foo: true} { #{foo} => foo, _ => false } }),
         true,
     };
 
     assert_eq! {
-        rune!(bool => fn main() { match #{} { #{..} => true, _ => false } }),
+        rune!(bool => pub fn main() { match #{} { #{..} => true, _ => false } }),
         true,
     };
 
     assert_eq! {
-        rune!(bool => fn main() { match #{"foo": 10, "bar": 0} { #{"foo": v, ..} => v == 10, _ => false } }),
+        rune!(bool => pub fn main() { match #{"foo": 10, "bar": 0} { #{"foo": v, ..} => v == 10, _ => false } }),
         true,
     };
 
     assert_eq! {
-        rune!(bool => fn main() { match #{"foo": 10, "bar": 0} { #{"foo": v} => v == 10, _ => false } }),
+        rune!(bool => pub fn main() { match #{"foo": 10, "bar": 0} { #{"foo": v} => v == 10, _ => false } }),
         false,
     };
 
     assert_eq! {
-        rune!(bool => fn main() { match #{"foo": 10, "bar": #{"baz": [1, 2]}} { #{"foo": v} => v == 10, _ => false } }),
+        rune!(bool => pub fn main() { match #{"foo": 10, "bar": #{"baz": [1, 2]}} { #{"foo": v} => v == 10, _ => false } }),
         false,
     };
 
     assert_eq! {
-        rune!(bool => fn main() { match #{"foo": 10, "bar": #{"baz": [1, 2]}} { #{"foo": v, ..} => v == 10, _ => false } }),
+        rune!(bool => pub fn main() { match #{"foo": 10, "bar": #{"baz": [1, 2]}} { #{"foo": v, ..} => v == 10, _ => false } }),
         true,
     };
 }
@@ -476,7 +476,7 @@ fn test_bad_pattern() {
     // Attempting to assign to an unmatched pattern leads to a panic.
     assert_vm_error!(
         r#"
-        fn main() {
+        pub fn main() {
             let [] = [1, 2, 3];
         }
         "#,
@@ -494,7 +494,7 @@ fn test_destructuring() {
                 [n, n + 1]
             }
 
-            fn main() {
+            pub fn main() {
                 let [a, b] = foo(3);
                 a + b
             }
@@ -507,7 +507,7 @@ fn test_destructuring() {
 fn test_if_pattern() {
     assert_eq! {
         rune! { bool =>
-            fn main() {
+            pub fn main() {
                 if let [value] = [()] {
                     true
                 } else {
@@ -520,7 +520,7 @@ fn test_if_pattern() {
 
     assert_eq! {
         rune! { bool =>
-            fn main() {
+            pub fn main() {
                 if let [value] = [(), ()] {
                     true
                 } else {
@@ -533,7 +533,7 @@ fn test_if_pattern() {
 
     assert_eq! {
         rune! { i64 =>
-            fn main() {
+            pub fn main() {
                 let value = [(), (), 2];
 
                 if let [(), ()] = value {
@@ -555,7 +555,7 @@ fn test_break_label() {
         rune! { i64 =>
             use std::iter::range;
 
-            fn main() {
+            pub fn main() {
                 let it = range(0, 1000);
                 let tail = 77;
 
@@ -586,7 +586,7 @@ fn test_break_label() {
 fn test_string_concat() {
     assert_eq! {
         rune! { String =>
-            fn main() {
+            pub fn main() {
                 let foo = String::from_str("foo");
                 foo += "/bar" + "/baz";
                 foo
@@ -600,7 +600,7 @@ fn test_string_concat() {
 fn test_template_string() {
     assert_eq! {
         rune_s! { String => r#"
-            fn main() {
+            pub fn main() {
                 let name = "John Doe";
                 `Hello ${name}, I am ${1 - 10} years old!`
             }
@@ -613,7 +613,7 @@ fn test_template_string() {
     // accidentally clobber the scope.
     assert_eq! {
         rune_s! { String => r#"
-            fn main() {
+            pub fn main() {
                 let name = "John Doe";
 
                 `Hello ${name}, I am ${{
@@ -637,7 +637,7 @@ fn test_variants_as_functions() {
                 tuple(1, 2)
             }
 
-            fn main() {
+            pub fn main() {
                 let foo = construct_tuple(Foo::B);
 
                 match foo {
@@ -654,7 +654,7 @@ fn test_variants_as_functions() {
 fn test_iter_drop() {
     assert_eq! {
         rune! { i64 =>
-            fn main() {
+            pub fn main() {
                 let sum = 0;
                 let values = [1, 2, 3, 4];
 
@@ -697,7 +697,7 @@ fn test_async_fn() {
                 b / a
             }
 
-            async fn main() {
+            pub async fn main() {
                 foo(2, 4).await + bar(2, 8)
             }
         },
@@ -714,7 +714,7 @@ fn test_complex_field_access() {
                 #{hello: #{world: 42}}
             }
 
-            fn main() {
+            pub fn main() {
                 Some((foo()).hello["world"])
             }
             "#
@@ -735,7 +735,7 @@ fn test_index_get() {
             fn c() { Named(3, 4, 5) }
             fn d() { Enum::Named(4, 5, 6) }
 
-            fn main() {
+            pub fn main() {
                 (a())[1] + (b())[1] + (c())[1] + (d())[1] + (a()).2 + (b()).2 + (c()).2 + (d()).2
             }
         },

--- a/crates/rune/tests/test_all/vm_generators.rs
+++ b/crates/rune/tests/test_all/vm_generators.rs
@@ -4,7 +4,7 @@ fn test_simple_generator() {
         rune! { i64 =>
             fn foo() { yield 1; yield 2; yield 3; }
 
-            fn main() {
+            pub fn main() {
                 let gen = foo();
                 let result = 0;
 
@@ -27,7 +27,7 @@ fn test_resume() {
 
             fn foo() { let a = yield 1; let b = yield a; b }
 
-            fn main() {
+            pub fn main() {
                 let gen = foo();
                 let result = 0;
 

--- a/crates/rune/tests/test_all/vm_is.rs
+++ b/crates/rune/tests/test_all/vm_is.rs
@@ -6,7 +6,7 @@ fn test_binop_override() {
         rune! { (bool, bool, bool, bool) =>
             struct Timeout;
 
-            fn main() {
+            pub fn main() {
                 let timeout = Timeout;
 
                 (

--- a/crates/rune/tests/test_all/vm_lazy_and_or.rs
+++ b/crates/rune/tests/test_all/vm_lazy_and_or.rs
@@ -1,22 +1,22 @@
 #[test]
 fn test_lazy_and_or() {
     assert_eq! {
-        rune!(bool => fn main() { true || return false }),
+        rune!(bool => pub fn main() { true || return false }),
         true,
     };
 
     assert_eq! {
-        rune!(bool => fn main() { false && return true }),
+        rune!(bool => pub fn main() { false && return true }),
         false,
     };
 
     assert_eq! {
-        rune!(bool => fn main() { false || false || {return true; false} || false }),
+        rune!(bool => pub fn main() { false || false || {return true; false} || false }),
         true,
     };
 
     assert_eq! {
-        rune!(bool => fn main() { false && false && {return false; false} || true }),
+        rune!(bool => pub fn main() { false && false && {return false; false} || true }),
         true,
     };
 }

--- a/crates/rune/tests/test_all/vm_literals.rs
+++ b/crates/rune/tests/test_all/vm_literals.rs
@@ -2,45 +2,48 @@ use rune::testing::*;
 
 #[test]
 fn test_literals() {
-    assert_eq!(rune!(String => fn main() { "Hello World" }), "Hello World");
     assert_eq!(
-        rune!(runestick::Bytes => fn main() { b"Hello World" }),
+        rune!(String => pub fn main() { "Hello World" }),
+        "Hello World"
+    );
+    assert_eq!(
+        rune!(runestick::Bytes => pub fn main() { b"Hello World" }),
         b"Hello World"[..]
     );
 
-    assert_eq!(rune!(i64 => fn main() { 0xff }), 0xff);
-    assert_eq!(rune!(i64 => fn main() { -0xff }), -0xff);
+    assert_eq!(rune!(i64 => pub fn main() { 0xff }), 0xff);
+    assert_eq!(rune!(i64 => pub fn main() { -0xff }), -0xff);
 
-    assert_eq!(rune!(i64 => fn main() { 0b10010001 }), 0b10010001);
-    assert_eq!(rune!(i64 => fn main() { -0b10010001 }), -0b10010001);
+    assert_eq!(rune!(i64 => pub fn main() { 0b10010001 }), 0b10010001);
+    assert_eq!(rune!(i64 => pub fn main() { -0b10010001 }), -0b10010001);
 
-    assert_eq!(rune!(i64 => fn main() { 0o77 }), 0o77);
-    assert_eq!(rune!(i64 => fn main() { -0o77 }), -0o77);
+    assert_eq!(rune!(i64 => pub fn main() { 0o77 }), 0o77);
+    assert_eq!(rune!(i64 => pub fn main() { -0o77 }), -0o77);
 
-    assert_eq!(rune!(u8 => fn main() { b'0' }), b'0');
-    assert_eq!(rune!(u8 => fn main() { b'\xaf' }), b'\xaf');
+    assert_eq!(rune!(u8 => pub fn main() { b'0' }), b'0');
+    assert_eq!(rune!(u8 => pub fn main() { b'\xaf' }), b'\xaf');
 
-    assert_eq!(rune!(char => fn main() { '\x60' }), '\x60');
-    assert_eq!(rune!(char => fn main() { '\u{1F4AF}' }), '\u{1F4AF}');
-    assert_eq!(rune!(char => fn main() { '💯' }), '💯');
+    assert_eq!(rune!(char => pub fn main() { '\x60' }), '\x60');
+    assert_eq!(rune!(char => pub fn main() { '\u{1F4AF}' }), '\u{1F4AF}');
+    assert_eq!(rune!(char => pub fn main() { '💯' }), '💯');
 }
 
 #[test]
 fn test_string_literals() {
     assert_eq!(
-        rune!(String => fn main() { "
+        rune!(String => pub fn main() { "
     " }),
         "\n    "
     );
 
     assert_eq!(
-        rune!(String => fn main() { "\
+        rune!(String => pub fn main() { "\
     " }),
         ""
     );
 
     assert_eq!(
-        rune!(String => fn main() { "\
+        rune!(String => pub fn main() { "\
     a \
     
     b" }),
@@ -51,19 +54,19 @@ fn test_string_literals() {
 #[test]
 fn test_byte_string_literals() {
     assert_eq!(
-        rune!(Bytes => fn main() { b"
+        rune!(Bytes => pub fn main() { b"
     " }),
         b"\n    "[..]
     );
 
     assert_eq!(
-        rune!(Bytes => fn main() { b"\
+        rune!(Bytes => pub fn main() { b"\
     " }),
         b""[..]
     );
 
     assert_eq!(
-        rune!(Bytes => fn main() { b"\
+        rune!(Bytes => pub fn main() { b"\
     a \
     
     b" }),

--- a/crates/rune/tests/test_all/vm_match.rs
+++ b/crates/rune/tests/test_all/vm_match.rs
@@ -3,7 +3,7 @@ fn test_path_type_match() {
     assert_eq! {
         rune! { bool =>
             enum Custom { A, B(a) }
-            fn main() {
+            pub fn main() {
                 match Custom::A { Custom::A => true, _ => false }
             }
         },
@@ -13,7 +13,7 @@ fn test_path_type_match() {
     assert_eq! {
         rune! { bool =>
             enum Custom { A, B(a) }
-            fn main() {
+            pub fn main() {
                 match Custom::B(0) { Custom::A => true, _ => false }
             }
         },
@@ -23,7 +23,7 @@ fn test_path_type_match() {
     assert_eq! {
         rune! { bool =>
             enum Custom { A, B(a) }
-            fn main() {
+            pub fn main() {
                 match Custom::B(0) { Custom::B(0) => true, _ => false }
             }
         },
@@ -33,7 +33,7 @@ fn test_path_type_match() {
     assert_eq! {
         rune! { bool =>
             enum Custom { A, B { a } }
-            fn main() {
+            pub fn main() {
                 match (Custom::B { a: 0 }) { Custom::B { a: 0 } => true, _ => false }
             }
         },
@@ -45,7 +45,7 @@ fn test_path_type_match() {
             enum Custom { A, B { a } }
             fn test(a) { a == 0 }
 
-            fn main() {
+            pub fn main() {
                 match (Custom::B { a: 0 }) { Custom::B { a } if test(a) => true, _ => false }
             }
         },
@@ -59,7 +59,7 @@ fn test_struct_matching() {
         rune! { i64 =>
             struct Foo { a, b }
 
-            fn main() {
+            pub fn main() {
                 let foo = Foo {
                     a: 1,
                     b: 2,
@@ -78,7 +78,7 @@ fn test_struct_matching() {
         rune! { i64 =>
             struct Foo { a, b }
 
-            fn main() {
+            pub fn main() {
                 let b = 2;
 
                 let foo = Foo {

--- a/crates/rune/tests/test_all/vm_not_used.rs
+++ b/crates/rune/tests/test_all/vm_not_used.rs
@@ -2,7 +2,7 @@
 fn test_not_used() {
     assert_eq! {
         rune! { () =>
-            fn main() {
+            pub fn main() {
                 0;
                 4.1;
                 'a';

--- a/crates/rune/tests/test_all/vm_option.rs
+++ b/crates/rune/tests/test_all/vm_option.rs
@@ -2,28 +2,28 @@
 fn test_option() {
     assert_eq! {
         rune! { i64 =>
-            fn main() { match Some("some") { Some("some") => 1,  _ => 2 } }
+            pub fn main() { match Some("some") { Some("some") => 1,  _ => 2 } }
         },
         1,
     };
 
     assert_eq! {
         rune! { i64 =>
-            fn main() { match Some("some") { Some("other") => 1,  _ => 2 } }
+            pub fn main() { match Some("some") { Some("other") => 1,  _ => 2 } }
         },
         2,
     };
 
     assert_eq! {
         rune! { i64 =>
-            fn main() { match None { None => 1,  _ => 2 } }
+            pub fn main() { match None { None => 1,  _ => 2 } }
         },
         1,
     };
 
     assert_eq! {
         rune! { i64 =>
-            fn main() { match None { Some("some") => 1,  _ => 2 } }
+            pub fn main() { match None { Some("some") => 1,  _ => 2 } }
         },
         2,
     };

--- a/crates/rune/tests/test_all/vm_pat.rs
+++ b/crates/rune/tests/test_all/vm_pat.rs
@@ -6,7 +6,7 @@ fn test_ignore_binding() {
                 let _ = 100;
             }
 
-            fn main() {
+            pub fn main() {
                 returns_unit(1) is unit
             }
         },
@@ -22,7 +22,7 @@ fn test_name_binding() {
                 let a = 100;
             }
 
-            fn main() {
+            pub fn main() {
                 returns_unit(1) is unit
             }
         },
@@ -38,7 +38,7 @@ fn test_match_binding() {
                 let [..] = [1, 2, 3];
             }
 
-            fn main() {
+            pub fn main() {
                 returns_unit(1) is unit
             }
         },

--- a/crates/rune/tests/test_all/vm_result.rs
+++ b/crates/rune/tests/test_all/vm_result.rs
@@ -2,21 +2,21 @@
 fn test_result() {
     assert_eq! {
         rune! { i64 =>
-            fn main() { match Err("err") { Err("err") => 1,  _ => 2 } }
+            pub fn main() { match Err("err") { Err("err") => 1,  _ => 2 } }
         },
         1,
     };
 
     assert_eq! {
         rune! { i64 =>
-            fn main() { match Err("err") { Ok("ok") => 1,  _ => 2 } }
+            pub fn main() { match Err("err") { Ok("ok") => 1,  _ => 2 } }
         },
         2,
     };
 
     assert_eq! {
         rune! { i64 =>
-            fn main() { match Ok("ok") { Ok("ok") => 1,  _ => 2 } }
+            pub fn main() { match Ok("ok") { Ok("ok") => 1,  _ => 2 } }
         },
         1,
     };

--- a/crates/rune/tests/test_all/vm_streams.rs
+++ b/crates/rune/tests/test_all/vm_streams.rs
@@ -14,7 +14,7 @@ fn test_simple_stream() {
                 yield give();
             }
 
-            async fn main() {
+            pub async fn main() {
                 let gen = foo();
                 let result = 0;
 
@@ -37,7 +37,7 @@ fn test_resume() {
 
             async fn foo() { let a = yield 1; let b = yield a; b }
 
-            async fn main() {
+            pub async fn main() {
                 let gen = foo();
                 let result = 0;
 

--- a/crates/rune/tests/test_all/vm_test_external_fn_ptr.rs
+++ b/crates/rune/tests/test_all/vm_test_external_fn_ptr.rs
@@ -15,7 +15,7 @@ fn test_external_function() -> runestick::Result<()> {
         (),
         r#"
         fn test() { 42 }
-        fn main() { test }
+        pub fn main() { test }
         "#,
     )?;
 
@@ -24,7 +24,7 @@ fn test_external_function() -> runestick::Result<()> {
         &["main"],
         (function,),
         r#"
-        fn main(f) { f() }
+        pub fn main(f) { f() }
         "#,
     )?;
 
@@ -46,7 +46,7 @@ fn test_external_generator() -> runestick::Result<()> {
         (),
         r#"
         fn test() { yield 42; }
-        fn main() { test }
+        pub fn main() { test }
         "#,
     )?;
 
@@ -55,7 +55,7 @@ fn test_external_generator() -> runestick::Result<()> {
         &["main"],
         (function,),
         r#"
-        fn main(f) { let gen = f(); (gen.next(), gen.next()) }
+        pub fn main(f) { let gen = f(); (gen.next(), gen.next()) }
         "#,
     )?;
 

--- a/crates/rune/tests/test_all/vm_test_from_value_derive.rs
+++ b/crates/rune/tests/test_all/vm_test_from_value_derive.rs
@@ -11,14 +11,14 @@ fn test_from_value_object_like() {
     let value = rune! { Proxy =>
         struct Ignored;
         struct Value { field, ignored }
-        fn main() { Value { field: 42, ignored: Ignored } }
+        pub fn main() { Value { field: 42, ignored: Ignored } }
     };
 
     assert_eq!(value.field, 42);
 
     let value = rune! { Proxy =>
         struct Ignored;
-        fn main() { #{ field: 42, ignored: Ignored } }
+        pub fn main() { #{ field: 42, ignored: Ignored } }
     };
 
     assert_eq!(value.field, 42);
@@ -31,13 +31,13 @@ fn test_from_value_tuple_like() {
 
     let value = rune! { Proxy =>
         struct Value(field);
-        fn main() { Value(42) }
+        pub fn main() { Value(42) }
     };
 
     assert_eq!(value.0, 42);
 
     let value = rune! { Proxy =>
-        fn main() { (42,) }
+        pub fn main() { (42,) }
     };
 
     assert_eq!(value.0, 42);
@@ -52,7 +52,7 @@ fn test_missing_dynamic_field() {
 
     assert_vm_error!(
         ProxyStruct => r#"
-        fn main() {
+        pub fn main() {
             struct Ignored;
             struct Value { other, ignored }
             Value { other: 42, ignored: Ignored }
@@ -69,7 +69,7 @@ fn test_missing_dynamic_field() {
 
     assert_vm_error!(
         ProxyTuple => r#"
-        fn main() {
+        pub fn main() {
             struct Ignored;
             struct Value(other);
             Value(42)
@@ -92,7 +92,7 @@ fn test_enum_proxy() {
     }
 
     let proxy = rune! { Proxy =>
-    fn main() {
+    pub fn main() {
         enum Proxy { Unit, Tuple(a), Struct { field } }
         Proxy::Unit
     }};
@@ -100,7 +100,7 @@ fn test_enum_proxy() {
     assert_eq!(proxy, Proxy::Unit);
 
     let proxy = rune! { Proxy =>
-    fn main() {
+    pub fn main() {
         enum Proxy { Unit, Tuple(a), Struct { field } }
         Proxy::Tuple("Hello World")
     }};
@@ -108,7 +108,7 @@ fn test_enum_proxy() {
     assert_eq!(proxy, Proxy::Tuple(String::from("Hello World")));
 
     let proxy = rune! { Proxy =>
-    fn main() {
+    pub fn main() {
         enum Proxy { Unit, Tuple(a), Struct { field } }
         Proxy::Struct { field: "Hello World" }
     }};

--- a/crates/rune/tests/test_all/vm_test_imports.rs
+++ b/crates/rune/tests/test_all/vm_test_imports.rs
@@ -21,3 +21,31 @@ fn test_grouped_imports() {
         (2, true, true),
     };
 }
+
+#[test]
+fn test_reexport() {
+    assert_eq! {
+        rune! { i64 =>
+            mod inner { fn func() { 42 } }
+            pub use self::inner::func as main;
+        },
+        42,
+    };
+
+    assert_eq! {
+        rune! { i64 =>
+            mod inner { fn func() { 42 } }
+            pub use crate::inner::func as main;
+        },
+        42,
+    };
+
+    assert_eq! {
+        rune! { i64 =>
+            mod inner2 { fn func() { 42 } }
+            mod inner1 { pub use super::inner2::func; }
+            pub use crate::inner1::func as main;
+        },
+        42,
+    };
+}

--- a/crates/rune/tests/test_all/vm_test_imports.rs
+++ b/crates/rune/tests/test_all/vm_test_imports.rs
@@ -14,7 +14,7 @@ fn test_grouped_imports() {
                 }
             }
 
-            fn main() {
+            pub fn main() {
                 (c::VALUE, Foo::Bar is a::b::Foo, Baz is a::b::Foo)
             }
         },

--- a/crates/rune/tests/test_all/vm_test_instance_fns.rs
+++ b/crates/rune/tests/test_all/vm_test_instance_fns.rs
@@ -30,7 +30,7 @@ fn test_instance_kinds() {
                 }
             }
 
-            fn main() {
+            pub fn main() {
                 (Foo { n: 3 }.test(1), Custom::A(4).test(), Custom::B{n: 5}.test(), Custom::C.test())
             }
         },

--- a/crates/rune/tests/test_all/vm_test_linked_list.rs
+++ b/crates/rune/tests/test_all/vm_test_linked_list.rs
@@ -67,7 +67,7 @@ fn test_linked_list() {
                 }
             }
 
-            fn main() {
+            pub fn main() {
                 let ll = List::new();
                 ll.push_back(1);
                 ll.push_back(2);

--- a/crates/rune/tests/test_all/vm_test_mod.rs
+++ b/crates/rune/tests/test_all/vm_test_mod.rs
@@ -15,7 +15,7 @@ fn test_nested_mods() {
                 }
             }
 
-            fn main() {
+            pub fn main() {
                 hello::test()
             }
         }

--- a/crates/rune/tests/test_all/vm_test_references.rs
+++ b/crates/rune/tests/test_all/vm_test_references.rs
@@ -30,7 +30,7 @@ fn vm_test_references() {
     sources.insert(Source::new(
         "test",
         r#"
-        fn main(number) {
+        pub fn main(number) {
             number += 1;
         }
         "#,

--- a/crates/rune/tests/test_all/vm_try.rs
+++ b/crates/rune/tests/test_all/vm_try.rs
@@ -10,7 +10,7 @@ fn test_unwrap() {
                 Err(b / a)
             }
 
-            fn main() {
+            pub fn main() {
                 Ok(foo(2, 4)? + bar(3, 9)?)
             }
         },
@@ -23,7 +23,7 @@ fn test_unwrap() {
                 Ok(b / a)
             }
 
-            fn main() {
+            pub fn main() {
                 Ok(foo(2, 4)? + {
                     Err(6 / 2)
                 }?)

--- a/crates/rune/tests/test_all/vm_tuples.rs
+++ b/crates/rune/tests/test_all/vm_tuples.rs
@@ -2,7 +2,7 @@
 fn test_mutate_tuples() {
     assert_eq! {
         rune_s! { String => r#"
-            fn main() {
+            pub fn main() {
                 let m = ("Now", "You", "See", "Me");
                 m.2 = "Don't";
                 m.3 = "!";

--- a/crates/rune/tests/test_all/vm_typed_tuple.rs
+++ b/crates/rune/tests/test_all/vm_typed_tuple.rs
@@ -4,7 +4,7 @@ fn test_defined_tuple() {
         rune! { i64 =>
             struct MyType(a, b);
 
-            fn main() { match MyType(1, 2) { MyType(a, b) => a + b,  _ => 0 } }
+            pub fn main() { match MyType(1, 2) { MyType(a, b) => a + b,  _ => 0 } }
         },
         3,
     };
@@ -13,7 +13,7 @@ fn test_defined_tuple() {
         rune! { i64 =>
             enum MyType { A(a, b), C(c), }
 
-            fn main() { match MyType::A(1, 2) { MyType::A(a, b) => a + b,  _ => 0 } }
+            pub fn main() { match MyType::A(1, 2) { MyType::A(a, b) => a + b,  _ => 0 } }
         },
         3,
     };
@@ -22,7 +22,7 @@ fn test_defined_tuple() {
         rune! { i64 =>
             enum MyType { A(a, b), C(c), }
 
-            fn main() { match MyType::C(4) { MyType::A(a, b) => a + b,  _ => 0 } }
+            pub fn main() { match MyType::C(4) { MyType::A(a, b) => a + b,  _ => 0 } }
         },
         0,
     };
@@ -31,7 +31,7 @@ fn test_defined_tuple() {
         rune! { i64 =>
             enum MyType { A(a, b), C(c), }
 
-            fn main() { match MyType::C(4) { MyType::C(a) => a,  _ => 0 } }
+            pub fn main() { match MyType::C(4) { MyType::C(a) => a,  _ => 0 } }
         },
         4,
     };

--- a/crates/rune/tests/test_all/vm_types.rs
+++ b/crates/rune/tests/test_all/vm_types.rs
@@ -1,29 +1,29 @@
 #[test]
 fn test_variant_typing() {
     assert_eq! {
-        rune!(bool => fn main() { Err(0) is Result }),
+        rune!(bool => pub fn main() { Err(0) is Result }),
         true,
     };
 
     assert_eq! {
-        rune!(bool => fn main() { Ok(0) is Result }),
+        rune!(bool => pub fn main() { Ok(0) is Result }),
         true,
     };
 
     assert_eq! {
-        rune!(bool => fn main() { Some(0) is Option }),
+        rune!(bool => pub fn main() { Some(0) is Option }),
         true,
     };
 
     assert_eq! {
-        rune!(bool => fn main() { None is Option }),
+        rune!(bool => pub fn main() { None is Option }),
         true,
     };
 
     assert_eq! {
         rune! { bool =>
             enum Custom { A, B(a) }
-            fn main() { Custom::A is Custom }
+            pub fn main() { Custom::A is Custom }
         },
         true,
     };
@@ -31,7 +31,7 @@ fn test_variant_typing() {
     assert_eq! {
         rune! { bool =>
             enum Custom { A, B(a) }
-            fn main() { Custom::B(42) is Custom }
+            pub fn main() { Custom::B(42) is Custom }
         },
         true,
     };
@@ -39,7 +39,7 @@ fn test_variant_typing() {
     assert_eq! {
         rune! { bool =>
             enum Custom { A, B(a) }
-            fn main() { Custom::A is Option }
+            pub fn main() { Custom::A is Option }
         },
         false,
     };
@@ -47,7 +47,7 @@ fn test_variant_typing() {
     assert_eq! {
         rune! { bool =>
             enum Custom { A, B(a) }
-            fn main() { Custom::A is not Option }
+            pub fn main() { Custom::A is not Option }
         },
         true,
     };

--- a/crates/rune/tests/test_all/wildcard_imports.rs
+++ b/crates/rune/tests/test_all/wildcard_imports.rs
@@ -5,21 +5,21 @@ fn test_wildcard_precedence() {
         mod b { struct Foo; }
         use a::*;
         use b::*;
-        fn main() { Foo is b::Foo }
+        pub fn main() { Foo is b::Foo }
     });
 
     assert!(rune! { bool =>
         mod a { struct Foo; }
         mod b { struct Foo; }
         use {a::*, b::*};
-        fn main() { Foo is b::Foo }
+        pub fn main() { Foo is b::Foo }
     });
 
     assert!(rune! { bool =>
         mod a { struct Foo; }
         mod b { struct Foo; }
         use {b::*, a::*};
-        fn main() { Foo is a::Foo }
+        pub fn main() { Foo is a::Foo }
     });
 
     assert!(rune! { bool =>
@@ -28,7 +28,7 @@ fn test_wildcard_precedence() {
         use a::*;
         use b::*;
         use a::Foo;
-        fn main() { Foo is a::Foo }
+        pub fn main() { Foo is a::Foo }
     });
 
     assert!(rune! { bool =>
@@ -37,6 +37,6 @@ fn test_wildcard_precedence() {
         use a::Foo;
         use a::*;
         use b::*;
-        fn main() { Foo is a::Foo }
+        pub fn main() { Foo is a::Foo }
     });
 }

--- a/scripts/arrays.rn
+++ b/scripts/arrays.rn
@@ -1,4 +1,4 @@
-fn main() {
+pub fn main() {
     let a = [1, 2, 3, 4];
     let b = [5, 6, 7, 8];
     dbg(a, b);

--- a/scripts/async.rn
+++ b/scripts/async.rn
@@ -14,7 +14,7 @@ async fn test(timeout, helpful_hint) {
     Ok((result.text().await?, helpful_hint))
 }
 
-async fn main() {
+pub async fn main() {
     let a = test(1000, "first call");
     let b = test(5000, "second call");
 

--- a/scripts/book/async/async_blocks.rn
+++ b/scripts/book/async/async_blocks.rn
@@ -4,7 +4,7 @@ fn do_request(url) {
     }
 }
 
-async fn main() {
+pub async fn main() {
     let future = do_request("https://google.com");
     let status = future.await?;
     println!("Status: {}", status);

--- a/scripts/book/async/async_closure.rn
+++ b/scripts/book/async/async_closure.rn
@@ -4,7 +4,7 @@ fn do_request(url) {
     }
 }
 
-async fn main() {
+pub async fn main() {
     let future = do_request("https://google.com");
     let status = future().await?;
     println!("Status: {}", status);

--- a/scripts/book/async/async_http.rn
+++ b/scripts/book/async/async_http.rn
@@ -1,4 +1,4 @@
-async fn main() {
+pub async fn main() {
     let a = http::get("https://google.com");
     let b = http::get("https://amazon.com");
 

--- a/scripts/book/async/async_http_concurrent.rn
+++ b/scripts/book/async/async_http_concurrent.rn
@@ -14,7 +14,7 @@ async fn request(timeout) {
     Ok(result)
 }
 
-async fn main() {
+pub async fn main() {
     for result in future::join([request(1000), request(4000)]).await {
         match result {
             Ok(result) => println!("Result: {}", result.status()),

--- a/scripts/book/async/async_http_timeout.rn
+++ b/scripts/book/async/async_http_timeout.rn
@@ -13,7 +13,7 @@ async fn request(timeout) {
     Ok(())
 }
 
-async fn main() {
+pub async fn main() {
     if let Err(Timeout) = request(1000).await {
         println("Request timed out!");
     }

--- a/scripts/book/closures/basic_closure.rn
+++ b/scripts/book/closures/basic_closure.rn
@@ -2,7 +2,7 @@ fn work(op) {
     op(1, 2)
 }
 
-fn main() {
+pub fn main() {
     let n = 1;
     println!("Result: {}", work(|a, b| n + a + b));
     println!("Result: {}", work(|a, b| n + a * b));

--- a/scripts/book/closures/function_pointers.rn
+++ b/scripts/book/closures/function_pointers.rn
@@ -10,7 +10,7 @@ fn sub(a, b) {
     a - b
 }
 
-fn main() {
+pub fn main() {
     println!("{}", do_thing(add));
     println!("{}", do_thing(sub));
 }

--- a/scripts/book/compiler_guide/closures.rn
+++ b/scripts/book/compiler_guide/closures.rn
@@ -1,4 +1,4 @@
-fn main() {
+pub fn main() {
     let callable = || 42;
     callable();
 }

--- a/scripts/book/compiler_guide/dead_code.rn
+++ b/scripts/book/compiler_guide/dead_code.rn
@@ -1,4 +1,4 @@
-fn main() {
+pub fn main() {
     return foo();
 
     fn foo() {

--- a/scripts/book/control_flow/conditional.rn
+++ b/scripts/book/control_flow/conditional.rn
@@ -1,4 +1,4 @@
-fn main() {
+pub fn main() {
     let number = 3;
 
     if number < 5 {

--- a/scripts/book/control_flow/conditional_else.rn
+++ b/scripts/book/control_flow/conditional_else.rn
@@ -1,4 +1,4 @@
-fn main() {
+pub fn main() {
     let number = 3;
 
     if number < 5 {

--- a/scripts/book/control_flow/conditional_else_ifs.rn
+++ b/scripts/book/control_flow/conditional_else_ifs.rn
@@ -1,4 +1,4 @@
-fn main() {
+pub fn main() {
     let number = 3;
 
     if number < 5 {

--- a/scripts/book/control_flow/first_match.rn
+++ b/scripts/book/control_flow/first_match.rn
@@ -1,4 +1,4 @@
-fn main() {
+pub fn main() {
     let number = 3;
 
     match number {

--- a/scripts/book/control_flow/numbers_game.rn
+++ b/scripts/book/control_flow/numbers_game.rn
@@ -6,7 +6,7 @@ fn foo(n) {
     "something else"
 }
 
-fn main() {
+pub fn main() {
     println(foo(0)); // => outputs: "less than one"
     println(foo(10)); // => outputs: "something else"
 }

--- a/scripts/book/dynamic_types/greeting.rn
+++ b/scripts/book/dynamic_types/greeting.rn
@@ -8,7 +8,7 @@ impl Person {
     }
 }
 
-fn main() {
+pub fn main() {
     let person = Person {
         name: "John-John Tedro",
     };

--- a/scripts/book/enums/count_numbers.rn
+++ b/scripts/book/enums/count_numbers.rn
@@ -8,7 +8,7 @@ fn count_numbers(limit) {
     }
 }
 
-fn main() {
+pub fn main() {
     println("First count!");
     count_numbers(None);
 

--- a/scripts/book/functions/main_function.rn
+++ b/scripts/book/functions/main_function.rn
@@ -1,3 +1,3 @@
-fn main() {
+pub fn main() {
     println("Hello World");
 }

--- a/scripts/book/functions/return_value.rn
+++ b/scripts/book/functions/return_value.rn
@@ -6,7 +6,7 @@ fn foo(condition) {
     }
 }
 
-fn main() {
+pub fn main() {
     println!("{}", foo(true));
     println!("{}", foo(false));
 }

--- a/scripts/book/generators/bootup.rn
+++ b/scripts/book/generators/bootup.rn
@@ -6,7 +6,7 @@ fn printer() {
     }
 }
 
-fn main() {
+pub fn main() {
     let printer = printer();
 
     println("firing off the printer...");

--- a/scripts/book/generators/error.rn
+++ b/scripts/book/generators/error.rn
@@ -2,7 +2,7 @@ fn print_once() {
     yield 1
 }
 
-fn main() {
+pub fn main() {
     let printer = print_once();
     dbg(printer);
     dbg(printer.resume(()));

--- a/scripts/book/generators/fib_generator.rn
+++ b/scripts/book/generators/fib_generator.rn
@@ -10,7 +10,7 @@ fn fib() {
     }
 }
 
-fn main() {
+pub fn main() {
     let g = fib();
 
     while let Some(n) = g.next() {

--- a/scripts/book/generators/send_values.rn
+++ b/scripts/book/generators/send_values.rn
@@ -5,7 +5,7 @@ fn printer() {
     }
 }
 
-fn main() {
+pub fn main() {
     let printer = printer();
     printer.resume(1);
     printer.resume("John");

--- a/scripts/book/generators/states.rn
+++ b/scripts/book/generators/states.rn
@@ -4,7 +4,7 @@ fn print_once() {
     2
 }
 
-fn main() {
+pub fn main() {
     let printer = print_once();
     dbg(printer.resume(()));
     dbg(printer.resume("John"));

--- a/scripts/book/getting_started/dbg.rn
+++ b/scripts/book/getting_started/dbg.rn
@@ -1,4 +1,4 @@
-fn main() {
+pub fn main() {
     let a = [1, 2, 3];
     let b = '今';
     let closure = || println("Hello");

--- a/scripts/book/getting_started/hello_world.rn
+++ b/scripts/book/getting_started/hello_world.rn
@@ -1,3 +1,3 @@
-fn main() {
+pub fn main() {
     println("Hello World");
 }

--- a/scripts/book/instance_functions/missing_instance_fn.rn
+++ b/scripts/book/instance_functions/missing_instance_fn.rn
@@ -6,7 +6,7 @@ impl Foo {
     }
 }
 
-fn main() {
+pub fn main() {
     let foo = Foo::new();
     foo.bar();
 }

--- a/scripts/book/items_imports/example_import.rn
+++ b/scripts/book/items_imports/example_import.rn
@@ -1,5 +1,5 @@
 use std::test::assert;
 
-fn main() {
+pub fn main() {
     assert!(1 < 2, "one is less than two");
 }

--- a/scripts/book/items_imports/foo/mod.rn
+++ b/scripts/book/items_imports/foo/mod.rn
@@ -1,3 +1,3 @@
-fn get_number() {
+pub fn get_number() {
     2
 }

--- a/scripts/book/items_imports/inline_modules.rn
+++ b/scripts/book/items_imports/inline_modules.rn
@@ -10,6 +10,6 @@ mod bar {
     }
 }
 
-fn main() {
+pub fn main() {
     foo::get_number() + bar::get_number()
 }

--- a/scripts/book/items_imports/missing_item.rn.fail
+++ b/scripts/book/items_imports/missing_item.rn.fail
@@ -1,3 +1,3 @@
-fn main() {
+pub fn main() {
     let foo = Foo::new();
 }

--- a/scripts/book/items_imports/modules.rn
+++ b/scripts/book/items_imports/modules.rn
@@ -1,6 +1,6 @@
 mod foo;
 mod bar;
 
-fn main() {
+pub fn main() {
     foo::get_number() + bar::get_number()
 }

--- a/scripts/book/loops/loop_break.rn
+++ b/scripts/book/loops/loop_break.rn
@@ -1,4 +1,4 @@
-fn main() {
+pub fn main() {
     let counter = 0;
 
     let total = loop {

--- a/scripts/book/loops/loop_forever.rn
+++ b/scripts/book/loops/loop_forever.rn
@@ -1,6 +1,6 @@
 use time::Duration;
 
-async fn main() {
+pub async fn main() {
     loop {
         println("Hello forever!");
         time::delay_for(Duration::from_secs(1)).await;

--- a/scripts/book/loops/while_loop.rn
+++ b/scripts/book/loops/while_loop.rn
@@ -1,4 +1,4 @@
-fn main() {
+pub fn main() {
     let value = 0;
 
     while value < 100 {

--- a/scripts/book/macros/stringy_math.rn
+++ b/scripts/book/macros/stringy_math.rn
@@ -1,6 +1,6 @@
 use std::experiments::stringy_math;
 
-fn main() {
+pub fn main() {
     let output = stringy_math!(add 10 sub 2 div 3 mul 100);
     println!("{}", output);
 }

--- a/scripts/book/objects/json.rn
+++ b/scripts/book/objects/json.rn
@@ -23,7 +23,7 @@ async fn get_commits(repo, limit) {
     commits
 }
 
-async fn main() {
+pub async fn main() {
     for commit in get_commits("rune-rs/rune", Some(5)).await {
         println(commit);
     }

--- a/scripts/book/objects/objects.rn
+++ b/scripts/book/objects/objects.rn
@@ -1,4 +1,4 @@
-fn main() {
+pub fn main() {
     let values = #{};
     values["first"] = "bar";
     values["second"] = 42;

--- a/scripts/book/pattern_matching/big_match.rn
+++ b/scripts/book/pattern_matching/big_match.rn
@@ -8,7 +8,7 @@ fn match_input(n) {
     }
 }
 
-fn main() {
+pub fn main() {
     match_input(1);
     match_input(2);
     match_input([1, 2, 42, 84]);

--- a/scripts/book/pattern_matching/bind.rn
+++ b/scripts/book/pattern_matching/bind.rn
@@ -4,6 +4,6 @@ fn test_ignore(vector) {
     }
 }
 
-fn main() {
+pub fn main() {
     test_ignore([1, 2]);
 }

--- a/scripts/book/pattern_matching/fast_cars.rn
+++ b/scripts/book/pattern_matching/fast_cars.rn
@@ -6,7 +6,7 @@ fn describe_car(car) {
     }
 }
 
-fn main() {
+pub fn main() {
     println(describe_car(#{"model": "Ford", "make": 2000}));
     println(describe_car(#{"model": "Honda", "make": 1980}));
     println(describe_car(#{"model": "Volvo", "make": 1910}));

--- a/scripts/book/pattern_matching/ignore.rn
+++ b/scripts/book/pattern_matching/ignore.rn
@@ -4,6 +4,6 @@ fn test_ignore(vector) {
     }
 }
 
-fn main() {
+pub fn main() {
     test_ignore([1, 2]);
 }

--- a/scripts/book/primitives/copy.rn
+++ b/scripts/book/primitives/copy.rn
@@ -1,4 +1,4 @@
-fn main() {
+pub fn main() {
     let a = 1;
     let b = a;
     a = 2;

--- a/scripts/book/primitives/primitives.rn
+++ b/scripts/book/primitives/primitives.rn
@@ -1,4 +1,4 @@
-fn main() {
+pub fn main() {
     let a = String::from_str("Hello");
     let b = a;
     a.push_str(" World");

--- a/scripts/book/streams/basic_stream.rn
+++ b/scripts/book/streams/basic_stream.rn
@@ -11,7 +11,7 @@ async fn send_requests(list) {
     }
 }
 
-async fn main() {
+pub async fn main() {
     let requests = send_requests([
         "https://google.com",
         "https://amazon.com",

--- a/scripts/book/structs/struct_matching.rn
+++ b/scripts/book/structs/struct_matching.rn
@@ -16,7 +16,7 @@ impl User {
     }
 }
 
-fn main() {
+pub fn main() {
     let user = User {
         username: "setbac",
         active: false,

--- a/scripts/book/structs/user_database.rn
+++ b/scripts/book/structs/user_database.rn
@@ -17,7 +17,7 @@ impl User {
     }
 }
 
-fn main() {
+pub fn main() {
     let user = User {
         username: "setbac",
         active: false,

--- a/scripts/book/template_strings/basic_template.rn
+++ b/scripts/book/template_strings/basic_template.rn
@@ -1,4 +1,4 @@
-fn main() {
+pub fn main() {
     let age = 30;
-    println(`I am ${age} years old!`);
+    dbg(`I am ${age} years old!`);
 }

--- a/scripts/book/template_strings/not_a_template.rn
+++ b/scripts/book/template_strings/not_a_template.rn
@@ -1,4 +1,4 @@
-fn main() {
+pub fn main() {
     let vec = [1, 2, 3];
-    println(`${vec}`);
+    dbg(`${vec}`);
 }

--- a/scripts/book/the_stack/add.rn
+++ b/scripts/book/the_stack/add.rn
@@ -1,3 +1,3 @@
-fn main() {
+pub fn main() {
     1 + 3
 }

--- a/scripts/book/the_stack/call_and_add.rn
+++ b/scripts/book/the_stack/call_and_add.rn
@@ -2,7 +2,7 @@ fn foo(a, b) {
     a + b
 }
 
-fn main() {
+pub fn main() {
     let a = 3;
     foo(1, 2) + a
 }

--- a/scripts/book/try_operator/basic_try.rn
+++ b/scripts/book/try_operator/basic_try.rn
@@ -3,12 +3,12 @@ fn checked_div_mod(a, b) {
     Some((div, a % b))
 }
 
-fn main() {
+pub fn main() {
     if let Some((div, m)) = checked_div_mod(5, 2) {
-        println(`Result: ${div}, ${m}`);
+        println!("Result: {}, {}", div, m);
     }
 
     if let Some((div, m)) = checked_div_mod(5, 0) {
-        println(`Result: ${div}, ${m}`);
+        println!("Result: {}, {}", div, m);
     }
 }

--- a/scripts/book/tuples/basic_tuples.rn
+++ b/scripts/book/tuples/basic_tuples.rn
@@ -2,6 +2,6 @@ fn foo() {
     (1, "test")
 }
 
-fn main() {
+pub fn main() {
     dbg(foo());
 }

--- a/scripts/book/tuples/tuple_masquerade.rn
+++ b/scripts/book/tuples/tuple_masquerade.rn
@@ -1,4 +1,4 @@
-fn main() {
+pub fn main() {
     let values = ("Now", "You", "See", "Me");
     dbg(values);
 

--- a/scripts/book/tuples/tuple_patterns.rn
+++ b/scripts/book/tuples/tuple_patterns.rn
@@ -1,4 +1,4 @@
-fn main() {
+pub fn main() {
     match ("test", 1) {
         ("test", n) => {
             dbg("the first part was a number:", n);

--- a/scripts/book/types/bad_type_check.rn
+++ b/scripts/book/types/bad_type_check.rn
@@ -1,3 +1,3 @@
-fn main() {
+pub fn main() {
     assert!(["hello", "world"] is String, "vectors should be strings");
 }

--- a/scripts/book/types/type_check.rn
+++ b/scripts/book/types/type_check.rn
@@ -8,8 +8,8 @@ fn dynamic_type(n) {
     }
 }
 
-fn main() {
-    println(dynamic_type("Hello"));
-    println(dynamic_type([1, 2, 3, 4]));
-    println(dynamic_type(42));
+pub fn main() {
+    println!("{}", dynamic_type("Hello"));
+    println!("{}", dynamic_type([1, 2, 3, 4]));
+    println!("{}", dynamic_type(42));
 }

--- a/scripts/book/types/type_check_patterns.rn
+++ b/scripts/book/types/type_check_patterns.rn
@@ -6,8 +6,8 @@ fn dynamic_type(n) {
     }
 }
 
-fn main() {
-    println(dynamic_type("Hello"));
-    println(dynamic_type([1, 2, 3, 4]));
-    println(dynamic_type(42));
+pub fn main() {
+    println!("{}", dynamic_type("Hello"));
+    println!("{}", dynamic_type([1, 2, 3, 4]));
+    println!("{}", dynamic_type(42));
 }

--- a/scripts/book/types/types.rn
+++ b/scripts/book/types/types.rn
@@ -1,4 +1,4 @@
-fn main() {
+pub fn main() {
     assert!(() is unit, "units should be units");
     assert!(true is bool, "bools should be bools");
     assert!('a' is char, "chars should be chars");

--- a/scripts/book/variables/is_readable.rn
+++ b/scripts/book/variables/is_readable.rn
@@ -1,12 +1,12 @@
-fn main() {
+pub fn main() {
     let object = #{field: 1};
     let object2 = object;
-    println(`field: ${object.field}`);
+    println!("field: {}", object.field);
     drop(object2);
 
     if is_readable(object) {
-        println(`field: ${object.field}`);
+        println!("field: {}", object.field);
     } else {
-        println("object is no longer readable 😢");
+        println!("object is no longer readable 😢");
     }
 }

--- a/scripts/book/variables/shared_ownership.rn
+++ b/scripts/book/variables/shared_ownership.rn
@@ -1,9 +1,9 @@
-fn main() {
+pub fn main() {
     let object = #{field: 1};
     let object2 = object;
-    println(`${object.field}`);
+    println!("{}", object.field);
     object2.field = 2;
 
     // Note: we changed `object2`, but read out `object`
-    println(`${object.field}`);
+    println!("{}", object.field);
 }

--- a/scripts/book/variables/take_argument.rn
+++ b/scripts/book/variables/take_argument.rn
@@ -1,7 +1,7 @@
-fn main() {
+pub fn main() {
     let object = #{field: 1};
     let object2 = object;
-    println(`field: ${object.field}`);
+    println!("field: {}", object.field);
     drop(object2);
-    println(`field: ${object.field}`);
+    println!("field: {}", object.field);
 }

--- a/scripts/book/variables/variables.rn
+++ b/scripts/book/variables/variables.rn
@@ -1,6 +1,6 @@
-fn main() {
+pub fn main() {
     let x = 5;
-    println(`The value of x is: ${x}`);
+    println!("The value of x is: {}", x);
     x = 6;
-    println(`The value of x is: ${x}`);
+    println!("The value of x is: {}", x);
 }

--- a/scripts/book/vectors/vectors.rn
+++ b/scripts/book/vectors/vectors.rn
@@ -1,10 +1,10 @@
-fn main() {
+pub fn main() {
     let values = ["Hello", 42];
 
-    dbg(values[0]);
-    dbg(values.1); // items be accessed like tuple fields.
+    println!("{}", values[0]);
+    println!("{}", values.1); // items in vectors can be accessed like tuple fields.
 
     for v in values {
-        dbg(v);
+        println!("{}", v);
     }
 }

--- a/scripts/book/vectors/vectors_rev.rn
+++ b/scripts/book/vectors/vectors_rev.rn
@@ -1,7 +1,7 @@
-fn main() {
+pub fn main() {
     let values = ["Hello", 42];
 
     for v in values.iter().rev() {
-        dbg(v);
+        println!("{}", v);
     }
 }

--- a/scripts/broken.rn
+++ b/scripts/broken.rn
@@ -1,3 +1,3 @@
-fn main() {
+pub fn main() {
     let v = [1, 2, 3, 4];
 }

--- a/scripts/bytes.rn
+++ b/scripts/bytes.rn
@@ -1,7 +1,7 @@
 use std::bytes::Bytes;
 use std::test::assert;
 
-fn main() {
+pub fn main() {
     let bytes = Bytes::new();
     bytes.extend_str("hello world");
     bytes.extend_str("hello world");

--- a/scripts/compile-fail/attributes.rn.fail
+++ b/scripts/compile-fail/attributes.rn.fail
@@ -136,7 +136,7 @@ fn definetypeinfunction() {
 
 /// 5.4. also works on async `fn` items
 #[wasm::bindgen]
-async fn main() {
+pub async fn main() {
 
 
     // 12. match expressions

--- a/scripts/compile-fail/experimental_macro_error.rn.fail
+++ b/scripts/compile-fail/experimental_macro_error.rn.fail
@@ -1,6 +1,6 @@
 use std::experiments::stringy_math;
 
-fn main() {
+pub fn main() {
     let a = 1;
 
     // This will error inside of the macro.

--- a/scripts/constant_expr.rn
+++ b/scripts/constant_expr.rn
@@ -1,5 +1,5 @@
 const VALUE = 0b001 << 3;
 
-fn main() {
+pub fn main() {
     VALUE == 8
 }

--- a/scripts/controls.rn
+++ b/scripts/controls.rn
@@ -54,7 +54,7 @@ fn returns_string() {
     "this is a string"
 }
 
-fn main() {
+pub fn main() {
     let a = test(0);
     let b = test2(1);
     let c = test3(2);

--- a/scripts/fib.rn
+++ b/scripts/fib.rn
@@ -6,6 +6,6 @@ fn fib(n) {
     }
 }
 
-fn main() {
+pub fn main() {
     fib(15)
 }

--- a/scripts/generator_as_iter.rn
+++ b/scripts/generator_as_iter.rn
@@ -4,7 +4,7 @@ fn foo() {
     yield 3;
 }
 
-fn main() {
+pub fn main() {
     let gen = foo();
 
     while let Some(value) = gen.next() {

--- a/scripts/generator_resume.rn
+++ b/scripts/generator_resume.rn
@@ -6,7 +6,7 @@ fn foo() {
     b
 }
 
-fn main() {
+pub fn main() {
     let gen = foo();
     let result = 0;
 

--- a/scripts/hello_world.rn
+++ b/scripts/hello_world.rn
@@ -1,3 +1,3 @@
-fn main() {
+pub fn main() {
     println("Hello World");
 }

--- a/scripts/http.rn
+++ b/scripts/http.rn
@@ -1,7 +1,7 @@
 use http;
 use json;
 
-async fn main() {
+pub async fn main() {
     let response = http::get("http://worldtimeapi.org/api/ip").await?;
     let json = response.json().await?;
 

--- a/scripts/json.rn
+++ b/scripts/json.rn
@@ -1,6 +1,6 @@
 use json;
 
-fn main() {
+pub fn main() {
     let data = json::from_string("{\"key\": 42}");
     dbg(data);
 }

--- a/scripts/linked_list.rn
+++ b/scripts/linked_list.rn
@@ -63,7 +63,7 @@ impl Iter {
     }
 }
 
-fn main() {
+pub fn main() {
     let ll = List::new();
     ll.push_back(1);
     ll.push_back(2);

--- a/scripts/not_used.rn
+++ b/scripts/not_used.rn
@@ -1,4 +1,4 @@
-fn main() {
+pub fn main() {
     "hello world";
     'a';
     [42, 42];

--- a/scripts/numbers.rn
+++ b/scripts/numbers.rn
@@ -1,4 +1,4 @@
-fn main() {
+pub fn main() {
     dbg(0.223e2 + (2).to_float());
     dbg((0.223e2).to_integer() + 2);
 

--- a/scripts/objects.rn
+++ b/scripts/objects.rn
@@ -1,4 +1,4 @@
-fn main() {
+pub fn main() {
     let object = #{"foo": 42};
     object["bar"] = object["foo"] + 1;
     object = #{"foo": 1};

--- a/scripts/rand.rn
+++ b/scripts/rand.rn
@@ -1,6 +1,6 @@
 use rand;
 
-fn main() {
+pub fn main() {
      let rng = rand::WyRand::new();
      let rand_int = rng.int();
      println!("Random int: {}", rand_int);

--- a/scripts/reverse_iterator.rn
+++ b/scripts/reverse_iterator.rn
@@ -1,6 +1,6 @@
 use std::iter::range;
 
-fn main() {
+pub fn main() {
     // NB: provisinal syntax until we have proper ranges.
     for v in range(0, 10).rev() {
         dbg(v);

--- a/scripts/strings.rn
+++ b/scripts/strings.rn
@@ -1,4 +1,4 @@
-fn main() {
+pub fn main() {
     let a = "foo";
 
     let s = String::with_capacity(42);

--- a/site/config.toml
+++ b/site/config.toml
@@ -26,7 +26,7 @@ fn fib(n) {
     }
 }
 
-fn main() {
+pub fn main() {
     fib(15)
 }
 """

--- a/site/content/posts/2020-09-18-hello-internet.md
+++ b/site/content/posts/2020-09-18-hello-internet.md
@@ -68,7 +68,7 @@ So now that I've set up the skeleton for it. Let's build something cool!
 P.S. And as a final treat, here's a code snippet that you can edit and run! 😊
 
 {% rune(footnote = "Showcasing the integrated editor. Neat, huh?") %}
-fn main() {
-    println("Hello World!");
+pub fn main() {
+    println!("Hello World!");
 }
 {% end %}

--- a/site/content/posts/2020-10-01-tmir1.md
+++ b/site/content/posts/2020-10-01-tmir1.md
@@ -55,7 +55,7 @@ pub mod submodule {
     }
 }
 
-fn main() {
+pub fn main() {
     submodule::my_method();
 }
 {% end %}
@@ -126,9 +126,9 @@ You can see it in action here:
 {% rune(footnote = "Use of the stringy_math! macro", options = "macros=true", experimental = true) %}
 use std::experiments::stringy_math;
 
-fn main() {
+pub fn main() {
     let value = stringy_math!(add 10 sub 5);
-    println(`result: {value}`);
+    println!("result: {}", value);
 }
 {% end %}
 
@@ -177,7 +177,7 @@ const GREETINGS = [
     greeting("Mio"),
 ];
 
-fn main() {
+pub fn main() {
     let rng = rand::Pcg64::new();
     let greetings = GREETINGS;
 
@@ -197,7 +197,7 @@ const fn fib(n) {
     }
 }
 
-fn main() {
+pub fn main() {
     fib(15)
 }
 {% end %}

--- a/tools/publish.rn
+++ b/tools/publish.rn
@@ -1,6 +1,6 @@
 use process::Command;
 
-async fn main() {
+pub async fn main() {
     let ctrl_c = signal::ctrl_c();
 
     let cargo_toml = fs::read_to_string("Cargo.toml").await?;

--- a/tools/readmes.rn
+++ b/tools/readmes.rn
@@ -6,7 +6,7 @@ async fn update_readme(project, output) {
     Ok(cargo.spawn()?.await?)
 }
 
-async fn main() {
+pub async fn main() {
     let cargo_toml = fs::read_to_string("Cargo.toml").await?;
     let cargo_toml = toml::from_string(cargo_toml)?;
     let projects = cargo_toml.workspace.members;


### PR DESCRIPTION
This is the final module change for now, and it's a pretty big one.

Previously, Rune programs could look like this:

```rust
fn main() {
    println!("Hello World!");
}
```

Now this will no longer work, since `main` is not exported. Exports are instead determined by root level items which are marked with `pub`. This include re-exports. So to make the above work you'd have to do:
```rust
pub fn main() {
    println!("Hello World!");
}
```
But you could also do:
```rust
mod inner {
    fn func() {
        println!("Hello World!");
    }
}

pub use self::inner::func as main;
```