### PR TITLE
minimal support for non-default LSPs

### DIFF
--- a/crates/rune-languageserver/src/lib.rs
+++ b/crates/rune-languageserver/src/lib.rs
@@ -55,3 +55,182 @@ pub use crate::connection::stdio;
 pub use crate::connection::{Input, Output};
 pub use crate::server::Server;
 pub use crate::state::State;
+use anyhow::Result;
+use tokio::sync::mpsc;
+
+pub fn run(context: runestick::Context, options: rune::Options) -> Result<()> {
+    let (mut input, output) = stdio()?;
+
+    let (rebuild_tx, mut rebuild_rx) = mpsc::channel(1);
+
+    let mut server = Server::new(output, rebuild_tx, context, options);
+
+    server.request_handler::<lsp::request::Initialize, _, _>(initialize);
+
+    server.request_handler::<lsp::request::GotoDefinition, _, _>(goto_definition);
+
+    server.notification_handler::<lsp::notification::DidOpenTextDocument, _, _>(
+        did_open_text_document,
+    );
+    server.notification_handler::<lsp::notification::DidChangeTextDocument, _, _>(
+        did_change_text_document,
+    );
+    server.notification_handler::<lsp::notification::DidCloseTextDocument, _, _>(
+        did_close_text_document,
+    );
+    server.notification_handler::<lsp::notification::DidSaveTextDocument, _, _>(
+        did_save_text_document,
+    );
+    server.notification_handler::<lsp::notification::Initialized, _, _>(initialized);
+
+    log::info!("Starting server");
+
+    tokio::runtime::Runtime::new()?.block_on(async {
+        loop {
+            tokio::select! {
+                _ = rebuild_rx.recv() => {
+                    server.rebuild().await?;
+                },
+                frame = input.next() => {
+                    let frame = match frame? {
+                        Some(frame) => frame,
+                        None => break,
+                    };
+
+                    let request: envelope::IncomingMessage = serde_json::from_slice(frame.content)?;
+                    server.process(request).await?;
+                },
+            }
+        }
+        Ok(())
+    })
+}
+
+/// Initialize the language server.
+async fn initialize(
+    state: State,
+    output: Output,
+    _: lsp::InitializeParams,
+) -> Result<lsp::InitializeResult> {
+    state.initialize();
+
+    output
+        .log(lsp::MessageType::Info, "Starting language server")
+        .await?;
+
+    let mut capabilities = lsp::ServerCapabilities::default();
+
+    capabilities.text_document_sync = Some(lsp::TextDocumentSyncCapability::Kind(
+        lsp::TextDocumentSyncKind::Incremental,
+    ));
+
+    capabilities.definition_provider = Some(true);
+
+    let server_info = lsp::ServerInfo {
+        name: String::from("Rune Language Server"),
+        version: None,
+    };
+
+    Ok(lsp::InitializeResult {
+        capabilities,
+        server_info: Some(server_info),
+    })
+}
+
+/// Handle initialized notification.
+async fn initialized(_: State, _: Output, _: lsp::InitializedParams) -> Result<()> {
+    log::info!("Initialized");
+    Ok(())
+}
+
+/// Handle initialized notification.
+async fn goto_definition(
+    state: State,
+    _: Output,
+    params: lsp::GotoDefinitionParams,
+) -> Result<Option<lsp::GotoDefinitionResponse>> {
+    let position = state
+        .goto_definition(
+            &params.text_document_position_params.text_document.uri,
+            params.text_document_position_params.position,
+        )
+        .await;
+
+    Ok(position.map(lsp::GotoDefinitionResponse::Scalar))
+}
+
+/// Handle open text document.
+async fn did_open_text_document(
+    state: State,
+    _: Output,
+    params: lsp::DidOpenTextDocumentParams,
+) -> Result<()> {
+    let mut sources = state.sources_mut().await;
+
+    if sources
+        .insert_text(params.text_document.uri.clone(), params.text_document.text)
+        .is_some()
+    {
+        log::warn!(
+            "opened text document `{}`, but it was already open!",
+            params.text_document.uri
+        );
+    }
+
+    state.rebuild_interest().await?;
+    Ok(())
+}
+
+/// Handle open text document.
+async fn did_change_text_document(
+    state: State,
+    _: Output,
+    params: lsp::DidChangeTextDocumentParams,
+) -> Result<()> {
+    let mut interest = false;
+
+    {
+        let mut sources = state.sources_mut().await;
+
+        if let Some(source) = sources.get_mut(&params.text_document.uri) {
+            for change in params.content_changes {
+                if let Some(range) = change.range {
+                    source.modify_lsp_range(range, &change.text)?;
+                    interest = true;
+                }
+            }
+        } else {
+            log::warn!(
+                "tried to modify `{}`, but it was not open!",
+                params.text_document.uri
+            );
+        }
+    }
+
+    if interest {
+        state.rebuild_interest().await?;
+    }
+
+    Ok(())
+}
+
+/// Handle open text document.
+async fn did_close_text_document(
+    state: State,
+    _: Output,
+    params: lsp::DidCloseTextDocumentParams,
+) -> Result<()> {
+    let mut sources = state.sources_mut().await;
+    sources.remove(&params.text_document.uri);
+    state.rebuild_interest().await?;
+    Ok(())
+}
+
+/// Handle saving of text documents.
+async fn did_save_text_document(
+    _: State,
+    _: Output,
+    _: lsp::DidSaveTextDocumentParams,
+) -> Result<()> {
+    Ok(())
+}

--- a/crates/rune-languageserver/src/main.rs
+++ b/crates/rune-languageserver/src/main.rs
@@ -45,10 +45,7 @@
 //! [Rune Language]: https://rune-rs.github.io
 
 use anyhow::{bail, Result};
-use rune_languageserver::envelope::IncomingMessage;
-use rune_languageserver::{Output, Server, State};
 use std::env;
-use tokio::sync::mpsc;
 
 fn setup_logging() -> Result<()> {
     // Set environment variable to get the language server to trace log to the
@@ -73,8 +70,7 @@ fn setup_logging() -> Result<()> {
     Ok(())
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
     setup_logging()?;
 
     let mut it = env::args();
@@ -99,177 +95,5 @@ async fn main() -> Result<()> {
     let mut options = rune::Options::default();
     options.macros(true);
 
-    let (mut input, output) = rune_languageserver::stdio()?;
-
-    let (rebuild_tx, mut rebuild_rx) = mpsc::channel(1);
-
-    let mut server = Server::new(output.clone(), rebuild_tx, context, options);
-
-    server.request_handler::<lsp::request::Initialize, _, _>(initialize);
-
-    server.request_handler::<lsp::request::GotoDefinition, _, _>(goto_definition);
-
-    server.notification_handler::<lsp::notification::DidOpenTextDocument, _, _>(
-        did_open_text_document,
-    );
-    server.notification_handler::<lsp::notification::DidChangeTextDocument, _, _>(
-        did_change_text_document,
-    );
-    server.notification_handler::<lsp::notification::DidCloseTextDocument, _, _>(
-        did_close_text_document,
-    );
-    server.notification_handler::<lsp::notification::DidSaveTextDocument, _, _>(
-        did_save_text_document,
-    );
-    server.notification_handler::<lsp::notification::Initialized, _, _>(initialized);
-
-    log::info!("Starting server");
-
-    loop {
-        tokio::select! {
-            _ = rebuild_rx.recv() => {
-                server.rebuild().await?;
-            },
-            frame = input.next() => {
-                let frame = match frame? {
-                    Some(frame) => frame,
-                    None => break,
-                };
-
-                let request: IncomingMessage = serde_json::from_slice(frame.content)?;
-                server.process(request).await?;
-            },
-        }
-    }
-
-    Ok(())
-}
-
-/// Initialize the language server.
-async fn initialize(
-    state: State,
-    output: Output,
-    _: lsp::InitializeParams,
-) -> Result<lsp::InitializeResult> {
-    state.initialize();
-
-    output
-        .log(lsp::MessageType::Info, "Starting language server")
-        .await?;
-
-    let mut capabilities = lsp::ServerCapabilities::default();
-
-    capabilities.text_document_sync = Some(lsp::TextDocumentSyncCapability::Kind(
-        lsp::TextDocumentSyncKind::Incremental,
-    ));
-
-    capabilities.definition_provider = Some(true);
-
-    let server_info = lsp::ServerInfo {
-        name: String::from("Rune Language Server"),
-        version: None,
-    };
-
-    Ok(lsp::InitializeResult {
-        capabilities,
-        server_info: Some(server_info),
-    })
-}
-
-/// Handle initialized notification.
-async fn initialized(_: State, _: Output, _: lsp::InitializedParams) -> Result<()> {
-    log::info!("Initialized");
-    Ok(())
-}
-
-/// Handle initialized notification.
-async fn goto_definition(
-    state: State,
-    _: Output,
-    params: lsp::GotoDefinitionParams,
-) -> Result<Option<lsp::GotoDefinitionResponse>> {
-    let position = state
-        .goto_definition(
-            &params.text_document_position_params.text_document.uri,
-            params.text_document_position_params.position,
-        )
-        .await;
-
-    Ok(position.map(lsp::GotoDefinitionResponse::Scalar))
-}
-
-/// Handle open text document.
-async fn did_open_text_document(
-    state: State,
-    _: Output,
-    params: lsp::DidOpenTextDocumentParams,
-) -> Result<()> {
-    let mut sources = state.sources_mut().await;
-
-    if sources
-        .insert_text(params.text_document.uri.clone(), params.text_document.text)
-        .is_some()
-    {
-        log::warn!(
-            "opened text document `{}`, but it was already open!",
-            params.text_document.uri
-        );
-    }
-
-    state.rebuild_interest().await?;
-    Ok(())
-}
-
-/// Handle open text document.
-async fn did_change_text_document(
-    state: State,
-    _: Output,
-    params: lsp::DidChangeTextDocumentParams,
-) -> Result<()> {
-    let mut interest = false;
-
-    {
-        let mut sources = state.sources_mut().await;
-
-        if let Some(source) = sources.get_mut(&params.text_document.uri) {
-            for change in params.content_changes {
-                if let Some(range) = change.range {
-                    source.modify_lsp_range(range, &change.text)?;
-                    interest = true;
-                }
-            }
-        } else {
-            log::warn!(
-                "tried to modify `{}`, but it was not open!",
-                params.text_document.uri
-            );
-        }
-    }
-
-    if interest {
-        state.rebuild_interest().await?;
-    }
-
-    Ok(())
-}
-
-/// Handle open text document.
-async fn did_close_text_document(
-    state: State,
-    _: Output,
-    params: lsp::DidCloseTextDocumentParams,
-) -> Result<()> {
-    let mut sources = state.sources_mut().await;
-    sources.remove(&params.text_document.uri);
-    state.rebuild_interest().await?;
-    Ok(())
-}
-
-/// Handle saving of text documents.
-async fn did_save_text_document(
-    _: State,
-    _: Output,
-    _: lsp::DidSaveTextDocumentParams,
-) -> Result<()> {
-    Ok(())
+    rune_languageserver::run(context, options)
 }

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -62,7 +62,17 @@
                 "scopeName": "source.rune",
                 "path": "./syntaxes/rune.tmGrammar.json"
             }
-        ]
+        ],
+        "configuration": {
+            "title": "Rune",
+            "properties": {
+                "rune.binaryPath": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Path to LSP server"
+                }
+            }
+        }
     },
     "activationEvents": [
         "onLanguage:rune"

--- a/editors/code/src/settings.ts
+++ b/editors/code/src/settings.ts
@@ -1,0 +1,13 @@
+import * as vscode from "vscode";
+
+
+export interface ISettings {
+    binaryPath: string,
+}
+
+export function load(myPluginId: string): ISettings {
+    let configuration = vscode.workspace.getConfiguration(myPluginId);
+    return {
+        binaryPath: configuration.get<string>("binaryPath", "")
+    }
+}


### PR DESCRIPTION
This adds support for using the LSP implemenation from other workspaces to expose custom bindings without reimplementing the whole binary. To make this easier, it also adds a VSCode extension setting so you can set the binary path to where your custom LSP lives. This gives you a workspace file with a minimum:

```json
{
    "rune.binaryPath": "/home/tgolsson/Repos/rune/target/release/rune-languageserver"
}
```

This is me using a locally built version of the rune languageserver as I build the whole toolchain locally.

For a fully custom integration, I do this when I'm working on my game-engine:

```rust
extern crate binds;
fn main() -> anyhow::Result<()> {
        let mut context = rune_modules::default_context()?;

        for module in binds::all_modules() {
            context.install(&module)?;
        }

        let mut options = rune::Options::default();
        options.macros(true);

        rune_languageserver::run(context, options)
}
```

and use a workspace file targeting this binary instead.
