### PR TITLE
Add support for pattern bindings in function arguments and perf improvements

### DIFF
--- a/crates/rune/src/ast/expr_closure.rs
+++ b/crates/rune/src/ast/expr_closure.rs
@@ -87,11 +87,19 @@ impl ExprClosureArgs {
         }
     }
 
-    /// Iterate over all arguments.
+    /// Get a slice over all arguments.
     pub fn as_slice(&self) -> &[(ast::FnArg, Option<T![,]>)] {
         match self {
             Self::Empty { .. } => &[],
             Self::List { args, .. } => &args[..],
+        }
+    }
+
+    /// Get a mutable slice over all arguments.
+    pub fn as_slice_mut(&mut self) -> &mut [(ast::FnArg, Option<T![,]>)] {
+        match self {
+            Self::Empty { .. } => &mut [],
+            Self::List { args, .. } => &mut args[..],
         }
     }
 }

--- a/crates/rune/src/ast/expr_for.rs
+++ b/crates/rune/src/ast/expr_for.rs
@@ -9,6 +9,7 @@ use crate::{ParseError, Parser, Spanned, ToTokens};
 /// use rune::{testing, ast};
 ///
 /// testing::roundtrip::<ast::ExprFor>("for i in x {}");
+/// testing::roundtrip::<ast::ExprFor>("for (a, _) in x {}");
 /// testing::roundtrip::<ast::ExprFor>("'label: for i in x {}");
 /// testing::roundtrip::<ast::ExprFor>("#[attr] 'label: for i in x {}");
 /// ```
@@ -22,9 +23,9 @@ pub struct ExprFor {
     pub label: Option<(ast::Label, T![:])>,
     /// The `for` keyword.
     pub for_token: T![for],
-    /// The variable binding.
-    /// TODO: should be a pattern when that is supported.
-    pub var: ast::Ident,
+    /// The pattern binding to use.
+    /// Non-trivial pattern bindings will panic if the value doesn't match.
+    pub binding: ast::Pat,
     /// The `in` keyword.
     pub in_: T![in],
     /// Expression producing the iterator.
@@ -44,7 +45,7 @@ impl ExprFor {
             attributes,
             label,
             for_token: parser.parse()?,
-            var: parser.parse()?,
+            binding: parser.parse()?,
             in_: parser.parse()?,
             iter: ast::Expr::parse_without_eager_brace(parser)?,
             body: parser.parse()?,

--- a/crates/rune/src/ast/fn_arg.rs
+++ b/crates/rune/src/ast/fn_arg.rs
@@ -16,24 +16,15 @@ use crate::{Parse, ParseError, Parser, Spanned, ToTokens};
 pub enum FnArg {
     /// The `self` parameter.
     SelfValue(T![self]),
-    /// Ignoring the argument with `_`.
-    Ignore(T![_]),
-    /// Binding the argument to an ident.
-    Ident(ast::Ident),
+    /// Function argument is a pattern binding.
+    Pat(ast::Pat),
 }
 
 impl Parse for FnArg {
     fn parse(p: &mut Parser<'_>) -> Result<Self, ParseError> {
         Ok(match p.nth(0)? {
             K![self] => Self::SelfValue(p.parse()?),
-            K![_] => Self::Ignore(p.parse()?),
-            K![ident] => Self::Ident(p.parse()?),
-            _ => {
-                return Err(ParseError::expected(
-                    &p.tok_at(0)?,
-                    "expected function argument",
-                ))
-            }
+            _ => Self::Pat(p.parse()?),
         })
     }
 }

--- a/crates/rune/src/compiling/assemble/expr_for.rs
+++ b/crates/rune/src/compiling/assemble/expr_for.rs
@@ -130,32 +130,8 @@ impl Assemble for ast::ExprFor {
             );
         }
 
-        // test loop condition and unwrap the option.
-        // TODO: introduce a dedicated instruction for this :|.
-        {
-            c.asm.push(
-                Inst::Copy {
-                    offset: binding_offset,
-                },
-                binding_span,
-            );
-            c.asm.push(Inst::IsValue, self.span());
-            c.asm.jump_if_not(end_label, self.span());
-            c.asm.push(
-                Inst::Copy {
-                    offset: binding_offset,
-                },
-                binding_span,
-            );
-            // unwrap the optional value.
-            c.asm.push(Inst::Unwrap, self.span());
-            c.asm.push(
-                Inst::Replace {
-                    offset: binding_offset,
-                },
-                binding_span,
-            );
-        }
+        // Test loop condition and unwrap the option, or jump to `end_label` if the current value is `None`.
+        c.asm.iter_next(binding_offset, end_label, binding_span);
 
         let body_span = self.body.span();
         let guard = c.scopes.push_child(body_span)?;

--- a/crates/rune/src/compiling/assemble/expr_let.rs
+++ b/crates/rune/src/compiling/assemble/expr_let.rs
@@ -9,7 +9,7 @@ impl Assemble for ast::ExprLet {
         let load = |c: &mut Compiler, needs: Needs| {
             // NB: assignments "move" the value being assigned.
             self.expr.assemble(c, needs)?.apply(c)?;
-            Ok(())
+            Ok(Asm::top(span))
         };
 
         let false_label = c.asm.new_label("let_panic");

--- a/crates/rune/src/compiling/assemble/expr_match.rs
+++ b/crates/rune/src/compiling/assemble/expr_match.rs
@@ -28,7 +28,7 @@ impl Assemble for ast::ExprMatch {
                     this.asm.push(Inst::Copy { offset }, span);
                 }
 
-                Ok(())
+                Ok(Asm::top(span))
             };
 
             c.compile_pat(&branch.pat, match_false, &load)?;

--- a/crates/rune/src/compiling/assemble/local.rs
+++ b/crates/rune/src/compiling/assemble/local.rs
@@ -6,11 +6,7 @@ impl Assemble for ast::Local {
         let span = self.span();
         log::trace!("Local => {:?}", c.source.source(span));
 
-        let load = |c: &mut Compiler, needs: Needs| {
-            // NB: assignments "move" the value being assigned.
-            self.expr.assemble(c, needs)?.apply(c)?;
-            Ok(())
-        };
+        let load = |c: &mut Compiler, needs: Needs| Ok(self.expr.assemble(c, needs)?);
 
         let false_label = c.asm.new_label("let_panic");
 

--- a/crates/rune/src/compiling/assembly.rs
+++ b/crates/rune/src/compiling/assembly.rs
@@ -8,11 +8,11 @@ use runestick::{Hash, Inst, Label, Location, Span};
 pub enum AssemblyInst {
     Jump { label: Label },
     JumpIf { label: Label },
-    JumpIfNot { label: Label },
     JumpIfOrPop { label: Label },
     JumpIfNotOrPop { label: Label },
     JumpIfBranch { branch: i64, label: Label },
     PopAndJumpIfNot { count: usize, label: Label },
+    IterNext { offset: usize, label: Label },
     Raw { raw: Inst },
 }
 
@@ -82,12 +82,6 @@ impl Assembly {
             .push((AssemblyInst::JumpIf { label }, span));
     }
 
-    /// Add a conditional jump to the given label.
-    pub(crate) fn jump_if_not(&mut self, label: Label, span: Span) {
-        self.instructions
-            .push((AssemblyInst::JumpIfNot { label }, span));
-    }
-
     /// Add a conditional jump to the given label. Only pops the top of the
     /// stack if the jump is not executed.
     pub(crate) fn jump_if_or_pop(&mut self, label: Label, span: Span) {
@@ -112,6 +106,12 @@ impl Assembly {
     pub(crate) fn pop_and_jump_if_not(&mut self, count: usize, label: Label, span: Span) {
         self.instructions
             .push((AssemblyInst::PopAndJumpIfNot { count, label }, span));
+    }
+
+    /// Add an instruction that advanced an iterator.
+    pub(crate) fn iter_next(&mut self, offset: usize, label: Label, span: Span) {
+        self.instructions
+            .push((AssemblyInst::IterNext { offset, label }, span));
     }
 
     /// Push a raw instruction.

--- a/crates/rune/src/compiling/scopes.rs
+++ b/crates/rune/src/compiling/scopes.rs
@@ -138,6 +138,20 @@ impl Scope {
         offset
     }
 
+    /// Insert a new local, and return the old one if there's a conflict.
+    fn decl_var_with_offset(&mut self, name: &str, offset: usize, span: Span) {
+        log::trace!("decl {} => {}", name, offset);
+
+        self.locals.insert(
+            name.to_owned(),
+            Var {
+                offset,
+                span,
+                moved_at: None,
+            },
+        );
+    }
+
     /// Declare an anonymous variable.
     ///
     /// This is used if cleanup is required in the middle of an expression.
@@ -313,6 +327,18 @@ impl Scopes {
     /// Declare the given variable.
     pub(crate) fn decl_var(&mut self, name: &str, span: Span) -> CompileResult<usize> {
         Ok(self.last_mut(span)?.decl_var(name, span))
+    }
+
+    /// Declare the given variable with a custom offset.
+    pub(crate) fn decl_var_with_offset(
+        &mut self,
+        name: &str,
+        offset: usize,
+        span: Span,
+    ) -> CompileResult<()> {
+        Ok(self
+            .last_mut(span)?
+            .decl_var_with_offset(name, offset, span))
     }
 
     /// Declare an anonymous variable.

--- a/crates/rune/src/compiling/unit_builder.rs
+++ b/crates/rune/src/compiling/unit_builder.rs
@@ -691,11 +691,6 @@ impl Inner {
                     let offset = translate_offset(span, pos, label, &assembly.labels)?;
                     self.instructions.push(Inst::JumpIf { offset });
                 }
-                AssemblyInst::JumpIfNot { label } => {
-                    comment = Some(format!("label:{}", label));
-                    let offset = translate_offset(span, pos, label, &assembly.labels)?;
-                    self.instructions.push(Inst::JumpIfNot { offset });
-                }
                 AssemblyInst::JumpIfOrPop { label } => {
                     comment = Some(format!("label:{}", label));
                     let offset = translate_offset(span, pos, label, &assembly.labels)?;
@@ -717,6 +712,11 @@ impl Inner {
                     let offset = translate_offset(span, pos, label, &assembly.labels)?;
                     self.instructions
                         .push(Inst::PopAndJumpIfNot { count, offset });
+                }
+                AssemblyInst::IterNext { offset, label } => {
+                    comment = Some(format!("label:{}", label));
+                    let jump = translate_offset(span, pos, label, &assembly.labels)?;
+                    self.instructions.push(Inst::IterNext { offset, jump });
                 }
                 AssemblyInst::Raw { raw } => {
                     self.instructions.push(raw);

--- a/crates/rune/src/indexing/index.rs
+++ b/crates/rune/src/indexing/index.rs
@@ -1565,7 +1565,7 @@ impl Index for ast::ExprFor {
         self.iter.index(idx)?;
 
         let _guard = idx.scopes.push_scope();
-        self.var.index(idx)?;
+        self.binding.index(idx)?;
         self.body.index(idx)?;
         Ok(())
     }

--- a/crates/rune/src/indexing/index_local.rs
+++ b/crates/rune/src/indexing/index_local.rs
@@ -1,0 +1,139 @@
+/// Indexing for local declarations.
+use crate::ast;
+use crate::compiling::CompileResult;
+use crate::indexing::Indexer;
+use crate::parsing::Resolve as _;
+use crate::Spanned as _;
+
+pub(crate) trait IndexLocal {
+    /// Walk the current type with the given item.
+    fn index_local(&mut self, idx: &mut Indexer<'_>) -> CompileResult<()>;
+}
+
+impl IndexLocal for ast::Pat {
+    fn index_local(&mut self, idx: &mut Indexer<'_>) -> CompileResult<()> {
+        let span = self.span();
+        log::trace!("Pat => {:?}", idx.source.source(span));
+
+        match self {
+            ast::Pat::PatPath(pat_path) => {
+                pat_path.index_local(idx)?;
+            }
+            ast::Pat::PatObject(pat_object) => {
+                pat_object.index_local(idx)?;
+            }
+            ast::Pat::PatVec(pat_vec) => {
+                pat_vec.index_local(idx)?;
+            }
+            ast::Pat::PatTuple(pat_tuple) => {
+                pat_tuple.index_local(idx)?;
+            }
+            ast::Pat::PatBinding(pat_binding) => {
+                pat_binding.index_local(idx)?;
+            }
+            ast::Pat::PatIgnore(..) => (),
+            ast::Pat::PatLit(..) => (),
+            ast::Pat::PatRest(..) => (),
+        }
+
+        Ok(())
+    }
+}
+
+impl IndexLocal for ast::PatPath {
+    fn index_local(&mut self, idx: &mut Indexer<'_>) -> CompileResult<()> {
+        let span = self.span();
+        log::trace!("Ident => {:?}", idx.source.source(span));
+        self.path.index_local(idx)?;
+        Ok(())
+    }
+}
+
+impl IndexLocal for ast::Path {
+    fn index_local(&mut self, idx: &mut Indexer<'_>) -> CompileResult<()> {
+        let span = self.span();
+        log::trace!("Ident => {:?}", idx.source.source(span));
+
+        let id = idx
+            .query
+            .insert_path(&idx.mod_item, idx.impl_item.as_ref(), &*idx.items.item());
+        self.id = Some(id);
+
+        if let Some(ident) = self.try_as_ident_mut() {
+            ident.index_local(idx)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl IndexLocal for ast::Ident {
+    fn index_local(&mut self, idx: &mut Indexer<'_>) -> CompileResult<()> {
+        let span = self.span();
+        log::trace!("Ident => {:?}", idx.source.source(span));
+
+        let span = self.span();
+        let ident = self.resolve(&idx.storage, &*idx.source)?;
+        idx.scopes.declare(ident.as_ref(), span)?;
+        Ok(())
+    }
+}
+
+impl IndexLocal for ast::PatObject {
+    fn index_local(&mut self, idx: &mut Indexer<'_>) -> CompileResult<()> {
+        let span = self.span();
+        log::trace!("PatObject => {:?}", idx.source.source(span));
+
+        match &mut self.ident {
+            ast::ObjectIdent::Anonymous(_) => {}
+            ast::ObjectIdent::Named(path) => {
+                path.index_local(idx)?;
+            }
+        }
+
+        for (pat, _) in &mut self.items {
+            pat.index_local(idx)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl IndexLocal for ast::PatVec {
+    fn index_local(&mut self, idx: &mut Indexer<'_>) -> CompileResult<()> {
+        let span = self.span();
+        log::trace!("PatVec => {:?}", idx.source.source(span));
+
+        for (pat, _) in &mut self.items {
+            pat.index_local(idx)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl IndexLocal for ast::PatTuple {
+    fn index_local(&mut self, idx: &mut Indexer<'_>) -> CompileResult<()> {
+        let span = self.span();
+        log::trace!("PatTuple => {:?}", idx.source.source(span));
+
+        if let Some(path) = &mut self.path {
+            path.index_local(idx)?;
+        }
+
+        for (pat, _) in &mut self.items {
+            pat.index_local(idx)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl IndexLocal for ast::PatBinding {
+    fn index_local(&mut self, idx: &mut Indexer<'_>) -> CompileResult<()> {
+        let span = self.span();
+        log::trace!("PatBinding => {:?}", idx.source.source(span));
+        self.pat.index_local(idx)?;
+        Ok(())
+    }
+}

--- a/crates/rune/src/indexing/mod.rs
+++ b/crates/rune/src/indexing/mod.rs
@@ -1,5 +1,7 @@
 mod index;
+mod index_local;
 mod index_scopes;
 
 pub(crate) use self::index::{Index, Indexer};
+pub(crate) use self::index_local::IndexLocal;
 pub(crate) use self::index_scopes::{IndexFnKind, IndexScopes};

--- a/crates/rune/src/ir/ir_compiler.rs
+++ b/crates/rune/src/ir/ir_compiler.rs
@@ -160,11 +160,16 @@ impl IrCompile for ast::ItemFn {
 
         for (arg, _) in &self.args {
             match arg {
-                ast::FnArg::Ident(ident) => {
-                    args.push(c.resolve(ident)?.into());
+                ast::FnArg::Pat(ast::Pat::PatPath(path)) => {
+                    if let Some(ident) = path.path.try_as_ident() {
+                        args.push(c.resolve(ident)?.into());
+                        continue;
+                    }
                 }
-                _ => return Err(IrError::msg(arg, "unsupported argument in const fn")),
+                _ => (),
             }
+
+            return Err(IrError::msg(arg, "unsupported argument in const fn"));
         }
 
         let ir_scope = self.body.compile(c)?;

--- a/crates/runestick/src/inst.rs
+++ b/crates/runestick/src/inst.rs
@@ -459,19 +459,6 @@ pub enum Inst {
         offset: isize,
     },
     /// Jump to `offset` relative to the current instruction pointer if the
-    /// condition is `false`.
-    ///
-    /// # Operation
-    ///
-    /// ```text
-    /// <boolean>
-    /// => *nothing*
-    /// ```
-    JumpIfNot {
-        /// Offset to jump to.
-        offset: isize,
-    },
-    /// Jump to `offset` relative to the current instruction pointer if the
     /// condition is `true`. Will only pop the stack is a jump is not performed.
     ///
     /// # Operation
@@ -928,6 +915,13 @@ pub enum Inst {
         /// The actual operation.
         op: InstAssignOp,
     },
+    /// Advance an iterator at the given position.
+    IterNext {
+        /// The offset of the value being advanced.
+        offset: usize,
+        /// A relative jump to perform if the iterator could not be advanced.
+        jump: isize,
+    },
     /// Cause the VM to panic and error out without a reason.
     ///
     /// This should only be used during testing or extreme scenarios that are
@@ -1081,9 +1075,6 @@ impl fmt::Display for Inst {
             Self::JumpIf { offset } => {
                 write!(fmt, "jump-if {}", offset)?;
             }
-            Self::JumpIfNot { offset } => {
-                write!(fmt, "jump-if-not {}", offset)?;
-            }
             Self::JumpIfOrPop { offset } => {
                 write!(fmt, "jump-if-or-pop {}", offset)?;
             }
@@ -1205,6 +1196,9 @@ impl fmt::Display for Inst {
             }
             Self::Assign { target, op } => {
                 write!(fmt, "assign {}, {}", target, op)?;
+            }
+            Self::IterNext { offset, jump } => {
+                write!(fmt, "iter-next {}, {}", offset, jump)?;
             }
             Self::Panic { reason } => {
                 write!(fmt, "panic {}", reason.ident())?;

--- a/tests/destructuring.rs
+++ b/tests/destructuring.rs
@@ -1,0 +1,52 @@
+macro_rules! test_case {
+    (($($st:tt)*), ($($ds:tt)*) $(, $($extra:tt)*)?) => {
+        assert_eq!(15, rune! { i64 =>
+            $($($extra)*)?
+
+            fn foo($($ds)*) {
+                a + b
+            }
+
+            pub fn main() {
+                let n = 0;
+
+                for (a, b) in [(1, 2), (2, 3), (3, 4)] {
+                    n += foo($($st)*);
+                }
+
+                n
+            }
+        });
+
+        assert_eq!(15, rune! { i64 =>
+            $($($extra)*)?
+
+            pub fn main() {
+                let foo = |$($ds)*| {
+                    a + b
+                };
+
+                let n = 0;
+
+                for (a, b) in [(1, 2), (2, 3), (3, 4)] {
+                    n += foo($($st)*);
+                }
+
+                n
+            }
+        });
+    }
+}
+
+#[test]
+fn test_fn_destructuring() {
+    test_case!((a, b), (a, b));
+    test_case!(((a, b)), ((a, b)));
+    test_case!((#{a, b}), (#{a, b}));
+    test_case!((#{a, c: b}), (#{a, c: b}));
+    test_case!((Foo { a, b }), (Foo { a, b }), struct Foo { a, b });
+    test_case!((Foo { a, c: b }), (Foo { a, c: b }), struct Foo { a, c });
+    test_case!((Foo(a, b)), (Foo(a, b)), struct Foo(a, b););
+    test_case!((Foo::Var {a, b}), (Foo::Var {a, b}), enum Foo { Var{a, b} };);
+    test_case!((Foo::Var(a, b)), (Foo::Var(a, b)), enum Foo { Var(a, b) };);
+}

--- a/tests/for_loop.rs
+++ b/tests/for_loop.rs
@@ -1,0 +1,53 @@
+#[test]
+fn test_binding_pattern() {
+    let out = rune! { i64 =>
+        pub fn main() {
+            let data = [(1, 2), (2, 3), (3, 4)];
+            let out = 0;
+
+            for (a, b) in data {
+                out += a * b;
+            }
+
+            out
+        }
+    };
+
+    assert_eq!(out, 1 * 2 + 2 * 3 + 3 * 4);
+}
+
+#[test]
+fn test_simple_binding() {
+    let out = rune! { i64 =>
+        pub fn main() {
+            let data = [1, 2, 3, 4];
+            let out = 0;
+
+            for v in data {
+                out += v;
+            }
+
+            out
+        }
+    };
+
+    assert_eq!(out, 1 + 2 + 3 + 4);
+}
+
+#[test]
+fn test_ignore_binding() {
+    let out = rune! { i64 =>
+        pub fn main() {
+            let data = [1, 2, 3, 4];
+            let out = 0;
+
+            for _ in data {
+                out += 1;
+            }
+
+            out
+        }
+    };
+
+    assert_eq!(out, 4);
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -145,6 +145,7 @@ mod compiler_visibility;
 mod compiler_warnings;
 mod core_macros;
 mod external_ops;
+mod for_loop;
 mod getter_setter;
 mod iterator;
 mod moved;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -144,6 +144,7 @@ mod compiler_use;
 mod compiler_visibility;
 mod compiler_warnings;
 mod core_macros;
+mod destructuring;
 mod external_ops;
 mod for_loop;
 mod getter_setter;


### PR DESCRIPTION
You can now use panicking pattern bindings in functions and closures:

```rust
fn foo((a, b), #{c, d}) {
    (a + b) / (c + d)
}

pub fn main() {
    let a = (3, 1);
    let b = #{c: 1, d: 7};
    foo(a, b)
}
```

Also added a few performance improvements leading to this result:
![image](https://user-images.githubusercontent.com/111092/101135909-ca82a880-360c-11eb-9b03-c6a5c846e1f7.png)

The big points are:
* More variable folding leading to less copies (all though return of investment of this is lower)
* A dedicated instruction for advancing iteration (5aa6d77388c265f9c8fc1b7a9b96d85eed71395d).