### PR TITLE
Make fields for struct meta non-optional

### DIFF
--- a/crates/rune/src/compiling/assemble/expr_object.rs
+++ b/crates/rune/src/compiling/assemble/expr_object.rs
@@ -49,19 +49,19 @@ impl Assemble for ast::ExprObject {
 
                 match &meta.kind {
                     CompileMetaKind::UnitStruct { .. } => {
-                        check_object_fields(Some(&HashSet::new()), check_keys, span, &meta.item)?;
+                        check_object_fields(&HashSet::new(), check_keys, span, &meta.item)?;
 
                         let hash = Hash::type_hash(&meta.item);
                         c.asm.push(Inst::UnitStruct { hash }, span);
                     }
                     CompileMetaKind::Struct { object, .. } => {
-                        check_object_fields(object.fields.as_ref(), check_keys, span, &meta.item)?;
+                        check_object_fields(&object.fields, check_keys, span, &meta.item)?;
 
                         let hash = Hash::type_hash(&meta.item);
                         c.asm.push(Inst::Struct { hash, slot }, span);
                     }
                     CompileMetaKind::StructVariant { object, .. } => {
-                        check_object_fields(object.fields.as_ref(), check_keys, span, &meta.item)?;
+                        check_object_fields(&object.fields, check_keys, span, &meta.item)?;
 
                         let hash = Hash::type_hash(&meta.item);
                         c.asm.push(Inst::StructVariant { hash, slot }, span);
@@ -90,20 +90,12 @@ impl Assemble for ast::ExprObject {
 }
 
 fn check_object_fields(
-    fields: Option<&HashSet<Box<str>>>,
+    fields: &HashSet<Box<str>>,
     check_keys: Vec<(Box<str>, Span)>,
     span: Span,
     item: &Item,
 ) -> CompileResult<()> {
-    let mut fields = match fields {
-        Some(fields) => fields.clone(),
-        None => {
-            return Err(CompileError::new(
-                span,
-                CompileErrorKind::MissingItem { item: item.clone() },
-            ));
-        }
-    };
+    let mut fields = fields.clone();
 
     for (field, span) in check_keys {
         if !fields.remove(&field) {

--- a/crates/rune/src/compiling/compiler.rs
+++ b/crates/rune/src/compiling/compiler.rs
@@ -550,17 +550,7 @@ impl<'a> Compiler<'a> {
                     }
                 };
 
-                let fields = match &object.fields {
-                    Some(fields) => fields,
-                    None => {
-                        // NB: might want to describe that field composition is unknown because it is an external meta item.
-                        return Err(CompileError::expected_meta(
-                            span,
-                            meta,
-                            "type that can be used in an object pattern",
-                        ));
-                    }
-                };
+                let fields = &object.fields;
 
                 for binding in &bindings {
                     if !fields.contains(binding.key()) {

--- a/crates/rune/src/query/mod.rs
+++ b/crates/rune/src/query/mod.rs
@@ -1734,9 +1734,7 @@ fn struct_body_meta(
         fields.insert(name.into());
     }
 
-    let object = CompileMetaStruct {
-        fields: Some(fields),
-    };
+    let object = CompileMetaStruct { fields };
 
     Ok(match enum_item {
         Some(enum_item) => CompileMetaKind::StructVariant {

--- a/crates/runestick/src/compile_meta.rs
+++ b/crates/runestick/src/compile_meta.rs
@@ -213,7 +213,7 @@ pub struct CompileMetaEmpty {
 #[derive(Debug, Clone)]
 pub struct CompileMetaStruct {
     /// Fields associated with the type.
-    pub fields: Option<HashSet<Box<str>>>,
+    pub fields: HashSet<Box<str>>,
 }
 
 /// The metadata about a variant.

--- a/crates/runestick/src/context.rs
+++ b/crates/runestick/src/context.rs
@@ -401,7 +401,9 @@ impl Context {
             item,
             kind: CompileMetaKind::Struct {
                 type_hash,
-                object: CompileMetaStruct { fields: None },
+                object: CompileMetaStruct {
+                    fields: Default::default(),
+                },
             },
             source: None,
         })?;


### PR DESCRIPTION
This allows for pattern matching over external types.