### PR TITLE
add support for deriving Any on generic types

### DIFF
--- a/crates/runestick-macros/src/any.rs
+++ b/crates/runestick-macros/src/any.rs
@@ -47,7 +47,8 @@ impl InternalCall {
             Ok(())
         };
 
-        ctx.expand_any(&self.path, &name, &expand_into, &tokens)
+        let generics = syn::Generics::default();
+        ctx.expand_any(&self.path, &name, &expand_into, &tokens, &generics)
     }
 }
 
@@ -75,7 +76,8 @@ impl Derive {
 
         let tokens = ctx.tokens_with_module(&attrs);
 
-        let install_with = match ctx.expand_install_with(&self.input, &tokens, &attrs) {
+        let generics = &self.input.generics;
+        let install_with = match ctx.expand_install_with(&self.input, &tokens, &attrs, generics) {
             Some(install_with) => install_with,
             None => return Err(ctx.errors),
         };
@@ -86,7 +88,8 @@ impl Derive {
         };
 
         let name = &quote!(#name);
+        let ident = &self.input.ident;
 
-        ctx.expand_any(&self.input.ident, &name, &install_with, &tokens)
+        ctx.expand_any(&ident, &name, &install_with, &tokens, generics)
     }
 }

--- a/crates/runestick-macros/src/context.rs
+++ b/crates/runestick-macros/src/context.rs
@@ -17,6 +17,7 @@ struct Generate<'a> {
     field_ident: &'a syn::Ident,
     ty: &'a syn::Type,
     name: &'a syn::LitStr,
+    ty_generics: &'a syn::TypeGenerics<'a>,
 }
 
 pub(crate) struct FieldProtocol {
@@ -166,6 +167,7 @@ impl Context {
 
     /// Parse field attributes.
     pub(crate) fn parse_field_attrs(&mut self, attrs: &[syn::Attribute]) -> Option<FieldAttrs> {
+        // let (_, ty_generics, _) = generics.split_for_impl();
         macro_rules! generate_op {
             ($proto:ident, $op:tt) => {
                 |g| {
@@ -174,6 +176,7 @@ impl Context {
                         field_ident,
                         ty,
                         name,
+                        ty_generics,
                         ..
                     } = g;
 
@@ -185,7 +188,7 @@ impl Context {
                         }
                     } else {
                         quote_spanned! { g.field.span() =>
-                            module.field_fn(#protocol, #name, |s: &mut #ident, value: #ty| {
+                            module.field_fn(#protocol, #name, |s: &mut #ident #ty_generics, value: #ty| {
                                 s.#field_ident $op value;
                             })?;
                         }
@@ -210,6 +213,7 @@ impl Context {
                                     ident,
                                     field_ident,
                                     name,
+                                    ty_generics,
                                     ..
                                 } = g;
 
@@ -222,7 +226,7 @@ impl Context {
                                 let protocol = g.tokens.protocol(PROTOCOL_GET);
 
                                 quote_spanned! { g.field.span() =>
-                                    module.field_fn(#protocol, #name, |s: &#ident| #access)?;
+                                    module.field_fn(#protocol, #name, |s: &#ident #ty_generics| #access)?;
                                 }
                             },
                         });
@@ -236,13 +240,13 @@ impl Context {
                                     field_ident,
                                     ty,
                                     name,
+                                    ty_generics,
                                     ..
                                 } = g;
 
                                 let protocol = g.tokens.protocol(PROTOCOL_SET);
-
                                 quote_spanned! { g.field.span() =>
-                                    module.field_fn(#protocol, #name, |s: &mut #ident, value: #ty| {
+                                    module.field_fn(#protocol, #name, |s: &mut #ident #ty_generics, value: #ty| {
                                         s.#field_ident = value;
                                     })?;
                                 }
@@ -412,6 +416,7 @@ impl Context {
         input: &syn::DeriveInput,
         tokens: &Tokens,
         attrs: &DeriveAttrs,
+        generics: &syn::Generics,
     ) -> Option<TokenStream> {
         let mut installers = Vec::new();
 
@@ -422,7 +427,7 @@ impl Context {
         }
 
         let ident = &input.ident;
-
+        let (_, ty_generics, _) = generics.split_for_impl();
         match &input.data {
             syn::Data::Struct(st) => {
                 for field in &st.fields {
@@ -456,6 +461,7 @@ impl Context {
                             field_ident,
                             ty,
                             name,
+                            ty_generics: &ty_generics,
                         }));
                     }
                 }
@@ -487,61 +493,86 @@ impl Context {
         &self,
         ident: T,
         name: &TokenStream,
-        install_with: &TokenStream,
+        installers: &TokenStream,
         tokens: &Tokens,
+        generics: &syn::Generics,
     ) -> Result<TokenStream, Vec<syn::Error>>
     where
         T: Copy + ToTokens,
     {
-        let any = &tokens.any;
-        let context_error = &tokens.context_error;
-        let hash = &tokens.hash;
-        let module = &tokens.module;
-        let named = &tokens.named;
-        let pointer_guard = &tokens.pointer_guard;
-        let raw_into_mut = &tokens.raw_into_mut;
-        let raw_into_ref = &tokens.raw_into_ref;
-        let raw_str = &tokens.raw_str;
-        let shared = &tokens.shared;
-        let type_info = &tokens.type_info;
-        let type_of = &tokens.type_of;
-        let unsafe_from_value = &tokens.unsafe_from_value;
-        let unsafe_to_value = &tokens.unsafe_to_value;
-        let value = &tokens.value;
-        let vm_error = &tokens.vm_error;
-        let install_into_trait = &tokens.install_with;
+        let Tokens {
+            any,
+            context_error,
+            hash,
+            module,
+            named,
+            pointer_guard,
+            raw_into_mut,
+            raw_into_ref,
+            raw_str,
+            shared,
+            type_info,
+            type_of,
+            unsafe_from_value,
+            unsafe_to_value,
+            value,
+            vm_error,
+            install_with,
+            ..
+        } = &tokens;
 
+        let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+        let generic_names = generics.type_params().map(|v| &v.ident).collect::<Vec<_>>();
+
+        let impl_named = if !generic_names.is_empty() {
+            quote! {
+
+            impl #impl_generics #named for #ident #ty_generics #where_clause {
+                const NAME: &'static str = #name;
+
+                fn exact() -> String {
+                    [#name, "<", #(#generic_names::NAME,)* ">"].join("")
+                }
+            }
+
+            }
+        } else {
+            quote! {
+                impl #impl_generics #named for #ident #ty_generics #where_clause {
+                    const NAME: &'static str = #name;
+                }
+            }
+        };
         Ok(quote! {
-            impl #any for #ident {
+            impl #impl_generics #any for #ident #ty_generics #where_clause {
                 fn type_hash() -> #hash {
                     // Safety: `Hash` asserts that it is layout compatible with `TypeId`.
                     // TODO: remove this once we can have transmute-like functionality in a const fn.
-                    #hash::from_type_id(std::any::TypeId::of::<#ident>())
+                    #hash::from_type_id(std::any::TypeId::of::<Self>())
                 }
             }
 
-            impl #install_into_trait for #ident {
+            impl #impl_generics #install_with for #ident #ty_generics #where_clause {
                 fn install_with(module: &mut #module) -> ::std::result::Result<(), #context_error> {
-                    #install_with
+                    #installers
                 }
             }
 
-            impl #named for #ident {
-                const NAME: #raw_str = #raw_str::from_str(#name);
-            }
+            #impl_named
 
-            impl #type_of for #ident {
+            impl #impl_generics #type_of for #ident #ty_generics #where_clause {
                 fn type_hash() -> #hash {
                     <Self as #any>::type_hash()
                 }
 
                 fn type_info() -> #type_info {
-                    #type_info::Any(<Self as #named>::NAME)
+                    #type_info::Any(#raw_str::from_str(std::any::type_name::<Self>()))
                 }
             }
 
-            impl #unsafe_from_value for &#ident {
-                type Output = *const #ident;
+            impl #impl_generics #unsafe_from_value for &#ident #ty_generics #where_clause {
+                type Output = *const #ident #ty_generics;
                 type Guard = #raw_into_ref;
 
                 fn from_value(
@@ -555,8 +586,8 @@ impl Context {
                 }
             }
 
-            impl #unsafe_from_value for &mut #ident {
-                type Output = *mut #ident;
+            impl #impl_generics #unsafe_from_value for &mut #ident #ty_generics #where_clause {
+                type Output = *mut #ident  #ty_generics;
                 type Guard = #raw_into_mut;
 
                 fn from_value(
@@ -570,7 +601,7 @@ impl Context {
                 }
             }
 
-            impl #unsafe_to_value for &#ident {
+            impl #impl_generics #unsafe_to_value for &#ident #ty_generics #where_clause {
                 type Guard = #pointer_guard;
 
                 unsafe fn unsafe_to_value(self) -> ::std::result::Result<(#value, Self::Guard), #vm_error> {
@@ -579,7 +610,7 @@ impl Context {
                 }
             }
 
-            impl #unsafe_to_value for &mut #ident {
+            impl #impl_generics #unsafe_to_value for &mut #ident #ty_generics #where_clause {
                 type Guard = #pointer_guard;
 
                 unsafe fn unsafe_to_value(self) -> ::std::result::Result<(#value, Self::Guard), #vm_error> {

--- a/crates/runestick-macros/src/context.rs
+++ b/crates/runestick-macros/src/context.rs
@@ -526,15 +526,13 @@ impl Context {
 
         let impl_named = if !generic_names.is_empty() {
             quote! {
+                impl #impl_generics #named for #ident #ty_generics #where_clause {
+                    const NAME: #raw_str  = #raw_str::from_str(#name);
 
-            impl #impl_generics #named for #ident #ty_generics #where_clause {
-                const NAME: #raw_str  = #raw_str::from_str(#name);
-
-                fn exact() -> String {
-                    [#name, "<", &#(#generic_names::exact(),)* ">"].join("")
+                    fn exact() -> String {
+                        [#name, "<", &#(#generic_names::exact(),)* ">"].join("")
+                    }
                 }
-            }
-
             }
         } else {
             quote! {

--- a/crates/runestick-macros/src/context.rs
+++ b/crates/runestick-macros/src/context.rs
@@ -167,7 +167,6 @@ impl Context {
 
     /// Parse field attributes.
     pub(crate) fn parse_field_attrs(&mut self, attrs: &[syn::Attribute]) -> Option<FieldAttrs> {
-        // let (_, ty_generics, _) = generics.split_for_impl();
         macro_rules! generate_op {
             ($proto:ident, $op:tt) => {
                 |g| {
@@ -532,7 +531,7 @@ impl Context {
                 const NAME: #raw_str  = #raw_str::from_str(#name);
 
                 fn exact() -> String {
-                    [#name, "<", #(#generic_names::NAME,)* ">"].join("")
+                    [#name, "<", &#(#generic_names::exact(),)* ">"].join("")
                 }
             }
 

--- a/crates/runestick-macros/src/context.rs
+++ b/crates/runestick-macros/src/context.rs
@@ -529,7 +529,7 @@ impl Context {
             quote! {
 
             impl #impl_generics #named for #ident #ty_generics #where_clause {
-                const NAME: &'static str = #name;
+                const NAME: #raw_str  = #raw_str::from_str(#name);
 
                 fn exact() -> String {
                     [#name, "<", #(#generic_names::NAME,)* ">"].join("")
@@ -540,7 +540,7 @@ impl Context {
         } else {
             quote! {
                 impl #impl_generics #named for #ident #ty_generics #where_clause {
-                    const NAME: &'static str = #name;
+                    const NAME: #raw_str = #raw_str::from_str(#name);
                 }
             }
         };

--- a/crates/runestick-macros/src/context.rs
+++ b/crates/runestick-macros/src/context.rs
@@ -527,17 +527,17 @@ impl Context {
         let impl_named = if !generic_names.is_empty() {
             quote! {
                 impl #impl_generics #named for #ident #ty_generics #where_clause {
-                    const NAME: #raw_str  = #raw_str::from_str(#name);
+                    const BASE_NAME: #raw_str  = #raw_str::from_str(#name);
 
-                    fn exact() -> String {
-                        [#name, "<", &#(#generic_names::exact(),)* ">"].join("")
+                    fn full_name() -> String {
+                        [#name, "<", &#(#generic_names::full_name(),)* ">"].join("")
                     }
                 }
             }
         } else {
             quote! {
                 impl #impl_generics #named for #ident #ty_generics #where_clause {
-                    const NAME: #raw_str = #raw_str::from_str(#name);
+                    const BASE_NAME: #raw_str = #raw_str::from_str(#name);
                 }
             }
         };

--- a/crates/runestick/src/any_obj.rs
+++ b/crates/runestick/src/any_obj.rs
@@ -431,28 +431,28 @@ fn debug_impl<T>(f: &mut fmt::Formatter<'_>) -> fmt::Result
 where
     T: Any,
 {
-    write!(f, "{}", T::NAME)
+    write!(f, "{}", T::BASE_NAME)
 }
 
 fn debug_ref_impl<T>(f: &mut fmt::Formatter<'_>) -> fmt::Result
 where
     T: Any,
 {
-    write!(f, "&{}", T::NAME)
+    write!(f, "&{}", T::BASE_NAME)
 }
 
 fn debug_mut_impl<T>(f: &mut fmt::Formatter<'_>) -> fmt::Result
 where
     T: Any,
 {
-    write!(f, "&mut {}", T::NAME)
+    write!(f, "&mut {}", T::BASE_NAME)
 }
 
 fn type_name_impl<T>() -> RawStr
 where
     T: Any,
 {
-    T::NAME
+    T::BASE_NAME
 }
 
 fn type_hash_impl<T>() -> Hash

--- a/crates/runestick/src/any_obj.rs
+++ b/crates/runestick/src/any_obj.rs
@@ -452,7 +452,7 @@ fn type_name_impl<T>() -> RawStr
 where
     T: Any,
 {
-    T::raw()
+    T::NAME
 }
 
 fn type_hash_impl<T>() -> Hash

--- a/crates/runestick/src/any_obj.rs
+++ b/crates/runestick/src/any_obj.rs
@@ -452,7 +452,7 @@ fn type_name_impl<T>() -> RawStr
 where
     T: Any,
 {
-    T::NAME
+    T::raw()
 }
 
 fn type_hash_impl<T>() -> Hash

--- a/crates/runestick/src/bytes.rs
+++ b/crates/runestick/src/bytes.rs
@@ -3,7 +3,8 @@
 //! [Value::Bytes]: crate::Value::Bytes.
 
 use crate::{
-    FromValue, InstallWith, Mut, Named, RawMut, RawRef, Ref, UnsafeFromValue, Value, VmError,
+    FromValue, InstallWith, Mut, Named, RawMut, RawRef, RawStr, Ref, UnsafeFromValue, Value,
+    VmError,
 };
 
 use std::cmp;
@@ -178,7 +179,7 @@ impl<'a> UnsafeFromValue for &'a [u8] {
 }
 
 impl Named for Bytes {
-    const NAME: &'static str = "Bytes";
+    const NAME: RawStr = RawStr::from_str("Bytes");
 }
 
 impl InstallWith for Bytes {}

--- a/crates/runestick/src/bytes.rs
+++ b/crates/runestick/src/bytes.rs
@@ -3,8 +3,7 @@
 //! [Value::Bytes]: crate::Value::Bytes.
 
 use crate::{
-    FromValue, InstallWith, Mut, Named, RawMut, RawRef, RawStr, Ref, UnsafeFromValue, Value,
-    VmError,
+    FromValue, InstallWith, Mut, Named, RawMut, RawRef, Ref, UnsafeFromValue, Value, VmError,
 };
 
 use std::cmp;
@@ -179,7 +178,7 @@ impl<'a> UnsafeFromValue for &'a [u8] {
 }
 
 impl Named for Bytes {
-    const NAME: RawStr = RawStr::from_str("Bytes");
+    const NAME: &'static str = "Bytes";
 }
 
 impl InstallWith for Bytes {}

--- a/crates/runestick/src/bytes.rs
+++ b/crates/runestick/src/bytes.rs
@@ -179,7 +179,7 @@ impl<'a> UnsafeFromValue for &'a [u8] {
 }
 
 impl Named for Bytes {
-    const NAME: RawStr = RawStr::from_str("Bytes");
+    const BASE_NAME: RawStr = RawStr::from_str("Bytes");
 }
 
 impl InstallWith for Bytes {}

--- a/crates/runestick/src/format.rs
+++ b/crates/runestick/src/format.rs
@@ -1,7 +1,7 @@
 //! Types for dealing with formatting specifications.
 
 use crate::protocol_caller::ProtocolCaller;
-use crate::{FromValue, InstallWith, Named, RawStr, Value, VmError, VmErrorKind};
+use crate::{FromValue, InstallWith, Named, Value, VmError, VmErrorKind};
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::fmt;
@@ -36,7 +36,7 @@ pub struct Format {
 }
 
 impl Named for Format {
-    const NAME: RawStr = RawStr::from_str("Format");
+    const NAME: &'static str = "Format";
 }
 
 impl InstallWith for Format {}

--- a/crates/runestick/src/format.rs
+++ b/crates/runestick/src/format.rs
@@ -1,7 +1,7 @@
 //! Types for dealing with formatting specifications.
 
 use crate::protocol_caller::ProtocolCaller;
-use crate::{FromValue, InstallWith, Named, Value, VmError, VmErrorKind};
+use crate::{FromValue, InstallWith, Named, RawStr, Value, VmError, VmErrorKind};
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::fmt;
@@ -36,7 +36,7 @@ pub struct Format {
 }
 
 impl Named for Format {
-    const NAME: &'static str = "Format";
+    const NAME: RawStr = RawStr::from_str("Format");
 }
 
 impl InstallWith for Format {}

--- a/crates/runestick/src/format.rs
+++ b/crates/runestick/src/format.rs
@@ -36,7 +36,7 @@ pub struct Format {
 }
 
 impl Named for Format {
-    const NAME: RawStr = RawStr::from_str("Format");
+    const BASE_NAME: RawStr = RawStr::from_str("Format");
 }
 
 impl InstallWith for Format {}

--- a/crates/runestick/src/future.rs
+++ b/crates/runestick/src/future.rs
@@ -144,7 +144,7 @@ impl UnsafeFromValue for &mut Future {
 }
 
 impl Named for Future {
-    const NAME: RawStr = RawStr::from_str("Future");
+    const BASE_NAME: RawStr = RawStr::from_str("Future");
 }
 
 impl InstallWith for Future {}

--- a/crates/runestick/src/future.rs
+++ b/crates/runestick/src/future.rs
@@ -1,6 +1,6 @@
 use crate::{
-    FromValue, InstallWith, Mut, Named, RawMut, RawRef, Ref, Shared, ToValue, UnsafeFromValue,
-    Value, VmError,
+    FromValue, InstallWith, Mut, Named, RawMut, RawRef, RawStr, Ref, Shared, ToValue,
+    UnsafeFromValue, Value, VmError,
 };
 use pin_project::pin_project;
 use std::fmt;
@@ -144,7 +144,7 @@ impl UnsafeFromValue for &mut Future {
 }
 
 impl Named for Future {
-    const NAME: &'static str = "Future";
+    const NAME: RawStr = RawStr::from_str("Future");
 }
 
 impl InstallWith for Future {}

--- a/crates/runestick/src/future.rs
+++ b/crates/runestick/src/future.rs
@@ -1,6 +1,6 @@
 use crate::{
-    FromValue, InstallWith, Mut, Named, RawMut, RawRef, RawStr, Ref, Shared, ToValue,
-    UnsafeFromValue, Value, VmError,
+    FromValue, InstallWith, Mut, Named, RawMut, RawRef, Ref, Shared, ToValue, UnsafeFromValue,
+    Value, VmError,
 };
 use pin_project::pin_project;
 use std::fmt;
@@ -144,7 +144,7 @@ impl UnsafeFromValue for &mut Future {
 }
 
 impl Named for Future {
-    const NAME: RawStr = RawStr::from_str("Future");
+    const NAME: &'static str = "Future";
 }
 
 impl InstallWith for Future {}

--- a/crates/runestick/src/generator.rs
+++ b/crates/runestick/src/generator.rs
@@ -88,7 +88,7 @@ impl fmt::Debug for Generator {
 }
 
 impl Named for Generator {
-    const NAME: RawStr = RawStr::from_str("Generator");
+    const BASE_NAME: RawStr = RawStr::from_str("Generator");
 }
 
 impl InstallWith for Generator {}

--- a/crates/runestick/src/generator.rs
+++ b/crates/runestick/src/generator.rs
@@ -1,5 +1,5 @@
 use crate::{
-    FromValue, GeneratorState, InstallWith, Mut, Named, RawMut, RawRef, Ref, Shared,
+    FromValue, GeneratorState, InstallWith, Mut, Named, RawMut, RawRef, RawStr, Ref, Shared,
     UnsafeFromValue, Value, Vm, VmError, VmErrorKind, VmExecution,
 };
 use std::fmt;
@@ -88,7 +88,7 @@ impl fmt::Debug for Generator {
 }
 
 impl Named for Generator {
-    const NAME: &'static str = "Generator";
+    const NAME: RawStr = RawStr::from_str("Generator");
 }
 
 impl InstallWith for Generator {}

--- a/crates/runestick/src/generator.rs
+++ b/crates/runestick/src/generator.rs
@@ -1,5 +1,5 @@
 use crate::{
-    FromValue, GeneratorState, InstallWith, Mut, Named, RawMut, RawRef, RawStr, Ref, Shared,
+    FromValue, GeneratorState, InstallWith, Mut, Named, RawMut, RawRef, Ref, Shared,
     UnsafeFromValue, Value, Vm, VmError, VmErrorKind, VmExecution,
 };
 use std::fmt;
@@ -88,7 +88,7 @@ impl fmt::Debug for Generator {
 }
 
 impl Named for Generator {
-    const NAME: RawStr = RawStr::from_str("Generator");
+    const NAME: &'static str = "Generator";
 }
 
 impl InstallWith for Generator {}

--- a/crates/runestick/src/iterator.rs
+++ b/crates/runestick/src/iterator.rs
@@ -1,6 +1,6 @@
 use crate::{
-    FromValue, Function, InstallWith, Mut, Named, RawMut, RawRef, RawStr, Ref, ToValue,
-    UnsafeFromValue, Value, VmError, VmErrorKind,
+    FromValue, Function, InstallWith, Mut, Named, RawMut, RawRef, Ref, ToValue, UnsafeFromValue,
+    Value, VmError, VmErrorKind,
 };
 use std::fmt;
 use std::iter;
@@ -343,7 +343,7 @@ impl fmt::Debug for Iterator {
 }
 
 impl Named for Iterator {
-    const NAME: RawStr = RawStr::from_str("Iterator");
+    const NAME: &'static str = "Iterator";
 }
 
 impl InstallWith for Iterator {}

--- a/crates/runestick/src/iterator.rs
+++ b/crates/runestick/src/iterator.rs
@@ -343,7 +343,7 @@ impl fmt::Debug for Iterator {
 }
 
 impl Named for Iterator {
-    const NAME: RawStr = RawStr::from_str("Iterator");
+    const BASE_NAME: RawStr = RawStr::from_str("Iterator");
 }
 
 impl InstallWith for Iterator {}

--- a/crates/runestick/src/iterator.rs
+++ b/crates/runestick/src/iterator.rs
@@ -1,6 +1,6 @@
 use crate::{
-    FromValue, Function, InstallWith, Mut, Named, RawMut, RawRef, Ref, ToValue, UnsafeFromValue,
-    Value, VmError, VmErrorKind,
+    FromValue, Function, InstallWith, Mut, Named, RawMut, RawRef, RawStr, Ref, ToValue,
+    UnsafeFromValue, Value, VmError, VmErrorKind,
 };
 use std::fmt;
 use std::iter;
@@ -343,7 +343,7 @@ impl fmt::Debug for Iterator {
 }
 
 impl Named for Iterator {
-    const NAME: &'static str = "Iterator";
+    const NAME: RawStr = RawStr::from_str("Iterator");
 }
 
 impl InstallWith for Iterator {}

--- a/crates/runestick/src/module.rs
+++ b/crates/runestick/src/module.rs
@@ -247,13 +247,13 @@ impl Module {
         let type_info = T::type_info();
 
         let ty = ModuleType {
-            name: T::exact().into_boxed_str(),
+            name: T::full_name().into_boxed_str(),
             type_info,
         };
 
         if let Some(old) = self.types.insert(type_hash, ty) {
             return Err(ContextError::ConflictingType {
-                item: Item::with_item(&[T::exact()]),
+                item: Item::with_item(&[T::full_name()]),
                 existing: old.type_info,
             });
         }

--- a/crates/runestick/src/module.rs
+++ b/crates/runestick/src/module.rs
@@ -253,7 +253,7 @@ impl Module {
 
         if let Some(old) = self.types.insert(type_hash, ty) {
             return Err(ContextError::ConflictingType {
-                item: Item::with_item(&[T::raw()]),
+                item: Item::with_item(&[T::exact()]),
                 existing: old.type_info,
             });
         }

--- a/crates/runestick/src/module.rs
+++ b/crates/runestick/src/module.rs
@@ -247,17 +247,16 @@ impl Module {
         let type_info = T::type_info();
 
         let ty = ModuleType {
-            name: String::from(&*T::NAME).into_boxed_str(),
+            name: T::exact().into_boxed_str(),
             type_info,
         };
 
         if let Some(old) = self.types.insert(type_hash, ty) {
             return Err(ContextError::ConflictingType {
-                item: Item::with_item(&[T::NAME]),
+                item: Item::with_item(&[T::raw()]),
                 existing: old.type_info,
             });
         }
-
         T::install_with(self)?;
         Ok(())
     }

--- a/crates/runestick/src/named.rs
+++ b/crates/runestick/src/named.rs
@@ -3,51 +3,46 @@ use crate::{InstallWith, RawStr};
 /// Something that is named.
 pub trait Named {
     /// The generic name of the named thing.
-    const NAME: &'static str;
-
-    /// Get the generic name as a RawStr
-    fn raw() -> RawStr {
-        RawStr::from_str(Self::NAME)
-    }
+    const NAME: RawStr;
 
     /// The exact type name
     fn exact() -> String {
-        Self::NAME.to_owned()
+        (*Self::NAME).to_owned()
     }
 }
 
 impl Named for String {
-    const NAME: &'static str = "String";
+    const NAME: RawStr = RawStr::from_str("String");
 }
 
 impl InstallWith for String {}
 
 impl Named for i64 {
-    const NAME: &'static str = "int";
+    const NAME: RawStr = RawStr::from_str("int");
 }
 
 impl InstallWith for i64 {}
 
 impl Named for f64 {
-    const NAME: &'static str = "float";
+    const NAME: RawStr = RawStr::from_str("float");
 }
 
 impl InstallWith for f64 {}
 
 impl Named for u8 {
-    const NAME: &'static str = "byte";
+    const NAME: RawStr = RawStr::from_str("byte");
 }
 
 impl InstallWith for u8 {}
 
 impl Named for char {
-    const NAME: &'static str = "char";
+    const NAME: RawStr = RawStr::from_str("char");
 }
 
 impl InstallWith for char {}
 
 impl Named for bool {
-    const NAME: &'static str = "bool";
+    const NAME: RawStr = RawStr::from_str("bool");
 }
 
 impl InstallWith for bool {}

--- a/crates/runestick/src/named.rs
+++ b/crates/runestick/src/named.rs
@@ -2,42 +2,52 @@ use crate::{InstallWith, RawStr};
 
 /// Something that is named.
 pub trait Named {
-    /// The name of the named thing.
-    const NAME: RawStr;
+    /// The generic name of the named thing.
+    const NAME: &'static str;
+
+    /// Get the generic name as a RawStr
+    fn raw() -> RawStr {
+        RawStr::from_str(Self::NAME)
+    }
+
+    /// The exact type name
+    fn exact() -> String {
+        Self::NAME.to_owned()
+    }
 }
 
 impl Named for String {
-    const NAME: RawStr = RawStr::from_str("String");
+    const NAME: &'static str = "String";
 }
 
 impl InstallWith for String {}
 
 impl Named for i64 {
-    const NAME: RawStr = RawStr::from_str("int");
+    const NAME: &'static str = "int";
 }
 
 impl InstallWith for i64 {}
 
 impl Named for f64 {
-    const NAME: RawStr = RawStr::from_str("float");
+    const NAME: &'static str = "float";
 }
 
 impl InstallWith for f64 {}
 
 impl Named for u8 {
-    const NAME: RawStr = RawStr::from_str("byte");
+    const NAME: &'static str = "byte";
 }
 
 impl InstallWith for u8 {}
 
 impl Named for char {
-    const NAME: RawStr = RawStr::from_str("char");
+    const NAME: &'static str = "char";
 }
 
 impl InstallWith for char {}
 
 impl Named for bool {
-    const NAME: RawStr = RawStr::from_str("bool");
+    const NAME: &'static str = "bool";
 }
 
 impl InstallWith for bool {}

--- a/crates/runestick/src/named.rs
+++ b/crates/runestick/src/named.rs
@@ -3,46 +3,46 @@ use crate::{InstallWith, RawStr};
 /// Something that is named.
 pub trait Named {
     /// The generic name of the named thing.
-    const NAME: RawStr;
+    const BASE_NAME: RawStr;
 
     /// The exact type name
-    fn exact() -> String {
-        (*Self::NAME).to_owned()
+    fn full_name() -> String {
+        (*Self::BASE_NAME).to_owned()
     }
 }
 
 impl Named for String {
-    const NAME: RawStr = RawStr::from_str("String");
+    const BASE_NAME: RawStr = RawStr::from_str("String");
 }
 
 impl InstallWith for String {}
 
 impl Named for i64 {
-    const NAME: RawStr = RawStr::from_str("int");
+    const BASE_NAME: RawStr = RawStr::from_str("int");
 }
 
 impl InstallWith for i64 {}
 
 impl Named for f64 {
-    const NAME: RawStr = RawStr::from_str("float");
+    const BASE_NAME: RawStr = RawStr::from_str("float");
 }
 
 impl InstallWith for f64 {}
 
 impl Named for u8 {
-    const NAME: RawStr = RawStr::from_str("byte");
+    const BASE_NAME: RawStr = RawStr::from_str("byte");
 }
 
 impl InstallWith for u8 {}
 
 impl Named for char {
-    const NAME: RawStr = RawStr::from_str("char");
+    const BASE_NAME: RawStr = RawStr::from_str("char");
 }
 
 impl InstallWith for char {}
 
 impl Named for bool {
-    const NAME: RawStr = RawStr::from_str("bool");
+    const BASE_NAME: RawStr = RawStr::from_str("bool");
 }
 
 impl InstallWith for bool {}

--- a/crates/runestick/src/object.rs
+++ b/crates/runestick/src/object.rs
@@ -1,7 +1,7 @@
 use crate::collections::{btree_map, BTreeMap};
 use crate::{
-    FromValue, InstallWith, Item, Mut, Named, RawMut, RawRef, Ref, ToValue, UnsafeFromValue, Value,
-    Vm, VmError,
+    FromValue, InstallWith, Item, Mut, Named, RawMut, RawRef, RawStr, Ref, ToValue,
+    UnsafeFromValue, Value, Vm, VmError,
 };
 use std::borrow;
 use std::cmp;
@@ -330,7 +330,7 @@ impl UnsafeFromValue for &mut Object {
 }
 
 impl Named for Object {
-    const NAME: &'static str = "Object";
+    const NAME: RawStr = RawStr::from_str("Object");
 }
 
 impl InstallWith for Object {}

--- a/crates/runestick/src/object.rs
+++ b/crates/runestick/src/object.rs
@@ -1,7 +1,7 @@
 use crate::collections::{btree_map, BTreeMap};
 use crate::{
-    FromValue, InstallWith, Item, Mut, Named, RawMut, RawRef, RawStr, Ref, ToValue,
-    UnsafeFromValue, Value, Vm, VmError,
+    FromValue, InstallWith, Item, Mut, Named, RawMut, RawRef, Ref, ToValue, UnsafeFromValue, Value,
+    Vm, VmError,
 };
 use std::borrow;
 use std::cmp;
@@ -330,7 +330,7 @@ impl UnsafeFromValue for &mut Object {
 }
 
 impl Named for Object {
-    const NAME: RawStr = RawStr::from_str("Object");
+    const NAME: &'static str = "Object";
 }
 
 impl InstallWith for Object {}

--- a/crates/runestick/src/object.rs
+++ b/crates/runestick/src/object.rs
@@ -330,7 +330,7 @@ impl UnsafeFromValue for &mut Object {
 }
 
 impl Named for Object {
-    const NAME: RawStr = RawStr::from_str("Object");
+    const BASE_NAME: RawStr = RawStr::from_str("Object");
 }
 
 impl InstallWith for Object {}

--- a/crates/runestick/src/range.rs
+++ b/crates/runestick/src/range.rs
@@ -1,5 +1,5 @@
 use crate::{
-    FromValue, InstallWith, Iterator, Mut, Named, Panic, RawMut, RawRef, Ref, ToValue,
+    FromValue, InstallWith, Iterator, Mut, Named, Panic, RawMut, RawRef, RawStr, Ref, ToValue,
     UnsafeFromValue, Value, Vm, VmError, VmErrorKind,
 };
 use std::fmt;
@@ -257,7 +257,7 @@ impl UnsafeFromValue for &mut Range {
 }
 
 impl Named for Range {
-    const NAME: &'static str = "Range";
+    const NAME: RawStr = RawStr::from_str("Range");
 }
 
 impl InstallWith for Range {

--- a/crates/runestick/src/range.rs
+++ b/crates/runestick/src/range.rs
@@ -1,5 +1,5 @@
 use crate::{
-    FromValue, InstallWith, Iterator, Mut, Named, Panic, RawMut, RawRef, RawStr, Ref, ToValue,
+    FromValue, InstallWith, Iterator, Mut, Named, Panic, RawMut, RawRef, Ref, ToValue,
     UnsafeFromValue, Value, Vm, VmError, VmErrorKind,
 };
 use std::fmt;
@@ -257,7 +257,7 @@ impl UnsafeFromValue for &mut Range {
 }
 
 impl Named for Range {
-    const NAME: RawStr = RawStr::from_str("Range");
+    const NAME: &'static str = "Range";
 }
 
 impl InstallWith for Range {

--- a/crates/runestick/src/range.rs
+++ b/crates/runestick/src/range.rs
@@ -257,7 +257,7 @@ impl UnsafeFromValue for &mut Range {
 }
 
 impl Named for Range {
-    const NAME: RawStr = RawStr::from_str("Range");
+    const BASE_NAME: RawStr = RawStr::from_str("Range");
 }
 
 impl InstallWith for Range {

--- a/crates/runestick/src/stream.rs
+++ b/crates/runestick/src/stream.rs
@@ -100,7 +100,7 @@ impl UnsafeFromValue for &mut Stream {
 }
 
 impl Named for Stream {
-    const NAME: RawStr = RawStr::from_str("Stream");
+    const BASE_NAME: RawStr = RawStr::from_str("Stream");
 }
 
 impl InstallWith for Stream {}

--- a/crates/runestick/src/stream.rs
+++ b/crates/runestick/src/stream.rs
@@ -1,5 +1,5 @@
 use crate::{
-    FromValue, GeneratorState, InstallWith, Mut, Named, RawMut, RawRef, RawStr, Ref, Shared,
+    FromValue, GeneratorState, InstallWith, Mut, Named, RawMut, RawRef, Ref, Shared,
     UnsafeFromValue, Value, Vm, VmError, VmErrorKind, VmExecution,
 };
 use std::fmt;
@@ -100,7 +100,7 @@ impl UnsafeFromValue for &mut Stream {
 }
 
 impl Named for Stream {
-    const NAME: RawStr = RawStr::from_str("Stream");
+    const NAME: &'static str = "Stream";
 }
 
 impl InstallWith for Stream {}

--- a/crates/runestick/src/stream.rs
+++ b/crates/runestick/src/stream.rs
@@ -1,5 +1,5 @@
 use crate::{
-    FromValue, GeneratorState, InstallWith, Mut, Named, RawMut, RawRef, Ref, Shared,
+    FromValue, GeneratorState, InstallWith, Mut, Named, RawMut, RawRef, RawStr, Ref, Shared,
     UnsafeFromValue, Value, Vm, VmError, VmErrorKind, VmExecution,
 };
 use std::fmt;
@@ -100,7 +100,7 @@ impl UnsafeFromValue for &mut Stream {
 }
 
 impl Named for Stream {
-    const NAME: &'static str = "Stream";
+    const NAME: RawStr = RawStr::from_str("Stream");
 }
 
 impl InstallWith for Stream {}

--- a/crates/runestick/src/vec.rs
+++ b/crates/runestick/src/vec.rs
@@ -1,6 +1,6 @@
 use crate::{
-    FromValue, InstallWith, Mut, Named, RawMut, RawRef, RawStr, Ref, Shared, ToValue,
-    UnsafeFromValue, Value, Vm, VmError,
+    FromValue, InstallWith, Mut, Named, RawMut, RawRef, Ref, Shared, ToValue, UnsafeFromValue,
+    Value, Vm, VmError,
 };
 use std::cmp;
 use std::fmt;
@@ -182,7 +182,7 @@ impl Vec {
 }
 
 impl Named for Vec {
-    const NAME: RawStr = RawStr::from_str("Vec");
+    const NAME: &'static str = "Vec";
 }
 
 impl InstallWith for Vec {}

--- a/crates/runestick/src/vec.rs
+++ b/crates/runestick/src/vec.rs
@@ -182,7 +182,7 @@ impl Vec {
 }
 
 impl Named for Vec {
-    const NAME: RawStr = RawStr::from_str("Vec");
+    const BASE_NAME: RawStr = RawStr::from_str("Vec");
 }
 
 impl InstallWith for Vec {}

--- a/crates/runestick/src/vec.rs
+++ b/crates/runestick/src/vec.rs
@@ -1,6 +1,6 @@
 use crate::{
-    FromValue, InstallWith, Mut, Named, RawMut, RawRef, Ref, Shared, ToValue, UnsafeFromValue,
-    Value, Vm, VmError,
+    FromValue, InstallWith, Mut, Named, RawMut, RawRef, RawStr, Ref, Shared, ToValue,
+    UnsafeFromValue, Value, Vm, VmError,
 };
 use std::cmp;
 use std::fmt;
@@ -182,7 +182,7 @@ impl Vec {
 }
 
 impl Named for Vec {
-    const NAME: &'static str = "Vec";
+    const NAME: RawStr = RawStr::from_str("Vec");
 }
 
 impl InstallWith for Vec {}

--- a/tests/tests/generic_native.rs
+++ b/tests/tests/generic_native.rs
@@ -1,0 +1,116 @@
+//! Tests for derive(Any) on generic types
+
+use rune_tests::*;
+use runestick::{Any, ContextError, Module, Named, ToValue, UnsafeFromValue};
+
+#[derive(Any)]
+struct Generic<T>
+where
+    T: 'static + Clone + Named + UnsafeFromValue + ToValue,
+{
+    #[rune(get, set)]
+    data: T,
+}
+
+impl<T> Generic<T>
+where
+    T: 'static + Clone + Copy + Named + UnsafeFromValue + ToValue,
+{
+    fn get_value(&self) -> T {
+        self.data
+    }
+}
+
+fn make_native_module() -> Result<Module, ContextError> {
+    let mut module = Module::with_crate("native_crate");
+    module.ty::<Generic<i64>>()?;
+    module.inst_fn("get_value", Generic::<i64>::get_value)?;
+
+    module.ty::<Generic<f64>>()?;
+    module.inst_fn("get_value", Generic::<f64>::get_value)?;
+    Ok(module)
+}
+
+#[test]
+fn test_generic_i64() {
+    let t1 = Generic { data: 1i64 };
+    assert_eq!(
+        rune_n! {
+            make_native_module().expect("failed making native module"),
+            (t1, ),
+            i64 =>
+                pub fn main(v) { v.get_value() }
+        },
+        1
+    );
+}
+
+#[test]
+fn test_generic_i64_get() {
+    let t1 = Generic { data: 2i64 };
+    assert_eq!(
+        rune_n! {
+            make_native_module().expect("failed making native module"),
+            (t1, ),
+            i64 =>
+                pub fn main(v) { v.data }
+        },
+        2
+    );
+}
+
+#[test]
+fn test_generic_i64_set() {
+    let t1 = Generic { data: 2i64 };
+    assert_eq!(
+        rune_n! {
+            make_native_module().expect("failed making native module"),
+            ( t1, ),
+            i64 =>
+                pub fn main(v) { v.data = 10; v.data }
+        },
+        10
+    );
+}
+
+#[test]
+fn test_generic_f64() {
+    let t1 = Generic { data: 2f64 };
+    assert_eq!(
+        rune_n! {
+            make_native_module().expect("failed making native module"),
+            (t1, ),
+            f64 =>
+                pub fn main(v) { v.get_value() }
+        },
+        2.0
+    );
+}
+
+#[test]
+fn test_generic_f64_get() {
+    let t1 = Generic { data: 2f64 };
+    assert_eq!(
+        rune_n! {
+            make_native_module().expect("failed making native module"),
+            (t1, ),
+            f64 =>
+                pub fn main(v) { v.data }
+        },
+        2.0
+    );
+}
+
+#[test]
+fn test_generic_f64_set() {
+    let t1 = Generic { data: 2f64 };
+    assert_eq!(
+        rune_n! {
+            make_native_module().expect("failed making native module"),
+            ( t1, ),
+            f64 =>
+                pub fn main(v) { v.data = 10.0; v.data }
+        },
+        10.0
+    );
+}


### PR DESCRIPTION
I'm not super happy with the way `exact` is implemented, but nothing constant can be done when using generics. Apart from that, all this does is propagate the type constraints etc to all generated impls. The only major change is the `Named` trait which specializes the `exact` to generate the type name. 