### PR TITLE
Introduce Interface helper to allow calling protocol functions

### DIFF
--- a/crates/runestick/src/call.rs
+++ b/crates/runestick/src/call.rs
@@ -1,3 +1,4 @@
+use crate::{Future, Generator, Stream, Value, Vm, VmError};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -15,6 +16,19 @@ pub enum Call {
     Generator,
     /// Functions are immediately called and control handed over.
     Immediate,
+}
+
+impl Call {
+    /// Perform the call with the given virtual machine.
+    #[inline]
+    pub(crate) fn call_with_vm(self, vm: Vm) -> Result<Value, VmError> {
+        Ok(match self {
+            Call::Stream => Value::from(Stream::new(vm)),
+            Call::Generator => Value::from(Generator::new(vm)),
+            Call::Immediate => vm.complete()?,
+            Call::Async => Value::from(Future::new(vm.async_complete())),
+        })
+    }
 }
 
 impl fmt::Display for Call {

--- a/crates/runestick/src/format.rs
+++ b/crates/runestick/src/format.rs
@@ -27,6 +27,16 @@ pub struct Format {
     pub(crate) spec: FormatSpec,
 }
 
+impl Named for Format {
+    const NAME: RawStr = RawStr::from_str("Format");
+}
+
+impl FromValue for Format {
+    fn from_value(value: Value) -> Result<Self, VmError> {
+        Ok(*value.into_format()?)
+    }
+}
+
 /// A format specification.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[non_exhaustive]
@@ -339,16 +349,6 @@ impl FormatSpec {
         }
 
         Ok(())
-    }
-}
-
-impl Named for Format {
-    const NAME: RawStr = RawStr::from_str("Format");
-}
-
-impl FromValue for Format {
-    fn from_value(value: Value) -> Result<Self, VmError> {
-        Ok(*value.into_format()?)
     }
 }
 

--- a/crates/runestick/src/interface.rs
+++ b/crates/runestick/src/interface.rs
@@ -1,0 +1,141 @@
+use crate::{
+    Args, Context, FromValue, Hash, IntoTypeHash, Iterator, Stack, Unit, UnitFn, Value, Vm,
+    VmError, VmErrorKind,
+};
+use std::cell::Cell;
+use std::marker;
+use std::ptr;
+use std::sync::Arc;
+
+thread_local! { static ENV: Cell<Env> = Cell::new(Env::null()) }
+
+/// An interface which wraps a value and allows for accessing protocols.
+///
+/// This can be used as an argument type for native functions who wants to call
+/// a protocol function like [INTO_ITER](crate::INTO_ITER) (see
+/// [into_iter][Self::into_iter]).
+pub struct Interface {
+    target: Value,
+    unit: Arc<Unit>,
+    context: Arc<Context>,
+}
+
+impl Interface {
+    /// Call the `into_iter` protocol on the value.
+    pub fn into_iter(mut self) -> Result<Iterator, VmError> {
+        let target = match std::mem::take(&mut self.target) {
+            Value::Iterator(iterator) => return Ok(iterator.take()?),
+            Value::Vec(vec) => return Ok(vec.borrow_ref()?.into_iterator()),
+            Value::Object(object) => return Ok(object.borrow_ref()?.into_iterator()),
+            target => target,
+        };
+
+        let value = self.call_instance_fn(crate::INTO_ITER, target, ())?;
+        Iterator::from_value(value)
+    }
+
+    /// Helper function to call an instance function.
+    fn call_instance_fn<H, A>(self, hash: H, target: Value, args: A) -> Result<Value, VmError>
+    where
+        H: IntoTypeHash,
+        A: Args,
+    {
+        let count = args.count() + 1;
+        let hash = Hash::instance_function(target.type_of()?, hash.into_type_hash());
+
+        if let Some(UnitFn::Offset {
+            offset,
+            args: expected,
+            call,
+        }) = self.unit.lookup(hash)
+        {
+            let mut vm = Vm::new(self.context.clone(), self.unit.clone());
+            Self::check_args(count, expected)?;
+            vm.stack.push(target);
+            args.into_stack(&mut vm.stack)?;
+            vm.set_ip(offset);
+            return call.call_with_vm(vm);
+        }
+
+        let handler = match self.context.lookup(hash) {
+            Some(handler) => handler,
+            None => return Err(VmError::from(VmErrorKind::MissingFunction { hash })),
+        };
+
+        let mut stack = Stack::with_capacity(count);
+        stack.push(target);
+        args.into_stack(&mut stack)?;
+        handler(&mut stack, count)?;
+        Ok(stack.pop()?)
+    }
+
+    /// Check that arguments matches expected or raise the appropriate error.
+    fn check_args(args: usize, expected: usize) -> Result<(), VmError> {
+        if args != expected {
+            return Err(VmError::from(VmErrorKind::BadArgumentCount {
+                actual: args,
+                expected,
+            }));
+        }
+
+        Ok(())
+    }
+}
+
+impl FromValue for Interface {
+    fn from_value(value: Value) -> Result<Self, VmError> {
+        let env = ENV.with(|env| env.get());
+        let Env { context, unit } = env;
+
+        if context.is_null() || unit.is_null() {
+            return Err(VmError::from(VmErrorKind::MissingInterfaceEnvironment));
+        }
+
+        // Safety: context and unit can only be registered publicly through
+        // [EnvGuard], which makes sure that they are live for the duration of
+        // the registration.
+        Ok(Interface {
+            target: value,
+            context: unsafe { (*context).clone() },
+            unit: unsafe { (*unit).clone() },
+        })
+    }
+}
+
+pub(crate) struct EnvGuard<'a> {
+    old: Env,
+    _marker: marker::PhantomData<&'a ()>,
+}
+
+impl<'a> EnvGuard<'a> {
+    /// Construct a new environment guard with the given context and unit.
+    pub(crate) fn new(context: &'a Arc<Context>, unit: &'a Arc<Unit>) -> EnvGuard<'a> {
+        let old = ENV.with(|e| e.replace(Env { context, unit }));
+
+        EnvGuard {
+            old,
+            _marker: marker::PhantomData,
+        }
+    }
+}
+
+impl Drop for EnvGuard<'_> {
+    fn drop(&mut self) {
+        ENV.with(|e| e.set(self.old));
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Env {
+    context: *const Arc<Context>,
+    unit: *const Arc<Unit>,
+}
+
+impl Env {
+    const fn null() -> Self {
+        Self {
+            context: ptr::null(),
+            unit: ptr::null(),
+        }
+    }
+}

--- a/crates/runestick/src/lib.rs
+++ b/crates/runestick/src/lib.rs
@@ -74,6 +74,7 @@ mod guarded_args;
 mod hash;
 mod id;
 mod inst;
+mod interface;
 mod item;
 mod iterator;
 mod label;
@@ -154,6 +155,7 @@ pub use self::generator::Generator;
 pub use self::generator_state::GeneratorState;
 pub use self::guarded_args::GuardedArgs;
 pub use self::id::Id;
+pub use self::interface::Interface;
 pub use self::iterator::Iterator;
 pub use self::label::{DebugLabel, Label};
 pub use self::module::{InstFnNameHash, Module};
@@ -166,8 +168,9 @@ pub use self::spanned_error::{SpannedError, WithSpan};
 pub use self::static_string::StaticString;
 pub use self::static_type::{
     StaticType, BOOL_TYPE, BYTES_TYPE, BYTE_TYPE, CHAR_TYPE, FLOAT_TYPE, FORMAT_TYPE,
-    FUNCTION_TYPE, FUTURE_TYPE, GENERATOR_STATE_TYPE, GENERATOR_TYPE, INTEGER_TYPE, OBJECT_TYPE,
-    OPTION_TYPE, RESULT_TYPE, STREAM_TYPE, STRING_TYPE, TUPLE_TYPE, UNIT_TYPE, VEC_TYPE,
+    FUNCTION_TYPE, FUTURE_TYPE, GENERATOR_STATE_TYPE, GENERATOR_TYPE, INTEGER_TYPE, INTERFACE_TYPE,
+    ITERATOR_TYPE, OBJECT_TYPE, OPTION_TYPE, RESULT_TYPE, STREAM_TYPE, STRING_TYPE, TUPLE_TYPE,
+    UNIT_TYPE, VEC_TYPE,
 };
 pub use self::stream::Stream;
 pub use self::to_value::{ToValue, UnsafeToValue};

--- a/crates/runestick/src/modules/object.rs
+++ b/crates/runestick/src/modules/object.rs
@@ -14,13 +14,9 @@ pub fn module() -> Result<Module, ContextError> {
     module.inst_fn("contains_key", contains_key)?;
     module.inst_fn("get", get)?;
 
-    module.inst_fn("iter", object_iter)?;
-    module.inst_fn(crate::INTO_ITER, object_iter)?;
+    module.inst_fn("iter", Object::into_iterator)?;
+    module.inst_fn(crate::INTO_ITER, Object::into_iterator)?;
     Ok(module)
-}
-
-fn object_iter(object: &Object) -> crate::Iterator {
-    crate::Iterator::from("std::object::Iter", object.clone().into_iter())
 }
 
 fn contains_key(object: &Object, key: &str) -> bool {

--- a/crates/runestick/src/modules/vec.rs
+++ b/crates/runestick/src/modules/vec.rs
@@ -9,16 +9,12 @@ pub fn module() -> Result<Module, ContextError> {
     module.ty::<Vec>()?;
 
     module.function(&["Vec", "new"], Vec::new)?;
-    module.inst_fn("iter", vec_iter)?;
+    module.inst_fn("iter", Vec::into_iterator)?;
     module.inst_fn("len", Vec::len)?;
     module.inst_fn("push", Vec::push)?;
     module.inst_fn("clear", Vec::clear)?;
     module.inst_fn("pop", Vec::pop)?;
 
-    module.inst_fn(crate::INTO_ITER, vec_iter)?;
+    module.inst_fn(crate::INTO_ITER, Vec::into_iterator)?;
     Ok(module)
-}
-
-fn vec_iter(vec: &Vec) -> crate::Iterator {
-    crate::Iterator::from_double_ended("std::vec::Iter", vec.clone().into_iter())
 }

--- a/crates/runestick/src/object.rs
+++ b/crates/runestick/src/object.rs
@@ -201,6 +201,11 @@ impl Object {
     pub(crate) fn debug_struct<'a>(&'a self, item: &'a Item) -> DebugStruct<'a> {
         DebugStruct { item, st: self }
     }
+
+    /// Convert into a runestick iterator.
+    pub fn into_iterator(&self) -> crate::Iterator {
+        crate::Iterator::from("std::object::Iter", self.clone().into_iter())
+    }
 }
 
 impl<'a> IntoIterator for &'a Object {

--- a/crates/runestick/src/serde.rs
+++ b/crates/runestick/src/serde.rs
@@ -88,6 +88,7 @@ impl ser::Serialize for Value {
             }
             Value::Function(..) => Err(ser::Error::custom("cannot serialize function pointers")),
             Value::Format(..) => Err(ser::Error::custom("cannot serialize format specifications")),
+            Value::Iterator(..) => Err(ser::Error::custom("cannot serialize iterators")),
             Value::Any(..) => Err(ser::Error::custom("cannot serialize external objects")),
         }
     }

--- a/crates/runestick/src/static_type.rs
+++ b/crates/runestick/src/static_type.rs
@@ -201,3 +201,19 @@ pub static FORMAT_TYPE: &StaticType = &StaticType {
 };
 
 impl_static_type!(crate::Format => FORMAT_TYPE);
+
+/// The specialized type information for an interface types.
+pub static ITERATOR_TYPE: &StaticType = &StaticType {
+    name: RawStr::from_str("Iterator"),
+    hash: Hash::new(0xe08fbd4d99f308e9),
+};
+
+impl_static_type!(crate::Iterator => ITERATOR_TYPE);
+
+/// The specialized type information for an interface types.
+pub static INTERFACE_TYPE: &StaticType = &StaticType {
+    name: RawStr::from_str("Interface"),
+    hash: Hash::new(0xf2b8e210ba53f362),
+};
+
+impl_static_type!(crate::Interface => INTERFACE_TYPE);

--- a/crates/runestick/src/vec.rs
+++ b/crates/runestick/src/vec.rs
@@ -114,6 +114,11 @@ impl Vec {
     pub fn clear(&mut self) {
         self.inner.clear();
     }
+
+    /// Convert into a runestick iterator.
+    pub fn into_iterator(&self) -> crate::Iterator {
+        crate::Iterator::from_double_ended("std::vec::Iter", self.clone().into_iter())
+    }
 }
 
 impl Named for Vec {

--- a/crates/runestick/src/vm_error.rs
+++ b/crates/runestick/src/vm_error.rs
@@ -297,6 +297,8 @@ pub enum VmErrorKind {
     ExpectedVariant { actual: TypeInfo },
     #[error("{actual} can't be converted to a constant value")]
     ConstNotSupported { actual: TypeInfo },
+    #[error("missing interface environment")]
+    MissingInterfaceEnvironment,
 }
 
 impl VmErrorKind {


### PR DESCRIPTION
This allows for rewriting functions to receive protocols as arguments, an example of this is the now rewritten `Iterator::chain`:

```rust
/// Chain this iterator with another.
pub fn chain(self, other: Interface) -> Result<Self, VmError> {
    let other = other.into_iter()?;

    Ok(Self {
         inner: Inner::Chain(Box::new(Chain {
             a: Some(self.inner),
             b: Some(other.inner),
        })),
    })
}
```
This used to receive `other: Iterator`, meaning the caller has to convert the argument into an iterator. This is now instead done in the caller.

This requires the addition of a thread-local and a little bit of unsafe. Without this, we would have to pass an optional environment into every vm call, which would be messy to do with external abstractions like `Function`. But it also means that external abstractions will error if an environment is not available.