### PR TITLE
Support moving values into closures and async blocks (fixes #150)

### DIFF
--- a/book/src/variables.md
+++ b/book/src/variables.md
@@ -56,12 +56,12 @@ raised in the virtual machine.
 ```text
 $> cargo run --bin rune -- scripts/book/variables/take_argument.rn
 field: 1
-== ! (failed to access value: cannot read, value is moved (at 14)) (469µs)
+== ! (cannot read, value is moved (at 14)) (469µs)
 error: virtual machine error
   ┌─ scripts/book/variables/take_argument.rn:6:27
   │
 6 │     println!("field: {}", object.field);
-  │                           ^^^^^^^^^^^^ failed to access value: cannot read, value is moved
+  │                           ^^^^^^^^^^^^ cannot read, value is moved
 ```
 
 If you need to, you can test if a variable is still accessible for reading with

--- a/crates/rune/src/ast/expr_block.rs
+++ b/crates/rune/src/ast/expr_block.rs
@@ -1,5 +1,5 @@
 use crate::ast;
-use crate::{Spanned, ToTokens};
+use crate::{Parse, Spanned, ToTokens};
 
 /// A block expression.
 ///
@@ -18,14 +18,18 @@ use crate::{Spanned, ToTokens};
 /// assert_eq!(expr.block.statements.len(), 1);
 /// assert_eq!(expr.attributes.len(), 1);
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, ToTokens, Spanned)]
+#[derive(Debug, Clone, PartialEq, Eq, Parse, ToTokens, Spanned)]
+#[rune(parse = "meta_only")]
 pub struct ExprBlock {
     /// The attributes for the block.
-    #[rune(iter)]
+    #[rune(iter, meta)]
     pub attributes: Vec<ast::Attribute>,
     /// The optional async token.
-    #[rune(iter)]
+    #[rune(iter, meta)]
     pub async_token: Option<T![async]>,
+    /// The optional move token.
+    #[rune(iter, meta)]
+    pub move_token: Option<T![move]>,
     /// The close brace.
     pub block: ast::Block,
 }

--- a/crates/rune/src/compiling/assemble/expr_assign.rs
+++ b/crates/rune/src/compiling/assemble/expr_assign.rs
@@ -22,11 +22,11 @@ impl Assemble for ast::ExprAssign {
             }
             // <expr>.<field> = <value>
             ast::Expr::FieldAccess(field_access) => {
+                let span = field_access.span();
+
                 // field assignment
                 match &field_access.expr_field {
                     ast::ExprField::Ident(index) => {
-                        let span = index.span();
-
                         let slot = index.resolve(c.storage, &*c.source)?;
                         let slot = c.unit.new_static_string(index, slot.as_ref())?;
 
@@ -44,7 +44,6 @@ impl Assemble for ast::ExprAssign {
                         true
                     }
                     ast::ExprField::LitNumber(field) => {
-                        let span = field.span();
                         let number = field.resolve(c.storage, &*c.source)?;
                         let index = number.as_tuple_index().ok_or_else(|| {
                             CompileError::new(

--- a/crates/rune/src/compiling/assemble/expr_call.rs
+++ b/crates/rune/src/compiling/assemble/expr_call.rs
@@ -72,7 +72,7 @@ impl Assemble for ast::ExprCall {
         if let Some(name) = named.as_local() {
             let local = c
                 .scopes
-                .try_get_var(name, c.source_id, c.visitor, path.span())
+                .try_get_var(name, c.source_id, c.visitor, path.span())?
                 .copied();
 
             if let Some(var) = local {

--- a/crates/rune/src/compiling/assemble/expr_field_access.rs
+++ b/crates/rune/src/compiling/assemble/expr_field_access.rs
@@ -88,7 +88,7 @@ fn try_immediate_field_access_optimization(
     let var =
         match this
             .scopes
-            .try_get_var(ident.as_ref(), this.source_id, this.visitor, path.span())
+            .try_get_var(ident.as_ref(), this.source_id, this.visitor, path.span())?
         {
             Some(var) => var,
             None => return Ok(false),

--- a/crates/rune/src/compiling/assemble/expr_path.rs
+++ b/crates/rune/src/compiling/assemble/expr_path.rs
@@ -26,7 +26,7 @@ impl Assemble for ast::Path {
 
         if let Needs::Value = needs {
             if let Some(local) = named.as_local() {
-                if let Some(var) = c.scopes.try_get_var(local, c.source_id, c.visitor, span) {
+                if let Some(var) = c.scopes.try_get_var(local, c.source_id, c.visitor, span)? {
                     var.copy(&mut c.asm, span, format!("var `{}`", local));
                     return Ok(());
                 }

--- a/crates/rune/src/compiling/compile_error.rs
+++ b/crates/rune/src/compiling/compile_error.rs
@@ -280,6 +280,8 @@ pub enum CompileErrorKind {
     },
     #[error("no such built-in macro `{name}`")]
     NoSuchBuiltInMacro { name: Box<str> },
+    #[error("variable moved")]
+    VariableMoved { moved_at: Span },
 }
 
 /// A single stap as an import entry.

--- a/crates/rune/src/diagnostics.rs
+++ b/crates/rune/src/diagnostics.rs
@@ -361,6 +361,12 @@ impl EmitDiagnostics for Error {
                         notes.push(note);
                     }
                 }
+                CompileErrorKind::VariableMoved { moved_at, .. } => {
+                    labels.push(
+                        Label::secondary(this.source_id(), moved_at.range())
+                            .with_message("moved here"),
+                    );
+                }
                 _ => (),
             }
 

--- a/crates/rune/src/parsing/parse.rs
+++ b/crates/rune/src/parsing/parse.rs
@@ -6,7 +6,7 @@ where
     Self: Sized,
 {
     /// Parse the current item from the parser.
-    fn parse(parser: &mut Parser) -> Result<Self, ParseError>;
+    fn parse(p: &mut Parser) -> Result<Self, ParseError>;
 }
 
 impl<A, B> Parse for (A, B)

--- a/crates/rune/src/query/mod.rs
+++ b/crates/rune/src/query/mod.rs
@@ -424,6 +424,7 @@ impl Query {
         ast: Box<ast::ExprClosure>,
         captures: Arc<[CompileMetaCapture]>,
         call: Call,
+        do_move: bool,
     ) -> Result<(), QueryError> {
         log::trace!("new closure: {:?}", query_item.item);
 
@@ -435,6 +436,7 @@ impl Query {
                     ast,
                     captures,
                     call,
+                    do_move,
                 }),
             },
             false,
@@ -451,6 +453,7 @@ impl Query {
         ast: ast::Block,
         captures: Arc<[CompileMetaCapture]>,
         call: Call,
+        do_move: bool,
     ) -> Result<(), QueryError> {
         log::trace!("new closure: {:?}", query_item.item);
 
@@ -462,6 +465,7 @@ impl Query {
                     ast,
                     captures,
                     call,
+                    do_move,
                 }),
             },
             false,
@@ -1263,6 +1267,7 @@ impl QueryInner {
             }
             Indexed::Closure(c) => {
                 let captures = c.captures.clone();
+                let do_move = c.do_move;
 
                 self.queue.push_back(BuildEntry {
                     location: query_item.location,
@@ -1275,10 +1280,12 @@ impl QueryInner {
                 CompileMetaKind::Closure {
                     type_of: Type::from(Hash::type_hash(&item.item)),
                     captures,
+                    do_move,
                 }
             }
             Indexed::AsyncBlock(b) => {
                 let captures = b.captures.clone();
+                let do_move = b.do_move;
 
                 self.queue.push_back(BuildEntry {
                     location: query_item.location,
@@ -1291,6 +1298,7 @@ impl QueryInner {
                 CompileMetaKind::AsyncBlock {
                     type_of: Type::from(Hash::type_hash(&item.item)),
                     captures,
+                    do_move,
                 }
             }
             Indexed::Const(c) => {
@@ -1500,6 +1508,8 @@ pub(crate) struct Closure {
     pub(crate) captures: Arc<[CompileMetaCapture]>,
     /// Calling convention used for closure.
     pub(crate) call: Call,
+    /// If the closure moves its captures.
+    pub(crate) do_move: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -1510,6 +1520,8 @@ pub(crate) struct AsyncBlock {
     pub(crate) captures: Arc<[CompileMetaCapture]>,
     /// Calling convention used for async block.
     pub(crate) call: Call,
+    /// If the block moves its captures.
+    pub(crate) do_move: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/rune/tests/test_all/mod.rs
+++ b/crates/rune/tests/test_all/mod.rs
@@ -9,6 +9,7 @@ mod compiler_use;
 mod compiler_visibility;
 mod compiler_warnings;
 mod core_macros;
+mod moved;
 mod vm_arithmetic;
 mod vm_assign_exprs;
 mod vm_async_block;

--- a/crates/rune/tests/test_all/moved.rs
+++ b/crates/rune/tests/test_all/moved.rs
@@ -1,0 +1,45 @@
+use rune::testing::*;
+
+#[test]
+fn test_closure_moved() {
+    assert_compile_error!(
+        r#"
+        pub fn main() {
+            let o = [];
+            let a = move || {
+                o.push(42);
+                o
+            };
+        
+            o.push(42);
+            a()
+        }
+        "#,
+        span, VariableMoved { moved_at } => {
+            assert_eq!(span, Span::new(161, 162));
+            assert_eq!(moved_at, Span::new(69, 138));
+        }
+    )
+}
+
+#[test]
+fn test_async_moved() {
+    assert_compile_error!(
+        r#"
+        pub async fn main() {
+            let o = [];
+            let a = async move {
+                o.push(42);
+                o
+            };
+
+            o.push(42);
+            a.await
+        }
+        "#,
+        span, VariableMoved { moved_at } => {
+            assert_eq!(span, Span::new(162, 163));
+            assert_eq!(moved_at, Span::new(75, 147));
+        }
+    )
+}

--- a/crates/runestick/src/compile_meta.rs
+++ b/crates/runestick/src/compile_meta.rs
@@ -169,6 +169,8 @@ pub enum CompileMetaKind {
         type_of: Type,
         /// Sequence of captured variables.
         captures: Arc<[CompileMetaCapture]>,
+        /// If the closure moves its environment.
+        do_move: bool,
     },
     /// An async block.
     AsyncBlock {
@@ -176,6 +178,8 @@ pub enum CompileMetaKind {
         type_of: Type,
         /// Sequence of captured variables.
         captures: Arc<[CompileMetaCapture]>,
+        /// If the async block moves its environment.
+        do_move: bool,
     },
     /// The constant expression.
     Const {

--- a/crates/runestick/src/inst.rs
+++ b/crates/runestick/src/inst.rs
@@ -368,6 +368,12 @@ pub enum Inst {
         /// Offset to copy value from.
         offset: usize,
     },
+    /// Move a variable from a location `offset` relative to the current call
+    /// frame.
+    Move {
+        /// Offset to move value from.
+        offset: usize,
+    },
     /// Drop the value in the given frame offset, cleaning out it's slot in
     /// memory.
     ///
@@ -940,6 +946,9 @@ impl fmt::Display for Inst {
             }
             Self::Copy { offset } => {
                 write!(fmt, "copy {}", offset)?;
+            }
+            Self::Move { offset } => {
+                write!(fmt, "move {}", offset)?;
             }
             Self::Dup => {
                 write!(fmt, "dup")?;

--- a/crates/runestick/src/value.rs
+++ b/crates/runestick/src/value.rs
@@ -387,6 +387,40 @@ impl Value {
         }))
     }
 
+    /// Take the interior value.
+    pub fn take(self) -> Result<Self, VmError> {
+        Ok(match self {
+            Self::Unit => Self::Unit,
+            Self::Bool(value) => Self::Bool(value),
+            Self::Byte(value) => Self::Byte(value),
+            Self::Char(value) => Self::Char(value),
+            Self::Integer(value) => Self::Integer(value),
+            Self::Float(value) => Self::Float(value),
+            Self::Type(value) => Self::Type(value),
+            Self::StaticString(value) => Self::StaticString(value),
+            Self::String(value) => Self::String(Shared::new(value.take()?)),
+            Self::Bytes(value) => Self::Bytes(Shared::new(value.take()?)),
+            Self::Vec(value) => Self::Vec(Shared::new(value.take()?)),
+            Self::Tuple(value) => Self::Tuple(Shared::new(value.take()?)),
+            Self::Object(value) => Self::Object(Shared::new(value.take()?)),
+            Self::Future(value) => Self::Future(Shared::new(value.take()?)),
+            Self::Stream(value) => Self::Stream(Shared::new(value.take()?)),
+            Self::Generator(value) => Self::Generator(Shared::new(value.take()?)),
+            Self::GeneratorState(value) => Self::GeneratorState(Shared::new(value.take()?)),
+            Self::Option(value) => Self::Option(Shared::new(value.take()?)),
+            Self::Result(value) => Self::Result(Shared::new(value.take()?)),
+            Self::UnitStruct(value) => Self::UnitStruct(Shared::new(value.take()?)),
+            Self::TupleStruct(value) => Self::TupleStruct(Shared::new(value.take()?)),
+            Self::Struct(value) => Self::Struct(Shared::new(value.take()?)),
+            Self::UnitVariant(value) => Self::UnitVariant(Shared::new(value.take()?)),
+            Self::TupleVariant(value) => Self::TupleVariant(Shared::new(value.take()?)),
+            Self::StructVariant(value) => Self::StructVariant(Shared::new(value.take()?)),
+            Self::Function(value) => Self::Function(Shared::new(value.take()?)),
+            Self::Format(value) => Self::Format(value),
+            Self::Any(value) => Self::Any(Shared::new(value.take()?)),
+        })
+    }
+
     /// Try to coerce value into a unit.
     #[inline]
     pub fn into_unit(self) -> Result<(), VmError> {

--- a/crates/runestick/src/vm.rs
+++ b/crates/runestick/src/vm.rs
@@ -432,6 +432,14 @@ impl Vm {
         Ok(())
     }
 
+    /// Move a value from a position relative to the top of the stack, to the
+    /// top of the stack.
+    fn op_move(&mut self, offset: usize) -> Result<(), VmError> {
+        let value = self.stack.at_offset(offset)?.clone();
+        self.stack.push(value.take()?);
+        Ok(())
+    }
+
     #[inline]
     fn op_drop(&mut self, offset: usize) -> Result<(), VmError> {
         let _ = self.stack.at_offset(offset)?;
@@ -2302,6 +2310,9 @@ impl Vm {
                 }
                 Inst::Copy { offset } => {
                     self.op_copy(offset)?;
+                }
+                Inst::Move { offset } => {
+                    self.op_move(offset)?;
                 }
                 Inst::Drop { offset } => {
                     self.op_drop(offset)?;

--- a/crates/runestick/src/vm_error.rs
+++ b/crates/runestick/src/vm_error.rs
@@ -144,7 +144,7 @@ pub enum VmErrorKind {
         /// The instruction pointer of where the original error happened.
         ip: usize,
     },
-    #[error("failed to access value: {error}")]
+    #[error("{error}")]
     AccessError {
         #[from]
         error: AccessError,


### PR DESCRIPTION
Also a minor patch to the `Spanned` derive, which calculated the wrong span for fields which have all optional fields except the last one.

This adds syntactical moving. So values used in the closure will be "moved" out of the scope. Even if they are copy (because there's no way to tell). This might be disable, because we also have a runtime check for moved values (which are *actually* moved).

![image](https://user-images.githubusercontent.com/111092/95698962-8cd45580-0c43-11eb-8160-dac82aa98314.png)
