### PR TITLE
add std macros to rune-wasm

### DIFF
--- a/crates/rune-wasm/Cargo.toml
+++ b/crates/rune-wasm/Cargo.toml
@@ -25,7 +25,7 @@ parking_lot = "0.11.0"
 
 rune = {version = "0.7.0", path = "../rune", features = []}
 rune-macros = {version = "0.7.0", path = "../rune-macros"}
-rune-modules = {version = "0.7.0", path = "../rune-modules", features = ["core", "test", "json", "toml", "rand", "experiments"]}
+rune-modules = {version = "0.7.0", path = "../rune-modules", features = ["core", "test", "json", "toml", "rand", "experiments", "macros"]}
 runestick = {version = "0.7.0", path = "../runestick"}
 
 [dependencies.web-sys]

--- a/crates/rune-wasm/src/lib.rs
+++ b/crates/rune-wasm/src/lib.rs
@@ -169,6 +169,7 @@ fn setup_context(experimental: bool) -> Result<runestick::Context, ContextError>
     context.install(&rune_modules::core::module(false)?)?;
     context.install(&rune_modules::test::module(false)?)?;
     context.install(&rune_modules::io::module(false)?)?;
+    context.install(&rune_modules::macros::module(false)?)?;
 
     if experimental {
         context.install(&rune_modules::experiments::module(false)?)?;


### PR DESCRIPTION
This should make the builtin macros available on the webpage too.