### PR TITLE
add lifetime to SourceLoader

### DIFF
--- a/crates/rune/src/compiling/mod.rs
+++ b/crates/rune/src/compiling/mod.rs
@@ -45,14 +45,14 @@ pub fn compile(
 }
 
 /// Encode the given object into a collection of asm.
-pub fn compile_with_options(
+pub fn compile_with_options<'a>(
     context: &Context,
     sources: &mut Sources,
     unit: &UnitBuilder,
     diagnostics: &mut Diagnostics,
     options: &Options,
     visitor: Rc<dyn CompileVisitor>,
-    source_loader: Rc<dyn SourceLoader>,
+    source_loader: Rc<dyn SourceLoader + 'a>,
 ) -> Result<(), ()> {
     // Global storage.
     let storage = Storage::new();
@@ -80,7 +80,7 @@ pub fn compile_with_options(
         let mod_item = match worker.query.insert_root_mod(source_id, Span::empty()) {
             Ok(result) => result,
             Err(error) => {
-                diagnostics.error(source_id, error);
+                worker.diagnostics.error(source_id, error);
                 return Err(());
             }
         };

--- a/crates/rune/src/indexing/index.rs
+++ b/crates/rune/src/indexing/index.rs
@@ -54,7 +54,7 @@ pub(crate) struct Indexer<'a> {
     /// Set if we are inside of an impl self.
     pub(crate) impl_item: Option<Arc<Item>>,
     pub(crate) visitor: Rc<dyn CompileVisitor>,
-    pub(crate) source_loader: Rc<dyn SourceLoader>,
+    pub(crate) source_loader: Rc<dyn SourceLoader + 'a>,
     /// Indicates if indexer is nested privately inside of another item, and if
     /// so, the descriptive span of its declaration.
     ///

--- a/crates/rune/src/load/mod.rs
+++ b/crates/rune/src/load/mod.rs
@@ -81,13 +81,13 @@ pub fn load_sources(
 }
 
 /// Load the specified sources with a visitor.
-pub fn load_sources_with_visitor(
+pub fn load_sources_with_visitor<'a>(
     context: &Context,
     options: &Options,
     sources: &mut Sources,
     diagnostics: &mut Diagnostics,
     visitor: Rc<dyn compiling::CompileVisitor>,
-    source_loader: Rc<dyn SourceLoader>,
+    source_loader: Rc<dyn SourceLoader + 'a>,
 ) -> Result<Unit, LoadSourcesError> {
     let unit = if context.has_default_modules() {
         compiling::UnitBuilder::with_default_prelude()

--- a/crates/rune/src/worker/mod.rs
+++ b/crates/rune/src/worker/mod.rs
@@ -24,7 +24,7 @@ pub(crate) struct Worker<'a> {
     options: &'a Options,
     pub(crate) diagnostics: &'a mut Diagnostics,
     pub(crate) visitor: Rc<dyn CompileVisitor>,
-    pub(crate) source_loader: Rc<dyn SourceLoader>,
+    pub(crate) source_loader: Rc<dyn SourceLoader + 'a>,
     /// Constants storage.
     pub(crate) consts: Consts,
     /// Worker queue.
@@ -49,7 +49,7 @@ impl<'a> Worker<'a> {
         consts: Consts,
         diagnostics: &'a mut Diagnostics,
         visitor: Rc<dyn CompileVisitor>,
-        source_loader: Rc<dyn SourceLoader>,
+        source_loader: Rc<dyn SourceLoader + 'a>,
         storage: Storage,
         gen: Gen,
     ) -> Self {
@@ -132,7 +132,7 @@ impl<'a> Worker<'a> {
                     };
 
                     if let Err(error) = file.index(&mut indexer) {
-                        self.diagnostics.error(source_id, error);
+                        indexer.diagnostics.error(source_id, error);
                     }
                 }
                 Task::ExpandImport(import) => {


### PR DESCRIPTION
This let's you use a SourceLoader with associated lifetimes. The reason it originally didn't work to add a lifetime was that I did it for both the CompileVisitor and SourceLoader. I ended up just skipping the visitor for now which sidesteps the MacroContext problem; but it's not very nice to have the two Rc's have different constraints (though there is also much less need for the visitor to have a borrow, so... meh).