### PR TITLE
Improve runtime hashing performance

### DIFF
--- a/crates/runestick/src/hash.rs
+++ b/crates/runestick/src/hash.rs
@@ -9,8 +9,8 @@ use twox_hash::XxHash64;
 
 const SEP: usize = 0x7f;
 const TYPE: usize = 1;
-const INSTANCE_FUNCTION: usize = 2;
-const FIELD_FN: usize = 3;
+const INSTANCE_FUNCTION_HASH: u64 = 0x5ea77ffbcdf5f302;
+const FIELD_FUNCTION_HASH: u64 = 0xab53b6a7a53c757e;
 const OBJECT_KEYS: usize = 4;
 
 /// The hash of a primitive thing.
@@ -56,21 +56,23 @@ impl Hash {
 
     /// Construct a hash to an instance function, where the instance is a
     /// pre-determined type.
+    #[inline]
     pub fn instance_function<N>(type_hash: Hash, name: N) -> Self
     where
         N: InstFnNameHash,
     {
         let name = name.inst_fn_name_hash();
-        Self::of((INSTANCE_FUNCTION, type_hash, SEP, name))
+        Self(INSTANCE_FUNCTION_HASH ^ (type_hash.0 ^ name.0))
     }
 
     /// Construct a hash corresponding to a field function.
+    #[inline]
     pub fn field_fn<N>(protocol: Protocol, type_hash: Hash, name: N) -> Self
     where
         N: InstFnNameHash,
     {
         let name = name.inst_fn_name_hash();
-        Self::of((FIELD_FN, protocol.hash, SEP, type_hash, SEP, name))
+        Self(FIELD_FUNCTION_HASH ^ ((type_hash.0 ^ protocol.hash.0) ^ name.0))
     }
 
     /// Get the hash corresponding to a static byte array.

--- a/crates/runestick/src/module.rs
+++ b/crates/runestick/src/module.rs
@@ -711,6 +711,7 @@ impl<'a> InstFnNameHash for &'a str {
 }
 
 impl<'a> InstFnNameHash for Hash {
+    #[inline]
     fn inst_fn_name_hash(self) -> Hash {
         self
     }


### PR DESCRIPTION
This improves the performance of common runtime hashing operations.

Improves the performance of the `aoc_2020_1b` benchmark by ~10% since this utilizes instance fns heavily.

Before:
```
test aoc_2020_1b ... bench:     668,483 ns/iter (+/- 20,836)
```

After:
```
test aoc_2020_1b ... bench:     582,291 ns/iter (+/- 12,307)
```

Thanks to @tgolsson for highlighting this!