### PR TITLE
Deny #[test] fns declared in nested items

### DIFF
--- a/crates/rune/src/ast/item_const.rs
+++ b/crates/rune/src/ast/item_const.rs
@@ -1,5 +1,6 @@
 use crate::ast;
 use crate::{Id, Parse, Spanned, ToTokens};
+use runestick::Span;
 
 /// A const declaration.
 ///
@@ -31,6 +32,14 @@ pub struct ItemConst {
     pub eq: T![=],
     /// The optional body of the module declaration.
     pub expr: ast::Expr,
+}
+
+impl ItemConst {
+    /// Get the descriptive span of this item, e.g. `const ITEM` instead of the
+    /// span for the whole expression.
+    pub fn descriptive_span(&self) -> Span {
+        self.const_token.span().join(self.name.span())
+    }
 }
 
 item_parse!(Const, ItemConst, "constant item");

--- a/crates/rune/src/ast/item_fn.rs
+++ b/crates/rune/src/ast/item_fn.rs
@@ -67,8 +67,9 @@ pub struct ItemFn {
 }
 
 impl ItemFn {
-    /// Get the identifying span for this function.
-    pub fn item_span(&self) -> Span {
+    /// Get the descriptive span of this item, e.g. `pub fn foo()` instead of
+    /// the span for the whole function declaration, body included.
+    pub fn descriptive_span(&self) -> Span {
         if let Some(async_token) = &self.async_token {
             async_token.span().join(self.args.span())
         } else {

--- a/crates/rune/src/compiling/compile_error.rs
+++ b/crates/rune/src/compiling/compile_error.rs
@@ -282,6 +282,8 @@ pub enum CompileErrorKind {
     VariableMoved { moved_at: Span },
     #[error("unsupported generic arguments")]
     UnsupportedGenerics,
+    #[error("#[test] attributes are not supported on nested items")]
+    NestedTest { nested_span: Span },
 }
 
 /// A single stap as an import entry.

--- a/crates/rune/src/diagnostics.rs
+++ b/crates/rune/src/diagnostics.rs
@@ -453,6 +453,12 @@ impl EmitDiagnostics for Error {
                 CompileErrorKind::CallMacroError { item, .. } => {
                     notes.push(format!("Error originated in the `{}` macro", item).into());
                 }
+                CompileErrorKind::NestedTest { nested_span } => {
+                    labels.push(
+                        Label::secondary(this.source_id(), nested_span.range())
+                            .with_message("nested in here"),
+                    );
+                }
                 _ => (),
             }
 

--- a/crates/rune/src/worker/mod.rs
+++ b/crates/rune/src/worker/mod.rs
@@ -135,6 +135,7 @@ impl<'a> Worker<'a> {
                         impl_item: Default::default(),
                         visitor: self.visitor.clone(),
                         source_loader: self.source_loader.clone(),
+                        nested_item: None,
                     };
 
                     if let Err(error) = file.index(&mut indexer) {

--- a/tests/tests/test_attribute.rs
+++ b/tests/tests/test_attribute.rs
@@ -1,0 +1,56 @@
+use rune_tests::*;
+
+#[test]
+fn basic_use() {
+    rune! {
+        () =>
+        mod private {
+            #[test]
+            fn test_case() {
+                assert_eq!(1 + 1, 2);
+            }
+        }
+
+        #[test]
+        fn test_case() {
+            assert_eq!(1 + 1, 2);
+        }
+
+        pub fn main() {
+        }
+    }
+}
+
+// We prevent tests from being declared inside of nested items at compile time.
+#[test]
+fn deny_nested_use() {
+    assert_compile_error! {
+        r#"
+        fn function() {
+            #[test]
+            fn test_fn() {
+                assert!(true != true);
+            }
+        }
+        "#,
+        span, NestedTest { nested_span } => {
+            assert_eq!(span, Span::new(37, 69));
+            assert_eq!(nested_span, Span::new(9, 22));
+        }  
+    }
+
+    assert_compile_error! {
+        r#"
+        const ITEM = {
+            #[test]
+            fn test_fn() {
+                assert!(true != true);
+            }
+        };
+        "#,
+        span, NestedTest { nested_span } => {
+            assert_eq!(span, Span::new(36, 68));
+            assert_eq!(nested_span, Span::new(9, 19));
+        }  
+    }
+}


### PR DESCRIPTION
This denies `#[test]` fns declared inside of other nested items, like these:

```rust
fn function() {
    #[test]
    fn test_fn() {
        assert!(true != true);
    }
}
```

The above would fail to compile with:

```text
  ┌─ scripts\test.rn:2:5
  │
1 │   fn function() {
  │   ------------- nested in here
2 │ ╭     #[test]
3 │ │     fn test_fn() {
  │ ╰────────────────^ #[test] attributes are not supported on nested items
```

#### TODO

We still need `#[test]` fns to be fully pruned during compilation in case we're not compiling for a test case.