### PR TITLE
AoC Day 12 changes

### DIFF
--- a/crates/rune/src/ast/expr.rs
+++ b/crates/rune/src/ast/expr.rs
@@ -806,6 +806,7 @@ impl Peek for Expr {
             K![true] => true,
             K![false] => true,
             K![ident] => true,
+            K![::] => true,
             K!['('] => true,
             K!['['] => true,
             K!['{'] => true,

--- a/crates/rune/src/ast/expr_field_access.rs
+++ b/crates/rune/src/ast/expr_field_access.rs
@@ -8,6 +8,9 @@ use crate::{Spanned, ToTokens};
 ///
 /// testing::roundtrip::<ast::ExprFieldAccess>("foo.bar");
 /// testing::roundtrip::<ast::ExprFieldAccess>("foo.bar::<A, B>");
+/// testing::roundtrip::<ast::ExprFieldAccess>("foo.0.bar");
+/// // Note: tuple accesses must be disambiguated.
+/// testing::roundtrip::<ast::ExprFieldAccess>("(foo.0).1");
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, ToTokens, Spanned)]
 pub struct ExprFieldAccess {

--- a/crates/rune/src/ast/stmt.rs
+++ b/crates/rune/src/ast/stmt.rs
@@ -80,7 +80,7 @@ impl Parse for Stmt {
             Self::Local(local)
         } else {
             let expr =
-                ast::Expr::parse_with_meta(p, &mut attributes, path, ast::expr::Callable(false))?;
+                ast::Expr::parse_with_meta(p, &mut attributes, path, ast::expr::Callable(true))?;
 
             Self::Expr(expr, p.parse()?)
         };
@@ -134,8 +134,7 @@ impl Parse for ItemOrExpr {
             return Err(ParseError::unsupported(span, "visibility modifier"));
         }
 
-        let expr =
-            ast::Expr::parse_with_meta(p, &mut attributes, path, ast::expr::Callable(false))?;
+        let expr = ast::Expr::parse_with_meta(p, &mut attributes, path, ast::expr::Callable(true))?;
 
         if let Some(span) = attributes.option_span() {
             return Err(ParseError::unsupported(span, "attributes"));

--- a/crates/rune/src/ast/stmt.rs
+++ b/crates/rune/src/ast/stmt.rs
@@ -103,16 +103,17 @@ pub enum ItemOrExpr {
 
 impl Peek for ItemOrExpr {
     fn peek(p: &mut Peeker<'_>) -> bool {
-        match [p.nth(0), p.nth(1)] {
-            [K![use], ..] => true,
-            [K![enum], ..] => true,
-            [K![struct], ..] => true,
-            [K![impl], ..] => true,
-            [K![async], K![fn]] => true,
-            [K![fn], ..] => true,
-            [K![mod], ..] => true,
-            [K![const], ..] => true,
-            [K![ident(..)], ..] => true,
+        match p.nth(0) {
+            K![use] => true,
+            K![enum] => true,
+            K![struct] => true,
+            K![impl] => true,
+            K![async] => matches!(p.nth(1), K![fn]),
+            K![fn] => true,
+            K![mod] => true,
+            K![const] => true,
+            K![ident(..)] => true,
+            K![::] => true,
             _ => ast::Expr::peek(p),
         }
     }

--- a/crates/runestick/src/modules/int.rs
+++ b/crates/runestick/src/modules/int.rs
@@ -15,6 +15,7 @@ pub fn module() -> Result<Module, ContextError> {
 
     module.inst_fn("to_float", to_float)?;
 
+    module.inst_fn("abs", i64::abs)?;
     module.inst_fn("checked_add", i64::checked_add)?;
     module.inst_fn("checked_sub", i64::checked_sub)?;
     module.inst_fn("checked_div", i64::checked_div)?;

--- a/crates/runestick/src/modules/string.rs
+++ b/crates/runestick/src/modules/string.rs
@@ -65,12 +65,12 @@ fn into_bytes(s: String) -> Bytes {
     Bytes::from_vec(s.into_bytes())
 }
 
-fn char_at(s: &str, index: usize) -> Result<Option<char>, NotCharBoundary> {
+fn char_at(s: &str, index: usize) -> Option<char> {
     if !s.is_char_boundary(index) {
-        return Err(NotCharBoundary(()));
+        return None;
     }
 
-    Ok(s[index..].chars().next())
+    s[index..].chars().next()
 }
 
 fn string_split(this: &str, value: Value) -> Result<Iterator, VmError> {


### PR DESCRIPTION
#### Fixed
* Global paths can now be parsed as part of a (block) statement.

####  Added
* Make tuple field accesses lexable.
* `abs` associated fn for integers.