### PR TITLE
Add support for SyncFunction

### DIFF
--- a/crates/rune/src/ir/eval/ir.rs
+++ b/crates/rune/src/ir/eval/ir.rs
@@ -20,7 +20,9 @@ impl IrEval for ir::Ir {
             ir::IrKind::Template(ir_template) => ir_template.eval(interp, used),
             ir::IrKind::Name(name) => Ok(interp.resolve_var(self.span(), name.as_ref(), used)?),
             ir::IrKind::Target(ir_target) => Ok(interp.scopes.get_target(ir_target)?),
-            ir::IrKind::Value(const_value) => Ok(IrValue::from_const(const_value.clone())),
+            ir::IrKind::Value(const_value) => {
+                Ok(IrValue::from_const(self.span, const_value.clone())?)
+            }
             ir::IrKind::Branches(branches) => branches.eval(interp, used),
             ir::IrKind::Loop(ir_loop) => ir_loop.eval(interp, used),
             ir::IrKind::Break(ir_break) => {

--- a/crates/rune/src/ir/ir_error.rs
+++ b/crates/rune/src/ir/ir_error.rs
@@ -141,4 +141,6 @@ pub enum IrErrorKind {
     FnNotFound,
     #[error("argument count mismatch, got {actual} but expected {expected}")]
     ArgumentCountMismatch { actual: usize, expected: usize },
+    #[error("value `{value}` is outside of the supported integer range")]
+    NotInteger { value: num::BigInt },
 }

--- a/crates/rune/src/ir/ir_interpreter.rs
+++ b/crates/rune/src/ir/ir_interpreter.rs
@@ -110,13 +110,13 @@ impl IrInterpreter<'_> {
             let item = base.extended(name);
 
             if let Some(const_value) = self.consts.get(&item) {
-                return Ok(IrValue::from_const(const_value));
+                return Ok(IrValue::from_const(spanned, const_value)?);
             }
 
             if let Some(meta) = self.query.query_meta(spanned, &item, used)? {
                 match &meta.kind {
                     CompileMetaKind::Const { const_value, .. } => {
-                        return Ok(IrValue::from_const(const_value.clone()));
+                        return Ok(IrValue::from_const(spanned, const_value.clone())?);
                     }
                     _ => {
                         return Err(IrError::new(spanned, IrErrorKind::UnsupportedMeta { meta }));

--- a/crates/runestick/src/bytes.rs
+++ b/crates/runestick/src/bytes.rs
@@ -95,6 +95,12 @@ impl Bytes {
     }
 }
 
+impl From<Vec<u8>> for Bytes {
+    fn from(bytes: Vec<u8>) -> Self {
+        Self { bytes }
+    }
+}
+
 impl fmt::Debug for Bytes {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_list().entries(&self.bytes).finish()

--- a/crates/runestick/src/const_value.rs
+++ b/crates/runestick/src/const_value.rs
@@ -1,5 +1,6 @@
 use crate::collections::HashMap;
-use crate::TypeInfo;
+use crate::{Bytes, Object, Shared, Tuple, TypeInfo, Value, Vec, VmError, VmErrorKind};
+use std::vec;
 
 /// A constant value.
 #[derive(Debug, Clone)]
@@ -13,15 +14,15 @@ pub enum ConstValue {
     /// A boolean constant value.
     Bool(bool),
     /// An integer constant.
-    Integer(num_bigint::BigInt),
+    Integer(i64),
     /// An float constant.
     Float(f64),
     /// A string constant designated by its slot.
     String(String),
     /// A byte string.
-    Bytes(Vec<u8>),
+    Bytes(Bytes),
     /// A vector of values.
-    Vec(Vec<ConstValue>),
+    Vec(vec::Vec<ConstValue>),
     /// An anonymous tuple.
     Tuple(Box<[ConstValue]>),
     /// An anonymous object.
@@ -29,6 +30,102 @@ pub enum ConstValue {
 }
 
 impl ConstValue {
+    /// Convert a value into a constant value.
+    pub fn from_value(value: Value) -> Result<Self, VmError> {
+        Ok(match value {
+            Value::Unit => ConstValue::Unit,
+            Value::Byte(b) => ConstValue::Byte(b),
+            Value::Char(c) => ConstValue::Char(c),
+            Value::Bool(b) => ConstValue::Bool(b),
+            Value::Integer(n) => ConstValue::Integer(n),
+            Value::Float(f) => ConstValue::Float(f),
+            Value::String(s) => {
+                let s = s.take()?;
+                ConstValue::String(s)
+            }
+            Value::Bytes(b) => {
+                let b = b.take()?;
+                ConstValue::Bytes(Bytes::from(b))
+            }
+            Value::Vec(vec) => {
+                let vec = vec.take()?;
+                let mut const_vec = vec::Vec::with_capacity(vec.len());
+
+                for value in vec {
+                    const_vec.push(Self::from_value(value)?);
+                }
+
+                ConstValue::Vec(const_vec)
+            }
+            Value::Tuple(tuple) => {
+                let tuple = tuple.take()?;
+                let mut const_tuple = vec::Vec::with_capacity(tuple.len());
+
+                for value in vec::Vec::from(tuple.into_inner()) {
+                    const_tuple.push(Self::from_value(value)?);
+                }
+
+                ConstValue::Tuple(const_tuple.into_boxed_slice())
+            }
+            Value::Object(object) => {
+                let object = object.take()?;
+                let mut const_object = HashMap::with_capacity(object.len());
+
+                for (key, value) in object {
+                    const_object.insert(key, Self::from_value(value)?);
+                }
+
+                ConstValue::Object(const_object)
+            }
+            value => {
+                return Err(VmError::from(VmErrorKind::ConstNotSupported {
+                    actual: value.type_info()?,
+                }))
+            }
+        })
+    }
+
+    /// Convert into VM value.
+    pub fn into_value(self) -> Value {
+        match self {
+            ConstValue::Unit => Value::Unit,
+            ConstValue::Byte(b) => Value::Byte(b),
+            ConstValue::Char(c) => Value::Char(c),
+            ConstValue::Bool(b) => Value::Bool(b),
+            ConstValue::Integer(n) => Value::Integer(n),
+            ConstValue::Float(n) => Value::Float(n),
+            ConstValue::String(s) => Value::String(Shared::new(s)),
+            ConstValue::Bytes(b) => Value::Bytes(Shared::new(b)),
+            ConstValue::Vec(vec) => {
+                let mut v = Vec::with_capacity(vec.len());
+
+                for value in vec {
+                    v.push(value.into_value());
+                }
+
+                Value::Vec(Shared::new(v))
+            }
+            ConstValue::Tuple(tuple) => {
+                let mut t = vec::Vec::with_capacity(tuple.len());
+
+                for value in vec::Vec::from(tuple) {
+                    t.push(value.into_value());
+                }
+
+                Value::Tuple(Shared::new(Tuple::from(t)))
+            }
+            ConstValue::Object(object) => {
+                let mut o = Object::with_capacity(object.len());
+
+                for (key, value) in object {
+                    o.insert(key, value.into_value());
+                }
+
+                Value::Object(Shared::new(o))
+            }
+        }
+    }
+
     /// Try to coerce into boolean.
     pub fn into_bool(self) -> Result<bool, Self> {
         match self {

--- a/crates/runestick/src/tuple.rs
+++ b/crates/runestick/src/tuple.rs
@@ -1,4 +1,4 @@
-use crate::{FromValue, Mut, Ref, Value, VmError};
+use crate::{ConstValue, FromValue, Mut, Ref, Value, VmError};
 use std::fmt;
 use std::ops;
 
@@ -101,6 +101,20 @@ impl From<Vec<Value>> for Tuple {
 impl From<Box<[Value]>> for Tuple {
     fn from(inner: Box<[Value]>) -> Self {
         Self { inner }
+    }
+}
+
+impl From<Box<[ConstValue]>> for Tuple {
+    fn from(inner: Box<[ConstValue]>) -> Self {
+        let mut out = Vec::with_capacity(inner.len());
+
+        for value in inner.into_vec() {
+            out.push(value.into_value());
+        }
+
+        Self {
+            inner: out.into_boxed_slice(),
+        }
     }
 }
 

--- a/crates/runestick/src/vm.rs
+++ b/crates/runestick/src/vm.rs
@@ -2038,8 +2038,7 @@ impl Vm {
             _ => return Err(VmError::from(VmErrorKind::MissingFunction { hash })),
         };
 
-        let environment = self.stack.pop_sequence(count)?;
-        let environment = Shared::new(Tuple::from(environment));
+        let environment = self.stack.pop_sequence(count)?.into_boxed_slice();
 
         let function = Function::from_closure(
             self.context.clone(),

--- a/crates/runestick/src/vm_error.rs
+++ b/crates/runestick/src/vm_error.rs
@@ -297,6 +297,8 @@ pub enum VmErrorKind {
     MissingVariant { name: Box<str> },
     #[error("expected an enum variant, but got `{actual}`")]
     ExpectedVariant { actual: TypeInfo },
+    #[error("{actual} can't be converted to a constant value")]
+    ConstNotSupported { actual: TypeInfo },
 }
 
 impl VmErrorKind {


### PR DESCRIPTION
Regular `Function`s are **not** thread-safe, since they might contain a closure which has captured some of the runtime state of Rune.

This adds support for `SyncFunction`, which takes ownership of the runtime state that it's captured and converts it into a `ConstValue`. `ConstValue`s are an owned variation of `Value` which does not perform the same ownership work as `Value`.

This currently does have the effect of **moving** any captured values, which really should be implemented in two separate ways. And the concepts map quite nicely to rust's `move` operator.

```rust
let value = /* .. */;

// This should clone the value if converted to a sync function.
let a = || {
    dbg(value);
}

let value = /* .. */;

// This should move value.
let b = move || {
    dbg(value);
}
```