### PR TITLE
refactor rune-cli to be more command oriented

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run tests
         run: cargo test --all
       - name: Run example scripts
-        run: cargo run --bin rune -- --recursive --test --experimental -O macros=true scripts
+        run: cargo run --bin rune -- --recursive --experimental -O macros=true scripts check
   wasm:
     name: Wasm Build
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run tests
         run: cargo test --all
       - name: Run example scripts
-        run: cargo run --bin rune -- --recursive --experimental -O macros=true scripts check
+        run: cargo run --bin rune -- check --recursive --experimental -O macros=true scripts
   wasm:
     name: Wasm Build
     runs-on: ubuntu-latest

--- a/book/src/async.md
+++ b/book/src/async.md
@@ -16,7 +16,7 @@ A typical example would be if we want to perform multiple HTTP requests at once:
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/async/async_http.rn
+$> cargo run --bin rune -- run scripts/book/async/async_http.rn
 200 OK
 200 OK
 == () (591.0319ms)
@@ -38,7 +38,7 @@ timeout:
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/async/async_http_timeout.rn
+$> cargo run --bin rune -- run scripts/book/async/async_http_timeout.rn
 200 OK
 Request timed out!
 == () (3.2231404s)
@@ -65,7 +65,7 @@ is only permitted inside of `async` functions and closures.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/async/async_http_concurrent.rn
+$> cargo run --bin rune -- run scripts/book/async/async_http_concurrent.rn
 Result: 200 OK
 Request timed out!
 == () (2.0028603s)
@@ -81,7 +81,7 @@ produce a future.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/async/async_closure.rn
+$> cargo run --bin rune -- run scripts/book/async/async_closure.rn
 Status: 200 OK
 == () (165.4817ms)
 ```
@@ -96,7 +96,7 @@ can capture variables the same way as closures do, but take no arguments.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/async/async_blocks.rn
+$> cargo run --bin rune -- run scripts/book/async/async_blocks.rn
 Status: 200 OK
 == () (179.9381ms)
 ```

--- a/book/src/call_frames.md
+++ b/book/src/call_frames.md
@@ -31,7 +31,7 @@ To look close at the mechanism, let's trace the following program:
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/the_stack/call_and_add.rn --trace --dump-stack
+$> cargo run --bin rune -- run scripts/book/the_stack/call_and_add.rn --trace --dump-stack
 fn main() (0xe7fc1d6083100dcd):
   0005 = integer 3
     0+0 = 3

--- a/book/src/closures.md
+++ b/book/src/closures.md
@@ -20,7 +20,7 @@ represents the operation you want another function to use.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/closures/function_pointers.rn
+$> cargo run --bin rune -- run scripts/book/closures/function_pointers.rn
 Result: 3
 Result: -1
 == () (5.4354ms)
@@ -37,7 +37,7 @@ them to be used when the function is being called.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/closures/basic_closure.rn
+$> cargo run --bin rune -- run scripts/book/closures/basic_closure.rn
 Result: 4
 Result: 3
 == () (5.4354ms)
@@ -81,7 +81,7 @@ cause a compile error.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/closures/closure_move.rn.fail
+$> cargo run --bin rune -- run scripts/book/closures/closure_move.rn.fail
 error: compile error
   ┌─ scripts/book/closures/closure_move.rn.fail:7:33
   │

--- a/book/src/compiler_guide.md
+++ b/book/src/compiler_guide.md
@@ -46,7 +46,7 @@ Consider the following unit:
 Let's dump all dynamic functions in it:
 
 ```text
-$> cargo run --bin rune -- scripts/book/compiler_guide/dead_code.rn --dump-functions
+$> cargo run --bin rune -- run scripts/book/compiler_guide/dead_code.rn --dump-functions
 # dynamic functions
 0xe7fc1d6083100dcd = main()
 0x20c6d8dd92b51018 = main::$0::foo()
@@ -106,7 +106,7 @@ script:
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/compiler_guide/closures.rn --dump-instructions --dump-functions
+$> cargo run --bin rune -- run scripts/book/compiler_guide/closures.rn --dump-instructions --dump-functions
 # instructions
 fn main() (0xa76ee18c7fed2b52):
   0000 = load-fn 0xca35663d3c51a903 // closure `main::$0::$0`

--- a/book/src/control_flow.md
+++ b/book/src/control_flow.md
@@ -18,7 +18,7 @@ what the function returns by default unless a `return` is specified.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/control_flow/numbers_game.rn
+$> cargo run --bin rune -- run scripts/book/control_flow/numbers_game.rn
 less than one
 something else
 == () (3.8608ms)
@@ -34,7 +34,7 @@ If the condition is `true`, the provided block of code will run.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/control_flow/conditional.rn
+$> cargo run --bin rune -- run scripts/book/control_flow/conditional.rn
 The number *is* smaller than 5
 == () (5.108ms)
 ```
@@ -47,7 +47,7 @@ the condition is false.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/control_flow/conditional_else.rn
+$> cargo run --bin rune -- run scripts/book/control_flow/conditional_else.rn
 the number is smaller than 5
 == () (196.1µs)
 ```
@@ -60,7 +60,7 @@ specify many different conditions.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/control_flow/conditional_else_ifs.rn
+$> cargo run --bin rune -- run scripts/book/control_flow/conditional_else_ifs.rn
 the number is smaller than 5
 == () (227.9µs)
 ```
@@ -75,7 +75,7 @@ This will be covered in a later section, but here is a sneak peek:
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/control_flow/first_match.rn
+$> cargo run --bin rune -- run scripts/book/control_flow/first_match.rn
 the number is smaller than 5
 == () (124.2µs)
 ```

--- a/book/src/dynamic_types.md
+++ b/book/src/dynamic_types.md
@@ -11,7 +11,7 @@ The following is a quick example of a `struct`:
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/dynamic_types/greeting.rn
+$> cargo run --bin rune -- run scripts/book/dynamic_types/greeting.rn
 Greetings from John-John Tedro, and good luck with this section!
 == () (2.7585ms)
 ```

--- a/book/src/enums.md
+++ b/book/src/enums.md
@@ -19,7 +19,7 @@ absent with `Option::None`.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/enums/count_numbers.rn
+$> cargo run --bin rune -- run scripts/book/enums/count_numbers.rn
 First count!
 Count: 0
 Count: 1

--- a/book/src/functions.md
+++ b/book/src/functions.md
@@ -21,7 +21,7 @@ simply what the Rune cli looks for when deciding what to execute.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/functions/main_function.rn
+$> cargo run --bin rune -- run scripts/book/functions/main_function.rn
 Hello World
 == () (277.8µs)
 ```
@@ -35,7 +35,7 @@ anything, even completely distinct types.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/functions/return_value.rn
+$> cargo run --bin rune -- run scripts/book/functions/return_value.rn
 Hello
 1
 == () (8.437ms)

--- a/book/src/generators.md
+++ b/book/src/generators.md
@@ -14,7 +14,7 @@ numbers.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/generators/fib_generator.rn
+$> cargo run --bin rune -- run scripts/book/generators/fib_generator.rn
 0
 1
 1
@@ -45,7 +45,7 @@ allowing the calling procedure to send values to the generator.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/generators/send_values.rn
+$> cargo run --bin rune -- run scripts/book/generators/send_values.rn
 "John"
 (1, 2, 3)
 == () (883.2µs)
@@ -63,7 +63,7 @@ instrumenting our code a little.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/generators/bootup.rn
+$> cargo run --bin rune -- run scripts/book/generators/bootup.rn
 firing off the printer...
 waiting for value...
 ready to go!
@@ -86,7 +86,7 @@ possible states a generator can suspend itself into.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/generators/states.rn
+$> cargo run --bin rune -- run scripts/book/generators/states.rn
 Yielded(1)
 "John"
 Complete(2)
@@ -107,7 +107,7 @@ error.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/generators/error.rn
+$> cargo run --bin rune -- run scripts/book/generators/error.rn
 Generator { completed: false }
 Yielded(1)
 Complete("John")

--- a/book/src/getting_started.md
+++ b/book/src/getting_started.md
@@ -9,7 +9,7 @@ be provided to it, and it will do its best to describe it.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/getting_started/dbg.rn
+$> cargo run --bin rune -- run scripts/book/getting_started/dbg.rn
 [1, 2, 3]
 '今'
 dynamic function (at: 0x17)
@@ -36,7 +36,7 @@ So for a more formal introduction, here is the official Rune `"Hello World"`:
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/getting_started/hello_world.rn
+$> cargo run --bin rune -- run scripts/book/getting_started/hello_world.rn
 Hello World
 == () (1.0864ms)
 ```

--- a/book/src/instance_functions.md
+++ b/book/src/instance_functions.md
@@ -13,7 +13,7 @@ instance functions must be looked up at runtime.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/instance_functions/missing_instance_fn.rn
+$> cargo run --bin rune -- run scripts/book/instance_functions/missing_instance_fn.rn
 error: virtual machine error
    ┌─ scripts/book/instance_functions/missing_instance_fn.rn:11:5
    │

--- a/book/src/items_imports.md
+++ b/book/src/items_imports.md
@@ -22,7 +22,7 @@ statement:
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/items_imports/example_import.rn
+$> cargo run --bin rune -- run scripts/book/items_imports/example_import.rn
 == Iterator (60µs)
 ```
 
@@ -33,7 +33,7 @@ Trying to use an item which doesn't exist results in a compile error:
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/items_imports/missing_item.rn.fail
+$> cargo run --bin rune -- run scripts/book/items_imports/missing_item.rn.fail
 error: compile error
   ┌─ scripts/book/items_imports/missing_item.rn.fail:2:15
   │
@@ -58,7 +58,7 @@ The following is an example of an *inline* module:
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/items_imports/inline_modules.rn
+$> cargo run --bin rune -- run scripts/book/items_imports/inline_modules.rn
 == 3 (33.2µs)
 ```
 
@@ -80,7 +80,7 @@ separate files:
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/items_imports/modules.rn
+$> cargo run --bin rune -- run scripts/book/items_imports/modules.rn
 == 3 (37.5µs)
 ```
 

--- a/book/src/loops.md
+++ b/book/src/loops.md
@@ -18,7 +18,7 @@ currently in and continue running right after it.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/loops/while_loop.rn
+$> cargo run --bin rune -- run scripts/book/loops/while_loop.rn
 The value is 50
 == () (501.1µs)
 ```
@@ -34,7 +34,7 @@ control flow operator like a `break` or a `return`.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/loops/loop_forever.rn
+$> cargo run --bin rune -- run scripts/book/loops/loop_forever.rn
 Hello forever!
 Hello forever!
 Hello forever!
@@ -56,7 +56,7 @@ By default, this is simply a unit `()`.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/loops/loop_break.rn
+$> cargo run --bin rune -- run scripts/book/loops/loop_break.rn
 The final count is: 11
 == () (281.5µs)
 ```

--- a/book/src/macros.md
+++ b/book/src/macros.md
@@ -51,7 +51,7 @@ With this module installed, we can now take `stringy_math!` for a spin.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/macros/stringy_math.rn -O macros=true --experimental
+$> cargo run --bin rune -- run scripts/book/macros/stringy_math.rn -O macros=true --experimental
 200
 == () (2.9737ms)
 ```

--- a/book/src/objects.md
+++ b/book/src/objects.md
@@ -8,7 +8,7 @@ keys.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/objects/objects.rn
+$> cargo run --bin rune -- run scripts/book/objects/objects.rn
 "bar"
 42
 key did not exist
@@ -28,7 +28,7 @@ we can natively handle data with unknown structure.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/objects/json.rn
+$> cargo run --bin rune -- run scripts/book/objects/json.rn
 9c4bdaf194410d8b2f5d7f9f52eb3e64709d3414
 06419f2580e7a18838f483321055fc06c0d75c4c
 cba225dad143779a0a9543cfb05cde9710083af5

--- a/book/src/pattern_matching.md
+++ b/book/src/pattern_matching.md
@@ -13,7 +13,7 @@ Below are some examples of its common uses to match on branch conditions:
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/pattern_matching/big_match.rn
+$> cargo run --bin rune -- run scripts/book/pattern_matching/big_match.rn
 The number one.
 Another number: 2.
 A vector starting with one and two, followed by 42.
@@ -67,7 +67,7 @@ This is called a *rest pattern*.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/pattern_matching/rest_pattern.rn
+$> cargo run --bin rune -- run scripts/book/pattern_matching/rest_pattern.rn
 == () (89.8µs)
 ```
 
@@ -83,7 +83,7 @@ what it is.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/pattern_matching/ignore.rn
+$> cargo run --bin rune -- run scripts/book/pattern_matching/ignore.rn
 Second item in vector is 2.
 == () (281.3µs)
 ```
@@ -97,7 +97,7 @@ give us access to it in the match arm.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/pattern_matching/bind.rn
+$> cargo run --bin rune -- run scripts/book/pattern_matching/bind.rn
 Second item in vector is 2.
 == () (6.25ms)
 ```
@@ -113,7 +113,7 @@ Here are some more examples:
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/pattern_matching/fast_cars.rn
+$> cargo run --bin rune -- run scripts/book/pattern_matching/fast_cars.rn
 Pretty fast!
 Can't tell 😞
 What, where did you get that?

--- a/book/src/primitives.md
+++ b/book/src/primitives.md
@@ -23,7 +23,7 @@ variable, because a separate copy of the value will be used automatically.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/primitives/copy.rn
+$> cargo run --bin rune -- run scripts/book/primitives/copy.rn
 2
 1
 == () (691.3µs)
@@ -38,7 +38,7 @@ same underlying data.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/primitives/primitives.rn
+$> cargo run --bin rune -- run scripts/book/primitives/primitives.rn
 Hello World
 Hello World
 == () (9.7406ms)

--- a/book/src/streams.md
+++ b/book/src/streams.md
@@ -11,7 +11,7 @@ the generator.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/streams/basic_stream.rn
+$> cargo run --bin rune -- run scripts/book/streams/basic_stream.rn
 200 OK
 200 OK
 == () (754.3946ms)

--- a/book/src/structs.md
+++ b/book/src/structs.md
@@ -12,7 +12,7 @@ struct.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/structs/user_database.rn
+$> cargo run --bin rune -- run scripts/book/structs/user_database.rn
 setbac is inactive
 setbac is active
 == () (6.2095ms)
@@ -28,7 +28,7 @@ ensure that you're only using fields which are defined.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/structs/struct_matching.rn
+$> cargo run --bin rune -- run scripts/book/structs/struct_matching.rn
 Yep, it's setbac.
 Other user: newt.
 == () (1.0652ms)

--- a/book/src/template_literals.md
+++ b/book/src/template_literals.md
@@ -12,7 +12,7 @@ environment.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/template_literals/basic_template.rn
+$> cargo run --bin rune -- run scripts/book/template_literals/basic_template.rn
 "I am 30 years old!"
 == () (4.5678ms)
 ```
@@ -59,7 +59,7 @@ types which do not implement this protocol will fail to run.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/template_literals/not_a_template.rn
+$> cargo run --bin rune -- run scripts/book/template_literals/not_a_template.rn
 == ! (`Vec` does not implement the `string_display` protocol (at 5)) (77.7µs)
 error: virtual machine error
   ┌─ scripts/book/template_literals/not_a_template.rn:3:9

--- a/book/src/the_stack.md
+++ b/book/src/the_stack.md
@@ -11,7 +11,7 @@ the add operation with `--trace` and `--dump-stack`.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/the_stack/add.rn --trace --dump-stack
+$> cargo run --bin rune -- run scripts/book/the_stack/add.rn --trace --dump-stack
 fn main() (0xe7fc1d6083100dcd):
   0000 = integer 1
     0+0 = 1

--- a/book/src/try_operator.md
+++ b/book/src/try_operator.md
@@ -11,7 +11,7 @@ variant.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/try_operator/basic_try.rn
+$> cargo run --bin rune -- run scripts/book/try_operator/basic_try.rn
 Result: 2, 1
 == () (7.4912ms)
 ```

--- a/book/src/tuples.md
+++ b/book/src/tuples.md
@@ -9,7 +9,7 @@ tuple.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/tuples/tuple_masquerade.rn
+$> cargo run --bin rune -- run scripts/book/tuples/tuple_masquerade.rn
 ("Now", "You", "See", "Me")
 ("Now", "You", "Don\'t", "!")
 == () (38.3136ms)
@@ -22,7 +22,7 @@ The following is a simple example of a function returning a tuple:
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/tuples/basic_tuples.rn
+$> cargo run --bin rune -- run scripts/book/tuples/basic_tuples.rn
 (1, "test")
 == () (387.6µs)
 ```
@@ -34,7 +34,7 @@ Tuples can also be pattern matched:
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/tuples/tuple_patterns.rn
+$> cargo run --bin rune -- run scripts/book/tuples/tuple_patterns.rn
 "the first part was a number:"
 1
 == () (7.7892ms)

--- a/book/src/types.md
+++ b/book/src/types.md
@@ -12,7 +12,7 @@ not` operations, like this:
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/types/types.rn
+$> cargo run --bin rune -- run scripts/book/types/types.rn
 == () (120µs)
 ```
 
@@ -24,7 +24,7 @@ of that type.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/types/bad_type_check.rn
+$> cargo run --bin rune -- run scripts/book/types/bad_type_check.rn
 == ! (panicked `assertion failed: vectors should be strings` (at 12)) (133.3µs)
 error: virtual machine error
   ┌─ scripts/book/types/bad_type_check.rn:2:5
@@ -41,7 +41,7 @@ make decisions depending on what type a value has.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/types/type_check.rn
+$> cargo run --bin rune -- run scripts/book/types/type_check.rn
 n is a String
 n is a vector
 n is unknown
@@ -57,7 +57,7 @@ are different types or variants in an enum.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/types/type_check_patterns.rn
+$> cargo run --bin rune -- run scripts/book/types/type_check_patterns.rn
 n is a String
 n is a vector
 n is unknown

--- a/book/src/variables.md
+++ b/book/src/variables.md
@@ -8,7 +8,7 @@ variables in Rune are mutable and can be changed at any time.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/variables/variables.rn
+$> cargo run --bin rune -- run scripts/book/variables/variables.rn
 The value of x is: 5
 The value of x is: 6
 ```
@@ -35,7 +35,7 @@ variables:
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/variables/shared_ownership.rn
+$> cargo run --bin rune -- run scripts/book/variables/shared_ownership.rn
 1
 2
 == () (913.4µs)
@@ -54,7 +54,7 @@ raised in the virtual machine.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/variables/take_argument.rn
+$> cargo run --bin rune -- run scripts/book/variables/take_argument.rn
 field: 1
 == ! (cannot read, value is moved (at 14)) (469µs)
 error: virtual machine error
@@ -74,7 +74,7 @@ to functions which need to move the value, like `drop`.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/variables/is_readable.rn
+$> cargo run --bin rune -- run scripts/book/variables/is_readable.rn
 field: 1
 object is no longer readable 😢
 == () (943.8µs)

--- a/book/src/vectors.md
+++ b/book/src/vectors.md
@@ -8,7 +8,7 @@ vector isn't typed, and can store *any* Rune values.
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/vectors/vectors.rn
+$> cargo run --bin rune -- run scripts/book/vectors/vectors.rn
 Hello
 42
 Hello
@@ -25,7 +25,7 @@ protocol. It is also possible to create and use an iterator manually using
 ```
 
 ```text
-$> cargo run --bin rune -- scripts/book/vectors/vectors_rev.rn
+$> cargo run --bin rune -- run scripts/book/vectors/vectors_rev.rn
 42
 Hello
 == () (2.9116ms)

--- a/crates/rune-cli/src/main.rs
+++ b/crates/rune-cli/src/main.rs
@@ -432,7 +432,8 @@ async fn run_path(args: &Args, options: &rune::Options, path: &Path) -> Result<E
                 ColorChoice::Never
             }
         }
-        _ => ColorChoice::Never,
+        "never" => ColorChoice::Never,
+        _ => ColorChoice::Auto,
     };
 
     let mut out = StandardStream::stdout(choice);

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -216,7 +216,7 @@ pub use self::load::{FileSourceLoader, SourceLoader, Sources};
 pub use self::macros::{
     with_context, MacroContext, Quote, Storage, ToTokens, TokenStream, TokenStreamIter,
 };
-pub use self::options::Options;
+pub use self::options::{ConfigurationError, Options};
 pub use self::parsing::{
     Id, Lexer, Parse, ParseError, ParseErrorKind, Parser, Peek, Peeker, Resolve, ResolveError,
     ResolveErrorKind, ResolveOwned,

--- a/crates/rune/src/options.rs
+++ b/crates/rune/src/options.rs
@@ -1,5 +1,6 @@
 use thiserror::Error;
 
+/// Error when parsing configuration.
 #[derive(Debug, Clone, Error)]
 pub enum ConfigurationError {
     /// Tried to configure the compiler with an unsupported optimzation option.

--- a/crates/runestick/src/value.rs
+++ b/crates/runestick/src/value.rs
@@ -1028,8 +1028,20 @@ impl fmt::Debug for Value {
             }
             value => {
                 let mut s = String::new();
-                let result = value.string_debug(&mut s).map_err(|_| fmt::Error)?;
+                let result = match value.string_debug(&mut s) {
+                    Ok(s) => s,
+                    Err(_) => {
+                        // this isn't very nice, but if protocol string fails
+                        // this used to crash out immediately... in this way,
+                        // one can at least get soms semblance of info for all
+                        // types. And if the type doesn't have type info
+                        // something else has gone terribly wrong.
+                        s = format!("{:?}", value.type_info().unwrap());
+                        Ok(())
+                    }
+                };
                 result?;
+
                 write!(f, "{}", s)?;
             }
         }


### PR DESCRIPTION
This PR changes rune (rune-cli) to be based around commands and feel a bit more like `cargo`. 

In this PR there is now three commands for Rune: 
* `check`: only compiles, emites all errors and warnings
* `test`: runs all tests
* `run`: runs the main entrypoint

Furthermore, there is now auto-find for the entrypoint as well, looking for main.rn, lib.rn, as well as in the subfolders src and script. This was necessary as one would otherwise have to make "path" part of every subcommand, which makes everything more complicated while being less ergonomic and needing more typing. The old mode is still possible by passing paths *before* the command.

Sample output:
```

➜ ../rune/target/debug/rune check
Checking: script/main.rn
// snip a ton of badly formatted warnings

➜ ../rune/target/debug/rune test
Found 23 tests...
Test day1::test_part1               passed
Test day1::test_part2               passed
Test day2::test_part1               passed
Test day2::test_part2               passed
Test day3::test_part1               passed
Test day3::test_part2               passed
Test day8::test_part1               passed
Test day8::test_part2               passed
Test day9::part2                    passed
Test day9::part1                    passed
Test day10::test_part1              passed
Test day10::test_part2              passed
Test day12::test_part1              passed
Test day12::test_part2              passed
Test day12::test_part2_rots         passed
Test day12::test_part2_ss           passed
Test day11::test_part1              passed
Test day11::test_part2              passed
Test day13::test_part1              passed
Test day13::test_part2              passed
Test day14::test_part1              passed
Test day14::test_part2              passed
Test day14::test_parse              passed
====
Executed 23 tests with 0 failures (0 skipped) in 0.308 seconds

➜ ../rune/target/debug/rune --color=always test -q
Found 23 tests...
.......................
====
Executed 23 tests with 0 failures (0 skipped) in 0.308 seconds

➜ ../rune/target/debug/rune run
== () (5.130348676s)
```