### PR TITLE
Expose APIs to conditionally construct Interface instances

### DIFF
--- a/crates/runestick/src/modules/collections.rs
+++ b/crates/runestick/src/modules/collections.rs
@@ -3,6 +3,7 @@
 use crate::{
     Any, ContextError, Interface, Iterator, Key, Module, Ref, Value, VmError, VmErrorKind,
 };
+use std::fmt;
 
 #[derive(Any)]
 #[rune(module = "crate")]
@@ -92,6 +93,12 @@ impl HashMap {
     #[inline]
     fn clear(&mut self) {
         self.map.clear()
+    }
+
+    #[inline]
+    fn string_debug(&self, s: &mut String) -> fmt::Result {
+        use std::fmt::Write as _;
+        write!(s, "{:?}", self.map)
     }
 }
 
@@ -193,6 +200,17 @@ impl HashSet {
 
         Ok(crate::Iterator::from("std::collections::set::Union", iter))
     }
+
+    #[inline]
+    fn string_debug(&self, s: &mut String) -> fmt::Result {
+        use std::fmt::Write as _;
+        write!(s, "{:?}", self.set)
+    }
+
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.set == other.set
+    }
 }
 
 struct Intersection<I>
@@ -241,6 +259,7 @@ where
     I: std::iter::Iterator<Item = Key>,
 {
     type Item = Key;
+
     fn next(&mut self) -> Option<Self::Item> {
         let other = self.other.take()?;
 
@@ -294,6 +313,7 @@ pub fn module() -> Result<Module, ContextError> {
     module.inst_fn(crate::Protocol::INTO_ITER, HashMap::iter)?;
     module.inst_fn(crate::Protocol::INDEX_SET, HashMap::insert)?;
     module.inst_fn(crate::Protocol::INDEX_GET, HashMap::fallible_get)?;
+    module.inst_fn(crate::Protocol::STRING_DEBUG, HashMap::string_debug)?;
 
     module.ty::<HashSet>()?;
     module.function(&["HashSet", "new"], HashSet::new)?;
@@ -309,6 +329,8 @@ pub fn module() -> Result<Module, ContextError> {
     module.inst_fn("intersection", HashSet::intersection)?;
     module.inst_fn("union", HashSet::union)?;
     module.inst_fn(crate::Protocol::INTO_ITER, HashSet::iter)?;
+    module.inst_fn(crate::Protocol::STRING_DEBUG, HashSet::string_debug)?;
+    module.inst_fn(crate::Protocol::EQ, HashSet::eq)?;
     Ok(module)
 }
 

--- a/crates/runestick/src/protocol.rs
+++ b/crates/runestick/src/protocol.rs
@@ -61,6 +61,12 @@ impl hash::Hash for Protocol {
 }
 
 impl Protocol {
+    /// Check two types for equality.
+    pub const EQ: Protocol = Protocol {
+        name: "eq",
+        hash: Hash::new(0x418f5becbf885806),
+    };
+
     /// The function to access a field.
     pub const GET: Protocol = Protocol {
         name: "get",
@@ -209,6 +215,12 @@ impl Protocol {
     pub const STRING_DISPLAY: Protocol = Protocol {
         name: "string_display",
         hash: Hash::new(0x811b62957ea9d9f9),
+    };
+
+    /// Protocol function used by custom debug impls.
+    pub const STRING_DEBUG: Protocol = Protocol {
+        name: "string_debug",
+        hash: Hash::new(0x4064e3867aaa0717),
     };
 
     /// Function used to convert an argument into an iterator.

--- a/crates/runestick/src/range.rs
+++ b/crates/runestick/src/range.rs
@@ -1,6 +1,6 @@
 use crate::{
     FromValue, InstallWith, Iterator, Mut, Named, Panic, RawMut, RawRef, RawStr, Ref, ToValue,
-    UnsafeFromValue, Value, VmError, VmErrorKind,
+    UnsafeFromValue, Value, Vm, VmError, VmErrorKind,
 };
 use std::fmt;
 use std::ops;
@@ -55,20 +55,20 @@ impl Range {
     }
 
     /// Value pointer equals implementation for a range.
-    pub(crate) fn value_ptr_eq(a: &Self, b: &Self) -> Result<bool, VmError> {
+    pub(crate) fn value_ptr_eq(vm: &mut Vm, a: &Self, b: &Self) -> Result<bool, VmError> {
         if a.limits != b.limits {
             return Ok(false);
         }
 
         match (&a.start, &b.start) {
             (None, None) => (),
-            (Some(a), Some(b)) if Value::value_ptr_eq(a, b)? => (),
+            (Some(a), Some(b)) if Value::value_ptr_eq(vm, a, b)? => (),
             _ => return Ok(false),
         }
 
         match (&a.end, &b.end) {
             (None, None) => (),
-            (Some(a), Some(b)) if Value::value_ptr_eq(a, b)? => (),
+            (Some(a), Some(b)) if Value::value_ptr_eq(vm, a, b)? => (),
             _ => return Ok(false),
         }
 

--- a/crates/runestick/src/tuple.rs
+++ b/crates/runestick/src/tuple.rs
@@ -1,4 +1,4 @@
-use crate::{ConstValue, FromValue, Mut, Ref, Value, VmError};
+use crate::{ConstValue, FromValue, Mut, Ref, Value, Vm, VmError};
 use std::fmt;
 use std::ops;
 use std::slice;
@@ -57,13 +57,13 @@ impl Tuple {
     }
 
     /// Value pointer equals implementation for a Tuple.
-    pub(crate) fn value_ptr_eq(a: &Self, b: &Self) -> Result<bool, VmError> {
+    pub(crate) fn value_ptr_eq(vm: &mut Vm, a: &Self, b: &Self) -> Result<bool, VmError> {
         if a.len() != b.len() {
             return Ok(false);
         }
 
         for (a, b) in a.iter().zip(b.iter()) {
-            if !Value::value_ptr_eq(a, b)? {
+            if !Value::value_ptr_eq(vm, a, b)? {
                 return Ok(false);
             }
         }

--- a/crates/runestick/src/vec.rs
+++ b/crates/runestick/src/vec.rs
@@ -1,6 +1,6 @@
 use crate::{
     FromValue, InstallWith, Interface, Mut, Named, RawMut, RawRef, RawStr, Ref, Shared, ToValue,
-    UnsafeFromValue, Value, VmError,
+    UnsafeFromValue, Value, Vm, VmError,
 };
 use std::cmp;
 use std::fmt;
@@ -155,13 +155,13 @@ impl Vec {
     }
 
     /// Compare two vectors for equality.
-    pub(crate) fn value_ptr_eq(a: &Self, b: &Self) -> Result<bool, VmError> {
+    pub(crate) fn value_ptr_eq(vm: &mut Vm, a: &Self, b: &Self) -> Result<bool, VmError> {
         if a.len() != b.len() {
             return Ok(false);
         }
 
         for (a, b) in a.iter().zip(b.iter()) {
-            if !Value::value_ptr_eq(a, b)? {
+            if !Value::value_ptr_eq(vm, a, b)? {
                 return Ok(false);
             }
         }


### PR DESCRIPTION
Use this interface to:
* Implement a `string_debug` protocol for `HashSet` and `HashMap`.
* Implement the `eq` protocol for `HashSet` (`HashMap` can't be
  implemented yet, because `Value` comparisons for it are not available).

This means that you can now correctly debug format an instance of `HashMap` and `HashSet`, even though they are external types:

```rust
use std::collections::HashMap;

struct Foo;

pub fn main() {
    let m = HashMap::new();
    m.insert(0, true);
    m.insert(1, Foo);
    dbg(m);
}
```

Correctly prints:

```
{0: true, 1: Foo}
```

Furethermore, `HashSet` (and soon `HashMap`) can not be checked for equality:

```rust
use std::collections::HashSet;

pub fn main() {
    let a = HashSet::new();
    let b = HashSet::new();
    b.insert(10);
    assert_eq!(a, b);
}
```

![image](https://user-images.githubusercontent.com/111092/101526756-5be77700-398d-11eb-8dea-875137059a7e.png)

Note: due to limitations, we currently have to use a temporary buffer in the `fmt::Debug` impl of `Value`. This can be fixed by making the debug formatting more explicit.