### PR TITLE
Changes for AoC Day 3

### DIFF
--- a/crates/rune-modules/src/core.rs
+++ b/crates/rune-modules/src/core.rs
@@ -26,7 +26,7 @@ use rune::{quote, Parser, TokenStream};
 
 /// Construct the `std::core` module.
 pub fn module(_stdio: bool) -> Result<runestick::Module, runestick::ContextError> {
-    let mut module = runestick::Module::with_crate_item("std", &["core"]);
+    let mut module = runestick::Module::with_crate("std");
     module.macro_(&["stringify"], stringify_macro)?;
     module.macro_(&["panic"], panic_macro)?;
     Ok(module)

--- a/crates/rune-wasm/rollup.config.js
+++ b/crates/rune-wasm/rollup.config.js
@@ -3,14 +3,14 @@ import rust from "@wasm-tool/rollup-plugin-rust";
 export default {
     input: "rune.js",
     output: {
-        dir: "../../site/static/rune",
+        dir: "../../site/static/js",
         format: "iife",
         name: "rune",
         sourcemap: true,
     },
     plugins: [
         rust({
-            serverPath: "/rune/"
+            serverPath: "/js/"
         }),
     ],
 };

--- a/crates/rune/src/compiling/unit_builder.rs
+++ b/crates/rune/src/compiling/unit_builder.rs
@@ -41,31 +41,31 @@ impl UnitBuilder {
 
         this.prelude("assert_eq", &["test", "assert_eq"]);
         this.prelude("assert", &["test", "assert"]);
-        this.prelude("bool", &["core", "bool"]);
-        this.prelude("byte", &["core", "byte"]);
-        this.prelude("char", &["core", "char"]);
+        this.prelude("bool", &["bool"]);
+        this.prelude("byte", &["byte"]);
+        this.prelude("char", &["char"]);
         this.prelude("dbg", &["io", "dbg"]);
-        this.prelude("drop", &["core", "drop"]);
+        this.prelude("drop", &["mem", "drop"]);
         this.prelude("Err", &["result", "Result", "Err"]);
         this.prelude("file", &["macros", "builtin", "file"]);
-        this.prelude("float", &["core", "float"]);
+        this.prelude("float", &["float"]);
         this.prelude("format", &["fmt", "format"]);
-        this.prelude("int", &["core", "int"]);
-        this.prelude("is_readable", &["core", "is_readable"]);
-        this.prelude("is_writable", &["core", "is_writable"]);
+        this.prelude("int", &["int"]);
+        this.prelude("is_readable", &["is_readable"]);
+        this.prelude("is_writable", &["is_writable"]);
         this.prelude("line", &["macros", "builtin", "line"]);
         this.prelude("None", &["option", "Option", "None"]);
         this.prelude("Object", &["object", "Object"]);
         this.prelude("Ok", &["result", "Result", "Ok"]);
         this.prelude("Option", &["option", "Option"]);
-        this.prelude("panic", &["core", "panic"]);
+        this.prelude("panic", &["panic"]);
         this.prelude("print", &["io", "print"]);
         this.prelude("println", &["io", "println"]);
         this.prelude("Result", &["result", "Result"]);
         this.prelude("Some", &["option", "Option", "Some"]);
         this.prelude("String", &["string", "String"]);
-        this.prelude("stringify", &["core", "stringify"]);
-        this.prelude("unit", &["core", "unit"]);
+        this.prelude("stringify", &["stringify"]);
+        this.prelude("unit", &["unit"]);
         this.prelude("Vec", &["vec", "Vec"]);
 
         Self {

--- a/crates/runestick/src/context.rs
+++ b/crates/runestick/src/context.rs
@@ -254,6 +254,7 @@ impl Context {
         this.install(&crate::modules::int::module()?)?;
         this.install(&crate::modules::io::module(stdio)?)?;
         this.install(&crate::modules::iter::module()?)?;
+        this.install(&crate::modules::mem::module()?)?;
         this.install(&crate::modules::object::module()?)?;
         this.install(&crate::modules::ops::module()?)?;
         this.install(&crate::modules::option::module()?)?;

--- a/crates/runestick/src/iterator.rs
+++ b/crates/runestick/src/iterator.rs
@@ -257,13 +257,13 @@ impl Iterator {
     }
 
     /// Compute the product under the assumption of a homogeonous iterator of type T.
-    pub fn product(self) -> Result<Option<Value>, VmError> {
+    pub fn product(self) -> Result<Value, VmError> {
         let product = Product { iter: self.iter };
         product.resolve()
     }
 
     /// Compute the sum under the assumption of a homogeonous iterator of type T.
-    pub fn sum(self) -> Result<Option<Value>, VmError> {
+    pub fn sum(self) -> Result<Value, VmError> {
         let sum = Sum { iter: self.iter };
         sum.resolve()
     }
@@ -998,19 +998,21 @@ where
         Ok(product)
     }
 
-    fn resolve(mut self) -> Result<Option<Value>, VmError> {
+    fn resolve(mut self) -> Result<Value, VmError> {
         match self.iter.next()? {
             Some(v) => match v {
-                Value::Byte(v) => Ok(Some(Value::Byte(self.resolve_internal_simple(v)?))),
-                Value::Integer(v) => Ok(Some(Value::Integer(self.resolve_internal_simple(v)?))),
-                Value::Float(v) => Ok(Some(Value::Float(self.resolve_internal_simple(v)?))),
+                Value::Byte(v) => Ok(Value::Byte(self.resolve_internal_simple(v)?)),
+                Value::Integer(v) => Ok(Value::Integer(self.resolve_internal_simple(v)?)),
+                Value::Float(v) => Ok(Value::Float(self.resolve_internal_simple(v)?)),
                 _ => Err(VmError::from(VmErrorKind::UnsupportedBinaryOperation {
                     op: "*",
                     lhs: v.type_info()?,
                     rhs: v.type_info()?,
                 })),
             },
-            None => Ok(None),
+            None => Err(VmError::panic(
+                "cannot take the product of an empty iterator",
+            )),
         }
     }
 }
@@ -1042,19 +1044,19 @@ where
         Ok(sum)
     }
 
-    fn resolve(mut self) -> Result<Option<Value>, VmError> {
+    fn resolve(mut self) -> Result<Value, VmError> {
         match self.iter.next()? {
             Some(v) => match v {
-                Value::Byte(v) => Ok(Some(Value::Byte(self.resolve_internal_simple(v)?))),
-                Value::Integer(v) => Ok(Some(Value::Integer(self.resolve_internal_simple(v)?))),
-                Value::Float(v) => Ok(Some(Value::Float(self.resolve_internal_simple(v)?))),
+                Value::Byte(v) => Ok(Value::Byte(self.resolve_internal_simple(v)?)),
+                Value::Integer(v) => Ok(Value::Integer(self.resolve_internal_simple(v)?)),
+                Value::Float(v) => Ok(Value::Float(self.resolve_internal_simple(v)?)),
                 _ => Err(VmError::from(VmErrorKind::UnsupportedBinaryOperation {
                     op: "*",
                     lhs: v.type_info()?,
                     rhs: v.type_info()?,
                 })),
             },
-            None => Ok(None),
+            None => Err(VmError::panic("cannot take the sum of an empty iterator")),
         }
     }
 }

--- a/crates/runestick/src/modules/core.rs
+++ b/crates/runestick/src/modules/core.rs
@@ -1,10 +1,10 @@
 //! The core `std` module.
 
-use crate::{ContextError, Module, Panic, Value, VmError};
+use crate::{ContextError, Module, Panic, Value};
 
 /// Construct the `std` module.
 pub fn module() -> Result<Module, ContextError> {
-    let mut module = Module::with_crate_item("std", &["core"]);
+    let mut module = Module::with_crate("std");
 
     module.unit("unit")?;
     module.ty::<bool>()?;
@@ -14,54 +14,9 @@ pub fn module() -> Result<Module, ContextError> {
     module.ty::<i64>()?;
 
     module.function(&["panic"], panic_impl)?;
-    module.function(&["drop"], drop_impl)?;
     module.function(&["is_readable"], is_readable)?;
     module.function(&["is_writable"], is_writable)?;
     Ok(module)
-}
-
-fn drop_impl(value: Value) -> Result<(), VmError> {
-    match value {
-        Value::Any(any) => {
-            any.take()?;
-        }
-        Value::String(string) => {
-            string.take()?;
-        }
-        Value::Bytes(bytes) => {
-            bytes.take()?;
-        }
-        Value::Vec(vec) => {
-            vec.take()?;
-        }
-        Value::Tuple(tuple) => {
-            tuple.take()?;
-        }
-        Value::Object(object) => {
-            object.take()?;
-        }
-        Value::UnitStruct(empty) => {
-            empty.take()?;
-        }
-        Value::TupleStruct(tuple) => {
-            tuple.take()?;
-        }
-        Value::Struct(object) => {
-            object.take()?;
-        }
-        Value::UnitVariant(empty) => {
-            empty.take()?;
-        }
-        Value::TupleVariant(tuple) => {
-            tuple.take()?;
-        }
-        Value::StructVariant(object) => {
-            object.take()?;
-        }
-        _ => (),
-    }
-
-    Ok::<(), VmError>(())
 }
 
 fn panic_impl(m: &str) -> Result<(), Panic> {

--- a/crates/runestick/src/modules/float.rs
+++ b/crates/runestick/src/modules/float.rs
@@ -21,6 +21,9 @@ pub fn module() -> Result<Module, ContextError> {
 
     module.ty::<ParseFloatError>()?;
     module.function(&["parse"], parse)?;
+    module.function(&["max"], f64::max)?;
+    module.function(&["min"], f64::min)?;
+
     module.inst_fn("to_integer", to_integer)?;
 
     Ok(module)

--- a/crates/runestick/src/modules/int.rs
+++ b/crates/runestick/src/modules/int.rs
@@ -10,6 +10,8 @@ pub fn module() -> Result<Module, ContextError> {
     module.ty::<ParseIntError>()?;
 
     module.function(&["parse"], parse)?;
+    module.function(&["max"], i64::max)?;
+    module.function(&["min"], i64::min)?;
 
     module.inst_fn("to_float", to_float)?;
 

--- a/crates/runestick/src/modules/mem.rs
+++ b/crates/runestick/src/modules/mem.rs
@@ -1,0 +1,15 @@
+//! The `std::mem` module.
+
+use crate::{ContextError, Module, Value, VmError};
+
+/// Construct the `std` module.
+pub fn module() -> Result<Module, ContextError> {
+    let mut module = Module::with_crate_item("std", &["mem"]);
+    module.function(&["drop"], drop_impl)?;
+    Ok(module)
+}
+
+fn drop_impl(value: Value) -> Result<(), VmError> {
+    value.take()?;
+    Ok(())
+}

--- a/crates/runestick/src/modules/mod.rs
+++ b/crates/runestick/src/modules/mod.rs
@@ -13,6 +13,7 @@ pub mod generator;
 pub mod int;
 pub mod io;
 pub mod iter;
+pub mod mem;
 pub mod object;
 pub mod ops;
 pub mod option;

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -1,2 +1,2 @@
 public/*
-static/rune
+static/js

--- a/site/templates/base.html
+++ b/site/templates/base.html
@@ -60,6 +60,6 @@
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.12/ace.js" integrity="sha512-GZ1RIgZaSc8rnco/8CXfRdCpDxRCphenIiZ2ztLy3XQfCbQUSCuk8IudvNHxkRA3oUg6q0qejgN/qqyG1duv5Q==" crossorigin="anonymous"></script>
     <script type="text/javascript"  src="{{ config.base_url }}/ace/mode-rune.js"></script>
-    <script type="text/javascript"  src="{{ config.base_url }}/rune/rune.js"></script>
+    <script type="text/javascript"  src="{{ config.base_url }}/js/rune.js"></script>
     <script type="text/javascript"  src="{{ config.base_url }}/index.js"></script>
 </html>

--- a/tests/test_iter.rs
+++ b/tests/test_iter.rs
@@ -2,78 +2,42 @@
 
 #[test]
 fn test_sum() {
-    assert_eq!(
-        rune! { Option<u32> =>
-
-            pub fn main() {
-                [1, 2, 3].iter().sum()
-            }
-        },
-        Some(6)
-    )
+    assert_eq!(rune!(u32 => pub fn main() { [1, 2, 3].iter().sum() }), 6)
 }
 
 #[test]
 fn test_sum_negative() {
-    assert_eq!(
-        rune! { Option<i32> =>
-
-            pub fn main() {
-                [1, -2, 3].iter().sum()
-            }
-        },
-        Some(2)
-    )
+    assert_eq!(rune!(i32 => pub fn main() { [1, -2, 3].iter().sum() }), 2)
 }
 
 #[test]
 fn test_prod() {
     assert_eq!(
-        rune! { Option<u32> =>
-
-            pub fn main() {
-                [1, 2, 3, 6].iter().product()
-            }
-        },
-        Some(36)
+        rune!(u32 => pub fn main() { [1, 2, 3, 6].iter().product() }),
+        36
     )
 }
 
 #[test]
 fn test_prod_negative() {
     assert_eq!(
-        rune! { Option<i32> =>
-
-            pub fn main() {
-                [-1, 2, 3, 6].iter().product()
-            }
-        },
-        Some(-36)
+        rune!(i32 => pub fn main() { [-1, 2, 3, 6].iter().product() }),
+        -36
     )
 }
 
 #[test]
 fn test_prod_float() {
     assert_eq!(
-        rune! { Option<f32> =>
-
-            pub fn main() {
-                [1.0, 0.5, 2.0, 3.0].iter().product()
-            }
-        },
-        Some(3.0)
+        rune!(f32 => pub fn main() { [1.0, 0.5, 2.0, 3.0].iter().product() }),
+        3.0
     )
 }
 
 #[test]
 fn test_prod_float_negative() {
     assert_eq!(
-        rune! { Option<f32> =>
-
-            pub fn main() {
-                [1.0, 0.5, 2.0, 0.0 - 3.0].iter().product()
-            }
-        },
-        Some(-3.0)
+        rune!(f32 => pub fn main() { [1.0, 0.5, 2.0, 0.0 - 3.0].iter().product() }),
+        -3.0
     )
 }

--- a/tests/type_name_native.rs
+++ b/tests/type_name_native.rs
@@ -73,11 +73,11 @@ fn test_field_fn() {
             (t1, ),
             String => pub fn main(val) { std::any::type_name_of_val(val.x) }
         },
-        "::std::core::int"
+        "::std::int"
     );
 }
 
-// Not sure what the right return should be here - it returns the field name, but it probably should return ::std::core::int?
+// Not sure what the right return should be here - it returns the field name, but it probably should return ::std::int?
 // #[test]
 // fn test_field_fn_ref() {
 //     assert_eq!(
@@ -89,6 +89,6 @@ fn test_field_fn() {
 //                 std::any::type_name_of_val(native_crate::NativeStruct::x)
 //             }
 //         },
-//         "::std::core::int"
+//         "::std::int"
 //     );
 // }

--- a/tests/type_name_rune.rs
+++ b/tests/type_name_rune.rs
@@ -17,10 +17,10 @@ fn test_trivial_types() {
             }
         },
         [
-            "::std::core::bool".to_owned(),
-            "::std::core::int".to_owned(),
-            "::std::core::float".to_owned(),
-            "::std::core::char".to_owned(),
+            "::std::bool".to_owned(),
+            "::std::int".to_owned(),
+            "::std::float".to_owned(),
+            "::std::char".to_owned(),
             "::std::string::String".to_owned(),
             "::std::option::Option".to_owned()
         ]


### PR DESCRIPTION
* Move all `::std::core::*` types into `::std::*`.

* Move `::std::core::mem::drop` to `::std::mem::drop` and make own
  module.

* Make `Iterator::sum` and `Iterator::product` panic on empty iterators
  instead of returning `Option`.

* Introduce `::std::int::{min, max}` and `::std::float::{min, max}`.
