### PR TITLE
AoC Day 5 changes

### DIFF
--- a/crates/rune-modules/src/core.rs
+++ b/crates/rune-modules/src/core.rs
@@ -47,5 +47,5 @@ pub(crate) fn panic_macro(
     let mut p = Parser::from_token_stream(stream);
     let args = p.parse_all::<macros::FormatArgs>()?;
     let expanded = args.expand()?;
-    Ok(quote!(std::core::panic(#expanded)).into_token_stream())
+    Ok(quote!(::std::panic(#expanded)).into_token_stream())
 }

--- a/crates/runestick/src/modules/ops.rs
+++ b/crates/runestick/src/modules/ops.rs
@@ -1,11 +1,21 @@
 //! The `std::ops` module.
 
-use crate::{ContextError, Module, Range};
+use crate::{ContextError, Module, Protocol, Range, Value};
 
 /// Construct the `std::ops` module.
 pub fn module() -> Result<Module, ContextError> {
     let mut module = Module::with_crate_item("std", &["ops"]);
     module.ty::<Range>()?;
     module.inst_fn("contains_int", Range::contains_int)?;
+    module.field_fn(Protocol::SET, "start", range_set_start)?;
+    module.field_fn(Protocol::SET, "end", range_set_end)?;
     Ok(module)
+}
+
+fn range_set_start(range: &mut Range, start: Option<Value>) {
+    range.start = start;
+}
+
+fn range_set_end(range: &mut Range, end: Option<Value>) {
+    range.end = end;
 }

--- a/crates/runestick/src/modules/string.rs
+++ b/crates/runestick/src/modules/string.rs
@@ -26,6 +26,8 @@ pub fn module() -> Result<Module, ContextError> {
     module.inst_fn("shrink_to_fit", String::shrink_to_fit)?;
     module.inst_fn("char_at", char_at)?;
     module.inst_fn("split", string_split)?;
+    module.inst_fn("trim", string_trim)?;
+    module.inst_fn("trim_end", string_trim_end)?;
     // TODO: deprecate this variant.
     module.inst_fn("split_str", string_split)?;
     module.inst_fn("is_empty", str::is_empty)?;
@@ -89,6 +91,14 @@ fn string_split(this: &str, value: Value) -> Result<Iterator, VmError> {
         "std::str::Split",
         lines.into_iter(),
     ))
+}
+
+fn string_trim(this: &str) -> String {
+    this.trim().to_owned()
+}
+
+fn string_trim_end(this: &str) -> String {
+    this.trim_end().to_owned()
 }
 
 fn parse_int(s: &str) -> Result<i64, std::num::ParseIntError> {

--- a/crates/runestick/src/value.rs
+++ b/crates/runestick/src/value.rs
@@ -859,12 +859,12 @@ impl Value {
             (Self::Option(a), Self::Option(b)) => match (&*a.borrow_ref()?, &*b.borrow_ref()?) {
                 (Some(a), Some(b)) => return Self::value_ptr_eq(a, b),
                 (None, None) => return Ok(true),
-                _ => (),
+                _ => return Ok(false),
             },
             (Self::Result(a), Self::Result(b)) => match (&*a.borrow_ref()?, &*b.borrow_ref()?) {
                 (Ok(a), Ok(b)) => return Self::value_ptr_eq(a, b),
                 (Err(a), Err(b)) => return Self::value_ptr_eq(a, b),
-                _ => (),
+                _ => return Ok(false),
             },
             // fast external comparison by slot.
             // TODO: implement ptr equals.

--- a/crates/runestick/src/vm_error.rs
+++ b/crates/runestick/src/vm_error.rs
@@ -30,7 +30,7 @@ impl VmError {
     where
         T: TypeOf,
     {
-        Ok(Self::from(VmErrorKind::BadArgumentType {
+        Ok(Self::from(VmErrorKind::BadArgumentAt {
             arg,
             expected: T::type_info(),
             actual: value.type_info()?,
@@ -205,7 +205,7 @@ pub enum VmErrorKind {
     #[error("wrong number of arguments `{actual}`, expected `{expected}`")]
     BadArgumentCount { actual: usize, expected: usize },
     #[error("bad argument #{arg}, expected `{expected}` but got `{actual}`")]
-    BadArgumentType {
+    BadArgumentAt {
         arg: usize,
         expected: TypeInfo,
         actual: TypeInfo,


### PR DESCRIPTION

#### Fixes
* Bug in how the panic macro was expanded. It was expanded to `::std::core::panic`, while the function has been moved to `::std::panic`.
* Bug in how internal eq operation worked for values. `Option` kinds which weren't equal errored instead of returned `false`.

APIs:
* Modified `String::split` to be able to take different kinds of arguments.
* Added getter / setter for `Range::start` / `Range::end`.