### PR TITLE
add set difference, intersection, union, fix sum error op

### DIFF
--- a/crates/runestick/src/iterator.rs
+++ b/crates/runestick/src/iterator.rs
@@ -209,6 +209,16 @@ impl Iterator {
         })
     }
 
+    /// Chain this iterator with another.
+    pub fn chain_raw(self, other: Self) -> Result<Self, VmError> {
+        Ok(Self {
+            iter: IterRepr::Chain(Box::new(Chain {
+                a: Some(self.iter),
+                b: Some(other.iter),
+            })),
+        })
+    }
+
     /// Map the iterator using the given function.
     pub fn rev(self) -> Result<Self, VmError> {
         if !self.iter.is_double_ended() {
@@ -1157,7 +1167,7 @@ where
                 Value::Integer(v) => Ok(Value::Integer(self.resolve_internal_simple(v)?)),
                 Value::Float(v) => Ok(Value::Float(self.resolve_internal_simple(v)?)),
                 _ => Err(VmError::from(VmErrorKind::UnsupportedBinaryOperation {
-                    op: "*",
+                    op: "+",
                     lhs: v.type_info()?,
                     rhs: v.type_info()?,
                 })),

--- a/crates/runestick/src/modules/collections.rs
+++ b/crates/runestick/src/modules/collections.rs
@@ -174,6 +174,12 @@ where
             }
         }
     }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, upper) = self.this.size_hint();
+        (0, upper)
+    }
 }
 
 struct Difference<I>
@@ -197,6 +203,12 @@ where
                 return Some(elt);
             }
         }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, upper) = self.this.size_hint();
+        (0, upper)
     }
 }
 

--- a/crates/runestick/src/modules/collections.rs
+++ b/crates/runestick/src/modules/collections.rs
@@ -165,24 +165,14 @@ where
 {
     type Item = Key;
     fn next(&mut self) -> Option<Self::Item> {
+        let other = self.other.take()?;
+
         loop {
-            // guaranteed to leave here unless the iterator is unbounded
-            match self.this.next() {
-                Some(elt) => {
-                    if self
-                        .other
-                        .as_ref()
-                        .expect("finished iterator came alive again")
-                        .set
-                        .contains(&elt)
-                    {
-                        return Some(elt);
-                    }
-                }
-                None => {
-                    self.other.take();
-                    return None;
-                }
+            let item = self.this.next()?;
+
+            if other.set.contains(&item) {
+                self.other = Some(other);
+                return Some(item);
             }
         }
     }
@@ -208,24 +198,14 @@ where
 {
     type Item = Key;
     fn next(&mut self) -> Option<Self::Item> {
+        let other = self.other.take()?;
+
         loop {
-            // guaranteed to leave here unless the iterator is unbounded
-            match self.this.next() {
-                Some(elt) => {
-                    if !self
-                        .other
-                        .as_ref()
-                        .expect("finished iterator came alive again")
-                        .set
-                        .contains(&elt)
-                    {
-                        return Some(elt);
-                    }
-                }
-                None => {
-                    self.other.take();
-                    return None;
-                }
+            let item = self.this.next()?;
+
+            if !other.set.contains(&item) {
+                self.other = Some(other);
+                return Some(item);
             }
         }
     }

--- a/crates/runestick/src/static_type.rs
+++ b/crates/runestick/src/static_type.rs
@@ -199,7 +199,6 @@ pub static FUNCTION_TYPE: &StaticType = &StaticType {
 
 impl_static_type!(crate::Function => FUNCTION_TYPE);
 impl_static_type!(crate::Shared<crate::Function> => FUNCTION_TYPE);
-impl_static_type!(crate::Ref<crate::Function> => FUNCTION_TYPE);
 impl_static_type!(impl<T> std::collections::HashMap<String, T> => OBJECT_TYPE);
 
 /// The specialized type information for a fmt spec types.

--- a/crates/runestick/src/type_of.rs
+++ b/crates/runestick/src/type_of.rs
@@ -36,3 +36,31 @@ where
         T::type_info()
     }
 }
+
+/// Blanket implementation for owned references.
+impl<T: ?Sized> TypeOf for crate::Ref<T>
+where
+    T: TypeOf,
+{
+    fn type_hash() -> Hash {
+        T::type_hash()
+    }
+
+    fn type_info() -> TypeInfo {
+        T::type_info()
+    }
+}
+
+/// Blanket implementation for owned mutable references.
+impl<T: ?Sized> TypeOf for crate::Mut<T>
+where
+    T: TypeOf,
+{
+    fn type_hash() -> Hash {
+        T::type_hash()
+    }
+
+    fn type_info() -> TypeInfo {
+        T::type_info()
+    }
+}


### PR DESCRIPTION
This adds `HashSet::{difference, intersection, union}` methods. To make that doable it adds more blanket implementations for `TypeOf` so we can take `self` as `Ref<Self>` in receiver position. This required removing one static type declaration. This required removing one static type declaration for `Ref<Function> - I can't really tell the extent of the impact that has, but that specific incantation seems to only be used in one FromValue declaration.

Also fixes a minor copy-paste error in Iterator summation leading to very confusing error messages.