### PR TITLE
Fix a number of bugs with visibility and simplify

### DIFF
--- a/crates/rune/src/compiling/assemble/expr_path.rs
+++ b/crates/rune/src/compiling/assemble/expr_path.rs
@@ -17,11 +17,6 @@ impl Assemble for ast::Path {
             return Ok(());
         }
 
-        // NB: do nothing if we don't need a value.
-        if !needs.value() {
-            c.warnings.not_used(c.source_id, span, c.context());
-        }
-
         let named = c.convert_path_to_named(self)?;
 
         if let Needs::Value = needs {

--- a/crates/rune/src/indexing/index.rs
+++ b/crates/rune/src/indexing/index.rs
@@ -480,9 +480,15 @@ impl<'a> Indexer<'a> {
 
         let item = self.items.item();
         let visibility = Visibility::from_ast(&item_mod.visibility)?;
-        let (id, mod_item) =
-            self.query
-                .insert_mod(self.source_id, item_mod.name_span(), &*item, visibility)?;
+
+        let (id, mod_item) = self.query.insert_mod(
+            self.source_id,
+            item_mod.name_span(),
+            &self.mod_item,
+            &*item,
+            visibility,
+        )?;
+
         item_mod.id = Some(id);
 
         let source = self.source_loader.load(root, &*item, span)?;
@@ -1235,7 +1241,7 @@ impl Index for ast::ItemEnum {
                 span,
                 &*idx.items.item(),
                 &idx.mod_item,
-                visibility,
+                Visibility::Public,
             )?;
             variant.id = Some(item.id);
 
@@ -1351,6 +1357,7 @@ impl Index for ast::ItemMod {
                 let (id, mod_item) = idx.query.insert_mod(
                     idx.source_id,
                     name_span,
+                    &idx.mod_item,
                     &*idx.items.item(),
                     visibility,
                 )?;

--- a/crates/rune/src/indexing/visibility.rs
+++ b/crates/rune/src/indexing/visibility.rs
@@ -42,10 +42,20 @@ impl Visibility {
     }
 
     /// Check if `from` can access `to` with the current visibility.
-    pub(crate) fn is_visible_to(self, from: &Item, to: &Item) -> bool {
+    pub(crate) fn is_visible(self, from: &Item, to: &Item) -> bool {
         match self {
             Visibility::Inherited | Visibility::SelfValue => from.is_super_of(to, 1),
             Visibility::Super => from.is_super_of(to, 2),
+            Visibility::Public => true,
+            Visibility::Crate => true,
+        }
+    }
+
+    /// Check if `from` can access `to` with the current visibility.
+    pub(crate) fn is_visible_inside(self, from: &Item, to: &Item) -> bool {
+        match self {
+            Visibility::Inherited | Visibility::SelfValue => from == to,
+            Visibility::Super => from.is_super_of(to, 1),
             Visibility::Public => true,
             Visibility::Crate => true,
         }

--- a/crates/rune/src/ir/ir_interpreter.rs
+++ b/crates/rune/src/ir/ir_interpreter.rs
@@ -16,7 +16,7 @@ pub struct IrInterpreter<'a> {
     /// allowed to evaluate.
     pub(crate) budget: IrBudget,
     /// The module in which the interpreter is run.
-    pub(crate) mod_item: Rc<QueryMod>,
+    pub(crate) module: Rc<QueryMod>,
     /// The item where the constant expression is located.
     pub(crate) item: Item,
     /// Constant scopes.

--- a/crates/rune/src/macros/macro_context.rs
+++ b/crates/rune/src/macros/macro_context.rs
@@ -154,7 +154,7 @@ impl MacroContext {
         let mut ir_interpreter = IrInterpreter {
             budget: IrBudget::new(1_000_000),
             scopes: Default::default(),
-            mod_item: self.item.mod_item.clone(),
+            module: self.item.module.clone(),
             item: self.item.item.clone(),
             consts: self.consts.clone(),
             query: &mut *ir_query,

--- a/crates/rune/src/query/query_error.rs
+++ b/crates/rune/src/query/query_error.rs
@@ -53,7 +53,7 @@ pub enum QueryErrorKind {
     MissingId { what: &'static str, id: Option<Id> },
     #[error("cannot define conflicting item `{item}`")]
     ItemConflict { item: Item, other: Location },
-    #[error("item `{item}` with {visibility} visibility, is not accessible from here")]
+    #[error("item `{item}` with {visibility} visibility, is not accessible from `{from}`")]
     NotVisible {
         chain: Vec<Location>,
         location: Location,
@@ -61,12 +61,13 @@ pub enum QueryErrorKind {
         item: Item,
         from: Item,
     },
-    #[error("module `{item}` with {visibility} visibility, is not accessible from here")]
+    #[error("module `{item}` with {visibility} visibility, is not accessible from `{from}`")]
     NotVisibleMod {
         chain: Vec<Location>,
         location: Location,
         visibility: Visibility,
         item: Item,
+        from: Item,
     },
     #[error("missing reverse lookup for `{item}`")]
     MissingRevItem { item: Item },

--- a/crates/rune/tests/test_all/compiler_visibility.rs
+++ b/crates/rune/tests/test_all/compiler_visibility.rs
@@ -105,3 +105,31 @@ fn test_rust_example() {
         }
     };
 }
+
+#[test]
+fn test_access_super() {
+    let value = rune! { i64 =>
+        struct Test;
+
+        mod c {
+            pub fn test() { let _ = super::Test; 1 }
+        }
+
+        pub fn main() {
+            c::test()
+        }
+    };
+
+    assert_eq!(value, 1);
+
+    let value = rune! { i64 =>
+        mod a { pub(super) fn test() { 1 } }
+        mod b { pub fn test() { crate::a::test() } }
+
+        pub fn main() {
+            b::test()
+        }
+    };
+
+    assert_eq!(value, 1);
+}

--- a/crates/rune/tests/test_all/wildcard_imports.rs
+++ b/crates/rune/tests/test_all/wildcard_imports.rs
@@ -1,30 +1,30 @@
 #[test]
 fn test_wildcard_precedence() {
     assert!(rune! { bool =>
-        mod a { struct Foo; }
-        mod b { struct Foo; }
+        mod a { pub struct Foo; }
+        mod b { pub struct Foo; }
         use a::*;
         use b::*;
         pub fn main() { Foo is b::Foo }
     });
 
     assert!(rune! { bool =>
-        mod a { struct Foo; }
-        mod b { struct Foo; }
+        mod a { pub struct Foo; }
+        mod b { pub struct Foo; }
         use {a::*, b::*};
         pub fn main() { Foo is b::Foo }
     });
 
     assert!(rune! { bool =>
-        mod a { struct Foo; }
-        mod b { struct Foo; }
+        mod a { pub struct Foo; }
+        mod b { pub struct Foo; }
         use {b::*, a::*};
         pub fn main() { Foo is a::Foo }
     });
 
     assert!(rune! { bool =>
-        mod a { struct Foo; }
-        mod b { struct Foo; }
+        mod a { pub struct Foo; }
+        mod b { pub struct Foo; }
         use a::*;
         use b::*;
         use a::Foo;
@@ -32,8 +32,8 @@ fn test_wildcard_precedence() {
     });
 
     assert!(rune! { bool =>
-        mod a { struct Foo; }
-        mod b { struct Foo; }
+        mod a { pub struct Foo; }
+        mod b { pub struct Foo; }
         use a::Foo;
         use a::*;
         use b::*;

--- a/scripts/book/items_imports/inline_modules.rn
+++ b/scripts/book/items_imports/inline_modules.rn
@@ -1,11 +1,11 @@
 mod foo {
-    fn get_number() {
+    pub fn get_number() {
         1
     }
 }
 
 mod bar {
-    fn get_number() {
+    pub fn get_number() {
         2
     }
 }


### PR DESCRIPTION
Visibility wasn't being resoled correctly under a couple of circumstances. I've fixed these and added tests.

As a bonus, `QueryMod` now keeps a reference to its parent module, which can be used instead of item traversal for testing module accessability.