### PR TITLE
Allow re-using a Vm by supporting mutable VmExecution

### DIFF
--- a/benches/benches/aoc_2020_11a.rs
+++ b/benches/benches/aoc_2020_11a.rs
@@ -18,7 +18,7 @@ fn aoc_2020_11a(b: &mut Bencher) -> runestick::Result<()> {
         .map(str::to_owned)
         .collect::<Vec<String>>();
 
-    let vm = rune_tests::rune_vm! {
+    let mut vm = rune_tests::rune_vm! {
         enum CellState {
             Floor,
             Unoccupied,
@@ -244,7 +244,7 @@ fn aoc_2020_11a(b: &mut Bencher) -> runestick::Result<()> {
     let entry = runestick::Hash::type_hash(&["main"]);
 
     b.iter(|| {
-        let execution = vm.clone().execute(entry, (input.clone(),));
+        let execution = vm.execute(entry, (input.clone(),));
         let mut execution = execution.expect("successful setup");
         execution.complete().expect("successful execution")
     });

--- a/benches/benches/aoc_2020_19b.rs
+++ b/benches/benches/aoc_2020_19b.rs
@@ -14,7 +14,7 @@ fn aoc_2020_19b(b: &mut Bencher) -> runestick::Result<()> {
         data.push(line.to_owned().into());
     }
 
-    let vm = rune_tests::rune_vm! {
+    let mut vm = rune_tests::rune_vm! {
         use std::collections::HashMap;
         fn get_rules() {
             HashMap::from([
@@ -237,7 +237,7 @@ fn aoc_2020_19b(b: &mut Bencher) -> runestick::Result<()> {
     let entry = runestick::Hash::type_hash(&["main"]);
 
     b.iter(|| {
-        let execution = vm.clone().execute(entry, (data.clone(),));
+        let execution = vm.execute(entry, (data.clone(),));
         let mut execution = execution.expect("successful setup");
         execution.complete().expect("successful execution")
     });

--- a/benches/benches/aoc_2020_1a.rs
+++ b/benches/benches/aoc_2020_1a.rs
@@ -18,7 +18,7 @@ fn aoc_2020_1a(b: &mut Bencher) -> runestick::Result<()> {
         data.push_value(str::parse::<i64>(line)?)?;
     }
 
-    let vm = rune_tests::rune_vm! {
+    let mut vm = rune_tests::rune_vm! {
         use std::string;
 
         struct NoSolution;
@@ -79,7 +79,7 @@ fn aoc_2020_1a(b: &mut Bencher) -> runestick::Result<()> {
     let entry = runestick::Hash::type_hash(&["main"]);
 
     b.iter(|| {
-        let execution = vm.clone().execute(entry, (data.clone(),));
+        let execution = vm.execute(entry, (data.clone(),));
         let mut execution = execution.expect("successful setup");
         execution.complete().expect("successful execution")
     });

--- a/benches/benches/aoc_2020_1b.rs
+++ b/benches/benches/aoc_2020_1b.rs
@@ -18,7 +18,7 @@ fn aoc_2020_1b(b: &mut Bencher) -> runestick::Result<()> {
         data.push_value(str::parse::<i64>(line)?)?;
     }
 
-    let vm = rune_tests::rune_vm! {
+    let mut vm = rune_tests::rune_vm! {
         mod iter {
             pub fn all_pairs(data) {
                let count = data.len();
@@ -63,7 +63,7 @@ fn aoc_2020_1b(b: &mut Bencher) -> runestick::Result<()> {
     let entry = runestick::Hash::type_hash(&["main"]);
 
     b.iter(|| {
-        let execution = vm.clone().execute(entry, (data.clone(),));
+        let execution = vm.execute(entry, (data.clone(),));
         let mut execution = execution.expect("successful setup");
         execution.complete().expect("successful execution")
     });

--- a/benches/benches/brainfuck.rs
+++ b/benches/benches/brainfuck.rs
@@ -103,13 +103,13 @@ fn make_vm() -> runestick::Result<runestick::Vm> {
 
 #[bench]
 fn bf_hello_world(b: &mut Bencher) -> runestick::Result<()> {
-    let vm = make_vm()?;
+    let mut vm = make_vm()?;
     let hello_world = "++++++++[>++++[>++>+++>+++>+<<<<-]>+>+>->>+[<]<-]>>.>---.+++++++..+++.>>.<-.<.+++.------.--------.>>+.>++.".to_owned();
 
     let entry = runestick::Hash::type_hash(&["main"]);
 
     b.iter(|| {
-        let execution = vm.clone().execute(entry, (hello_world.clone(), 00));
+        let execution = vm.execute(entry, (hello_world.clone(), 00));
         let mut execution = execution.expect("successful setup");
         execution.complete().expect("successful execution")
     });
@@ -121,14 +121,14 @@ fn bf_hello_world(b: &mut Bencher) -> runestick::Result<()> {
 
 #[bench]
 fn bf_hello_world2(b: &mut Bencher) -> runestick::Result<()> {
-    let vm = make_vm()?;
+    let mut vm = make_vm()?;
     // interesting hello world which wraps cells on the negative side
     let hello_world = "+[-[<<[+[--->]-[<<<]]]>>>-]>-.---.>..>.<<<<-.<+.>>>>>.>.<<.<-.".to_owned();
 
     let entry = runestick::Hash::type_hash(&["main"]);
 
     b.iter(|| {
-        let execution = vm.clone().execute(entry, (hello_world.clone(), 0));
+        let execution = vm.execute(entry, (hello_world.clone(), 0));
         let mut execution = execution.expect("successful setup");
         execution.complete().expect("successful execution")
     });
@@ -140,14 +140,14 @@ fn bf_hello_world2(b: &mut Bencher) -> runestick::Result<()> {
 
 #[bench]
 fn bf_fib(b: &mut Bencher) -> runestick::Result<()> {
-    let vm = make_vm()?;
+    let mut vm = make_vm()?;
     // Computes the first 16 fib numbers
     let src = "++++++++++++++++++++++++++++++++++++++++++++>++++++++++++++++++++++++++++++++>++ ++++++++++++++>>+<<[>>>>++++++++++<<[->+>-[>+>>]>[+[-<+>]>+>>]<<<<<<]>[<+>-]>[-] >>>++++++++++<[->-[>+>>]>[+[-<+>]>+>>]<<<<<]>[-]>>[+++++++++++++++++++++++++++++ +++++++++++++++++++.[-]]<[++++++++++++++++++++++++++++++++++++++++++++++++.[-]]< <<++++++++++++++++++++++++++++++++++++++++++++++++.[-]<<<<<<<.>.>>[>>+<<-]>[>+<< +>-]>[<+>-]<<<-]<<++..."
         .to_owned();
     let entry = runestick::Hash::type_hash(&["main"]);
 
     b.iter(|| {
-        let execution = vm.clone().execute(entry, (src.clone(), 0));
+        let execution = vm.execute(entry, (src.clone(), 0));
         let mut execution = execution.expect("successful setup");
         execution.complete().expect("successful execution");
     });
@@ -159,13 +159,13 @@ fn bf_fib(b: &mut Bencher) -> runestick::Result<()> {
 
 #[bench]
 fn bf_loopity(b: &mut Bencher) -> runestick::Result<()> {
-    let vm = make_vm()?;
+    let mut vm = make_vm()?;
     // Just a program that runs a lot of instructions
     let src = ">+[>++>+++[-<]>>]+".to_owned();
     let entry = runestick::Hash::type_hash(&["main"]);
 
     b.iter(|| {
-        let execution = vm.clone().execute(entry, (src.clone(), 5));
+        let execution = vm.execute(entry, (src.clone(), 5));
         let mut execution = execution.expect("successful setup");
         execution.complete().expect("successful execution");
     });

--- a/benches/benches/fib.rs
+++ b/benches/benches/fib.rs
@@ -6,7 +6,7 @@ use test::Bencher;
 
 #[bench]
 fn fib_15(b: &mut Bencher) -> runestick::Result<()> {
-    let vm = rune_tests::rune_vm! {
+    let mut vm = rune_tests::rune_vm! {
             fn fib(n) {
         if n <= 1 {
             n
@@ -23,7 +23,7 @@ fn fib_15(b: &mut Bencher) -> runestick::Result<()> {
     let entry = runestick::Hash::type_hash(&["main"]);
 
     b.iter(|| {
-        let execution = vm.clone().execute(entry, (15,));
+        let execution = vm.execute(entry, (15,));
         let mut execution = execution.expect("successful setup");
         execution.complete().expect("successful execution")
     });
@@ -33,7 +33,7 @@ fn fib_15(b: &mut Bencher) -> runestick::Result<()> {
 
 #[bench]
 fn fib_20(b: &mut Bencher) -> runestick::Result<()> {
-    let vm = rune_tests::rune_vm! {
+    let mut vm = rune_tests::rune_vm! {
             fn fib(n) {
         if n <= 1 {
             n
@@ -50,7 +50,7 @@ fn fib_20(b: &mut Bencher) -> runestick::Result<()> {
     let entry = runestick::Hash::type_hash(&["main"]);
 
     b.iter(|| {
-        let execution = vm.clone().execute(entry, (20,));
+        let execution = vm.execute(entry, (20,));
         let mut execution = execution.expect("successful setup");
         execution.complete().expect("successful execution")
     });

--- a/crates/rune-cli/src/main.rs
+++ b/crates/rune-cli/src/main.rs
@@ -606,7 +606,7 @@ async fn do_run(
 ) -> Result<ExitCode> {
     let last = std::time::Instant::now();
 
-    let vm = runestick::Vm::new(runtime, unit.clone());
+    let mut vm = runestick::Vm::new(runtime, unit.clone());
     let mut execution: runestick::VmExecution<_> = vm.execute(&["main"], ())?;
     let result = if args.trace {
         match do_trace(

--- a/crates/rune-modules/src/http.rs
+++ b/crates/rune-modules/src/http.rs
@@ -78,6 +78,7 @@ pub fn module(_stdio: bool) -> Result<Module, ContextError> {
     module.inst_fn("header", RequestBuilder::header)?;
     module.async_inst_fn("body_bytes", RequestBuilder::body_bytes)?;
 
+    module.inst_fn(Protocol::STRING_DISPLAY, Error::display)?;
     module.inst_fn(Protocol::STRING_DISPLAY, StatusCode::display)?;
     Ok(module)
 }
@@ -90,6 +91,12 @@ pub struct Error {
 impl From<reqwest::Error> for Error {
     fn from(inner: reqwest::Error) -> Self {
         Self { inner }
+    }
+}
+
+impl Error {
+    fn display(&self, buf: &mut String) -> fmt::Result {
+        write!(buf, "{}", self.inner)
     }
 }
 

--- a/crates/rune-wasm/src/lib.rs
+++ b/crates/rune-wasm/src/lib.rs
@@ -331,7 +331,7 @@ async fn inner_compile(input: String, config: JsValue) -> Result<CompileResult, 
         None
     };
 
-    let vm = runestick::Vm::new(Arc::new(context.runtime()), unit);
+    let mut vm = runestick::Vm::new(Arc::new(context.runtime()), unit);
 
     let mut execution = match vm.execute(&["main"], ()) {
         Ok(execution) => execution,

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -130,7 +130,7 @@
 //!     }
 //!
 //!     let unit = result?;
-//!     let vm = Vm::new(Arc::new(context.runtime()), Arc::new(unit));
+//!     let mut vm = Vm::new(Arc::new(context.runtime()), Arc::new(unit));
 //!
 //!     let mut execution = vm.execute(&["calculate"], (10i64, 20i64))?;
 //!     let value = execution.async_complete().await?;

--- a/crates/runestick/src/generator.rs
+++ b/crates/runestick/src/generator.rs
@@ -7,7 +7,7 @@ use std::mem;
 
 /// A generator with a stored virtual machine.
 pub struct Generator {
-    execution: Option<VmExecution>,
+    execution: Option<VmExecution<Vm>>,
     first: bool,
 }
 
@@ -37,7 +37,7 @@ impl Generator {
             .ok_or(VmErrorKind::GeneratorComplete)?;
 
         if !mem::take(&mut self.first) {
-            execution.vm_mut()?.stack_mut().push(value);
+            execution.vm_mut().stack_mut().push(value);
         }
 
         let state = execution.resume()?;

--- a/crates/runestick/src/stream.rs
+++ b/crates/runestick/src/stream.rs
@@ -7,7 +7,7 @@ use std::mem;
 
 /// A stream with a stored virtual machine.
 pub struct Stream {
-    execution: Option<VmExecution>,
+    execution: Option<VmExecution<Vm>>,
     first: bool,
 }
 
@@ -36,7 +36,7 @@ impl Stream {
             .ok_or(VmErrorKind::GeneratorComplete)?;
 
         if !mem::take(&mut self.first) {
-            execution.vm_mut()?.stack_mut().push(value);
+            execution.vm_mut().stack_mut().push(value);
         }
 
         let state = execution.async_resume().await?;

--- a/crates/runestick/src/vm.rs
+++ b/crates/runestick/src/vm.rs
@@ -240,7 +240,7 @@ impl Vm {
     ///     Ok(())
     /// }
     /// ```
-    pub fn execute<A, N>(mut self, name: N, args: A) -> Result<VmExecution, VmError>
+    pub fn execute<A, N>(mut self, name: N, args: A) -> Result<VmExecution<Self>, VmError>
     where
         N: IntoTypeHash,
         A: Args,
@@ -303,7 +303,7 @@ impl Vm {
     }
 
     /// Convert this virtual machine into an execution.
-    fn into_execution(self) -> VmExecution {
+    fn into_execution(self) -> VmExecution<Self> {
         VmExecution::new(self)
     }
 
@@ -2966,6 +2966,18 @@ impl Vm {
 
             self.advance();
         }
+    }
+}
+
+impl AsMut<Vm> for Vm {
+    fn as_mut(&mut self) -> &mut Vm {
+        self
+    }
+}
+
+impl AsRef<Vm> for Vm {
+    fn as_ref(&self) -> &Vm {
+        self
     }
 }
 

--- a/crates/runestick/src/vm.rs
+++ b/crates/runestick/src/vm.rs
@@ -374,6 +374,7 @@ impl Vm {
 
         self.ip = offset;
         self.stack.clear();
+        self.call_frames.clear();
         Ok(())
     }
 

--- a/crates/runestick/src/vm.rs
+++ b/crates/runestick/src/vm.rs
@@ -291,7 +291,9 @@ impl Vm {
     {
         self.set_entrypoint(name, args.count())?;
 
-        // Safety: We hold onto the guard until the vm has completed.
+        // Safety: We hold onto the guard until the vm has completed and
+        // `VmExecution` will clear the stack before this function returns.
+        // Erronously or not.
         let guard = unsafe { args.unsafe_into_stack(&mut self.stack)? };
 
         let value = VmExecution::new(self).complete()?;
@@ -325,7 +327,9 @@ impl Vm {
     {
         self.set_entrypoint(name, args.count())?;
 
-        // Safety: We hold onto the guard until the vm has completed.
+        // Safety: We hold onto the guard until the vm has completed and
+        // `VmExecution` will clear the stack before this function returns.
+        // Erronously or not.
         let guard = unsafe { args.unsafe_into_stack(&mut self.stack)? };
 
         let value = VmExecution::new(self).async_complete().await?;

--- a/crates/runestick/src/vm_call.rs
+++ b/crates/runestick/src/vm_call.rs
@@ -14,7 +14,10 @@ impl VmCall {
     }
 
     /// Encode the push itno an execution.
-    pub(crate) fn into_execution(self, execution: &mut VmExecution) -> Result<(), VmError> {
+    pub(crate) fn into_execution<T>(self, execution: &mut VmExecution<T>) -> Result<(), VmError>
+    where
+        T: AsMut<Vm>,
+    {
         let value = match self.call {
             Call::Async => Value::from(Future::new(self.vm.async_complete())),
             Call::Stream => Value::from(Stream::new(self.vm)),
@@ -25,7 +28,7 @@ impl VmCall {
             }
         };
 
-        let vm = execution.vm_mut()?;
+        let vm = execution.vm_mut();
         vm.stack_mut().push(value);
         vm.advance();
         Ok(())

--- a/examples/examples/basic_add.rs
+++ b/examples/examples/basic_add.rs
@@ -24,7 +24,7 @@ fn main() -> runestick::Result<()> {
         &mut diagnostics,
     )?;
 
-    let vm = Vm::new(Arc::new(context.runtime()), Arc::new(unit));
+    let mut vm = Vm::new(Arc::new(context.runtime()), Arc::new(unit));
     let output = vm.execute(&["main"], (33i64,))?.complete()?;
     let output = i64::from_value(output)?;
 

--- a/examples/examples/custom_instance_fn.rs
+++ b/examples/examples/custom_instance_fn.rs
@@ -30,7 +30,7 @@ async fn main() -> runestick::Result<()> {
 
     let unit = rune::load_sources(&context, &options, &mut sources, &mut diagnostics)?;
 
-    let vm = Vm::new(Arc::new(context.runtime()), Arc::new(unit));
+    let mut vm = Vm::new(Arc::new(context.runtime()), Arc::new(unit));
     let output = vm.execute(&["main"], (33i64,))?.complete()?;
     let output = i64::from_value(output)?;
 

--- a/examples/examples/custom_mul.rs
+++ b/examples/examples/custom_mul.rs
@@ -46,7 +46,7 @@ fn main() -> runestick::Result<()> {
         &mut diagnostics,
     )?;
 
-    let vm = Vm::new(Arc::new(context.runtime()), Arc::new(unit));
+    let mut vm = Vm::new(Arc::new(context.runtime()), Arc::new(unit));
     let output = vm.execute(&["main"], (Foo { field: 5 },))?.complete()?;
     let output = Foo::from_value(output)?;
 

--- a/examples/examples/run_diagnostics.rs
+++ b/examples/examples/run_diagnostics.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
 
     let unit = result?;
-    let vm = Vm::new(Arc::new(context.runtime()), Arc::new(unit));
+    let mut vm = Vm::new(Arc::new(context.runtime()), Arc::new(unit));
 
     let mut execution = vm.execute(&["calculate"], (10i64, 20i64))?;
     let value = execution.async_complete().await?;

--- a/examples/examples/run_minimal.rs
+++ b/examples/examples/run_minimal.rs
@@ -21,7 +21,7 @@ fn main() -> runestick::Result<()> {
         &mut diagnostics,
     )?;
 
-    let vm = runestick::Vm::new(Arc::new(context.runtime()), Arc::new(unit));
+    let mut vm = runestick::Vm::new(Arc::new(context.runtime()), Arc::new(unit));
     let output = i64::from_value(vm.execute(&["main"], (1,))?.complete()?)?;
 
     println!("output: {}", output);

--- a/examples/examples/use_references.rs
+++ b/examples/examples/use_references.rs
@@ -41,7 +41,7 @@ fn main() -> runestick::Result<()> {
         &mut diagnostics,
     )?;
 
-    let vm = Vm::new(Arc::new(context.runtime()), Arc::new(unit));
+    let mut vm = Vm::new(Arc::new(context.runtime()), Arc::new(unit));
 
     let mut foo = Foo::default();
 

--- a/examples/examples/vec_args.rs
+++ b/examples/examples/vec_args.rs
@@ -34,7 +34,7 @@ fn main() -> runestick::Result<()> {
 
     let unit = rune::load_sources(&context, &options, &mut sources, &mut diagnostics)?;
 
-    let vm = Vm::new(Arc::new(context.runtime()), Arc::new(unit));
+    let mut vm = Vm::new(Arc::new(context.runtime()), Arc::new(unit));
     let _ = vm.execute(&["main"], ())?.complete()?;
 
     Ok(())

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -111,7 +111,7 @@ where
     A: runestick::Args,
     T: FromValue,
 {
-    let vm = vm(context, sources)?;
+    let mut vm = vm(context, sources)?;
 
     let output = vm
         .execute(&Item::with_item(function), args)
@@ -154,7 +154,7 @@ where
     A: runestick::Args,
     T: FromValue,
 {
-    let vm = vm(context, sources)?;
+    let mut vm = vm(context, sources)?;
 
     let output = vm
         .execute(&Item::with_item(function), args)
@@ -258,7 +258,7 @@ pub fn build(
 /// use runestick::Value;
 ///
 /// # fn main() {
-/// let vm = rune_tests::rune_vm!(pub fn main() { true || false });
+/// let mut vm = rune_tests::rune_vm!(pub fn main() { true || false });
 /// let result = vm.execute(&["main"], ()).unwrap().complete().unwrap();
 /// assert_eq!(result.into_bool().unwrap(), true);
 /// # }
@@ -282,7 +282,7 @@ macro_rules! rune_vm {
 /// use runestick::Value;
 ///
 /// # fn main() {
-/// let vm = rune_tests::rune_vm!(pub fn main() { true || false });
+/// let mut vm = rune_tests::rune_vm!(pub fn main() { true || false });
 /// let result = vm.execute(&["main"], ()).unwrap().complete().unwrap();
 /// assert_eq!(result.into_bool().unwrap(), true);
 /// # }

--- a/tests/tests/getter_setter.rs
+++ b/tests/tests/getter_setter.rs
@@ -39,7 +39,7 @@ fn test_getter_setter() {
     )
     .unwrap();
 
-    let vm = Vm::new(Arc::new(context.runtime()), Arc::new(unit));
+    let mut vm = Vm::new(Arc::new(context.runtime()), Arc::new(unit));
 
     let mut foo = Foo {
         number: 42,

--- a/tests/tests/reference_error.rs
+++ b/tests/tests/reference_error.rs
@@ -37,7 +37,7 @@ fn test_reference_error() {
     )
     .unwrap();
 
-    let vm = Vm::new(Arc::new(context.runtime()), Arc::new(unit));
+    let mut vm = Vm::new(Arc::new(context.runtime()), Arc::new(unit));
 
     let mut foo = Foo::default();
     assert_eq!(foo.value, 0);


### PR DESCRIPTION
Been dragging my feet on this since I mostly use Rune while calling a single function. But this adds the ability to perform multiple calls on the same virtual machine assuming you have mutable access to it.

The solution adds a generic parameter to `VmExecution` to hold the head virtual machine, which is constrained to implement `AsRef<Vm>` and `AsMut<Vm>` as appropriate. This allows `VmExecution` to both take an exlusive reference `VmExecution<&mut Vm>` and ownership (default) `VmExecution<Vm>`. All the corresponding functions on `Vm` that does take `self` by ownership has been changed to take `&mut self` instead where possible.

As far as I can tell, nothing bad should be possible - since mutable access implies exclusive access to the same degree as ownership does (minus that the code is not responsible for dropping the virtual machine). The only point I'm a little bit concerned about is `GuardedArgs` since it allows for passing in references during async function calls. But since everything must be pinned and due to the pinning guarantee there should be no way for the guard that is created to leak anyways.

Fixes #286 since the solution then becomes obvious. Re-use the same `Vm`.