### PR TITLE
Don't require macro function to be Copy

### DIFF
--- a/crates/runestick/src/module.rs
+++ b/crates/runestick/src/module.rs
@@ -484,7 +484,7 @@ impl Module {
     /// Register a native macro handler.
     pub fn macro_<N, M, A, O>(&mut self, name: N, f: M) -> Result<(), ContextError>
     where
-        M: 'static + Send + Sync + Copy + Fn(&A) -> Result<O, crate::Error>,
+        M: 'static + Send + Sync + Clone + Fn(&A) -> Result<O, crate::Error>,
         A: any::Any,
         O: any::Any,
         N: IntoIterator,


### PR DESCRIPTION
Requiring the macro closure to be Copy disallows capturing things like `HashMap` or other complex structures which are `Clone` but not `Copy`. Changing the requirement to `Clone` still allows Rune to copy the closure if needed. 

Example where it could be useful:

```rust
/// Returns the literal value stored in the `params` map under the key given as the first 
/// macro arg, and if not found, returns the expression from the second arg.
fn param(params: &HashMap<String, String>, ts: &TokenStream) -> runestick::Result<TokenStream> {
...
}

...
let mut params = HashMap::new(); 
params.add("foo".to_string(), "1".to_string());

let mut my_module = Module::default();
my_module.macro_(&["param"], move |ts| Self::param(&params, ts)).unwrap();
...
```

Then I can use it in Rune script:

```rust
const FOO = param!("foo", -1);
```