### PR TITLE
use BTreeMap as backing store for objects

### DIFF
--- a/crates/runestick/src/lib.rs
+++ b/crates/runestick/src/lib.rs
@@ -226,4 +226,5 @@ pub use runestick_macros::{Any, FromValue};
 mod collections {
     pub use hashbrown::{hash_map, HashMap};
     pub use hashbrown::{hash_set, HashSet};
+    pub use std::collections::{btree_map, BTreeMap};
 }

--- a/crates/runestick/src/object.rs
+++ b/crates/runestick/src/object.rs
@@ -1,13 +1,12 @@
+use crate::collections::{btree_map, BTreeMap};
 use crate::{
     FromValue, InstallWith, Item, Mut, Named, RawMut, RawRef, RawStr, Ref, ToValue,
     UnsafeFromValue, Value, Vm, VmError,
 };
 use std::borrow;
 use std::cmp;
-use std::collections::BTreeMap as HashMap;
 use std::fmt;
 use std::hash;
-
 /// An owning iterator over the entries of a `Object`.
 ///
 /// This `struct` is created by the [`into_iter`] method on [`Object`]
@@ -15,7 +14,7 @@ use std::hash;
 ///
 /// [`into_iter`]: struct.Object.html#method.into_iter
 /// [`Object`]: struct.Object.html
-pub type IntoIter = std::collections::btree_map::IntoIter<String, Value>;
+pub type IntoIter = btree_map::IntoIter<String, Value>;
 
 /// A mutable iterator over the entries of a `Object`.
 ///
@@ -24,7 +23,7 @@ pub type IntoIter = std::collections::btree_map::IntoIter<String, Value>;
 ///
 /// [`iter_mut`]: struct.Object.html#method.iter_mut
 /// [`Object`]: struct.Object.html
-pub type IterMut<'a> = std::collections::btree_map::IterMut<'a, String, Value>;
+pub type IterMut<'a> = btree_map::IterMut<'a, String, Value>;
 
 /// An iterator over the entries of a `Object`.
 ///
@@ -33,7 +32,7 @@ pub type IterMut<'a> = std::collections::btree_map::IterMut<'a, String, Value>;
 ///
 /// [`iter`]: struct.Object.html#method.iter
 /// [`Object`]: struct.Object.html
-pub type Iter<'a> = std::collections::btree_map::Iter<'a, String, Value>;
+pub type Iter<'a> = btree_map::Iter<'a, String, Value>;
 
 /// An iterator over the keys of a `HashMap`.
 ///
@@ -42,7 +41,7 @@ pub type Iter<'a> = std::collections::btree_map::Iter<'a, String, Value>;
 ///
 /// [`keys`]: struct.Object.html#method.keys
 /// [`Object`]: struct.Object.html
-pub type Keys<'a> = std::collections::btree_map::Keys<'a, String, Value>;
+pub type Keys<'a> = btree_map::Keys<'a, String, Value>;
 
 /// An iterator over the values of a `HashMap`.
 ///
@@ -51,7 +50,7 @@ pub type Keys<'a> = std::collections::btree_map::Keys<'a, String, Value>;
 ///
 /// [`values`]: struct.Object.html#method.values
 /// [`Object`]: struct.Object.html
-pub type Values<'a> = std::collections::btree_map::Values<'a, String, Value>;
+pub type Values<'a> = btree_map::Values<'a, String, Value>;
 
 /// Struct representing a dynamic anonymous object.
 ///
@@ -74,7 +73,7 @@ pub type Values<'a> = std::collections::btree_map::Values<'a, String, Value>;
 #[derive(Default, Clone)]
 #[repr(transparent)]
 pub struct Object {
-    inner: HashMap<String, Value>,
+    inner: BTreeMap<String, Value>,
 }
 
 impl Object {
@@ -82,7 +81,7 @@ impl Object {
     #[inline]
     pub fn new() -> Self {
         Self {
-            inner: HashMap::new(),
+            inner: BTreeMap::new(),
         }
     }
 
@@ -91,7 +90,7 @@ impl Object {
     pub fn with_capacity(_cap: usize) -> Self {
         /* BTreeMap doesn't support setting capacity on creation but we keep this here in case we want to switch store later */
         Self {
-            inner: HashMap::new(),
+            inner: BTreeMap::new(),
         }
     }
 
@@ -188,7 +187,7 @@ impl Object {
     }
 
     /// Convert into inner.
-    pub fn into_inner(self) -> HashMap<String, Value> {
+    pub fn into_inner(self) -> BTreeMap<String, Value> {
         self.inner
     }
 
@@ -270,9 +269,11 @@ impl fmt::Debug for Object {
     }
 }
 
-impl From<HashMap<String, Value>> for Object {
-    fn from(object: HashMap<String, Value>) -> Self {
-        Self { inner: object }
+impl std::iter::FromIterator<(String, Value)> for Object {
+    fn from_iter<T: IntoIterator<Item = (String, Value)>>(src: T) -> Self {
+        Self {
+            inner: src.into_iter().collect(),
+        }
     }
 }
 
@@ -354,8 +355,8 @@ impl fmt::Display for DebugStruct<'_> {
 /// Helper function two compare two hashmaps of values.
 pub(crate) fn map_ptr_eq<K>(
     vm: &mut Vm,
-    a: &HashMap<K, Value>,
-    b: &HashMap<K, Value>,
+    a: &BTreeMap<K, Value>,
+    b: &BTreeMap<K, Value>,
 ) -> Result<bool, VmError>
 where
     K: cmp::Eq + cmp::Ord,

--- a/crates/runestick/src/value.rs
+++ b/crates/runestick/src/value.rs
@@ -121,7 +121,7 @@ impl Struct {
     pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&Value>
     where
         String: std::borrow::Borrow<Q>,
-        Q: std::hash::Hash + std::cmp::Eq,
+        Q: std::hash::Hash + std::cmp::Eq + std::cmp::Ord,
     {
         self.data.get(k)
     }
@@ -130,7 +130,7 @@ impl Struct {
     pub fn get_mut<Q: ?Sized>(&mut self, k: &Q) -> Option<&mut Value>
     where
         String: std::borrow::Borrow<Q>,
-        Q: std::hash::Hash + std::cmp::Eq,
+        Q: std::hash::Hash + std::cmp::Eq + std::cmp::Ord,
     {
         self.data.get_mut(k)
     }


### PR DESCRIPTION
I've tried a dozen different methods here to see if I can improve some usages, and this seems to be the simplest and most stupid one: simply switch backing storage. I think the tradeoff here is that since BTreeMaps use cmp::Ord instead of cmp::Eq, we have to prefix search at each node of the BTree, so if there's a common prefix to members lookups will increase in cost.

Overall these results are expected: the brainfuck interpreter relies heavily on `self` so I'd expect it to improve, and the fibonnaci is pure recursive calls and should be unaffected. I cannot motivate why aoc_2020_{1a, 1b} got faster, however, nor that 11a does not improve... It might just be completely overshadowed by some other operation.

@udoprog it'd be interesting to see if you can replicate similar gains.
 
```
➜ cargo benchcmp before btreemap
 name             before ns/iter  btreemap ns/iter  diff ns/iter   diff %  speedup
 aoc_2020_11a     277,658,677     276,582,186         -1,076,491   -0.39%   x 1.00
 aoc_2020_1a      193,316         184,086                 -9,230   -4.77%   x 1.05
 aoc_2020_1b      581,259         572,379                 -8,880   -1.53%   x 1.02
 bf_fib           52,909,632      46,863,458          -6,046,174  -11.43%   x 1.13
 bf_hello_world   871,338         841,625                -29,713   -3.41%   x 1.04
 bf_hello_world2  9,531,777       8,708,816             -822,961   -8.63%   x 1.09
 bf_loopity       8,027,656       7,703,409             -324,247   -4.04%   x 1.04
 fib_15           313,758         317,448                  3,690    1.18%   x 0.99
 fib_20           3,520,573       3,556,172               35,599    1.01%   x 0.99
```

Methods I've also tried:

* precompute keys inside objects
* precompute all keys (yes, *all*. ConstValue, IrValue, you name it.)
* VecMap (vector-map version)
* Every possible hasher under the sun
* BTreeMap + precomputed keys
* ordered map

This version has:

* least variable results (all the hash based ones are +-3% run-over-run, making most results statistically insignificant
* little to no impact when objects are not used
* maintains the current API
* doesn't add any dependencies or performance cliffs
