### PR TITLE
add support for "lightweight" function pointers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,21 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all -- --check
 
+  build_documentation:
+    name: Build Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          default: true
+      - run: cargo doc --package rune
+        env:
+          RUSTFLAGS: --cfg docsrs
+          RUSTDOCFLAGS: --cfg docsrs
+
   build_wasm:
     name: Build Wasm
     runs-on: ubuntu-latest


### PR DESCRIPTION
I've had a bunch of use-cases where I want to store callbacks etc to Rune functions inside Rust, and the regular Function objects has a lot of baggage and works badly in threaded contexts (being neither Sync nor Send iirc). These raw functions behave like `fn` in Rust, as opposed to Fn, making them easier to store. I'm a bit annoyed at the code duplication and considered making these a sub=enum of the regular Function hierarchy, but I think this implementation is *cleaner*.