### PR TITLE
Defined Result as std::result::Result to prevent bug

### DIFF
--- a/crates/runestick-macros/src/any.rs
+++ b/crates/runestick-macros/src/any.rs
@@ -24,7 +24,7 @@ impl syn::parse::Parse for InternalCall {
 }
 
 impl InternalCall {
-    pub fn expand(self) -> std::result::Result<TokenStream, Vec<syn::Error>> {
+    pub fn expand(self) -> Result<TokenStream, Vec<syn::Error>> {
         let ctx = Context::with_module(&quote!(crate));
         let attrs = DeriveAttrs::default();
         let tokens = ctx.tokens_with_module(&attrs);
@@ -65,7 +65,7 @@ impl syn::parse::Parse for Derive {
 }
 
 impl Derive {
-    pub(super) fn expand(self) -> std::result::Result<TokenStream, Vec<syn::Error>> {
+    pub(super) fn expand(self) -> Result<TokenStream, Vec<syn::Error>> {
         let mut ctx = Context::new();
 
         let attrs = match ctx.parse_derive_attrs(&self.input.attrs) {

--- a/crates/runestick-macros/src/any.rs
+++ b/crates/runestick-macros/src/any.rs
@@ -24,7 +24,7 @@ impl syn::parse::Parse for InternalCall {
 }
 
 impl InternalCall {
-    pub fn expand(self) -> Result<TokenStream, Vec<syn::Error>> {
+    pub fn expand(self) -> std::result::Result<TokenStream, Vec<syn::Error>> {
         let ctx = Context::with_module(&quote!(crate));
         let attrs = DeriveAttrs::default();
         let tokens = ctx.tokens_with_module(&attrs);
@@ -65,7 +65,7 @@ impl syn::parse::Parse for Derive {
 }
 
 impl Derive {
-    pub(super) fn expand(self) -> Result<TokenStream, Vec<syn::Error>> {
+    pub(super) fn expand(self) -> std::result::Result<TokenStream, Vec<syn::Error>> {
         let mut ctx = Context::new();
 
         let attrs = match ctx.parse_derive_attrs(&self.input.attrs) {

--- a/crates/runestick-macros/src/context.rs
+++ b/crates/runestick-macros/src/context.rs
@@ -489,7 +489,7 @@ impl Context {
         name: &TokenStream,
         install_with: &TokenStream,
         tokens: &Tokens,
-    ) -> std::result::Result<TokenStream, Vec<syn::Error>>
+    ) -> Result<TokenStream, Vec<syn::Error>>
     where
         T: Copy + ToTokens,
     {
@@ -521,7 +521,7 @@ impl Context {
             }
 
             impl #install_into_trait for #ident {
-                fn install_with(module: &mut #module) -> std::result::Result<(), #context_error> {
+                fn install_with(module: &mut #module) -> ::std::result::Result<(), #context_error> {
                     #install_with
                 }
             }
@@ -546,7 +546,7 @@ impl Context {
 
                 fn from_value(
                     value: #value,
-                ) -> std::result::Result<(Self::Output, Self::Guard), #vm_error> {
+                ) -> ::std::result::Result<(Self::Output, Self::Guard), #vm_error> {
                     Ok(value.into_any_ptr()?)
                 }
 
@@ -561,7 +561,7 @@ impl Context {
 
                 fn from_value(
                     value: #value,
-                ) -> std::result::Result<(Self::Output, Self::Guard), #vm_error> {
+                ) -> ::std::result::Result<(Self::Output, Self::Guard), #vm_error> {
                     Ok(value.into_any_mut()?)
                 }
 
@@ -573,7 +573,7 @@ impl Context {
             impl #unsafe_to_value for &#ident {
                 type Guard = #pointer_guard;
 
-                unsafe fn unsafe_to_value(self) -> std::result::Result<(#value, Self::Guard), #vm_error> {
+                unsafe fn unsafe_to_value(self) -> ::std::result::Result<(#value, Self::Guard), #vm_error> {
                     let (shared, guard) = #shared::from_ref(self);
                     Ok((#value::from(shared), guard))
                 }
@@ -582,7 +582,7 @@ impl Context {
             impl #unsafe_to_value for &mut #ident {
                 type Guard = #pointer_guard;
 
-                unsafe fn unsafe_to_value(self) -> std::result::Result<(#value, Self::Guard), #vm_error> {
+                unsafe fn unsafe_to_value(self) -> ::std::result::Result<(#value, Self::Guard), #vm_error> {
                     let (shared, guard) = #shared::from_mut(self);
                     Ok((#value::from(shared), guard))
                 }

--- a/crates/runestick-macros/src/context.rs
+++ b/crates/runestick-macros/src/context.rs
@@ -489,7 +489,7 @@ impl Context {
         name: &TokenStream,
         install_with: &TokenStream,
         tokens: &Tokens,
-    ) -> Result<TokenStream, Vec<syn::Error>>
+    ) -> std::result::Result<TokenStream, Vec<syn::Error>>
     where
         T: Copy + ToTokens,
     {
@@ -521,7 +521,7 @@ impl Context {
             }
 
             impl #install_into_trait for #ident {
-                fn install_with(module: &mut #module) -> Result<(), #context_error> {
+                fn install_with(module: &mut #module) -> std::result::Result<(), #context_error> {
                     #install_with
                 }
             }
@@ -546,7 +546,7 @@ impl Context {
 
                 fn from_value(
                     value: #value,
-                ) -> Result<(Self::Output, Self::Guard), #vm_error> {
+                ) -> std::result::Result<(Self::Output, Self::Guard), #vm_error> {
                     Ok(value.into_any_ptr()?)
                 }
 
@@ -561,7 +561,7 @@ impl Context {
 
                 fn from_value(
                     value: #value,
-                ) -> Result<(Self::Output, Self::Guard), #vm_error> {
+                ) -> std::result::Result<(Self::Output, Self::Guard), #vm_error> {
                     Ok(value.into_any_mut()?)
                 }
 
@@ -573,7 +573,7 @@ impl Context {
             impl #unsafe_to_value for &#ident {
                 type Guard = #pointer_guard;
 
-                unsafe fn unsafe_to_value(self) -> Result<(#value, Self::Guard), #vm_error> {
+                unsafe fn unsafe_to_value(self) -> std::result::Result<(#value, Self::Guard), #vm_error> {
                     let (shared, guard) = #shared::from_ref(self);
                     Ok((#value::from(shared), guard))
                 }
@@ -582,7 +582,7 @@ impl Context {
             impl #unsafe_to_value for &mut #ident {
                 type Guard = #pointer_guard;
 
-                unsafe fn unsafe_to_value(self) -> Result<(#value, Self::Guard), #vm_error> {
+                unsafe fn unsafe_to_value(self) -> std::result::Result<(#value, Self::Guard), #vm_error> {
                     let (shared, guard) = #shared::from_mut(self);
                     Ok((#value::from(shared), guard))
                 }

--- a/crates/runestick-macros/src/from_value.rs
+++ b/crates/runestick-macros/src/from_value.rs
@@ -76,7 +76,7 @@ impl Expander {
 
         Some(quote! {
             impl #from_value for #ident {
-                fn from_value(value: #value) -> std::result::Result<Self, #vm_error> {
+                fn from_value(value: #value) -> ::std::result::Result<Self, #vm_error> {
                     match value {
                         #expanded
                         actual => {
@@ -167,7 +167,7 @@ impl Expander {
 
         Some(quote_spanned! { input.span() =>
             impl #from_value for #ident {
-                fn from_value(value: #value) -> std::result::Result<Self, #vm_error> {
+                fn from_value(value: #value) -> ::std::result::Result<Self, #vm_error> {
                     match value {
                         #variant,
                         actual => {
@@ -263,7 +263,7 @@ impl Expander {
     }
 }
 
-pub(super) fn expand(input: &syn::DeriveInput) -> std::result::Result<TokenStream, Vec<syn::Error>> {
+pub(super) fn expand(input: &syn::DeriveInput) -> Result<TokenStream, Vec<syn::Error>> {
     let mut ctx = Context::new();
 
     let attrs = match ctx.parse_derive_attrs(&input.attrs) {

--- a/crates/runestick-macros/src/from_value.rs
+++ b/crates/runestick-macros/src/from_value.rs
@@ -76,7 +76,7 @@ impl Expander {
 
         Some(quote! {
             impl #from_value for #ident {
-                fn from_value(value: #value) -> Result<Self, #vm_error> {
+                fn from_value(value: #value) -> std::result::Result<Self, #vm_error> {
                     match value {
                         #expanded
                         actual => {
@@ -167,7 +167,7 @@ impl Expander {
 
         Some(quote_spanned! { input.span() =>
             impl #from_value for #ident {
-                fn from_value(value: #value) -> Result<Self, #vm_error> {
+                fn from_value(value: #value) -> std::result::Result<Self, #vm_error> {
                     match value {
                         #variant,
                         actual => {
@@ -263,7 +263,7 @@ impl Expander {
     }
 }
 
-pub(super) fn expand(input: &syn::DeriveInput) -> Result<TokenStream, Vec<syn::Error>> {
+pub(super) fn expand(input: &syn::DeriveInput) -> std::result::Result<TokenStream, Vec<syn::Error>> {
     let mut ctx = Context::new();
 
     let attrs = match ctx.parse_derive_attrs(&input.attrs) {

--- a/crates/runestick-macros/src/to_value.rs
+++ b/crates/runestick-macros/src/to_value.rs
@@ -24,7 +24,7 @@ impl Expander {
 
         Some(quote! {
             impl #to_value for #ident {
-                fn to_value(self) -> Result<#value, #vm_error> {
+                fn to_value(self) -> std::result::Result<#value, #vm_error> {
                     #inner
                 }
             }
@@ -119,7 +119,7 @@ impl Expander {
     }
 }
 
-pub(super) fn expand(input: &syn::DeriveInput) -> Result<TokenStream, Vec<syn::Error>> {
+pub(super) fn expand(input: &syn::DeriveInput) -> std::result::Result<TokenStream, Vec<syn::Error>> {
     let mut ctx = Context::new();
 
     let attrs = match ctx.parse_derive_attrs(&input.attrs) {

--- a/crates/runestick-macros/src/to_value.rs
+++ b/crates/runestick-macros/src/to_value.rs
@@ -24,7 +24,7 @@ impl Expander {
 
         Some(quote! {
             impl #to_value for #ident {
-                fn to_value(self) -> std::result::Result<#value, #vm_error> {
+                fn to_value(self) -> ::std::result::Result<#value, #vm_error> {
                     #inner
                 }
             }
@@ -119,7 +119,7 @@ impl Expander {
     }
 }
 
-pub(super) fn expand(input: &syn::DeriveInput) -> std::result::Result<TokenStream, Vec<syn::Error>> {
+pub(super) fn expand(input: &syn::DeriveInput) -> Result<TokenStream, Vec<syn::Error>> {
     let mut ctx = Context::new();
 
     let attrs = match ctx.parse_derive_attrs(&input.attrs) {


### PR DESCRIPTION
To remove the bug of dervice Any is not working when a project defines a own Result implementation, this PR is calling out all Results as std::result::Result to prevent this bug.