### PR TITLE
Add support for const blocks

### DIFF
--- a/crates/rune/src/ast/expr.rs
+++ b/crates/rune/src/ast/expr.rs
@@ -369,6 +369,7 @@ impl Expr {
 
         let mut label = p.parse::<Option<(ast::Label, T![:])>>()?;
         let mut async_token = p.parse::<Option<T![async]>>()?;
+        let mut const_token = p.parse::<Option<T![const]>>()?;
         let mut move_token = p.parse::<Option<T![move]>>()?;
 
         let expr = match p.nth(0)? {
@@ -427,6 +428,7 @@ impl Expr {
                 p,
                 take(attributes),
                 take(&mut async_token),
+                take(&mut const_token),
                 take(&mut move_token),
             )?)),
             K![break] => Self::Break(Box::new(ast::ExprBreak::parse_with_meta(
@@ -452,6 +454,10 @@ impl Expr {
 
         if let Some(span) = async_token.option_span() {
             return Err(ParseError::unsupported(span, "async modifier"));
+        }
+
+        if let Some(span) = const_token.option_span() {
+            return Err(ParseError::unsupported(span, "const modifier"));
         }
 
         if let Some(span) = move_token.option_span() {

--- a/crates/rune/src/ast/expr_block.rs
+++ b/crates/rune/src/ast/expr_block.rs
@@ -27,6 +27,9 @@ pub struct ExprBlock {
     /// The optional async token.
     #[rune(iter, meta)]
     pub async_token: Option<T![async]>,
+    /// The optional const token.
+    #[rune(iter, meta)]
+    pub const_token: Option<T![const]>,
     /// The optional move token.
     #[rune(iter, meta)]
     pub move_token: Option<T![move]>,

--- a/crates/rune/src/ast/mod.rs
+++ b/crates/rune/src/ast/mod.rs
@@ -151,7 +151,7 @@ pub use self::local::Local;
 pub use self::macro_call::MacroCall;
 pub use self::pat::{Pat, PatBinding, PatLit, PatObject, PatPath, PatTuple, PatVec};
 pub use self::path::{Path, PathKind, PathSegment};
-pub use self::stmt::{ItemOrExpr, Stmt};
+pub use self::stmt::{ItemOrExpr, Stmt, StmtSortKey};
 pub use self::token::{
     BuiltIn, CopySource, Delimiter, Number, NumberBase, NumberSource, NumberText, StrSource,
     StrText, StringSource, Token,

--- a/crates/rune/src/compiling/compile_error.rs
+++ b/crates/rune/src/compiling/compile_error.rs
@@ -200,6 +200,8 @@ pub enum CompileErrorKind {
     ExpectedMacroSemi,
     #[error("an `fn` can't both be `async` and `const` at the same time")]
     FnConstAsyncConflict,
+    #[error("a block can't both be `async` and `const` at the same time")]
+    BlockConstAsyncConflict,
     #[error("const functions can't be generators")]
     FnConstNotGenerator,
     #[error("unsupported closure kind")]

--- a/crates/rune/src/compiling/compile_error.rs
+++ b/crates/rune/src/compiling/compile_error.rs
@@ -120,8 +120,8 @@ pub enum CompileErrorKind {
     VariableConflict { name: String, existing_span: Span },
     #[error("missing macro `{item}`")]
     MissingMacro { item: Item },
-    #[error("error while calling macro: {error}")]
-    CallMacroError { error: runestick::Error },
+    #[error("{error}")]
+    CallMacroError { item: Item, error: runestick::Error },
     #[error("no local variable `{name}`")]
     MissingLocal { name: String },
     #[error("no such type `{item}`")]

--- a/crates/rune/src/diagnostics.rs
+++ b/crates/rune/src/diagnostics.rs
@@ -367,6 +367,9 @@ impl EmitDiagnostics for Error {
                             .with_message("moved here"),
                     );
                 }
+                CompileErrorKind::CallMacroError { item, .. } => {
+                    notes.push(format!("Error originated in the `{}` macro", item).into());
+                }
                 _ => (),
             }
 

--- a/crates/rune/src/ir/ir_compiler.rs
+++ b/crates/rune/src/ir/ir_compiler.rs
@@ -101,7 +101,7 @@ impl IrCompile for ast::Expr {
             ast::Expr::Loop(expr_loop) => ir::Ir::new(self.span(), expr_loop.compile(c)?),
             ast::Expr::While(expr_while) => ir::Ir::new(self.span(), expr_while.compile(c)?),
             ast::Expr::Lit(expr_lit) => expr_lit.compile(c)?,
-            ast::Expr::Block(expr_block) => ir::Ir::new(self.span(), expr_block.block.compile(c)?),
+            ast::Expr::Block(expr_block) => expr_block.compile(c)?,
             ast::Expr::Path(path) => path.compile(c)?,
             ast::Expr::FieldAccess(..) => ir::Ir::new(self.span(), c.ir_target(self)?),
             ast::Expr::Break(expr_break) => ir::Ir::new(expr_break, expr_break.compile(c)?),
@@ -402,10 +402,10 @@ impl IrCompile for ast::LitChar {
 }
 
 impl IrCompile for ast::ExprBlock {
-    type Output = ir::IrScope;
+    type Output = ir::Ir;
 
     fn compile(&self, c: &mut IrCompiler<'_>) -> Result<Self::Output, IrError> {
-        self.block.compile(c)
+        Ok(ir::Ir::new(self.span(), self.block.compile(c)?))
     }
 }
 

--- a/crates/rune/src/macros/macro_compiler.rs
+++ b/crates/rune/src/macros/macro_compiler.rs
@@ -91,6 +91,7 @@ impl MacroCompiler<'_> {
                         return Err(CompileError::new(
                             error.span(),
                             CompileErrorKind::CallMacroError {
+                                item: named.item.clone(),
                                 error: error.into_inner(),
                             },
                         ));
@@ -100,7 +101,10 @@ impl MacroCompiler<'_> {
 
                 return Err(CompileError::new(
                     span,
-                    CompileErrorKind::CallMacroError { error },
+                    CompileErrorKind::CallMacroError {
+                        item: named.item.clone(),
+                        error,
+                    },
                 ));
             }
         };
@@ -111,6 +115,7 @@ impl MacroCompiler<'_> {
                 return Err(CompileError::new(
                     span,
                     CompileErrorKind::CallMacroError {
+                        item: named.item.clone(),
                         error: runestick::Error::msg(format!(
                             "failed to downcast macro result, expected `{}`",
                             std::any::type_name::<TokenStream>()

--- a/crates/rune/src/query/mod.rs
+++ b/crates/rune/src/query/mod.rs
@@ -4,7 +4,7 @@ use crate::ast;
 use crate::collections::{HashMap, HashSet};
 use crate::indexing::Visibility;
 use crate::ir;
-use crate::ir::{IrBudget, IrCompiler, IrInterpreter, IrQuery};
+use crate::ir::{IrBudget, IrCompile, IrCompiler, IrInterpreter, IrQuery};
 use crate::parsing::Opaque;
 use crate::shared::{Consts, Location};
 use crate::{
@@ -299,12 +299,15 @@ impl Query {
     }
 
     /// Index a constant expression.
-    pub fn index_const(
+    pub fn index_const<T>(
         &self,
         query_item: &Rc<QueryItem>,
         source: &Arc<Source>,
-        item_const: Box<ast::ItemConst>,
-    ) -> Result<(), QueryError> {
+        expr: &T,
+    ) -> Result<(), QueryError>
+    where
+        T: IrCompile<Output = ir::Ir>,
+    {
         log::trace!("new const: {:?}", query_item.item);
 
         let mut inner = self.inner.borrow_mut();
@@ -315,7 +318,7 @@ impl Query {
             query: &mut *inner,
         };
 
-        let ir = ir_compiler.compile(&item_const.expr)?;
+        let ir = ir_compiler.compile(expr)?;
 
         inner.index(
             IndexedEntry {

--- a/crates/rune/src/shared/items.rs
+++ b/crates/rune/src/shared/items.rs
@@ -74,18 +74,6 @@ impl Items {
     }
 
     /// Push a component and return a guard to it.
-    pub(crate) fn push_async_block(&mut self) -> Guard {
-        let mut inner = self.inner.borrow_mut();
-
-        let id = inner.id;
-        inner.item.push(Component::AsyncBlock(id));
-
-        Guard {
-            inner: self.inner.clone(),
-        }
-    }
-
-    /// Push a component and return a guard to it.
     pub(crate) fn push_name(&mut self, name: &str) -> Guard {
         let mut inner = self.inner.borrow_mut();
 

--- a/crates/rune/tests/test_all/vm_const_exprs.rs
+++ b/crates/rune/tests/test_all/vm_const_exprs.rs
@@ -231,3 +231,36 @@ fn test_const_fn_visibility() {
 
     assert_eq!(result, 3);
 }
+
+#[test]
+fn test_const_block() {
+    let result = rune! { i64 =>
+        pub fn main() {
+            let u = 2;
+            let value = const { 1 << test() };
+            return value - u;
+            const fn test() { 32 }
+        }
+    };
+
+    assert_eq!(result, (1i64 << 32) - 2);
+
+    let result = rune! { String =>
+        pub fn main() {
+            let var = "World";
+            format!(const { "Hello {}" }, var)
+        }
+    };
+
+    assert_eq!(result, "Hello World");
+
+    let result = rune! { String =>
+        pub fn main() {
+            let var = "World";
+            return format!(const { FORMAT }, var);
+            const FORMAT = "Hello {}";
+        }
+    };
+
+    assert_eq!(result, "Hello World");
+}


### PR DESCRIPTION
This PR adds support for constant blocks:

```rust
let value = const { 1 + 3 };
println!("{}", value);
```

Constant blocks are similarly to constant functions and declarations evaluated at compile time. They are a kind of anonymous constant declaration that can be used inline.

They have the same rules for scope evaluation as other constant eval: They can only reference and use other constant values.

There's an outstanding issue with constant evaluation that was discovered when working with this, which has been outlined in #154.