### PR TITLE
make float associated fns... associated.

### DIFF
--- a/crates/runestick/src/modules/float.rs
+++ b/crates/runestick/src/modules/float.rs
@@ -21,8 +21,11 @@ pub fn module() -> Result<Module, ContextError> {
 
     module.ty::<ParseFloatError>()?;
     module.function(&["parse"], parse)?;
-    module.function(&["max"], f64::max)?;
-    module.function(&["min"], f64::min)?;
+    module.inst_fn("max", f64::max)?;
+    module.inst_fn("min", f64::min)?;
+    module.inst_fn("abs", f64::abs)?;
+    module.inst_fn("powf", f64::powf)?;
+    module.inst_fn("powi", f64::powi)?;
 
     module.inst_fn("to_integer", to_integer)?;
 


### PR DESCRIPTION
It seems like max and min won't work as associated fns today, i.e., https://rune-rs.github.io/play/?c=CnB1YiBmbiBtYWluKCkgewoJbGV0IGEgPSAxLjA7CglsZXQgYiA9IDIuMDsKCWxldCBjID0gYS5taW4oYik7Cn0K. This fixes that and also adds powf, powi, and abs. (I think the caveat here is that this trades using them as loose functions for using them as assoc fns... I'm going to guess that with this change, the "loose function" path would be... `std::core::f64::min`? Or something like that. 