### PR TITLE
Add a few optimizations to reduce the number of copies

### DIFF
--- a/crates/rune/src/compiling/assemble/builtin_format.rs
+++ b/crates/rune/src/compiling/assemble/builtin_format.rs
@@ -4,7 +4,7 @@ use runestick::format;
 
 /// Compile a literal template string.
 impl Assemble for BuiltInFormat {
-    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<()> {
+    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<Asm> {
         let span = self.span;
         log::trace!("BuiltInFormat => {:?}", c.source.source(span));
 
@@ -46,13 +46,13 @@ impl Assemble for BuiltInFormat {
 
         let spec = format::FormatSpec::new(flags, fill, align, width, precision, format_type);
 
-        self.value.assemble(c, Needs::Value)?;
+        self.value.assemble(c, Needs::Value)?.apply(c)?;
         c.asm.push(Inst::Format { spec }, span);
 
         if !needs.value() {
             c.asm.push(Inst::Pop, span);
         }
 
-        Ok(())
+        Ok(Asm::top(span))
     }
 }

--- a/crates/rune/src/compiling/assemble/builtin_template.rs
+++ b/crates/rune/src/compiling/assemble/builtin_template.rs
@@ -3,7 +3,7 @@ use crate::query::BuiltInTemplate;
 
 /// Compile a literal template string.
 impl Assemble for BuiltInTemplate {
-    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<()> {
+    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<Asm> {
         let span = self.span;
         log::trace!("BuiltInTemplate => {:?}", c.source.source(span));
 
@@ -29,7 +29,7 @@ impl Assemble for BuiltInTemplate {
             }
 
             expansions += 1;
-            expr.assemble(c, Needs::Value)?;
+            expr.assemble(c, Needs::Value)?.apply(c)?;
             c.scopes.decl_anon(span)?;
         }
 
@@ -51,6 +51,6 @@ impl Assemble for BuiltInTemplate {
         }
 
         let _ = c.scopes.pop(expected, span)?;
-        Ok(())
+        Ok(Asm::top(span))
     }
 }

--- a/crates/rune/src/compiling/assemble/expr.rs
+++ b/crates/rune/src/compiling/assemble/expr.rs
@@ -3,114 +3,48 @@ use crate::query::BuiltInMacro;
 
 /// Compile an expression.
 impl Assemble for ast::Expr {
-    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<()> {
+    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<Asm> {
         let span = self.span();
         log::trace!("Expr => {:?}", c.source.source(span));
 
-        match self {
-            ast::Expr::Path(path) => {
-                path.assemble(c, needs)?;
-            }
-            ast::Expr::While(expr_while) => {
-                expr_while.assemble(c, needs)?;
-            }
-            ast::Expr::For(expr_for) => {
-                expr_for.assemble(c, needs)?;
-            }
-            ast::Expr::Loop(expr_loop) => {
-                expr_loop.assemble(c, needs)?;
-            }
-            ast::Expr::Let(expr_let) => {
-                expr_let.assemble(c, needs)?;
-            }
-            ast::Expr::Group(expr) => {
-                expr.expr.assemble(c, needs)?;
-            }
-            ast::Expr::Unary(expr_unary) => {
-                expr_unary.assemble(c, needs)?;
-            }
-            ast::Expr::Assign(expr_assign) => {
-                expr_assign.assemble(c, needs)?;
-            }
-            ast::Expr::Binary(expr_binary) => {
-                expr_binary.assemble(c, needs)?;
-            }
-            ast::Expr::If(expr_if) => {
-                expr_if.assemble(c, needs)?;
-            }
-            ast::Expr::Index(expr_index_get) => {
-                expr_index_get.assemble(c, needs)?;
-            }
-            ast::Expr::Break(expr_break) => {
-                expr_break.assemble(c, needs)?;
-            }
-            ast::Expr::Continue(expr_continue) => {
-                expr_continue.assemble(c, needs)?;
-            }
-            ast::Expr::Yield(expr_yield) => {
-                expr_yield.assemble(c, needs)?;
-            }
-            ast::Expr::Block(expr_block) => {
-                expr_block.assemble(c, needs)?;
-            }
-            ast::Expr::Return(expr_return) => {
-                expr_return.assemble(c, needs)?;
-            }
-            ast::Expr::Match(expr_match) => {
-                expr_match.assemble(c, needs)?;
-            }
-            ast::Expr::Await(expr_await) => {
-                expr_await.assemble(c, needs)?;
-            }
-            ast::Expr::Try(expr_try) => {
-                expr_try.assemble(c, needs)?;
-            }
-            ast::Expr::Select(expr_select) => {
-                expr_select.assemble(c, needs)?;
-            }
-            ast::Expr::Call(expr_call) => {
-                expr_call.assemble(c, needs)?;
-            }
-            ast::Expr::FieldAccess(expr_field_access) => {
-                expr_field_access.assemble(c, needs)?;
-            }
-            ast::Expr::Closure(expr_closure) => {
-                expr_closure.assemble(c, needs)?;
-            }
-            ast::Expr::Lit(expr_lit) => {
-                expr_lit.lit.assemble(c, needs)?;
-            }
-            ast::Expr::ForceSemi(force_semi) => {
-                force_semi.expr.assemble(c, needs)?;
-            }
-            ast::Expr::Tuple(expr_tuple) => {
-                expr_tuple.assemble(c, needs)?;
-            }
-            ast::Expr::Vec(expr_vec) => {
-                expr_vec.assemble(c, needs)?;
-            }
-            ast::Expr::Object(expr_object) => {
-                expr_object.assemble(c, needs)?;
-            }
-            ast::Expr::Range(expr_range) => {
-                expr_range.assemble(c, needs)?;
-            }
+        let asm = match self {
+            ast::Expr::Path(path) => path.assemble(c, needs)?,
+            ast::Expr::While(expr_while) => expr_while.assemble(c, needs)?,
+            ast::Expr::For(expr_for) => expr_for.assemble(c, needs)?,
+            ast::Expr::Loop(expr_loop) => expr_loop.assemble(c, needs)?,
+            ast::Expr::Let(expr_let) => expr_let.assemble(c, needs)?,
+            ast::Expr::Group(expr) => expr.expr.assemble(c, needs)?,
+            ast::Expr::Unary(expr_unary) => expr_unary.assemble(c, needs)?,
+            ast::Expr::Assign(expr_assign) => expr_assign.assemble(c, needs)?,
+            ast::Expr::Binary(expr_binary) => expr_binary.assemble(c, needs)?,
+            ast::Expr::If(expr_if) => expr_if.assemble(c, needs)?,
+            ast::Expr::Index(expr_index_get) => expr_index_get.assemble(c, needs)?,
+            ast::Expr::Break(expr_break) => expr_break.assemble(c, needs)?,
+            ast::Expr::Continue(expr_continue) => expr_continue.assemble(c, needs)?,
+            ast::Expr::Yield(expr_yield) => expr_yield.assemble(c, needs)?,
+            ast::Expr::Block(expr_block) => expr_block.assemble(c, needs)?,
+            ast::Expr::Return(expr_return) => expr_return.assemble(c, needs)?,
+            ast::Expr::Match(expr_match) => expr_match.assemble(c, needs)?,
+            ast::Expr::Await(expr_await) => expr_await.assemble(c, needs)?,
+            ast::Expr::Try(expr_try) => expr_try.assemble(c, needs)?,
+            ast::Expr::Select(expr_select) => expr_select.assemble(c, needs)?,
+            ast::Expr::Call(expr_call) => expr_call.assemble(c, needs)?,
+            ast::Expr::FieldAccess(expr_field_access) => expr_field_access.assemble(c, needs)?,
+            ast::Expr::Closure(expr_closure) => expr_closure.assemble(c, needs)?,
+            ast::Expr::Lit(expr_lit) => expr_lit.lit.assemble(c, needs)?,
+            ast::Expr::ForceSemi(force_semi) => force_semi.expr.assemble(c, needs)?,
+            ast::Expr::Tuple(expr_tuple) => expr_tuple.assemble(c, needs)?,
+            ast::Expr::Vec(expr_vec) => expr_vec.assemble(c, needs)?,
+            ast::Expr::Object(expr_object) => expr_object.assemble(c, needs)?,
+            ast::Expr::Range(expr_range) => expr_range.assemble(c, needs)?,
             ast::Expr::MacroCall(expr_call_macro) => {
                 let internal_macro = c.query.builtin_macro_for(&**expr_call_macro)?;
 
                 match &*internal_macro {
-                    BuiltInMacro::Template(template) => {
-                        template.assemble(c, needs)?;
-                    }
-                    BuiltInMacro::Format(format) => {
-                        format.assemble(c, needs)?;
-                    }
-                    BuiltInMacro::Line(line) => {
-                        line.value.assemble(c, needs)?;
-                    }
-                    BuiltInMacro::File(file) => {
-                        file.value.assemble(c, needs)?;
-                    }
+                    BuiltInMacro::Template(template) => template.assemble(c, needs)?,
+                    BuiltInMacro::Format(format) => format.assemble(c, needs)?,
+                    BuiltInMacro::Line(line) => line.value.assemble(c, needs)?,
+                    BuiltInMacro::File(file) => file.value.assemble(c, needs)?,
                 }
             }
             // NB: declarations are not used in this compilation stage.
@@ -122,9 +56,11 @@ impl Assemble for ast::Expr {
                 if needs.value() {
                     c.asm.push(Inst::unit(), span);
                 }
-            }
-        }
 
-        Ok(())
+                Asm::top(span)
+            }
+        };
+
+        Ok(asm)
     }
 }

--- a/crates/rune/src/compiling/assemble/expr_await.rs
+++ b/crates/rune/src/compiling/assemble/expr_await.rs
@@ -2,17 +2,17 @@ use crate::compiling::assemble::prelude::*;
 
 /// Compile an `.await` expression.
 impl Assemble for ast::ExprAwait {
-    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<()> {
+    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<Asm> {
         let span = self.span();
         log::trace!("ExprAwait => {:?}", c.source.source(span));
 
-        self.expr.assemble(c, Needs::Value)?;
+        self.expr.assemble(c, Needs::Value)?.apply(c)?;
         c.asm.push(Inst::Await, span);
 
         if !needs.value() {
             c.asm.push(Inst::Pop, span);
         }
 
-        Ok(())
+        Ok(Asm::top(span))
     }
 }

--- a/crates/rune/src/compiling/assemble/expr_binary.rs
+++ b/crates/rune/src/compiling/assemble/expr_binary.rs
@@ -2,7 +2,7 @@ use crate::compiling::assemble::prelude::*;
 
 /// Compile a binary expression.
 impl Assemble for ast::ExprBinary {
-    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<()> {
+    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<Asm> {
         let span = self.span();
         log::trace!("ExprBinary => {:?}", c.source.source(span));
         log::trace!(
@@ -18,22 +18,20 @@ impl Assemble for ast::ExprBinary {
         // Special expressions which operates on the stack in special ways.
         if self.op.is_assign() {
             compile_assign_binop(c, &self.lhs, &self.rhs, self.op, needs)?;
-
-            return Ok(());
+            return Ok(Asm::top(span));
         }
 
         if self.op.is_conditional() {
             compile_conditional_binop(c, &self.lhs, &self.rhs, self.op, needs)?;
-
-            return Ok(());
+            return Ok(Asm::top(span));
         }
 
         // NB: need to declare these as anonymous local variables so that they
         // get cleaned up in case there is an early break (return, try, ...).
-        self.lhs.assemble(c, Needs::Value)?;
+        self.lhs.assemble(c, Needs::Value)?.apply(c)?;
         c.scopes.decl_anon(span)?;
 
-        self.rhs.assemble(c, rhs_needs_of(self.op))?;
+        self.rhs.assemble(c, rhs_needs_of(self.op))?.apply(c)?;
         c.scopes.decl_anon(span)?;
 
         let inst = match self.op {
@@ -75,7 +73,7 @@ impl Assemble for ast::ExprBinary {
         }
 
         c.scopes.undecl_anon(span, 2)?;
-        Ok(())
+        Ok(Asm::top(span))
     }
 }
 
@@ -99,7 +97,7 @@ fn compile_conditional_binop(
 
     let end_label = c.asm.new_label("conditional_end");
 
-    lhs.assemble(c, Needs::Value)?;
+    lhs.assemble(c, Needs::Value)?.apply(c)?;
 
     match bin_op {
         ast::BinOp::And => {
@@ -116,7 +114,7 @@ fn compile_conditional_binop(
         }
     }
 
-    rhs.assemble(c, Needs::Value)?;
+    rhs.assemble(c, Needs::Value)?.apply(c)?;
 
     c.asm.label(end_label)?;
 
@@ -139,7 +137,7 @@ fn compile_assign_binop(
     let supported = match lhs {
         // <var> <op> <expr>
         ast::Expr::Path(path) if path.rest.is_empty() => {
-            rhs.assemble(c, Needs::Value)?;
+            rhs.assemble(c, Needs::Value)?.apply(c)?;
 
             let segment = path
                 .first
@@ -152,8 +150,8 @@ fn compile_assign_binop(
         }
         // <expr>.<field> <op> <value>
         ast::Expr::FieldAccess(field_access) => {
-            field_access.expr.assemble(c, Needs::Value)?;
-            rhs.assemble(c, Needs::Value)?;
+            field_access.expr.assemble(c, Needs::Value)?.apply(c)?;
+            rhs.assemble(c, Needs::Value)?.apply(c)?;
 
             // field assignment
             match &field_access.expr_field {

--- a/crates/rune/src/compiling/assemble/expr_block.rs
+++ b/crates/rune/src/compiling/assemble/expr_block.rs
@@ -2,7 +2,7 @@ use crate::compiling::assemble::prelude::*;
 
 /// Compile a block expression.
 impl Assemble for ast::ExprBlock {
-    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<()> {
+    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<Asm> {
         let span = self.span();
         log::trace!("ExprBlock => {:?}", c.source.source(span));
 
@@ -59,6 +59,6 @@ impl Assemble for ast::ExprBlock {
             }
         };
 
-        Ok(())
+        Ok(Asm::top(span))
     }
 }

--- a/crates/rune/src/compiling/assemble/expr_break.rs
+++ b/crates/rune/src/compiling/assemble/expr_break.rs
@@ -4,7 +4,7 @@ use crate::compiling::assemble::prelude::*;
 ///
 /// NB: loops are expected to produce a value at the end of their expression.
 impl Assemble for ast::ExprBreak {
-    fn assemble(&self, c: &mut Compiler<'_>, _: Needs) -> CompileResult<()> {
+    fn assemble(&self, c: &mut Compiler<'_>, _: Needs) -> CompileResult<Asm> {
         let span = self.span();
         log::trace!("ExprBreak => {:?}", c.source.source(span));
 
@@ -21,7 +21,7 @@ impl Assemble for ast::ExprBreak {
         let (last_loop, to_drop, has_value) = if let Some(expr) = &self.expr {
             match expr {
                 ast::ExprBreakValue::Expr(expr) => {
-                    expr.assemble(c, current_loop.needs)?;
+                    expr.assemble(c, current_loop.needs)?.apply(c)?;
                     (current_loop, current_loop.drop.into_iter().collect(), true)
                 }
                 ast::ExprBreakValue::Label(label) => {
@@ -57,6 +57,6 @@ impl Assemble for ast::ExprBreak {
         }
 
         c.asm.jump(last_loop.break_label, span);
-        Ok(())
+        Ok(Asm::top(span))
     }
 }

--- a/crates/rune/src/compiling/assemble/expr_closure.rs
+++ b/crates/rune/src/compiling/assemble/expr_closure.rs
@@ -40,7 +40,7 @@ impl AssembleClosure for ast::ExprClosure {
             c.scopes.total_var_count(span)?
         };
 
-        self.body.assemble(c, Needs::Value)?;
+        self.body.assemble(c, Needs::Value)?.apply(c)?;
 
         if count != 0 {
             c.asm.push(Inst::Clean { count }, span);
@@ -55,13 +55,13 @@ impl AssembleClosure for ast::ExprClosure {
 
 /// Compile a closure expression.
 impl Assemble for ast::ExprClosure {
-    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<()> {
+    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<Asm> {
         let span = self.span();
         log::trace!("ExprClosure => {:?}", c.source.source(span));
 
         if !needs.value() {
             c.warnings.not_used(c.source_id, span, c.context());
-            return Ok(());
+            return Ok(Asm::top(span));
         }
 
         let item = c.query.item_for(self)?;
@@ -126,6 +126,6 @@ impl Assemble for ast::ExprClosure {
             );
         }
 
-        Ok(())
+        Ok(Asm::top(span))
     }
 }

--- a/crates/rune/src/compiling/assemble/expr_continue.rs
+++ b/crates/rune/src/compiling/assemble/expr_continue.rs
@@ -2,7 +2,7 @@ use crate::compiling::assemble::prelude::*;
 
 /// Compile a continue expression.
 impl Assemble for ast::ExprContinue {
-    fn assemble(&self, c: &mut Compiler<'_>, _: Needs) -> CompileResult<()> {
+    fn assemble(&self, c: &mut Compiler<'_>, _: Needs) -> CompileResult<Asm> {
         let span = self.span();
         log::trace!("ExprContinue => {:?}", c.source.source(span));
 
@@ -32,6 +32,6 @@ impl Assemble for ast::ExprContinue {
         c.locals_pop(vars, span);
 
         c.asm.jump(last_loop.continue_label, span);
-        Ok(())
+        Ok(Asm::top(span))
     }
 }

--- a/crates/rune/src/compiling/assemble/expr_for.rs
+++ b/crates/rune/src/compiling/assemble/expr_for.rs
@@ -2,7 +2,7 @@ use crate::compiling::assemble::prelude::*;
 
 /// Compile a for loop.
 impl Assemble for ast::ExprFor {
-    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<()> {
+    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<Asm> {
         let span = self.span();
         log::trace!("ExprFor => {:?}", c.source.source(span));
 
@@ -14,7 +14,7 @@ impl Assemble for ast::ExprFor {
 
         let (iter_offset, loop_scope_expected) = {
             let loop_scope_expected = c.scopes.push_child(span)?;
-            self.iter.assemble(c, Needs::Value)?;
+            self.iter.assemble(c, Needs::Value)?.apply(c)?;
 
             let iter_offset = c.scopes.decl_anon(span)?;
             c.asm.push_with_comment(
@@ -156,7 +156,7 @@ impl Assemble for ast::ExprFor {
             );
         }
 
-        self.body.assemble(c, Needs::None)?;
+        self.body.assemble(c, Needs::None)?.apply(c)?;
         c.asm.jump(continue_label, span);
         c.asm.label(end_label)?;
 
@@ -177,6 +177,6 @@ impl Assemble for ast::ExprFor {
 
         // NB: breaks produce their own value.
         c.asm.label(break_label)?;
-        Ok(())
+        Ok(Asm::top(span))
     }
 }

--- a/crates/rune/src/compiling/assemble/expr_let.rs
+++ b/crates/rune/src/compiling/assemble/expr_let.rs
@@ -2,13 +2,13 @@ use crate::compiling::assemble::prelude::*;
 
 /// Compile a let expression.
 impl Assemble for ast::ExprLet {
-    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<()> {
+    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<Asm> {
         let span = self.span();
         log::trace!("ExprLet => {:?}", c.source.source(span));
 
         let load = |c: &mut Compiler, needs: Needs| {
             // NB: assignments "move" the value being assigned.
-            self.expr.assemble(c, needs)?;
+            self.expr.assemble(c, needs)?.apply(c)?;
             Ok(())
         };
 
@@ -36,6 +36,6 @@ impl Assemble for ast::ExprLet {
             c.asm.push(Inst::unit(), span);
         }
 
-        Ok(())
+        Ok(Asm::top(span))
     }
 }

--- a/crates/rune/src/compiling/assemble/expr_loop.rs
+++ b/crates/rune/src/compiling/assemble/expr_loop.rs
@@ -2,7 +2,7 @@ use crate::compiling::assemble::prelude::*;
 
 /// Compile a loop.
 impl Assemble for ast::ExprLoop {
-    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<()> {
+    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<Asm> {
         let span = self.span();
         log::trace!("ExprLoop => {:?}", c.source.source(span));
 
@@ -22,10 +22,10 @@ impl Assemble for ast::ExprLoop {
         });
 
         c.asm.label(continue_label)?;
-        self.body.assemble(c, Needs::None)?;
+        self.body.assemble(c, Needs::None)?.apply(c)?;
         c.asm.jump(continue_label, span);
         c.asm.label(break_label)?;
 
-        Ok(())
+        Ok(Asm::top(span))
     }
 }

--- a/crates/rune/src/compiling/assemble/expr_match.rs
+++ b/crates/rune/src/compiling/assemble/expr_match.rs
@@ -1,13 +1,13 @@
 use crate::compiling::assemble::prelude::*;
 
 impl Assemble for ast::ExprMatch {
-    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<()> {
+    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<Asm> {
         let span = self.span();
         log::trace!("ExprMatch => {:?}", c.source.source(span));
 
         let expected_scopes = c.scopes.push_child(span)?;
 
-        self.expr.assemble(c, Needs::Value)?;
+        self.expr.assemble(c, Needs::Value)?.apply(c)?;
         // Offset of the expression.
         let offset = c.scopes.decl_anon(span)?;
 
@@ -39,7 +39,7 @@ impl Assemble for ast::ExprMatch {
                 let scope = c.scopes.child(span)?;
                 let guard = c.scopes.push(scope);
 
-                condition.assemble(c, Needs::Value)?;
+                condition.assemble(c, Needs::Value)?.apply(c)?;
                 c.clean_last_scope(span, guard, Needs::Value)?;
                 let scope = c.scopes.pop(parent_guard, span)?;
 
@@ -74,7 +74,7 @@ impl Assemble for ast::ExprMatch {
             c.asm.label(*label)?;
 
             let expected = c.scopes.push(scope.clone());
-            branch.body.assemble(c, needs)?;
+            branch.body.assemble(c, needs)?.apply(c)?;
             c.clean_last_scope(span, expected, needs)?;
 
             if it.peek().is_some() {
@@ -86,6 +86,6 @@ impl Assemble for ast::ExprMatch {
 
         // pop the implicit scope where we store the anonymous match variable.
         c.clean_last_scope(span, expected_scopes, needs)?;
-        Ok(())
+        Ok(Asm::top(span))
     }
 }

--- a/crates/rune/src/compiling/assemble/expr_object.rs
+++ b/crates/rune/src/compiling/assemble/expr_object.rs
@@ -3,7 +3,7 @@ use crate::compiling::assemble::prelude::*;
 
 /// Compile a literal object.
 impl Assemble for ast::ExprObject {
-    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<()> {
+    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<Asm> {
         let span = self.span();
         log::trace!("ExprObject => {:?} {:?}", c.source.source(span), needs);
 
@@ -32,7 +32,7 @@ impl Assemble for ast::ExprObject {
             let span = assign.span();
 
             if let Some((_, expr)) = &assign.assign {
-                expr.assemble(c, Needs::Value)?;
+                expr.assemble(c, Needs::Value)?.apply(c)?;
             } else {
                 let key = assign.key.resolve(&c.storage, &*c.source)?;
                 let var = c.scopes.get_var(&*key, c.source_id, c.visitor, span)?;
@@ -85,7 +85,7 @@ impl Assemble for ast::ExprObject {
             c.asm.push(Inst::Pop, span);
         }
 
-        Ok(())
+        Ok(Asm::top(span))
     }
 }
 

--- a/crates/rune/src/compiling/assemble/expr_path.rs
+++ b/crates/rune/src/compiling/assemble/expr_path.rs
@@ -21,8 +21,7 @@ impl Assemble for ast::Path {
         if let Needs::Value = needs {
             if let Some(local) = named.as_local() {
                 if let Some(var) = c.scopes.try_get_var(local, c.source_id, c.visitor, span)? {
-                    var.copy(&mut c.asm, span, format!("var `{}`", local));
-                    return Ok(Asm::top(span));
+                    return Ok(Asm::var(span, *var, local.into()));
                 }
             }
         }

--- a/crates/rune/src/compiling/assemble/expr_range.rs
+++ b/crates/rune/src/compiling/assemble/expr_range.rs
@@ -2,7 +2,7 @@ use crate::compiling::assemble::prelude::*;
 
 /// Compile a range expression.
 impl Assemble for ast::ExprRange {
-    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<()> {
+    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<Asm> {
         let span = self.span();
         log::trace!("ExprRange => {:?}", c.source.source(span));
 
@@ -10,7 +10,7 @@ impl Assemble for ast::ExprRange {
 
         if needs.value() {
             let from = if let Some(from) = &self.from {
-                from.assemble(c, needs)?;
+                from.assemble(c, needs)?.apply(c)?;
                 c.asm.push(
                     Inst::Variant {
                         variant: InstVariant::Some,
@@ -31,7 +31,7 @@ impl Assemble for ast::ExprRange {
             c.scopes.decl_anon(from)?;
 
             let to = if let Some(to) = &self.to {
-                to.assemble(c, needs)?;
+                to.assemble(c, needs)?.apply(c)?;
                 c.asm.push(
                     Inst::Variant {
                         variant: InstVariant::Some,
@@ -60,15 +60,15 @@ impl Assemble for ast::ExprRange {
             c.scopes.undecl_anon(span, 2)?;
         } else {
             if let Some(from) = &self.from {
-                from.assemble(c, needs)?;
+                from.assemble(c, needs)?.apply(c)?;
             }
 
             if let Some(to) = &self.to {
-                to.assemble(c, needs)?;
+                to.assemble(c, needs)?.apply(c)?;
             }
         }
 
         c.scopes.pop(guard, span)?;
-        Ok(())
+        Ok(Asm::top(span))
     }
 }

--- a/crates/rune/src/compiling/assemble/expr_return.rs
+++ b/crates/rune/src/compiling/assemble/expr_return.rs
@@ -2,7 +2,7 @@ use crate::compiling::assemble::prelude::*;
 
 /// Compile a return.
 impl Assemble for ast::ExprReturn {
-    fn assemble(&self, c: &mut Compiler<'_>, _: Needs) -> CompileResult<()> {
+    fn assemble(&self, c: &mut Compiler<'_>, _: Needs) -> CompileResult<Asm> {
         let span = self.span();
         log::trace!("ExprReturn => {:?}", c.source.source(span));
 
@@ -18,7 +18,7 @@ impl Assemble for ast::ExprReturn {
         let total_var_count = c.scopes.total_var_count(span)?;
 
         if let Some(expr) = &self.expr {
-            expr.assemble(c, Needs::Value)?;
+            expr.assemble(c, Needs::Value)?.apply(c)?;
             c.locals_clean(total_var_count, span);
             c.asm.push(Inst::Return, span);
         } else {
@@ -26,6 +26,6 @@ impl Assemble for ast::ExprReturn {
             c.asm.push(Inst::ReturnUnit, span);
         }
 
-        Ok(())
+        Ok(Asm::top(span))
     }
 }

--- a/crates/rune/src/compiling/assemble/expr_select.rs
+++ b/crates/rune/src/compiling/assemble/expr_select.rs
@@ -2,7 +2,7 @@ use crate::compiling::assemble::prelude::*;
 
 /// Compile a select expression.
 impl Assemble for ast::ExprSelect {
-    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<()> {
+    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<Asm> {
         let span = self.span();
         log::trace!("ExprSelect => {:?}", c.source.source(span));
         let len = self.branches.len();
@@ -34,7 +34,7 @@ impl Assemble for ast::ExprSelect {
         }
 
         for (_, branch) in &branches {
-            branch.expr.assemble(c, Needs::Value)?;
+            branch.expr.assemble(c, Needs::Value)?.apply(c)?;
         }
 
         c.asm.push(Inst::Select { len }, span);
@@ -86,14 +86,14 @@ impl Assemble for ast::ExprSelect {
             }
 
             // Set up a new scope with the binding.
-            branch.body.assemble(c, needs)?;
+            branch.body.assemble(c, needs)?.apply(c)?;
             c.clean_last_scope(span, expected, needs)?;
             c.asm.jump(end_label, span);
         }
 
         if let Some((branch, label)) = default_branch {
             c.asm.label(label)?;
-            branch.body.assemble(c, needs)?;
+            branch.body.assemble(c, needs)?.apply(c)?;
         }
 
         c.asm.label(end_label)?;
@@ -102,6 +102,6 @@ impl Assemble for ast::ExprSelect {
             .pop()
             .ok_or_else(|| CompileError::msg(&span, "missing parent context"))?;
 
-        Ok(())
+        Ok(Asm::top(span))
     }
 }

--- a/crates/rune/src/compiling/assemble/expr_try.rs
+++ b/crates/rune/src/compiling/assemble/expr_try.rs
@@ -2,13 +2,13 @@ use crate::compiling::assemble::prelude::*;
 
 /// Compile a try expression.
 impl Assemble for ast::ExprTry {
-    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<()> {
+    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<Asm> {
         let span = self.span();
         log::trace!("ExprTry => {:?}", c.source.source(span));
 
         let not_error = c.asm.new_label("try_not_error");
 
-        self.expr.assemble(c, Needs::Value)?;
+        self.expr.assemble(c, Needs::Value)?.apply(c)?;
         c.asm.push(Inst::Dup, span);
         c.asm.push(Inst::IsValue, span);
         c.asm.jump_if(not_error, span);
@@ -26,6 +26,6 @@ impl Assemble for ast::ExprTry {
             c.asm.push(Inst::Pop, span);
         }
 
-        Ok(())
+        Ok(Asm::top(span))
     }
 }

--- a/crates/rune/src/compiling/assemble/expr_tuple.rs
+++ b/crates/rune/src/compiling/assemble/expr_tuple.rs
@@ -2,7 +2,7 @@ use crate::compiling::assemble::prelude::*;
 
 /// Compile a literal tuple.
 impl Assemble for ast::ExprTuple {
-    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<()> {
+    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<Asm> {
         let span = self.span();
         log::trace!("ExprTuple => {:?}", c.source.source(span));
 
@@ -10,7 +10,7 @@ impl Assemble for ast::ExprTuple {
             c.asm.push(Inst::unit(), span);
         } else {
             for (expr, _) in &self.items {
-                expr.assemble(c, Needs::Value)?;
+                expr.assemble(c, Needs::Value)?.apply(c)?;
                 c.scopes.decl_anon(expr.span())?;
             }
 
@@ -27,9 +27,8 @@ impl Assemble for ast::ExprTuple {
         if !needs.value() {
             c.warnings.not_used(c.source_id, span, c.context());
             c.asm.push(Inst::Pop, span);
-            return Ok(());
         }
 
-        Ok(())
+        Ok(Asm::top(span))
     }
 }

--- a/crates/rune/src/compiling/assemble/expr_tuple.rs
+++ b/crates/rune/src/compiling/assemble/expr_tuple.rs
@@ -1,5 +1,27 @@
 use crate::compiling::assemble::prelude::*;
 
+macro_rules! tuple {
+    ($slf:expr, $variant:ident, $c:ident, $span:expr, $($var:ident),*) => {{
+        let guard = $c.scopes.push_child($span)?;
+
+        let mut it = $slf.items.iter();
+
+        $(
+        let ($var, _) = it.next().ok_or_else(|| CompileError::new($span, CompileErrorKind::Custom { message: "items ended unexpectedly" }))?;
+        let $var = $var.assemble($c, Needs::Value)?.apply_targeted($c)?;
+        )*
+
+        $c.asm.push(
+            Inst::$variant {
+                args: [$($var,)*],
+            },
+            $span,
+        );
+
+        $c.scopes.pop(guard, $span)?;
+    }};
+}
+
 /// Compile a literal tuple.
 impl Assemble for ast::ExprTuple {
     fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<Asm> {
@@ -9,19 +31,27 @@ impl Assemble for ast::ExprTuple {
         if self.items.is_empty() {
             c.asm.push(Inst::unit(), span);
         } else {
-            for (expr, _) in &self.items {
-                expr.assemble(c, Needs::Value)?.apply(c)?;
-                c.scopes.decl_anon(expr.span())?;
+            match self.items.len() {
+                1 => tuple!(self, Tuple1, c, span, e1),
+                2 => tuple!(self, Tuple2, c, span, e1, e2),
+                3 => tuple!(self, Tuple3, c, span, e1, e2, e3),
+                4 => tuple!(self, Tuple4, c, span, e1, e2, e3, e4),
+                _ => {
+                    for (expr, _) in &self.items {
+                        expr.assemble(c, Needs::Value)?.apply(c)?;
+                        c.scopes.decl_anon(expr.span())?;
+                    }
+
+                    c.asm.push(
+                        Inst::Tuple {
+                            count: self.items.len(),
+                        },
+                        span,
+                    );
+
+                    c.scopes.undecl_anon(span, self.items.len())?;
+                }
             }
-
-            c.asm.push(
-                Inst::Tuple {
-                    count: self.items.len(),
-                },
-                span,
-            );
-
-            c.scopes.undecl_anon(span, self.items.len())?;
         }
 
         if !needs.value() {

--- a/crates/rune/src/compiling/assemble/expr_unary.rs
+++ b/crates/rune/src/compiling/assemble/expr_unary.rs
@@ -2,7 +2,7 @@ use crate::compiling::assemble::prelude::*;
 
 /// Compile a unary expression.
 impl Assemble for ast::ExprUnary {
-    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<()> {
+    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<Asm> {
         let span = self.span();
         log::trace!("ExprUnary => {:?}", c.source.source(span));
 
@@ -35,11 +35,11 @@ impl Assemble for ast::ExprUnary {
                     }
                 }
 
-                return Ok(());
+                return Ok(Asm::top(span));
             }
         }
 
-        self.expr.assemble(c, Needs::Value)?;
+        self.expr.assemble(c, Needs::Value)?.apply(c)?;
 
         match self.op {
             ast::UnOp::Not { .. } => {
@@ -62,6 +62,6 @@ impl Assemble for ast::ExprUnary {
             c.asm.push(Inst::Pop, span);
         }
 
-        Ok(())
+        Ok(Asm::top(span))
     }
 }

--- a/crates/rune/src/compiling/assemble/expr_vec.rs
+++ b/crates/rune/src/compiling/assemble/expr_vec.rs
@@ -2,14 +2,14 @@ use crate::compiling::assemble::prelude::*;
 
 /// Compile a literal vector.
 impl Assemble for ast::ExprVec {
-    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<()> {
+    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<Asm> {
         let span = self.span();
         log::trace!("ExprVec => {:?}", c.source.source(span));
 
         let count = self.items.len();
 
         for (expr, _) in &self.items {
-            expr.assemble(c, Needs::Value)?;
+            expr.assemble(c, Needs::Value)?.apply(c)?;
             c.scopes.decl_anon(expr.span())?;
         }
 
@@ -23,6 +23,6 @@ impl Assemble for ast::ExprVec {
             c.asm.push(Inst::Pop, span);
         }
 
-        Ok(())
+        Ok(Asm::top(span))
     }
 }

--- a/crates/rune/src/compiling/assemble/expr_while.rs
+++ b/crates/rune/src/compiling/assemble/expr_while.rs
@@ -2,7 +2,7 @@ use crate::compiling::assemble::prelude::*;
 
 /// Compile a while loop.
 impl Assemble for ast::ExprWhile {
-    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<()> {
+    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<Asm> {
         let span = self.span();
         log::trace!("ExprWhile => {:?}", c.source.source(span));
 
@@ -31,7 +31,7 @@ impl Assemble for ast::ExprWhile {
         c.asm.jump(end_label, span);
         c.asm.label(then_label)?;
 
-        self.body.assemble(c, Needs::None)?;
+        self.body.assemble(c, Needs::None)?.apply(c)?;
         c.clean_last_scope(span, expected, Needs::None)?;
 
         c.asm.jump(continue_label, span);
@@ -43,6 +43,6 @@ impl Assemble for ast::ExprWhile {
 
         // NB: breaks produce their own value / perform their own cleanup.
         c.asm.label(break_label)?;
-        Ok(())
+        Ok(Asm::top(span))
     }
 }

--- a/crates/rune/src/compiling/assemble/expr_yield.rs
+++ b/crates/rune/src/compiling/assemble/expr_yield.rs
@@ -2,12 +2,12 @@ use crate::compiling::assemble::prelude::*;
 
 /// Compile a `yield` expression.
 impl Assemble for ast::ExprYield {
-    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<()> {
+    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<Asm> {
         let span = self.span();
         log::trace!("ExprYield => {:?}", c.source.source(span));
 
         if let Some(expr) = &self.expr {
-            expr.assemble(c, Needs::Value)?;
+            expr.assemble(c, Needs::Value)?.apply(c)?;
             c.asm.push(Inst::Yield, span);
         } else {
             c.asm.push(Inst::YieldUnit, span);
@@ -17,6 +17,6 @@ impl Assemble for ast::ExprYield {
             c.asm.push(Inst::Pop, span);
         }
 
-        Ok(())
+        Ok(Asm::top(span))
     }
 }

--- a/crates/rune/src/compiling/assemble/item_fn.rs
+++ b/crates/rune/src/compiling/assemble/item_fn.rs
@@ -41,13 +41,13 @@ impl AssembleFn for ast::ItemFn {
         }
 
         if !self.body.produces_nothing() {
-            self.body.assemble(c, Needs::Value)?;
+            self.body.assemble(c, Needs::Value)?.apply(c)?;
 
             let total_var_count = c.scopes.total_var_count(span)?;
             c.locals_clean(total_var_count, span);
             c.asm.push(Inst::Return, span);
         } else {
-            self.body.assemble(c, Needs::None)?;
+            self.body.assemble(c, Needs::None)?.apply(c)?;
 
             let total_var_count = c.scopes.total_var_count(span)?;
             c.locals_pop(total_var_count, span);

--- a/crates/rune/src/compiling/assemble/lit.rs
+++ b/crates/rune/src/compiling/assemble/lit.rs
@@ -2,31 +2,19 @@ use crate::compiling::assemble::prelude::*;
 
 /// Compile a literal value.
 impl Assemble for ast::Lit {
-    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<()> {
+    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<Asm> {
         let span = self.span();
         log::trace!("Lit => {:?}", c.source.source(span));
 
-        match self {
-            ast::Lit::Bool(lit_bool) => {
-                lit_bool.assemble(c, needs)?;
-            }
-            ast::Lit::Number(lit_number) => {
-                lit_number.assemble(c, needs)?;
-            }
-            ast::Lit::Char(lit_char) => {
-                lit_char.assemble(c, needs)?;
-            }
-            ast::Lit::Str(lit_str) => {
-                lit_str.assemble(c, needs)?;
-            }
-            ast::Lit::Byte(lit_char) => {
-                lit_char.assemble(c, needs)?;
-            }
-            ast::Lit::ByteStr(lit_byte_str) => {
-                lit_byte_str.assemble(c, needs)?;
-            }
-        }
+        let asm = match self {
+            ast::Lit::Bool(lit_bool) => lit_bool.assemble(c, needs)?,
+            ast::Lit::Number(lit_number) => lit_number.assemble(c, needs)?,
+            ast::Lit::Char(lit_char) => lit_char.assemble(c, needs)?,
+            ast::Lit::Str(lit_str) => lit_str.assemble(c, needs)?,
+            ast::Lit::Byte(lit_char) => lit_char.assemble(c, needs)?,
+            ast::Lit::ByteStr(lit_byte_str) => lit_byte_str.assemble(c, needs)?,
+        };
 
-        Ok(())
+        Ok(asm)
     }
 }

--- a/crates/rune/src/compiling/assemble/lit_bool.rs
+++ b/crates/rune/src/compiling/assemble/lit_bool.rs
@@ -2,17 +2,17 @@ use crate::compiling::assemble::prelude::*;
 
 /// Compile a literal boolean such as `true`.
 impl Assemble for ast::LitBool {
-    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<()> {
+    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<Asm> {
         let span = self.span();
         log::trace!("LitBool => {:?}", c.source.source(span));
 
         // If the value is not needed, no need to encode it.
         if !needs.value() {
             c.warnings.not_used(c.source_id, span, c.context());
-            return Ok(());
+        } else {
+            c.asm.push(Inst::bool(self.value), span);
         }
 
-        c.asm.push(Inst::bool(self.value), span);
-        Ok(())
+        Ok(Asm::top(span))
     }
 }

--- a/crates/rune/src/compiling/assemble/lit_byte.rs
+++ b/crates/rune/src/compiling/assemble/lit_byte.rs
@@ -2,18 +2,18 @@ use crate::compiling::assemble::prelude::*;
 
 /// Compile a literal byte such as `b'a'`.
 impl Assemble for ast::LitByte {
-    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<()> {
+    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<Asm> {
         let span = self.span();
         log::trace!("LitByte => {:?}", c.source.source(span));
 
         // NB: Elide the entire literal if it's not needed.
         if !needs.value() {
             c.warnings.not_used(c.source_id, span, c.context());
-            return Ok(());
+            return Ok(Asm::top(span));
         }
 
         let b = self.resolve(&c.storage, &*c.source)?;
         c.asm.push(Inst::byte(b), span);
-        Ok(())
+        Ok(Asm::top(span))
     }
 }

--- a/crates/rune/src/compiling/assemble/lit_byte_str.rs
+++ b/crates/rune/src/compiling/assemble/lit_byte_str.rs
@@ -2,19 +2,19 @@ use crate::compiling::assemble::prelude::*;
 
 /// Compile a literal string `b"Hello World"`.
 impl Assemble for ast::LitByteStr {
-    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<()> {
+    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<Asm> {
         let span = self.span();
         log::trace!("LitByteStr => {:?}", c.source.source(span));
 
         // NB: Elide the entire literal if it's not needed.
         if !needs.value() {
             c.warnings.not_used(c.source_id, span, c.context());
-            return Ok(());
+            return Ok(Asm::top(span));
         }
 
         let bytes = self.resolve(&c.storage, &*c.source)?;
         let slot = c.unit.new_static_bytes(span, &*bytes)?;
         c.asm.push(Inst::Bytes { slot }, span);
-        Ok(())
+        Ok(Asm::top(span))
     }
 }

--- a/crates/rune/src/compiling/assemble/lit_char.rs
+++ b/crates/rune/src/compiling/assemble/lit_char.rs
@@ -2,18 +2,18 @@ use crate::compiling::assemble::prelude::*;
 
 /// Compile a literal character.
 impl Assemble for ast::LitChar {
-    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<()> {
+    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<Asm> {
         let span = self.span();
         log::trace!("LitChar => {:?}", c.source.source(span));
 
         // NB: Elide the entire literal if it's not needed.
         if !needs.value() {
             c.warnings.not_used(c.source_id, span, c.context());
-            return Ok(());
+            return Ok(Asm::top(span));
         }
 
         let ch = self.resolve(&c.storage, &*c.source)?;
         c.asm.push(Inst::char(ch), span);
-        Ok(())
+        Ok(Asm::top(span))
     }
 }

--- a/crates/rune/src/compiling/assemble/lit_number.rs
+++ b/crates/rune/src/compiling/assemble/lit_number.rs
@@ -2,7 +2,7 @@ use crate::compiling::assemble::prelude::*;
 
 /// Compile a literal number.
 impl Assemble for ast::LitNumber {
-    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<()> {
+    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<Asm> {
         use num::ToPrimitive as _;
 
         let span = self.span();
@@ -11,7 +11,7 @@ impl Assemble for ast::LitNumber {
         // NB: don't encode unecessary literal.
         if !needs.value() {
             c.warnings.not_used(c.source_id, span, c.context());
-            return Ok(());
+            return Ok(Asm::top(span));
         }
 
         let number = self.resolve(&c.storage, &*c.source)?;
@@ -35,6 +35,6 @@ impl Assemble for ast::LitNumber {
             }
         }
 
-        Ok(())
+        Ok(Asm::top(span))
     }
 }

--- a/crates/rune/src/compiling/assemble/lit_str.rs
+++ b/crates/rune/src/compiling/assemble/lit_str.rs
@@ -2,19 +2,19 @@ use crate::compiling::assemble::prelude::*;
 
 /// Compile a literal string `"Hello World"`.
 impl Assemble for ast::LitStr {
-    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<()> {
+    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<Asm> {
         let span = self.span();
         log::trace!("LitStr => {:?}", c.source.source(span));
 
         // NB: Elide the entire literal if it's not needed.
         if !needs.value() {
             c.warnings.not_used(c.source_id, span, c.context());
-            return Ok(());
+            return Ok(Asm::top(span));
         }
 
         let string = self.resolve(&c.storage, &*c.source)?;
         let slot = c.unit.new_static_string(span, &*string)?;
         c.asm.push(Inst::String { slot }, span);
-        Ok(())
+        Ok(Asm::top(span))
     }
 }

--- a/crates/rune/src/compiling/assemble/local.rs
+++ b/crates/rune/src/compiling/assemble/local.rs
@@ -2,13 +2,13 @@ use crate::compiling::assemble::prelude::*;
 
 /// Compile a let expression.
 impl Assemble for ast::Local {
-    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<()> {
+    fn assemble(&self, c: &mut Compiler<'_>, needs: Needs) -> CompileResult<Asm> {
         let span = self.span();
         log::trace!("Local => {:?}", c.source.source(span));
 
         let load = |c: &mut Compiler, needs: Needs| {
             // NB: assignments "move" the value being assigned.
-            self.expr.assemble(c, needs)?;
+            self.expr.assemble(c, needs)?.apply(c)?;
             Ok(())
         };
 
@@ -36,6 +36,6 @@ impl Assemble for ast::Local {
             c.asm.push(Inst::unit(), span);
         }
 
-        Ok(())
+        Ok(Asm::top(span))
     }
 }

--- a/crates/rune/src/compiling/assemble/prelude.rs
+++ b/crates/rune/src/compiling/assemble/prelude.rs
@@ -1,6 +1,6 @@
 pub(crate) use crate::ast;
 pub(crate) use crate::compiling::{
-    Assemble, AssembleClosure, AssembleConst, AssembleFn, Compiler, Loop, Needs,
+    Asm, Assemble, AssembleClosure, AssembleConst, AssembleFn, Compiler, Loop, Needs,
 };
 pub(crate) use crate::{
     CompileError, CompileErrorKind, CompileResult, ParseErrorKind, Resolve, Spanned,

--- a/crates/rune/src/compiling/compiler.rs
+++ b/crates/rune/src/compiling/compiler.rs
@@ -251,7 +251,7 @@ impl<'a> Compiler<'a> {
             ast::Condition::Expr(expr) => {
                 let span = expr.span();
 
-                expr.assemble(self, Needs::Value)?;
+                expr.assemble(self, Needs::Value)?.apply(self)?;
                 self.asm.jump_if(then_label, span);
 
                 Ok(self.scopes.child(span)?)
@@ -265,7 +265,7 @@ impl<'a> Compiler<'a> {
                 let expected = self.scopes.push(scope);
 
                 let load = |c: &mut Self, needs: Needs| {
-                    expr_let.expr.assemble(c, needs)?;
+                    expr_let.expr.assemble(c, needs)?.apply(c)?;
                     Ok(())
                 };
 

--- a/crates/rune/src/compiling/mod.rs
+++ b/crates/rune/src/compiling/mod.rs
@@ -21,7 +21,7 @@ pub use self::scopes::Var;
 pub use self::unit_builder::{BuildError, InsertMetaError, LinkerError, UnitBuilder};
 use crate::parsing::Resolve as _;
 
-pub(crate) use self::assemble::{Assemble, AssembleClosure, AssembleConst, AssembleFn};
+pub(crate) use self::assemble::{Asm, Assemble, AssembleClosure, AssembleConst, AssembleFn};
 pub(crate) use self::assembly::{Assembly, AssemblyInst};
 pub(crate) use self::compiler::{Compiler, Needs};
 pub(crate) use self::loops::{Loop, Loops};

--- a/crates/runestick/src/inst.rs
+++ b/crates/runestick/src/inst.rs
@@ -525,6 +525,50 @@ pub enum Inst {
         /// The size of the vector.
         count: usize,
     },
+    /// Construct a push a one-tuple value onto the stack.
+    ///
+    /// # Operation
+    ///
+    /// ```text
+    /// => <tuple>
+    /// ```
+    Tuple1 {
+        /// First element of the tuple.
+        args: [InstAddress; 1],
+    },
+    /// Construct a push a two-tuple value onto the stack.
+    ///
+    /// # Operation
+    ///
+    /// ```text
+    /// => <tuple>
+    /// ```
+    Tuple2 {
+        /// Tuple arguments.
+        args: [InstAddress; 2],
+    },
+    /// Construct a push a three-tuple value onto the stack.
+    ///
+    /// # Operation
+    ///
+    /// ```text
+    /// => <tuple>
+    /// ```
+    Tuple3 {
+        /// Tuple arguments.
+        args: [InstAddress; 3],
+    },
+    /// Construct a push a four-tuple value onto the stack.
+    ///
+    /// # Operation
+    ///
+    /// ```text
+    /// => <tuple>
+    /// ```
+    Tuple4 {
+        /// Tuple arguments.
+        args: [InstAddress; 4],
+    },
     /// Construct a push a tuple value onto the stack. The number of elements
     /// in the tuple are determined by `count` and are popped from the stack.
     ///
@@ -857,13 +901,15 @@ pub enum Inst {
     /// # Operation
     ///
     /// ```text
-    /// <value>
-    /// <value>
     /// => <value>
     /// ```
     Op {
         /// The actual operation.
         op: InstOp,
+        /// The address of the first argument.
+        a: InstAddress,
+        /// The address of the second argument.
+        b: InstAddress,
     },
     /// A built-in operation that assigns to the left-hand side operand. Like
     /// `a += b`.
@@ -1050,6 +1096,18 @@ impl fmt::Display for Inst {
             Self::Vec { count } => {
                 write!(fmt, "vec {}", count)?;
             }
+            Self::Tuple1 { args: [a] } => {
+                write!(fmt, "tuple-1 {}", a)?;
+            }
+            Self::Tuple2 { args: [a, b] } => {
+                write!(fmt, "tuple-2 {}, {}", a, b)?;
+            }
+            Self::Tuple3 { args: [a, b, c] } => {
+                write!(fmt, "tuple-3 {}, {}, {}", a, b, c)?;
+            }
+            Self::Tuple4 { args: [a, b, c, d] } => {
+                write!(fmt, "tuple-4 {}, {}, {}, {}", a, b, c, d)?;
+            }
             Self::Tuple { count } => {
                 write!(fmt, "tuple {}", count)?;
             }
@@ -1142,8 +1200,8 @@ impl fmt::Display for Inst {
             Self::Variant { variant } => {
                 write!(fmt, "variant {}", variant)?;
             }
-            Self::Op { op } => {
-                write!(fmt, "op {}", op)?;
+            Self::Op { op, a, b } => {
+                write!(fmt, "op {}, {}, {}", op, a, b)?;
             }
             Self::Assign { target, op } => {
                 write!(fmt, "assign {}, {}", target, op)?;

--- a/crates/runestick/src/inst.rs
+++ b/crates/runestick/src/inst.rs
@@ -176,7 +176,12 @@ pub enum Inst {
     /// <index>
     /// => <value>
     /// ```
-    IndexGet,
+    IndexGet {
+        /// How the target is addressed.
+        target: InstAddress,
+        /// How the index is addressed.
+        index: InstAddress,
+    },
     /// Get the given index out of a tuple on the top of the stack.
     /// Errors if the item doesn't exist or the item is not a tuple.
     ///
@@ -958,8 +963,8 @@ impl fmt::Display for Inst {
             Self::LoadInstanceFn { hash } => {
                 write!(fmt, "load-instance-fn {}", hash)?;
             }
-            Self::IndexGet => {
-                write!(fmt, "index-get")?;
+            Self::IndexGet { target, index } => {
+                write!(fmt, "index-get {}, {}", target, index)?;
             }
             Self::TupleIndexGet { index } => {
                 write!(fmt, "tuple-index-get {}", index)?;
@@ -1166,6 +1171,24 @@ impl fmt::Display for Inst {
                     None => write!(f, "?"),
                 }
             }
+        }
+    }
+}
+
+/// How an instruction addresses a value.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum InstAddress {
+    /// Addressed from the top of the stack.
+    Top,
+    /// Value addressed at the given offset.
+    Offset(usize),
+}
+
+impl fmt::Display for InstAddress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Top => write!(f, "top"),
+            Self::Offset(offset) => write!(f, "offset({})", offset),
         }
     }
 }

--- a/crates/runestick/src/lib.rs
+++ b/crates/runestick/src/lib.rs
@@ -198,8 +198,8 @@ pub use crate::function::{Function, SyncFunction};
 pub use crate::future::Future;
 pub use crate::hash::{Hash, IntoTypeHash};
 pub use crate::inst::{
-    Inst, InstAssignOp, InstOp, InstRangeLimits, InstTarget, InstValue, InstVariant, PanicReason,
-    TypeCheck,
+    Inst, InstAddress, InstAssignOp, InstOp, InstRangeLimits, InstTarget, InstValue, InstVariant,
+    PanicReason, TypeCheck,
 };
 pub use crate::item::{Component, ComponentRef, IntoComponent, Item};
 pub use crate::names::Names;

--- a/crates/runestick/src/stack.rs
+++ b/crates/runestick/src/stack.rs
@@ -1,4 +1,4 @@
-use crate::Value;
+use crate::{InstAddress, Value};
 use std::iter;
 use std::mem;
 use std::slice;
@@ -126,6 +126,14 @@ impl Stack {
         }
 
         self.stack.pop().ok_or_else(|| StackError(()))
+    }
+
+    /// Address a value on the stack.
+    pub fn address(&mut self, address: InstAddress) -> Result<Value, StackError> {
+        Ok(match address {
+            InstAddress::Top => self.pop()?,
+            InstAddress::Offset(offset) => self.at_offset(offset)?.clone(),
+        })
     }
 
     /// Pop the given number of elements from the stack.

--- a/crates/runestick/src/stack.rs
+++ b/crates/runestick/src/stack.rs
@@ -1,4 +1,5 @@
 use crate::{InstAddress, Value};
+use std::borrow::Cow;
 use std::iter;
 use std::mem;
 use std::slice;
@@ -133,6 +134,14 @@ impl Stack {
         Ok(match address {
             InstAddress::Top => self.pop()?,
             InstAddress::Offset(offset) => self.at_offset(offset)?.clone(),
+        })
+    }
+
+    /// Address a value on the stack.
+    pub fn address_ref(&mut self, address: InstAddress) -> Result<Cow<'_, Value>, StackError> {
+        Ok(match address {
+            InstAddress::Top => Cow::Owned(self.pop()?),
+            InstAddress::Offset(offset) => Cow::Borrowed(self.at_offset(offset)?),
         })
     }
 

--- a/crates/runestick/src/vec.rs
+++ b/crates/runestick/src/vec.rs
@@ -153,6 +153,21 @@ impl Vec {
     pub fn into_iterator(&self) -> crate::Iterator {
         crate::Iterator::from_double_ended("std::vec::Iter", self.clone().into_iter())
     }
+
+    /// Compare two vectors for equality.
+    pub(crate) fn value_ptr_eq(a: &Self, b: &Self) -> Result<bool, VmError> {
+        if a.len() != b.len() {
+            return Ok(false);
+        }
+
+        for (a, b) in a.iter().zip(b.iter()) {
+            if !Value::value_ptr_eq(a, b)? {
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
 }
 
 impl Named for Vec {

--- a/crates/runestick/src/vm.rs
+++ b/crates/runestick/src/vm.rs
@@ -3,11 +3,11 @@ use crate::future::SelectFuture;
 use crate::unit::UnitFn;
 use crate::{
     Args, Awaited, BorrowMut, Bytes, Call, Format, FormatSpec, FromValue, Function, Future,
-    Generator, GuardedArgs, Hash, Inst, InstAssignOp, InstFnNameHash, InstOp, InstRangeLimits,
-    InstTarget, InstValue, InstVariant, IntoTypeHash, Object, Panic, Protocol, Range, RangeLimits,
-    RuntimeContext, Select, Shared, Stack, Stream, Struct, StructVariant, Tuple, TypeCheck, Unit,
-    UnitStruct, UnitVariant, Value, Vec, VmError, VmErrorKind, VmExecution, VmHalt, VmIntegerRepr,
-    VmSendExecution,
+    Generator, GuardedArgs, Hash, Inst, InstAddress, InstAssignOp, InstFnNameHash, InstOp,
+    InstRangeLimits, InstTarget, InstValue, InstVariant, IntoTypeHash, Object, Panic, Protocol,
+    Range, RangeLimits, RuntimeContext, Select, Shared, Stack, Stream, Struct, StructVariant,
+    Tuple, TypeCheck, Unit, UnitStruct, UnitVariant, Value, Vec, VmError, VmErrorKind, VmExecution,
+    VmHalt, VmIntegerRepr, VmSendExecution,
 };
 use std::fmt;
 use std::mem;
@@ -1920,9 +1920,9 @@ impl Vm {
 
     /// Perform an index get operation.
     #[cfg_attr(feature = "bench", inline(never))]
-    fn op_index_get(&mut self) -> Result<(), VmError> {
-        let index = self.stack.pop()?;
-        let target = self.stack.pop()?;
+    fn op_index_get(&mut self, target: InstAddress, index: InstAddress) -> Result<(), VmError> {
+        let index = self.stack.address(index)?;
+        let target = self.stack.address(target)?;
 
         // This is a useful pattern.
         #[allow(clippy::never_loop)]
@@ -2740,8 +2740,8 @@ impl Vm {
                 Inst::LoadInstanceFn { hash } => {
                     self.op_load_instance_fn(hash)?;
                 }
-                Inst::IndexGet => {
-                    self.op_index_get()?;
+                Inst::IndexGet { target, index } => {
+                    self.op_index_get(target, index)?;
                 }
                 Inst::TupleIndexGet { index } => {
                     self.op_tuple_index_get(index)?;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -6,7 +6,7 @@ extern crate rune_tests;
 macro_rules! assert_parse_error {
     ($source:expr, $span:ident, $pat:pat => $cond:expr) => {{
         let context = std::sync::Arc::new(rune_modules::default_context().unwrap());
-        let errors = rune_tests::compile_source(&context, &$source).unwrap_err();
+        let errors = ::rune_tests::compile_source(&context, &$source).unwrap_err();
         let err = errors.into_iter().next().expect("expected one error");
 
         let e = match err.into_kind() {
@@ -41,10 +41,10 @@ macro_rules! assert_vm_error {
     // Second variant which allows for specifyinga type.
     ($ty:ty => $source:expr, $pat:pat => $cond:block) => {{
         let context = std::sync::Arc::new(rune_modules::default_context().unwrap());
-        let e = rune_tests::run::<_, _, $ty>(&context, $source, &["main"], ()).unwrap_err();
+        let e = ::rune_tests::run::<_, _, $ty>(&context, $source, &["main"], ()).unwrap_err();
 
         let (e, _) = match e {
-            rune_tests::RunError::VmError(e) => e.into_unwound(),
+            ::rune_tests::RunError::VmError(e) => e.into_unwound(),
             actual => {
                 panic!("expected vm error `{}` but was `{:?}`", stringify!($pat), actual);
             }
@@ -63,7 +63,7 @@ macro_rules! assert_vm_error {
 macro_rules! assert_parse {
     ($source:expr) => {{
         let context = rune_modules::default_context().unwrap();
-        rune_tests::compile_source(&context, $source).unwrap()
+        ::rune_tests::compile_source(&context, $source).unwrap()
     }};
 }
 
@@ -71,7 +71,7 @@ macro_rules! assert_parse {
 macro_rules! assert_compile_error {
     ($source:expr, $span:ident, $pat:pat => $cond:expr) => {{
         let context = rune_modules::default_context().unwrap();
-        let e = rune_tests::compile_source(&context, $source).unwrap_err();
+        let e = ::rune_tests::compile_source(&context, $source).unwrap_err();
         let e = e.into_iter().next().expect("expected one error");
 
         let e = match e.into_kind() {
@@ -101,7 +101,7 @@ macro_rules! assert_compile_error {
 macro_rules! assert_warnings {
     ($source:expr $(, $pat:pat => $cond:expr)*) => {{
         let context = rune_modules::default_context().unwrap();
-        let (_, warnings) = rune_tests::compile_source(&context, $source).expect("source should compile");
+        let (_, warnings) = ::rune_tests::compile_source(&context, $source).expect("source should compile");
         assert!(!warnings.is_empty(), "no warnings produced");
 
         let mut it = warnings.into_iter();


### PR DESCRIPTION
This adds infrastructure to delay the assembly of values so that they can if appropriate target the stack directly instead of always having to resort to copy the value from a position in the stack to the top of it.

This has several benefits:
* This reduces peak memory use, since the stack will overall be smaller.
* This reduces the number of ref count increase/decreases a value has to go through when operating over it. Like we do with the `IndexGet` operation (see use of `Stack::address_ref` which can even use a reference of the value).

My own benchmarks shows a 50% reduction in the number of copies in `aoc_2020_1a` and a ~10% performance gain.

Because this has to live side-by-side with the existing assembler, `Asm` has to support both modes:
* `Asm::apply` will cause the assembly to generate the necessary instructions. No compiler state will be modified, since this is currently the norm.
* `Asm::apply_targeted` will produce an `InstTarget` appropriate for the operation. If a value is copied onto the stack, it will be declared as anonymous. This should be used immediately in a scope so the scope can be cleaned up.