### PR TITLE
Fix miscompilation by realizing that struct literal construction potentially requires cleanup

### DIFF
--- a/tests/tests/vm_try.rs
+++ b/tests/tests/vm_try.rs
@@ -20,6 +20,20 @@ fn test_unwrap() {
     };
 
     assert_eq! {
+        rune! { Option<bool> =>
+            struct Bar {
+                x, 
+                y,
+            }
+            
+            pub fn main() {
+                (Bar{ x: Some(1), y: None? }).x
+            }            
+        },
+        None,
+    };
+
+    assert_eq! {
         rune! { Result<i64, i64> =>
             fn foo(a, b) {
                 Ok(b / a)


### PR DESCRIPTION
Fixes #200. I shortened the test case for brevity.