### PR TITLE
add generator::iter, clarify move/clone/reference for algebraic types

### DIFF
--- a/crates/runestick/src/from_value.rs
+++ b/crates/runestick/src/from_value.rs
@@ -141,6 +141,19 @@ impl UnsafeFromValue for &mut Option<Value> {
     }
 }
 
+impl UnsafeFromValue for &mut Result<Value, Value> {
+    type Output = *mut Result<Value, Value>;
+    type Guard = RawMut;
+
+    fn from_value(value: Value) -> Result<(Self::Output, Self::Guard), VmError> {
+        Ok(Mut::into_raw(value.into_result()?.into_mut()?))
+    }
+
+    unsafe fn unsafe_coerce(output: Self::Output) -> Self {
+        &mut *output
+    }
+}
+
 // String impls
 
 impl FromValue for String {

--- a/crates/runestick/src/generator.rs
+++ b/crates/runestick/src/generator.rs
@@ -48,6 +48,35 @@ impl Generator {
 
         Ok(state)
     }
+
+    /// Convert into iterator
+    pub fn into_iterator(self) -> Result<crate::Iterator, VmError> {
+        Ok(crate::Iterator::from(
+            "std::generator::GeneratorIterator",
+            self.into_iter(),
+        ))
+    }
+}
+
+impl IntoIterator for Generator {
+    type Item = Result<Value, VmError>;
+    type IntoIter = GeneratorIterator;
+
+    fn into_iter(self) -> GeneratorIterator {
+        GeneratorIterator { generator: self }
+    }
+}
+
+pub struct GeneratorIterator {
+    generator: Generator,
+}
+
+impl std::iter::Iterator for GeneratorIterator {
+    type Item = Result<Value, VmError>;
+
+    fn next(&mut self) -> Option<Result<Value, VmError>> {
+        self.generator.next().transpose()
+    }
 }
 
 impl fmt::Debug for Generator {

--- a/crates/runestick/src/iterator.rs
+++ b/crates/runestick/src/iterator.rs
@@ -161,6 +161,18 @@ impl Iterator {
         }
     }
 
+    /// Find the first matching value in the iterator using the given function.
+    pub fn find(mut self, find: Function) -> Result<Option<Value>, VmError> {
+        while let Some(value) = self.next()? {
+            let result = find.call::<_, bool>((value.clone(),))?;
+            if result {
+                return Ok(Some(value.clone()));
+            }
+        }
+
+        Ok(None)
+    }
+
     /// Chain this iterator with another.
     pub fn chain(self, other: Interface) -> Result<Self, VmError> {
         let other = other.into_iter()?;

--- a/crates/runestick/src/modules/generator.rs
+++ b/crates/runestick/src/modules/generator.rs
@@ -1,6 +1,6 @@
 //! The `std::generator` module.
 
-use crate::{ContextError, Generator, Module};
+use crate::{ContextError, Generator, Module, Protocol};
 
 /// Construct the `std::generator` module.
 pub fn module() -> Result<Module, ContextError> {
@@ -10,5 +10,8 @@ pub fn module() -> Result<Module, ContextError> {
 
     module.inst_fn("next", Generator::next)?;
     module.inst_fn("resume", Generator::resume)?;
+    module.inst_fn("iter", Generator::into_iterator)?;
+    module.inst_fn(Protocol::INTO_ITER, Generator::into_iterator)?;
+
     Ok(module)
 }

--- a/crates/runestick/src/modules/iter.rs
+++ b/crates/runestick/src/modules/iter.rs
@@ -16,6 +16,7 @@ pub fn module() -> Result<Module, ContextError> {
     module.inst_fn("collect_tuple", collect_tuple)?;
     module.inst_fn("enumerate", Iterator::enumerate)?;
     module.inst_fn("filter", Iterator::filter)?;
+    module.inst_fn("find", Iterator::find)?;
     module.inst_fn("flat_map", Iterator::flat_map)?;
     module.inst_fn("map", Iterator::map)?;
     module.inst_fn("next", Iterator::next)?;

--- a/crates/runestick/src/modules/option.rs
+++ b/crates/runestick/src/modules/option.rs
@@ -13,6 +13,7 @@ pub fn module() -> Result<Module, ContextError> {
     module.inst_fn("is_some", Option::<Value>::is_some)?;
     module.inst_fn("iter", option_iter)?;
     module.inst_fn("map", map_impl)?;
+    module.inst_fn("take", take_impl)?;
     module.inst_fn("transpose", transpose_impl)?;
     module.inst_fn("unwrap", unwrap_impl)?;
     module.inst_fn("unwrap_or", Option::<Value>::unwrap_or)?;
@@ -52,16 +53,22 @@ fn expect_impl(option: Option<Value>, message: &str) -> Result<Value, VmError> {
     option.ok_or_else(|| VmError::panic(message.to_owned()))
 }
 
-fn map_impl(option: Option<Value>, then: Function) -> Result<Option<Value>, VmError> {
+fn map_impl(option: &Option<Value>, then: Function) -> Result<Option<Value>, VmError> {
     match option {
+        // no need to clone v, passing the same reference forward
         Some(v) => then.call::<_, _>((v,)).map(Some),
         None => Ok(None),
     }
 }
 
-fn and_then_impl(option: Option<Value>, then: Function) -> Result<Option<Value>, VmError> {
+fn and_then_impl(option: &Option<Value>, then: Function) -> Result<Option<Value>, VmError> {
     match option {
+        // no need to clone v, passing the same reference forward
         Some(v) => then.call::<_, _>((v,)),
         None => Ok(None),
     }
+}
+
+fn take_impl(option: &mut Option<Value>) -> Option<Value> {
+    option.take()
 }

--- a/crates/runestick/src/modules/result.rs
+++ b/crates/runestick/src/modules/result.rs
@@ -42,6 +42,7 @@ fn and_then_impl(
     then: Function,
 ) -> Result<Result<Value, Value>, VmError> {
     match this {
+        // No need to clone v, passing the same reference forward
         Ok(v) => Ok(then.call::<_, _>((v,))?),
         Err(e) => Ok(Err(e.clone())),
     }
@@ -49,6 +50,7 @@ fn and_then_impl(
 
 fn map_impl(this: &Result<Value, Value>, then: Function) -> Result<Result<Value, Value>, VmError> {
     match this {
+        // No need to clone v, passing the same reference forward
         Ok(v) => Ok(Ok(then.call::<_, _>((v,))?)),
         Err(e) => Ok(Err(e.clone())),
     }

--- a/crates/runestick/src/vm.rs
+++ b/crates/runestick/src/vm.rs
@@ -2322,14 +2322,14 @@ impl Vm {
         let value = self.stack.pop()?;
 
         let value = match value {
-            Value::Option(option) => match option.take()? {
-                Some(value) => value,
+            Value::Option(option) => match &*(option.borrow_ref()?) {
+                Some(value) => value.clone(),
                 None => {
                     return Err(VmError::from(VmErrorKind::UnsupportedUnwrapNone));
                 }
             },
-            Value::Result(result) => match result.take()? {
-                Ok(value) => value,
+            Value::Result(result) => match &*(result.borrow_ref()?) {
+                Ok(value) => value.clone(),
                 Err(err) => {
                     return Err(VmError::from(VmErrorKind::UnsupportedUnwrapErr {
                         err: err.type_info()?,

--- a/crates/runestick/src/vm.rs
+++ b/crates/runestick/src/vm.rs
@@ -2322,13 +2322,13 @@ impl Vm {
         let value = self.stack.pop()?;
 
         let value = match value {
-            Value::Option(option) => match &*(option.borrow_ref()?) {
+            Value::Option(option) => match &*option.borrow_ref()? {
                 Some(value) => value.clone(),
                 None => {
                     return Err(VmError::from(VmErrorKind::UnsupportedUnwrapNone));
                 }
             },
-            Value::Result(result) => match &*(result.borrow_ref()?) {
+            Value::Result(result) => match &*result.borrow_ref()? {
                 Ok(value) => value.clone(),
                 Err(err) => {
                     return Err(VmError::from(VmErrorKind::UnsupportedUnwrapErr {


### PR DESCRIPTION
This adds generator::iter and INTO_ITER protocols.

Also, I noticed that the clone vs auto-ref vs move behaviour of Options/Result was unclear and so I've opted to implement `as_ref()` using an autoboxing approach. This isn't... optimal, performance-wise, but should be safe.

As far as I can tell this should work already using the defined ToValue methods for Option<T: ToValue> and &Value, but that code path causes the SharedBox to drop/inc out of order and I'm not sure why - and this is more explicit. It's a bit lewd to write to self in what should be a pure operation but it works and is safe. 