### PR TITLE
Get rid of reverse lookup of items

### DIFF
--- a/crates/rune/src/query/query_error.rs
+++ b/crates/rune/src/query/query_error.rs
@@ -72,8 +72,6 @@ pub enum QueryErrorKind {
         item: Item,
         from: Item,
     },
-    #[error("missing reverse lookup for `{item}`")]
-    MissingRevItem { item: Item },
     #[error("missing item for id {id:?}")]
     MissingRevId { id: Id },
     #[error("missing query meta for module {item}")]


### PR DESCRIPTION
Reverse lookup of ids was a temporary measure to lookup `CompileItem` from an `Item`. This changes `Items` to keep track of inserted identifiers so that the exact `CompileItem` can be looked up by `Id` directly instead.