### PR TITLE
Improve diagnostics when performing illegal any coercion (fixes #212)

### DIFF
--- a/crates/runestick/src/access.rs
+++ b/crates/runestick/src/access.rs
@@ -1,4 +1,4 @@
-use crate::RawStr;
+use crate::{AnyObjError, RawStr};
 use std::cell::Cell;
 use std::fmt;
 use std::future::Future;
@@ -17,39 +17,34 @@ const TAKEN: isize = (isize::max_value() ^ FLAG) >> 1;
 const MAX_USES: isize = 0b11isize.rotate_right(2);
 
 /// An error raised while downcasting.
+#[allow(missing_docs)]
 #[derive(Debug, Error)]
 pub enum AccessError {
-    /// Error raised when we expect a specific external type but got another.
     #[error("expected data of type `{expected}`, but found `{actual}`")]
-    UnexpectedType {
-        /// The type that was expected.
-        expected: RawStr,
-        /// The type that was found.
-        actual: RawStr,
-    },
-    /// Trying to access an inaccessible reference.
+    UnexpectedType { expected: RawStr, actual: RawStr },
     #[error("{error}")]
     NotAccessibleRef {
-        /// Source error.
         #[source]
         #[from]
         error: NotAccessibleRef,
     },
-    /// Trying to access an inaccessible mutable reference.
     #[error("{error}")]
     NotAccessibleMut {
-        /// Source error.
         #[source]
         #[from]
         error: NotAccessibleMut,
     },
-    /// Trying to access an inaccessible taking.
     #[error("{error}")]
     NotAccessibleTake {
-        /// Source error.
         #[source]
         #[from]
         error: NotAccessibleTake,
+    },
+    #[error("{error}")]
+    AnyObjError {
+        #[source]
+        #[from]
+        error: AnyObjError,
     },
 }
 

--- a/crates/runestick/src/lib.rs
+++ b/crates/runestick/src/lib.rs
@@ -147,7 +147,7 @@ pub type Result<T, E = anyhow::Error> = std::result::Result<T, E>;
 /// Exported boxed error type for convenience.
 pub type Error = anyhow::Error;
 
-pub use self::any_obj::{AnyObj, AnyObjVtable};
+pub use self::any_obj::{AnyObj, AnyObjError, AnyObjVtable};
 pub use self::args::Args;
 pub use self::compile_meta::{
     CompileItem, CompileMeta, CompileMetaCapture, CompileMetaEmpty, CompileMetaKind,


### PR DESCRIPTION
This fixes the error message showcase in #212 from:
```
Error: bad argument #0: expected data of type `mut_instance_fn::Foo`, but found `Foo` (at inst 2)
```
To:
```
Error: bad argument #0: cannot borrow a shared reference `&Foo` mutably as `&mut Foo` (at inst 2)
```