### PR TITLE
add `file!()` and `line!()` macros

### DIFF
--- a/crates/rune-modules/Cargo.toml
+++ b/crates/rune-modules/Cargo.toml
@@ -11,12 +11,12 @@ documentation = "https://docs.rs/rune-modules"
 keywords = ["language", "scripting"]
 categories = []
 description = """
-Native modules for Rune, an embeddable dynamic programming language for Rust. 
+Native modules for Rune, an embeddable dynamic programming language for Rust.
 """
 
 [features]
-default = ["test", "core", "io", "fmt"]
-full = ["time", "http", "json", "toml", "fs", "process", "signal", "rand", "io", "fmt"]
+default = ["test", "core", "io", "fmt", "macros"]
+full = ["time", "http", "json", "toml", "fs", "process", "signal", "rand", "io", "fmt", "macros"]
 time = ["tokio", "tokio/time"]
 fs = ["tokio", "tokio/fs"]
 http = ["reqwest"]
@@ -29,6 +29,7 @@ test = []
 core = []
 io = []
 fmt = []
+macros = []
 
 [dependencies]
 reqwest = {version = "0.10.7", optional = true, default-features = false, features = ["rustls-tls", "gzip", "json"]}

--- a/crates/rune-modules/src/lib.rs
+++ b/crates/rune-modules/src/lib.rs
@@ -131,6 +131,7 @@ modules! {
     http, "http",
     io, "io",
     json, "json",
+    macros, "macros",
     process, "process",
     rand, "rand",
     signal, "signal",

--- a/crates/rune-modules/src/macros.rs
+++ b/crates/rune-modules/src/macros.rs
@@ -15,9 +15,17 @@
 //! ```rust
 //! # fn main() -> runestick::Result<()> {
 //! let mut context = runestick::Context::with_default_modules()?;
-//! context.install(&rune_modules::macros::module()?)?;
+//! context.install(&rune_modules::macros::module(true)?)?;
 //! # Ok(())
 //! # }
+//! ```
+//!
+//! Use it in Rune:
+//!
+//! ```rust,ignore
+//! fn main() {
+//!     println(`Hello from ${file!()}:${line!()});
+//! }
 //! ```
 
 use rune::{Parser, TokenStream};

--- a/crates/rune-modules/src/macros.rs
+++ b/crates/rune-modules/src/macros.rs
@@ -1,0 +1,57 @@
+//! `std::macros` module for the [Rune Language].
+//!
+//! [Rune Language]: https://rune-rs.github.io
+//!
+//! ## Usage
+//!
+//! Add the following to your `Cargo.toml`:
+//!
+//! ```toml
+//! rune-modules = {version = "0.7.0", features = ["macros"]}
+//! ```
+//!
+//! Install it into your context:
+//!
+//! ```rust
+//! # fn main() -> runestick::Result<()> {
+//! let mut context = runestick::Context::with_default_modules()?;
+//! context.install(&rune_modules::macros::module()?)?;
+//! # Ok(())
+//! # }
+//! ```
+
+use rune::{Parser, TokenStream};
+
+/// Construct the supplemental `std::macros` module.
+pub fn module(_unused: bool) -> Result<runestick::Module, runestick::ContextError> {
+    let mut builtins = runestick::Module::new(&["std", "macros", "builtin"]);
+    builtins.macro_(&["file"], emit_file)?;
+    builtins.macro_(&["line"], emit_line)?;
+    Ok(builtins)
+}
+
+/// Implementation for the `line!()` macro
+pub(crate) fn emit_line(stream: &TokenStream) -> runestick::Result<TokenStream> {
+    let mut parser = Parser::from_token_stream(stream);
+
+    parser.eof()?;
+
+    Ok(rune::quote!(
+        #[builtin]
+        line!()
+    )
+    .into_token_stream())
+}
+
+/// Implementation for the `file!()` macro
+pub(crate) fn emit_file(stream: &TokenStream) -> runestick::Result<TokenStream> {
+    let mut parser = Parser::from_token_stream(stream);
+
+    parser.eof()?;
+
+    Ok(rune::quote!(
+        #[builtin]
+        file!()
+    )
+    .into_token_stream())
+}

--- a/crates/rune/src/compiling/assemble/expr.rs
+++ b/crates/rune/src/compiling/assemble/expr.rs
@@ -99,6 +99,12 @@ impl Assemble for ast::Expr {
                     BuiltInMacro::Format(format) => {
                         format.assemble(c, needs)?;
                     }
+                    BuiltInMacro::Line(line) => {
+                        line.value.assemble(c, needs)?;
+                    }
+                    BuiltInMacro::File(file) => {
+                        file.value.assemble(c, needs)?;
+                    }
                 }
             }
             // NB: declarations are not used in this compilation stage.

--- a/crates/rune/src/compiling/unit_builder.rs
+++ b/crates/rune/src/compiling/unit_builder.rs
@@ -101,6 +101,9 @@ impl UnitBuilder {
         this.prelude
             .insert("assert_eq".into(), Item::of(&["std", "test", "assert_eq"]));
 
+        this.prelude.insert("line".into(), Item::of(&["std", "macros", "builtin", "line"]));
+        this.prelude.insert("file".into(), Item::of(&["std", "macros", "builtin", "file"]));
+
         Self {
             inner: Rc::new(RefCell::new(this)),
         }

--- a/crates/rune/src/query/mod.rs
+++ b/crates/rune/src/query/mod.rs
@@ -31,6 +31,8 @@ mod query_error;
 pub(crate) enum BuiltInMacro {
     Template(BuiltInTemplate),
     Format(BuiltInFormat),
+    File(BuiltInFile),
+    Line(BuiltInLine),
 }
 
 /// An internally resolved template.
@@ -60,6 +62,22 @@ pub(crate) struct BuiltInFormat {
     pub(crate) format_type: Option<(ast::Ident, format::Type)>,
     /// The value being formatted.
     pub(crate) value: ast::Expr,
+}
+
+/// Macro data for `file!()`
+pub struct BuiltInFile {
+    /// The span of the built-in-file
+    pub(crate) span: Span,
+    /// Path value to use
+    pub(crate) value: ast::LitStr,
+}
+
+/// Macro data for `line!()`
+pub struct BuiltInLine {
+    /// The span of the built-in-file
+    pub(crate) span: Span,
+    /// The line number
+    pub(crate) value: ast::LitNumber,
 }
 
 pub use self::query_error::{QueryError, QueryErrorKind};


### PR DESCRIPTION
Hello!

From discussion on Discord - this adds the `file!()` and `line!()` macros, which transform into string and number literals representing the current filename and line number (1-indexed). I tried to follow the pattern from `format!()`, but it seems a bit awkward being unable to implement these in runestick, instead feature-gating it in `rune-modules`.

```
➜ cat test.rn
pub fn main() {
   println(`Hello from ${file!()}:${line!()}`);
}

➜ target/release/rune test.rn
Hello from test.rn:2
== () (25.346µs)
```