### PR TITLE
Simplify and fix imports for better visibility checks

### DIFF
--- a/crates/rune/src/compiling/compile_error.rs
+++ b/crates/rune/src/compiling/compile_error.rs
@@ -5,9 +5,7 @@ use crate::{
     ResolveErrorKind, Spanned,
 };
 use runestick::debug::DebugSignature;
-use runestick::{
-    CompileMeta, Hash, Item, Label, Location, SourceId, Span, SpannedError, Visibility,
-};
+use runestick::{CompileMeta, Hash, Item, Label, Location, SourceId, Span, SpannedError};
 use std::io;
 use std::path::PathBuf;
 use thiserror::Error;
@@ -287,8 +285,6 @@ pub enum CompileErrorKind {
 pub struct ImportEntryStep {
     /// The location of the import.
     pub location: Location,
-    /// The visibility of the import.
-    pub visibility: Visibility,
     /// The item being imported.
     pub item: Item,
 }

--- a/crates/rune/src/indexing/index.rs
+++ b/crates/rune/src/indexing/index.rs
@@ -742,7 +742,7 @@ impl Index for ast::ItemFn {
             idx.query.insert_meta(span, meta)?;
         } else {
             idx.query.index(IndexedEntry {
-                query_item: item,
+                item,
                 source: idx.source.clone(),
                 indexed: Indexed::Function(fun),
             });

--- a/crates/rune/src/query/query_error.rs
+++ b/crates/rune/src/query/query_error.rs
@@ -56,7 +56,7 @@ pub enum QueryErrorKind {
         item: Item,
         locations: Vec<(Location, Item)>,
     },
-    #[error("item `{item}` with {visibility} visibility, is not accessible from `{from}`")]
+    #[error("`{item}` with {visibility} visibility, is not accessible from module `{from}`")]
     NotVisible {
         chain: Vec<Location>,
         location: Location,
@@ -64,7 +64,9 @@ pub enum QueryErrorKind {
         item: Item,
         from: Item,
     },
-    #[error("module `{item}` with {visibility} visibility, is not accessible from `{from}`")]
+    #[error(
+        "module `{item}` with {visibility} visibility, is not accessible from module `{from}`"
+    )]
     NotVisibleMod {
         chain: Vec<Location>,
         location: Location,

--- a/crates/rune/tests/test_all/compiler_use.rs
+++ b/crates/rune/tests/test_all/compiler_use.rs
@@ -37,7 +37,7 @@ fn test_import_cycle() {
         "#,
         span, QueryError { error: ImportCycle { path, .. } } => {
             assert_eq!(span, Span::new(177, 183));
-            assert_eq!(2, path.len());
+            assert_eq!(3, path.len());
             assert_eq!(Span::new(107, 120), path[0].location.span);
             assert_eq!(Span::new(37, 50), path[1].location.span);
         }

--- a/crates/rune/tests/test_all/compiler_visibility.rs
+++ b/crates/rune/tests/test_all/compiler_visibility.rs
@@ -46,6 +46,25 @@ fn test_access_hidden() {
 }
 
 #[test]
+fn test_hidden_reexport() {
+    assert_compile_error! {
+        r#"
+        mod a { struct Foo; }
+
+        mod b {
+            use crate::a::Foo;
+            pub fn test() { Foo }
+        }
+
+        pub fn main() { b::test() }
+        "#,
+        span, QueryError { error: NotVisible { .. } } => {
+            assert_eq!(span, Span::new(107, 110));
+        }
+    }
+}
+
+#[test]
 fn test_indirect_access() {
     let result = rune! { i64 =>
         mod d {

--- a/crates/runestick/src/compile_meta.rs
+++ b/crates/runestick/src/compile_meta.rs
@@ -197,6 +197,10 @@ pub enum CompileMetaKind {
     },
     /// Purely an import.
     Import {
+        /// The module of the target.
+        module: Arc<CompileMod>,
+        /// The location of the import.
+        location: Location,
         /// The imported target.
         target: Item,
     },


### PR DESCRIPTION
This (among other things) makes sure that the following visibility test fails:

```rust
mod a { struct Foo; }

mod b {
    use crate::a::Foo;
    pub fn test() { Foo }
}

pub fn main() { b::test() }
```