### PR TITLE
Refcounted hooks

### DIFF
--- a/crates/rune-cli/src/main.rs
+++ b/crates/rune-cli/src/main.rs
@@ -310,7 +310,7 @@ async fn run_path(args: &Args, options: &rune::Options, path: &Path) -> Result<E
             let mut warnings = rune::Warnings::new();
 
             let test_finder = Rc::new(tests::TestVisitor::default());
-            let mut source_loader = rune::FileSourceLoader::new();
+            let source_loader = Rc::new(rune::FileSourceLoader::new());
 
             let unit = match rune::load_sources_with_visitor(
                 &context,
@@ -319,7 +319,7 @@ async fn run_path(args: &Args, options: &rune::Options, path: &Path) -> Result<E
                 &mut errors,
                 &mut warnings,
                 test_finder.clone(),
-                &mut source_loader,
+                source_loader.clone(),
             ) {
                 Ok(unit) => unit,
                 Err(rune::LoadSourcesError) => {

--- a/crates/rune/src/attrs/mod.rs
+++ b/crates/rune/src/attrs/mod.rs
@@ -51,11 +51,9 @@ impl Attribute for BuiltIn {
     const PATH: &'static str = "builtin";
 }
 
+/// NB: at this point we don't support attributes beyond the empty `#[test]`.
 #[derive(Parse)]
-pub(crate) struct Test {
-    /// Arguments to the test.
-    pub args: Option<ast::Parenthesized<ast::Ident, T![,]>>,
-}
+pub(crate) struct Test {}
 
 impl Attribute for Test {
     /// Must match the specified name.

--- a/crates/rune/src/compiling/compile_visitor.rs
+++ b/crates/rune/src/compiling/compile_visitor.rs
@@ -2,14 +2,17 @@ use runestick::{CompileMeta, SourceId, Span};
 
 /// A visitor that will be called for every language item compiled.
 pub trait CompileVisitor {
+    /// Called when a meta item is registered.
+    fn register_meta(&self, _meta: &CompileMeta) {}
+
     /// Mark that we've encountered a specific compile meta at the given span.
-    fn visit_meta(&mut self, _source_id: SourceId, _meta: &CompileMeta, _span: Span) {}
+    fn visit_meta(&self, _source_id: SourceId, _meta: &CompileMeta, _span: Span) {}
 
     /// Visit a variable use.
-    fn visit_variable_use(&mut self, _source_id: SourceId, _var_span: Span, _span: Span) {}
+    fn visit_variable_use(&self, _source_id: SourceId, _var_span: Span, _span: Span) {}
 
     /// Visit something that is a module.
-    fn visit_mod(&mut self, _source_id: SourceId, _span: Span) {}
+    fn visit_mod(&self, _source_id: SourceId, _span: Span) {}
 }
 
 /// A compile visitor that does nothing.

--- a/crates/rune/src/compiling/mod.rs
+++ b/crates/rune/src/compiling/mod.rs
@@ -30,7 +30,7 @@ pub fn compile(
     warnings: &mut Warnings,
 ) -> Result<(), ()> {
     let visitor = Rc::new(NoopCompileVisitor::new());
-    let mut source_loader = FileSourceLoader::new();
+    let source_loader = Rc::new(FileSourceLoader::new());
 
     compile_with_options(
         context,
@@ -40,7 +40,7 @@ pub fn compile(
         warnings,
         &Default::default(),
         visitor,
-        &mut source_loader,
+        source_loader,
     )?;
 
     Ok(())
@@ -55,7 +55,7 @@ pub fn compile_with_options(
     warnings: &mut Warnings,
     options: &Options,
     visitor: Rc<dyn CompileVisitor>,
-    source_loader: &mut dyn SourceLoader,
+    source_loader: Rc<dyn SourceLoader>,
 ) -> Result<(), ()> {
     // Global storage.
     let storage = Storage::new();

--- a/crates/rune/src/compiling/v1/assemble/expr_assign.rs
+++ b/crates/rune/src/compiling/v1/assemble/expr_assign.rs
@@ -16,7 +16,7 @@ impl Assemble for ast::ExprAssign {
                     .try_as_ident()
                     .ok_or_else(|| CompileError::msg(path, "unsupported path"))?;
                 let ident = segment.resolve(c.storage, &*c.source)?;
-                let var = c.scopes.get_var(&*ident, c.source_id, c.visitor, span)?;
+                let var = c.scopes.get_var(&*ident, c.source_id, span)?;
                 c.asm.push(Inst::Replace { offset: var.offset }, span);
                 true
             }

--- a/crates/rune/src/compiling/v1/assemble/expr_binary.rs
+++ b/crates/rune/src/compiling/v1/assemble/expr_binary.rs
@@ -147,7 +147,7 @@ fn compile_assign_binop(
                 .ok_or_else(|| CompileError::msg(path, "unsupported path segment"))?;
 
             let ident = segment.resolve(c.storage, &*c.source)?;
-            let var = c.scopes.get_var(&*ident, c.source_id, c.visitor, span)?;
+            let var = c.scopes.get_var(&*ident, c.source_id, span)?;
 
             Some(InstTarget::Offset(var.offset))
         }

--- a/crates/rune/src/compiling/v1/assemble/expr_block.rs
+++ b/crates/rune/src/compiling/v1/assemble/expr_block.rs
@@ -22,16 +22,10 @@ impl Assemble for ast::ExprBlock {
 
                 for ident in captures {
                     if do_move {
-                        let var = c
-                            .scopes
-                            .take_var(&ident.ident, c.source_id, c.visitor, span)?;
-
+                        let var = c.scopes.take_var(&ident.ident, c.source_id, span)?;
                         var.do_move(&mut c.asm, span, format!("captures `{}`", ident.ident));
                     } else {
-                        let var = c
-                            .scopes
-                            .get_var(&ident.ident, c.source_id, c.visitor, span)?;
-
+                        let var = c.scopes.get_var(&ident.ident, c.source_id, span)?;
                         var.copy(&mut c.asm, span, format!("captures `{}`", ident.ident));
                     }
                 }

--- a/crates/rune/src/compiling/v1/assemble/expr_call.rs
+++ b/crates/rune/src/compiling/v1/assemble/expr_call.rs
@@ -77,7 +77,7 @@ impl Assemble for ast::ExprCall {
         if let Some(name) = named.as_local() {
             let local = c
                 .scopes
-                .try_get_var(name, c.source_id, c.visitor, path.span())?
+                .try_get_var(name, c.source_id, path.span())?
                 .copied();
 
             if let Some(var) = local {

--- a/crates/rune/src/compiling/v1/assemble/expr_closure.rs
+++ b/crates/rune/src/compiling/v1/assemble/expr_closure.rs
@@ -102,16 +102,10 @@ impl Assemble for ast::ExprClosure {
             // Construct a closure environment.
             for capture in captures {
                 if do_move {
-                    let var = c
-                        .scopes
-                        .take_var(&capture.ident, c.source_id, c.visitor, span)?;
-
+                    let var = c.scopes.take_var(&capture.ident, c.source_id, span)?;
                     var.do_move(&mut c.asm, span, format!("capture `{}`", capture.ident));
                 } else {
-                    let var = c
-                        .scopes
-                        .get_var(&capture.ident, c.source_id, c.visitor, span)?;
-
+                    let var = c.scopes.get_var(&capture.ident, c.source_id, span)?;
                     var.copy(&mut c.asm, span, format!("capture `{}`", capture.ident));
                 }
             }

--- a/crates/rune/src/compiling/v1/assemble/expr_field_access.rs
+++ b/crates/rune/src/compiling/v1/assemble/expr_field_access.rs
@@ -80,14 +80,13 @@ fn try_immediate_field_access_optimization(
         Err(..) => return Ok(false),
     };
 
-    let var =
-        match this
-            .scopes
-            .try_get_var(ident.as_ref(), this.source_id, this.visitor, path.span())?
-        {
-            Some(var) => var,
-            None => return Ok(false),
-        };
+    let var = match this
+        .scopes
+        .try_get_var(ident.as_ref(), this.source_id, path.span())?
+    {
+        Some(var) => var,
+        None => return Ok(false),
+    };
 
     this.asm.push(
         Inst::TupleIndexGetAt {

--- a/crates/rune/src/compiling/v1/assemble/expr_object.rs
+++ b/crates/rune/src/compiling/v1/assemble/expr_object.rs
@@ -35,7 +35,7 @@ impl Assemble for ast::ExprObject {
                 expr.assemble(c, Needs::Value)?.apply(c)?;
             } else {
                 let key = assign.key.resolve(&c.storage, &*c.source)?;
-                let var = c.scopes.get_var(&*key, c.source_id, c.visitor, span)?;
+                let var = c.scopes.get_var(&*key, c.source_id, span)?;
                 var.copy(&mut c.asm, span, format!("name `{}`", key));
             }
         }

--- a/crates/rune/src/compiling/v1/assemble/expr_path.rs
+++ b/crates/rune/src/compiling/v1/assemble/expr_path.rs
@@ -7,7 +7,7 @@ impl Assemble for ast::Path {
         log::trace!("Path => {:?}", c.source.source(span));
 
         if let Some(ast::PathKind::SelfValue) = self.as_kind() {
-            let var = c.scopes.get_var("self", c.source_id, c.visitor, span)?;
+            let var = c.scopes.get_var("self", c.source_id, span)?;
 
             if needs.value() {
                 var.copy(&mut c.asm, span, "self");
@@ -20,7 +20,7 @@ impl Assemble for ast::Path {
 
         if let Needs::Value = needs {
             if let Some(local) = named.as_local() {
-                if let Some(var) = c.scopes.try_get_var(local, c.source_id, c.visitor, span)? {
+                if let Some(var) = c.scopes.try_get_var(local, c.source_id, span)? {
                     return Ok(Asm::var(span, *var, local.into()));
                 }
             }

--- a/crates/rune/src/compiling/v1/mod.rs
+++ b/crates/rune/src/compiling/v1/mod.rs
@@ -12,6 +12,7 @@ use runestick::{
     CompileItem, CompileMeta, CompileMetaKind, ConstValue, Context, Inst, InstValue, Item, Label,
     Source, Span, TypeCheck,
 };
+use std::rc::Rc;
 use std::sync::Arc;
 
 mod assemble;
@@ -40,6 +41,8 @@ impl Needs {
 }
 
 pub(crate) struct Compiler<'a> {
+    /// Compiler visitor.
+    pub(crate) visitor: Rc<dyn CompileVisitor>,
     /// The source id of the source.
     pub(crate) source_id: usize,
     /// The source we are compiling for.
@@ -66,8 +69,6 @@ pub(crate) struct Compiler<'a> {
     pub(crate) options: &'a Options,
     /// Compilation warnings.
     pub(crate) warnings: &'a mut Warnings,
-    /// Compiler visitor.
-    pub(crate) visitor: &'a mut dyn CompileVisitor,
 }
 
 impl<'a> Compiler<'a> {

--- a/crates/rune/src/indexing/index.rs
+++ b/crates/rune/src/indexing/index.rs
@@ -54,7 +54,7 @@ pub(crate) struct Indexer<'a> {
     /// Set if we are inside of an impl self.
     pub(crate) impl_item: Option<Arc<Item>>,
     pub(crate) visitor: Rc<dyn CompileVisitor>,
-    pub(crate) source_loader: &'a mut dyn SourceLoader,
+    pub(crate) source_loader: Rc<dyn SourceLoader>,
 }
 
 impl<'a> Indexer<'a> {

--- a/crates/rune/src/indexing/index.rs
+++ b/crates/rune/src/indexing/index.rs
@@ -23,6 +23,7 @@ use runestick::{
 use std::collections::VecDeque;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
+use std::rc::Rc;
 use std::sync::Arc;
 
 pub(crate) struct Indexer<'a> {
@@ -52,7 +53,7 @@ pub(crate) struct Indexer<'a> {
     pub(crate) mod_item: Arc<CompileMod>,
     /// Set if we are inside of an impl self.
     pub(crate) impl_item: Option<Arc<Item>>,
-    pub(crate) visitor: &'a mut dyn CompileVisitor,
+    pub(crate) visitor: Rc<dyn CompileVisitor>,
     pub(crate) source_loader: &'a mut dyn SourceLoader,
 }
 

--- a/crates/rune/src/ir/ir_query.rs
+++ b/crates/rune/src/ir/ir_query.rs
@@ -8,7 +8,7 @@ pub(crate) trait IrQuery {
     /// Query for the given meta.
     fn query_meta(
         &mut self,
-        spanned: Span,
+        span: Span,
         item: &Item,
         used: Used,
     ) -> Result<Option<CompileMeta>, QueryError>;
@@ -16,10 +16,10 @@ pub(crate) trait IrQuery {
     /// Get resolved internal macro with the given id.
     fn builtin_macro_for(
         &self,
-        spanned: Span,
+        span: Span,
         id: Option<Id>,
     ) -> Result<Arc<BuiltInMacro>, QueryError>;
 
     /// Query for the constant function related to the given id.
-    fn const_fn_for(&self, spanned: Span, id: Option<Id>) -> Result<Arc<QueryConstFn>, QueryError>;
+    fn const_fn_for(&self, span: Span, id: Option<Id>) -> Result<Arc<QueryConstFn>, QueryError>;
 }

--- a/crates/rune/src/load/mod.rs
+++ b/crates/rune/src/load/mod.rs
@@ -85,7 +85,7 @@ pub fn load_sources(
     warnings: &mut Warnings,
 ) -> Result<Unit, LoadSourcesError> {
     let visitor = Rc::new(compiling::NoopCompileVisitor::new());
-    let mut source_loader = FileSourceLoader::new();
+    let source_loader = Rc::new(FileSourceLoader::new());
 
     load_sources_with_visitor(
         context,
@@ -94,7 +94,7 @@ pub fn load_sources(
         errors,
         warnings,
         visitor,
-        &mut source_loader,
+        source_loader,
     )
 }
 
@@ -106,7 +106,7 @@ pub fn load_sources_with_visitor(
     errors: &mut Errors,
     warnings: &mut Warnings,
     visitor: Rc<dyn compiling::CompileVisitor>,
-    source_loader: &mut dyn SourceLoader,
+    source_loader: Rc<dyn SourceLoader>,
 ) -> Result<Unit, LoadSourcesError> {
     let unit = if context.has_default_modules() {
         compiling::UnitBuilder::with_default_prelude()

--- a/crates/rune/src/load/mod.rs
+++ b/crates/rune/src/load/mod.rs
@@ -1,6 +1,7 @@
 use crate::compiling;
 use crate::Options;
 use runestick::{Context, Unit};
+use std::rc::Rc;
 use thiserror::Error;
 
 mod error;
@@ -83,7 +84,7 @@ pub fn load_sources(
     errors: &mut Errors,
     warnings: &mut Warnings,
 ) -> Result<Unit, LoadSourcesError> {
-    let mut visitor = compiling::NoopCompileVisitor::new();
+    let visitor = Rc::new(compiling::NoopCompileVisitor::new());
     let mut source_loader = FileSourceLoader::new();
 
     load_sources_with_visitor(
@@ -92,7 +93,7 @@ pub fn load_sources(
         sources,
         errors,
         warnings,
-        &mut visitor,
+        visitor,
         &mut source_loader,
     )
 }
@@ -104,7 +105,7 @@ pub fn load_sources_with_visitor(
     sources: &mut Sources,
     errors: &mut Errors,
     warnings: &mut Warnings,
-    visitor: &mut dyn compiling::CompileVisitor,
+    visitor: Rc<dyn compiling::CompileVisitor>,
     source_loader: &mut dyn SourceLoader,
 ) -> Result<Unit, LoadSourcesError> {
     let unit = if context.has_default_modules() {

--- a/crates/rune/src/load/source_loader.rs
+++ b/crates/rune/src/load/source_loader.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 /// A source loader.
 pub trait SourceLoader {
     /// Load the given URL.
-    fn load(&mut self, root: &Path, item: &Item, span: Span) -> Result<Source, CompileError>;
+    fn load(&self, root: &Path, item: &Item, span: Span) -> Result<Source, CompileError>;
 }
 
 /// A filesystem-based source loader.
@@ -20,7 +20,7 @@ impl FileSourceLoader {
 }
 
 impl SourceLoader for FileSourceLoader {
-    fn load(&mut self, root: &Path, item: &Item, span: Span) -> Result<Source, CompileError> {
+    fn load(&self, root: &Path, item: &Item, span: Span) -> Result<Source, CompileError> {
         let mut base = root.to_owned();
 
         if !base.pop() {

--- a/crates/rune/src/query/mod.rs
+++ b/crates/rune/src/query/mod.rs
@@ -7,8 +7,8 @@ use crate::ir::{IrBudget, IrCompile, IrCompiler, IrInterpreter, IrQuery};
 use crate::parsing::Opaque;
 use crate::shared::{Consts, Gen, Items};
 use crate::{
-    CompileError, CompileErrorKind, CompileVisitor, Id, ImportEntryStep, Resolve as _, Spanned,
-    Storage, UnitBuilder,
+    CompileError, CompileErrorKind, CompileVisitor, Id, ImportEntryStep, NoopCompileVisitor,
+    Resolve as _, Spanned, Storage, UnitBuilder,
 };
 use runestick::format;
 use runestick::{
@@ -83,23 +83,23 @@ pub struct BuiltInLine {
 impl IrQuery for QueryInner {
     fn query_meta(
         &mut self,
-        spanned: Span,
+        span: Span,
         item: &Item,
         used: Used,
     ) -> Result<Option<CompileMeta>, QueryError> {
-        QueryInner::query_meta(self, spanned, item, used)
+        QueryInner::query_meta(self, span, item, used)
     }
 
     fn builtin_macro_for(
         &self,
-        spanned: Span,
+        span: Span,
         id: Option<Id>,
     ) -> Result<Arc<BuiltInMacro>, QueryError> {
-        QueryInner::builtin_macro_for(self, spanned, id)
+        QueryInner::builtin_macro_for(self, span, id)
     }
 
-    fn const_fn_for(&self, spanned: Span, id: Option<Id>) -> Result<Arc<QueryConstFn>, QueryError> {
-        QueryInner::const_fn_for(self, spanned, id)
+    fn const_fn_for(&self, span: Span, id: Option<Id>) -> Result<Arc<QueryConstFn>, QueryError> {
+        QueryInner::const_fn_for(self, span, id)
     }
 }
 
@@ -110,9 +110,16 @@ pub(crate) struct Query {
 
 impl Query {
     /// Construct a new compilation context.
-    pub fn new(storage: Storage, unit: UnitBuilder, consts: Consts, gen: Gen) -> Self {
+    pub fn new(
+        visitor: Rc<dyn CompileVisitor>,
+        storage: Storage,
+        unit: UnitBuilder,
+        consts: Consts,
+        gen: Gen,
+    ) -> Self {
         Self {
             inner: Rc::new(RefCell::new(QueryInner {
+                visitor,
                 meta: HashMap::new(),
                 storage,
                 prelude: unit.prelude(),
@@ -466,10 +473,7 @@ impl Query {
     /// Remove and queue up unused entries for building.
     ///
     /// Returns boolean indicating if any unused entries were queued up.
-    pub(crate) fn queue_unused_entries(
-        &self,
-        visitor: &mut dyn CompileVisitor,
-    ) -> Result<bool, (SourceId, QueryError)> {
+    pub(crate) fn queue_unused_entries(&self) -> Result<bool, (SourceId, QueryError)> {
         let mut inner = self.inner.borrow_mut();
 
         let unused = inner
@@ -490,7 +494,7 @@ impl Query {
                 .query_meta(query_item.location.span, &query_item.item, Used::Unused)
                 .map_err(|e| (query_item.location.source_id, e))?
             {
-                visitor.visit_meta(
+                inner.visitor.visit_meta(
                     query_item.location.source_id,
                     &meta,
                     query_item.location.span,
@@ -505,11 +509,11 @@ impl Query {
     /// items reverse map to identify.
     pub(crate) fn query_meta(
         &self,
-        spanned: Span,
+        span: Span,
         item: &Item,
         used: Used,
     ) -> Result<Option<CompileMeta>, QueryError> {
-        self.inner.borrow_mut().query_meta(spanned, item, used)
+        self.inner.borrow_mut().query_meta(span, item, used)
     }
 
     /// Convert the given path.
@@ -529,7 +533,7 @@ impl Query {
     pub(crate) fn insert_import(
         &self,
         source_id: SourceId,
-        spanned: Span,
+        span: Span,
         source: &Arc<Source>,
         module: &Arc<CompileMod>,
         visibility: Visibility,
@@ -544,10 +548,10 @@ impl Query {
             .as_ref()
             .map(IntoComponent::as_component_ref)
             .or_else(|| target.last())
-            .ok_or_else(|| QueryError::new(spanned, QueryErrorKind::LastUseComponent))?;
+            .ok_or_else(|| QueryError::new(span, QueryErrorKind::LastUseComponent))?;
 
         let item = at.extended(last);
-        let location = Location::new(source_id, spanned.span());
+        let location = Location::new(source_id, span);
 
         let entry = ImportEntry {
             location,
@@ -557,7 +561,7 @@ impl Query {
         };
 
         let id = inner.gen.next();
-        let item = inner.insert_new_item_with(id, &item, source_id, spanned, module, visibility)?;
+        let item = inner.insert_new_item_with(id, &item, source_id, span, module, visibility)?;
 
         // toplevel public uses are re-exported.
         if item.is_public() {
@@ -572,8 +576,8 @@ impl Query {
 
         inner.index(IndexedEntry {
             item,
-            indexed: Indexed::Import(Import { wildcard, entry }),
             source: source.clone(),
+            indexed: Indexed::Import(Import { wildcard, entry }),
         });
 
         return Ok(());
@@ -601,18 +605,20 @@ impl Query {
 
     pub(crate) fn import(
         &self,
-        spanned: Span,
+        span: Span,
         module: &Arc<CompileMod>,
         item: &Item,
         used: Used,
     ) -> Result<Option<Item>, QueryError> {
         let mut inner = self.inner.borrow_mut();
-        inner.import(spanned, module, item, used)
+        inner.import(span, module, item, used)
     }
 }
 
-#[derive(Default, Clone)]
+#[derive(Clone)]
 struct QueryInner {
+    /// Visitor for the compiler meta.
+    visitor: Rc<dyn CompileVisitor>,
     /// Resolved meta about every single item during a compilation.
     meta: HashMap<Item, CompileMeta>,
     /// Macro storage.
@@ -646,6 +652,28 @@ struct QueryInner {
     names: Names,
     /// Modules and associated metadata.
     modules: HashMap<Item, Arc<CompileMod>>,
+}
+
+impl Default for QueryInner {
+    fn default() -> Self {
+        Self {
+            visitor: Rc::new(NoopCompileVisitor::new()),
+            meta: Default::default(),
+            storage: Default::default(),
+            prelude: Default::default(),
+            unit: Default::default(),
+            consts: Default::default(),
+            gen: Default::default(),
+            queue: Default::default(),
+            indexed: Default::default(),
+            const_fns: Default::default(),
+            query_paths: Default::default(),
+            internal_macros: Default::default(),
+            items: Default::default(),
+            names: Default::default(),
+            modules: Default::default(),
+        }
+    }
 }
 
 impl QueryInner {
@@ -783,7 +811,7 @@ impl QueryInner {
             .insert_meta(&meta)
             .map_err(|error| QueryError::new(span, error))?;
 
-        self.insert_meta(span, meta.clone())?;
+        self.insert_meta(span, meta)?;
         Ok(())
     }
 
@@ -1004,16 +1032,14 @@ impl QueryInner {
 
     /// Insert meta without registering peripherals under the assumption that it
     /// already has been registered.
-    pub(crate) fn insert_meta(
-        &mut self,
-        spanned: Span,
-        meta: CompileMeta,
-    ) -> Result<(), QueryError> {
+    fn insert_meta(&mut self, span: Span, meta: CompileMeta) -> Result<(), QueryError> {
         let item = meta.item.item.clone();
+
+        self.visitor.register_meta(&meta);
 
         if let Some(existing) = self.meta.insert(item, meta.clone()) {
             return Err(QueryError::new(
-                spanned,
+                span,
                 QueryErrorKind::MetaConflict {
                     current: meta,
                     existing,
@@ -1170,14 +1196,14 @@ impl QueryInner {
     /// Build a single, indexed entry and return its metadata.
     fn build_indexed_entry(
         &mut self,
-        spanned: Span,
+        span: Span,
         entry: IndexedEntry,
         used: Used,
     ) -> Result<CompileMeta, QueryError> {
         let IndexedEntry {
+            item: query_item,
             indexed,
             source,
-            item: query_item,
         } = entry;
 
         let path = source.path().map(ToOwned::to_owned);
@@ -1190,7 +1216,7 @@ impl QueryInner {
                 let enum_item = self.item_for(query_item.location.span, Some(variant.enum_id))?;
 
                 // Assert that everything is built for the enum.
-                self.query_meta(spanned, &enum_item.item, Default::default())?;
+                self.query_meta(span, &enum_item.item, Default::default())?;
 
                 variant_into_item_decl(
                     &query_item.item,
@@ -1354,7 +1380,7 @@ impl QueryInner {
     /// Check that the given item is accessible from the given module.
     fn check_access_to(
         &self,
-        spanned: Span,
+        span: Span,
         from: &CompileMod,
         item: &Item,
         module: &CompileMod,
@@ -1371,7 +1397,7 @@ impl QueryInner {
 
             let m = self.modules.get(&current_module).ok_or_else(|| {
                 QueryError::new(
-                    spanned,
+                    span,
                     QueryErrorKind::MissingMod {
                         item: current_module.clone(),
                     },
@@ -1380,7 +1406,7 @@ impl QueryInner {
 
             if !m.visibility.is_visible(&common, &current_module) {
                 return Err(QueryError::new(
-                    spanned,
+                    span,
                     QueryErrorKind::NotVisibleMod {
                         chain: into_chain(std::mem::take(chain)),
                         location: m.location,
@@ -1394,7 +1420,7 @@ impl QueryInner {
 
         if !visibility.is_visible_inside(&common, &module.item) {
             return Err(QueryError::new(
-                spanned,
+                span,
                 QueryErrorKind::NotVisible {
                     chain: into_chain(std::mem::take(chain)),
                     location,

--- a/crates/rune/src/query/mod.rs
+++ b/crates/rune/src/query/mod.rs
@@ -560,7 +560,7 @@ impl Query {
         let item = inner.insert_new_item_with(id, &item, source_id, spanned, module, visibility)?;
 
         // toplevel public uses are re-exported.
-        if module.item.is_empty() && item.visibility.is_public() {
+        if item.is_public() {
             inner.queue.push_back(BuildEntry {
                 location,
                 item: item.clone(),

--- a/crates/rune/src/shared/items.rs
+++ b/crates/rune/src/shared/items.rs
@@ -40,11 +40,6 @@ impl Items {
         Ref::map(self.inner.borrow(), |inner| &inner.item)
     }
 
-    /// Check if the current path is empty.
-    pub(crate) fn is_empty(&self) -> bool {
-        self.inner.borrow().item.is_empty()
-    }
-
     /// Push a component and return a guard to it.
     pub(crate) fn push_id(&self) -> Guard {
         let mut inner = self.inner.borrow_mut();

--- a/crates/rune/src/worker/mod.rs
+++ b/crates/rune/src/worker/mod.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 use runestick::{Context, Item, SourceId, Span};
 use std::collections::VecDeque;
+use std::rc::Rc;
 
 mod import;
 mod task;
@@ -25,7 +26,7 @@ pub(crate) struct Worker<'a> {
     options: &'a Options,
     pub(crate) errors: &'a mut Errors,
     pub(crate) warnings: &'a mut Warnings,
-    pub(crate) visitor: &'a mut dyn CompileVisitor,
+    pub(crate) visitor: Rc<dyn CompileVisitor>,
     pub(crate) source_loader: &'a mut dyn SourceLoader,
     /// Constants storage.
     pub(crate) consts: Consts,
@@ -51,7 +52,7 @@ impl<'a> Worker<'a> {
         consts: Consts,
         errors: &'a mut Errors,
         warnings: &'a mut Warnings,
-        visitor: &'a mut dyn CompileVisitor,
+        visitor: Rc<dyn CompileVisitor>,
         source_loader: &'a mut dyn SourceLoader,
         storage: Storage,
         gen: Gen,
@@ -62,11 +63,11 @@ impl<'a> Worker<'a> {
             options,
             errors,
             warnings,
-            visitor,
+            visitor: visitor.clone(),
             source_loader,
             consts: consts.clone(),
             queue: VecDeque::new(),
-            query: Query::new(storage.clone(), unit, consts, gen.clone()),
+            query: Query::new(visitor, storage.clone(), unit, consts, gen.clone()),
             storage,
             gen,
             loaded: HashMap::new(),
@@ -132,7 +133,7 @@ impl<'a> Worker<'a> {
                         scopes: IndexScopes::new(),
                         mod_item,
                         impl_item: Default::default(),
-                        visitor: self.visitor,
+                        visitor: self.visitor.clone(),
                         source_loader: self.source_loader,
                     };
 

--- a/crates/rune/src/worker/mod.rs
+++ b/crates/rune/src/worker/mod.rs
@@ -27,7 +27,7 @@ pub(crate) struct Worker<'a> {
     pub(crate) errors: &'a mut Errors,
     pub(crate) warnings: &'a mut Warnings,
     pub(crate) visitor: Rc<dyn CompileVisitor>,
-    pub(crate) source_loader: &'a mut dyn SourceLoader,
+    pub(crate) source_loader: Rc<dyn SourceLoader>,
     /// Constants storage.
     pub(crate) consts: Consts,
     /// Worker queue.
@@ -53,7 +53,7 @@ impl<'a> Worker<'a> {
         errors: &'a mut Errors,
         warnings: &'a mut Warnings,
         visitor: Rc<dyn CompileVisitor>,
-        source_loader: &'a mut dyn SourceLoader,
+        source_loader: Rc<dyn SourceLoader>,
         storage: Storage,
         gen: Gen,
     ) -> Self {
@@ -134,7 +134,7 @@ impl<'a> Worker<'a> {
                         mod_item,
                         impl_item: Default::default(),
                         visitor: self.visitor.clone(),
-                        source_loader: self.source_loader,
+                        source_loader: self.source_loader.clone(),
                     };
 
                     if let Err(error) = file.index(&mut indexer) {

--- a/crates/runestick/src/compile_meta.rs
+++ b/crates/runestick/src/compile_meta.rs
@@ -250,6 +250,13 @@ pub struct CompileItem {
     pub module: Arc<CompileMod>,
 }
 
+impl CompileItem {
+    /// Test if the item is public (and should be exported).
+    pub fn is_public(&self) -> bool {
+        self.visibility.is_public() && self.module.is_public()
+    }
+}
+
 impl From<Item> for CompileItem {
     fn from(item: Item) -> Self {
         Self {
@@ -273,4 +280,21 @@ pub struct CompileMod {
     pub visibility: Visibility,
     /// The kind of the module.
     pub parent: Option<Arc<CompileMod>>,
+}
+
+impl CompileMod {
+    /// Test if the module recursively is public.
+    pub fn is_public(&self) -> bool {
+        let mut current = Some(self);
+
+        while let Some(m) = current.take() {
+            if !m.visibility.is_public() {
+                return false;
+            }
+
+            current = m.parent.as_deref();
+        }
+
+        true
+    }
 }


### PR DESCRIPTION
This accomplishes the following:
* Public items are correctly exported if they're within a recursively public module.
* `#[test]` functions are correctly discovered regardless of where they are using a new `CompileVisitor::register_meta` hook that is called for every item registered (instead of every item used).
* For consistency, the file loader hook is also made to be refcounted.

#### TODO

On issue this causes is that nested test functions are picked up incorrectly:
```
fn function() {
    #[test]
    fn test_fn() {
        assert!(true);
    }
}
```

Strictly speaking this also exports functions like this if they are pub. This could be fixed by setting up an internal module which prevents it from being public.