### PR TITLE
upgrade nanorand to 0.5.2

### DIFF
--- a/crates/rune-modules/Cargo.toml
+++ b/crates/rune-modules/Cargo.toml
@@ -36,7 +36,7 @@ reqwest = { version = "0.10.9", optional = true, default-features = false, featu
 tokio = { version = "0.2.22", optional = true }
 serde_json = { version = "1.0.60", optional = true }
 toml = { version = "0.5.7", optional = true }
-nanorand = { version = "0.4.4", optional = true, features = ["getrandom"] }
+nanorand = { version = "0.5.2", optional = true, features = ["getrandom"] }
 
 rune = {version = "0.7.0", path = "../rune"}
 runestick = {version = "0.7.0", path = "../runestick"}

--- a/crates/rune-modules/src/rand.rs
+++ b/crates/rune-modules/src/rand.rs
@@ -80,12 +80,12 @@ impl WyRand {
 
     /// Generate a random integer
     fn int(&mut self) -> Value {
-        Value::Integer(self.inner.generate::<i64>())
+        Value::Integer(self.inner.generate::<u64>() as i64)
     }
 
     /// Generate a random integer within the specified range
     fn int_range(&mut self, lower: i64, upper: i64) -> Value {
-        Value::Integer(self.inner.generate_range::<i64>(lower, upper))
+        Value::Integer(self.inner.generate_range::<u64>(0, (upper - lower) as u64) as i64 + lower)
     }
 }
 
@@ -111,21 +111,23 @@ impl Pcg64 {
 
     /// Generate a random integer
     fn int(&mut self) -> Value {
-        Value::Integer(self.inner.generate::<i64>())
+        Value::Integer(self.inner.generate::<u64>() as i64)
     }
 
     /// Generate a random integer within the specified range
     fn int_range(&mut self, lower: i64, upper: i64) -> Value {
-        Value::Integer(self.inner.generate_range::<i64>(lower, upper))
+        Value::Integer(self.inner.generate_range::<u64>(0, (upper - lower) as u64) as i64 + lower)
     }
 }
 
 fn int() -> runestick::Result<Value> {
-    Ok(Value::Integer(nanorand::WyRand::new().generate::<i64>()))
+    Ok(Value::Integer(
+        nanorand::WyRand::new().generate::<u64>() as i64
+    ))
 }
 
 fn int_range(lower: i64, upper: i64) -> runestick::Result<Value> {
     Ok(Value::Integer(
-        nanorand::WyRand::new().generate_range::<i64>(lower, upper),
+        nanorand::WyRand::new().generate_range::<u64>(0, (upper - lower) as u64) as i64 + lower,
     ))
 }

--- a/crates/rune-modules/src/rand.rs
+++ b/crates/rune-modules/src/rand.rs
@@ -131,3 +131,36 @@ fn int_range(lower: i64, upper: i64) -> runestick::Result<Value> {
         nanorand::WyRand::new().generate_range::<u64>(0, (upper - lower) as u64) as i64 + lower,
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{int, int_range};
+
+    #[test]
+    fn test_range_is_exclusive() {
+        for _ in 0..100 {
+            assert_eq!(int_range(0, 1).unwrap().into_integer().unwrap(), 0);
+        }
+    }
+
+    #[test]
+    fn test_range_can_be_negative() {
+        for _ in 0..100 {
+            assert_eq!(int_range(-2, -1).unwrap().into_integer().unwrap(), -2);
+        }
+    }
+
+    #[test]
+    fn test_int_is_properly_signed() {
+        let mut any_negative = false;
+        let mut any_positive = false;
+        for _ in 0..100 {
+            let v = int().unwrap().into_integer().unwrap();
+            any_negative = any_negative || v < 0;
+            any_positive = any_positive || v > 0;
+        }
+
+        assert!(any_positive);
+        assert!(any_negative);
+    }
+}


### PR DESCRIPTION
nanorand generates incorrect random numbers before 0.5.1, see [RUSTSEC-2020-0089](https://github.com/RustSec/advisory-db/blob/master/crates/nanorand/RUSTSEC-2020-0089.md). It also doesn't support generating signed numbers any more, so this PR adds a workaround for that.