### PR TITLE
make ContextSignature, ContextTypeInfo public

### DIFF
--- a/crates/runestick/src/context.rs
+++ b/crates/runestick/src/context.rs
@@ -124,12 +124,14 @@ impl fmt::Display for ContextTypeInfo {
 /// A description of a function signature.
 #[derive(Debug, Clone)]
 pub enum ContextSignature {
+    /// An unbound or static function
     Function {
         /// Path to the function.
         item: Item,
         /// Arguments.
         args: Option<usize>,
     },
+    /// An instance function or method
     Instance {
         /// Path to the instance function.
         item: Item,

--- a/crates/runestick/src/lib.rs
+++ b/crates/runestick/src/lib.rs
@@ -187,7 +187,7 @@ pub use crate::any::Any;
 pub use crate::awaited::Awaited;
 pub use crate::bytes::Bytes;
 pub use crate::call::Call;
-pub use crate::context::{Context, ContextError};
+pub use crate::context::{Context, ContextError, ContextSignature, ContextTypeInfo};
 pub use crate::debug::{DebugInfo, DebugInst};
 pub use crate::function::{Function, SyncFunction};
 pub use crate::future::Future;


### PR DESCRIPTION
These are part of the public Context API but the enum is unusable since it's not exported. And also, since they are not public you don't get proper information shown on docs.rs:
![image](https://user-images.githubusercontent.com/8234817/100514068-f536b200-3171-11eb-9eee-0292ba96bfc4.png)
