### PR TITLE
Introduce rune bench for running micro benchmarks

### DIFF
--- a/crates/rune-cli/src/benches.rs
+++ b/crates/rune-cli/src/benches.rs
@@ -1,0 +1,109 @@
+use crate::ExitCode;
+use rune::termcolor::StandardStream;
+use rune::{EmitDiagnostics, Sources};
+use runestick::{Any, Item};
+use runestick::{CompileMeta, Function, Hash, RuntimeContext, Unit, Value};
+use std::io::Write;
+use std::sync::Arc;
+use std::time::Instant;
+
+#[derive(Default, Any)]
+pub(crate) struct Bencher {
+    fns: Vec<runestick::Function>,
+}
+
+impl Bencher {
+    fn iter(&mut self, f: runestick::Function) {
+        self.fns.push(f);
+    }
+}
+
+/// Registers `std::test` module.
+pub(crate) fn test_module() -> Result<runestick::Module, runestick::ContextError> {
+    let mut module = runestick::Module::with_item(&["std", "test"]);
+    module.ty::<Bencher>()?;
+    module.inst_fn("iter", Bencher::iter)?;
+    Ok(module)
+}
+
+/// Run benchmarks.
+pub(crate) async fn do_benches(
+    args: &crate::BenchFlags,
+    mut out: StandardStream,
+    runtime: Arc<RuntimeContext>,
+    unit: Arc<Unit>,
+    sources: Sources,
+    found: Vec<(Hash, CompileMeta)>,
+) -> anyhow::Result<ExitCode> {
+    let mut vm = runestick::Vm::new(runtime, unit.clone());
+
+    writeln!(out, "Found {} benches...", found.len())?;
+
+    let mut any_error = false;
+
+    for (hash, meta) in found {
+        let mut bencher = Bencher::default();
+
+        if let Err(error) = vm.call(hash, (&mut bencher,)) {
+            writeln!(out, "Error in benchmark `{}`", meta.item.item)?;
+            error.emit_diagnostics(&mut out, &sources)?;
+            any_error = true;
+            continue;
+        }
+
+        for (i, f) in bencher.fns.iter().enumerate() {
+            if let Err(e) = bench_fn(&mut out, i, &meta.item.item, args, f) {
+                writeln!(out, "Error running benchmark iteration: {}", e)?;
+                any_error = true;
+            }
+        }
+    }
+
+    if any_error {
+        Ok(ExitCode::Failure)
+    } else {
+        Ok(ExitCode::Success)
+    }
+}
+
+fn bench_fn(
+    out: &mut StandardStream,
+    i: usize,
+    item: &Item,
+    args: &crate::BenchFlags,
+    f: &Function,
+) -> anyhow::Result<()> {
+    for _ in 0..args.warmup {
+        let value = f.call::<_, Value>(())?;
+        drop(value);
+    }
+
+    let mut collected = Vec::with_capacity(args.iterations as usize);
+
+    for _ in 0..args.iterations {
+        let start = Instant::now();
+        let value = f.call::<_, Value>(())?;
+        let duration = Instant::now().duration_since(start);
+        collected.push(duration.as_nanos() as i128);
+        drop(value);
+    }
+
+    collected.sort();
+
+    let len = collected.len() as f64;
+    let average = collected.iter().copied().sum::<i128>() as f64 / len;
+    let variance = collected
+        .iter()
+        .copied()
+        .map(|n| (n as f64 - average).powf(2.0))
+        .sum::<f64>()
+        / len;
+    let stddev = variance.sqrt();
+
+    writeln!(
+        out,
+        "bench {}#{}: mean={:.2}ns, stddev={:.2}, iterations={}",
+        item, i, average, stddev, args.iterations,
+    )?;
+    Ok(())
+}

--- a/crates/rune-cli/src/tests.rs
+++ b/crates/rune-cli/src/tests.rs
@@ -1,35 +1,9 @@
 use crate::ExitCode;
 use rune::{termcolor::StandardStream, EmitDiagnostics, Sources};
-use runestick::{
-    CompileMeta, CompileMetaKind, Hash, RuntimeContext, Unit, UnitFn, Value, Vm, VmError,
-    VmErrorKind,
-};
-use std::{cell::RefCell, io::Write, sync::Arc, time::Instant};
-
-#[derive(Default)]
-pub struct TestVisitor {
-    test_functions: RefCell<Vec<(Hash, CompileMeta)>>,
-}
-
-impl TestVisitor {
-    /// Convert visitor into test functions.
-    pub(crate) fn into_test_functions(self) -> Vec<(Hash, CompileMeta)> {
-        self.test_functions.into_inner()
-    }
-}
-
-impl rune::CompileVisitor for TestVisitor {
-    fn register_meta(&self, meta: &CompileMeta) {
-        let type_hash = match &meta.kind {
-            CompileMetaKind::Function { is_test, type_hash } if *is_test => type_hash,
-            _ => return,
-        };
-
-        self.test_functions
-            .borrow_mut()
-            .push((*type_hash, meta.clone()));
-    }
-}
+use runestick::{CompileMeta, Hash, RuntimeContext, Unit, UnitFn, Value, Vm, VmError, VmErrorKind};
+use std::io::Write;
+use std::sync::Arc;
+use std::time::Instant;
 
 #[derive(Debug)]
 enum FailureReason {

--- a/crates/rune-cli/src/visitor.rs
+++ b/crates/rune-cli/src/visitor.rs
@@ -1,0 +1,57 @@
+use runestick::{CompileMeta, CompileMetaKind, Hash};
+use std::cell::RefCell;
+
+/// Attribute to collect.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum Attribute {
+    /// Do not collect any functions.
+    None,
+    /// Collect `#[test]` functions.
+    Test,
+    /// Collect `#[bench]` functions.
+    Bench,
+}
+
+/// A compile visitor that collects functions with a specific attribute.
+pub struct FunctionVisitor {
+    attribute: Attribute,
+    functions: RefCell<Vec<(Hash, CompileMeta)>>,
+}
+
+impl FunctionVisitor {
+    pub(crate) fn new(kind: Attribute) -> Self {
+        Self {
+            attribute: kind,
+            functions: Default::default(),
+        }
+    }
+
+    /// Convert visitor into test functions.
+    pub(crate) fn into_functions(self) -> Vec<(Hash, CompileMeta)> {
+        self.functions.into_inner()
+    }
+}
+
+impl rune::CompileVisitor for FunctionVisitor {
+    fn register_meta(&self, meta: &CompileMeta) {
+        let type_hash = match (self.attribute, &meta.kind) {
+            (
+                Attribute::Test,
+                CompileMetaKind::Function {
+                    is_test, type_hash, ..
+                },
+            ) if *is_test => type_hash,
+            (
+                Attribute::Bench,
+                CompileMetaKind::Function {
+                    is_bench,
+                    type_hash,
+                    ..
+                },
+            ) if *is_bench => type_hash,
+            _ => return,
+        };
+
+        self.functions.borrow_mut().push((*type_hash, meta.clone()));
+    }
+}

--- a/crates/rune-ssa/src/global.rs
+++ b/crates/rune-ssa/src/global.rs
@@ -39,7 +39,7 @@ impl fmt::Display for StaticId {
 #[derive(Debug, Clone, Copy)]
 struct SharedAssign {
     id: StaticId,
-    block: BlockId,
+    _block: BlockId,
 }
 
 /// The descriptor of a single assignment.
@@ -57,7 +57,7 @@ impl Assign {
     #[inline]
     pub(crate) fn new(id: StaticId, block: BlockId) -> Self {
         Self {
-            shared: Rc::new(Cell::new(SharedAssign { id, block })),
+            shared: Rc::new(Cell::new(SharedAssign { id, _block: block })),
         }
     }
 

--- a/crates/rune/src/attrs/mod.rs
+++ b/crates/rune/src/attrs/mod.rs
@@ -59,3 +59,12 @@ impl Attribute for Test {
     /// Must match the specified name.
     const PATH: &'static str = "test";
 }
+
+/// NB: at this point we don't support attributes beyond the empty `#[bench]`.
+#[derive(Parse)]
+pub(crate) struct Bench {}
+
+impl Attribute for Bench {
+    /// Must match the specified name.
+    const PATH: &'static str = "bench";
+}

--- a/crates/rune/src/compiling/compile_error.rs
+++ b/crates/rune/src/compiling/compile_error.rs
@@ -300,6 +300,8 @@ pub enum CompileErrorKind {
     UnsupportedGenerics,
     #[error("#[test] attributes are not supported on nested items")]
     NestedTest { nested_span: Span },
+    #[error("#[bench] attributes are not supported on nested items")]
+    NestedBench { nested_span: Span },
 }
 
 /// A single stap as an import entry.

--- a/crates/rune/src/compiling/v1/assemble/mod.rs
+++ b/crates/rune/src/compiling/v1/assemble/mod.rs
@@ -49,7 +49,6 @@ use runestick::{CompileMetaCapture, InstAddress, Span};
 pub(crate) struct Asm {
     span: Span,
     kind: AsmKind,
-    decl_anon: bool,
 }
 
 impl Asm {
@@ -59,7 +58,6 @@ impl Asm {
         Self {
             span,
             kind: AsmKind::Top,
-            decl_anon: false,
         }
     }
 
@@ -67,7 +65,6 @@ impl Asm {
         Self {
             span,
             kind: AsmKind::Var(var, local),
-            decl_anon: false,
         }
     }
 }

--- a/crates/rune/src/diagnostics/error.rs
+++ b/crates/rune/src/diagnostics/error.rs
@@ -8,8 +8,6 @@ use thiserror::Error;
 /// An error raised when using one of the `load_*` functions.
 #[derive(Debug)]
 pub struct Error {
-    /// Last error in chain of reported errors.
-    pub(super) last: Option<usize>,
     /// The source id of the error.
     pub(super) source_id: SourceId,
     /// The kind of the load error.

--- a/crates/rune/src/diagnostics/mod.rs
+++ b/crates/rune/src/diagnostics/mod.rs
@@ -59,10 +59,10 @@ pub struct Diagnostics {
     diagnostics: Vec<Diagnostic>,
     /// If warnings are collected or not.
     mode: DiagnosticsMode,
-    /// First error in chain.
-    last_error: Option<usize>,
-    /// First warning in chain.
-    last_warning: Option<usize>,
+    /// Indicates if diagnostics indicates errors.
+    has_error: bool,
+    /// Indicates if diagnostics contains warnings.
+    has_warning: bool,
 }
 
 impl Diagnostics {
@@ -70,8 +70,8 @@ impl Diagnostics {
         Self {
             diagnostics: Vec::new(),
             mode,
-            last_error: None,
-            last_warning: None,
+            has_error: false,
+            has_warning: false,
         }
     }
 
@@ -128,12 +128,12 @@ impl Diagnostics {
 
     /// Check if diagnostics has any errors reported.
     pub fn has_error(&self) -> bool {
-        self.last_error.is_some()
+        self.has_error
     }
 
     /// Check if diagnostics has any warnings reported.
     pub fn has_warning(&self) -> bool {
-        self.last_warning.is_some()
+        self.has_warning
     }
 
     /// Access underlying diagnostics.
@@ -220,15 +220,12 @@ impl Diagnostics {
             return;
         }
 
-        let current = Some(self.diagnostics.len());
-
         self.diagnostics.push(Diagnostic::Warning(Warning {
-            last: self.last_warning,
             source_id,
             kind: kind.into(),
         }));
 
-        self.last_warning = current;
+        self.has_warning = true;
     }
 
     /// Report an error.
@@ -236,15 +233,12 @@ impl Diagnostics {
     where
         ErrorKind: From<T>,
     {
-        let current = Some(self.diagnostics.len());
-
         self.diagnostics.push(Diagnostic::Error(Error {
-            last: self.last_error,
             source_id,
             kind: Box::new(kind.into()),
         }));
 
-        self.last_error = current;
+        self.has_error = true;
     }
 }
 

--- a/crates/rune/src/diagnostics/warning.rs
+++ b/crates/rune/src/diagnostics/warning.rs
@@ -6,8 +6,6 @@ use thiserror::Error;
 /// Compilation warning.
 #[derive(Debug, Clone, Copy)]
 pub struct Warning {
-    /// The last warning reported in the chain.
-    pub(super) last: Option<usize>,
     /// The id of the source where the warning happened.
     pub(super) source_id: SourceId,
     /// The kind of the warning.

--- a/crates/rune/src/emit_diagnostics.rs
+++ b/crates/rune/src/emit_diagnostics.rs
@@ -463,6 +463,12 @@ where
                         .with_message("nested in here"),
                 );
             }
+            CompileErrorKind::NestedBench { nested_span } => {
+                labels.push(
+                    Label::secondary(this.source_id(), nested_span.range())
+                        .with_message("nested in here"),
+                );
+            }
             _ => (),
         }
 

--- a/crates/rune/src/query/mod.rs
+++ b/crates/rune/src/query/mod.rs
@@ -1240,6 +1240,7 @@ impl QueryInner {
                 CompileMetaKind::Function {
                     type_hash: Hash::type_hash(&query_item.item),
                     is_test: false,
+                    is_bench: false,
                 }
             }
             Indexed::Closure(c) => {

--- a/crates/runestick/src/compile_meta.rs
+++ b/crates/runestick/src/compile_meta.rs
@@ -167,8 +167,11 @@ pub enum CompileMetaKind {
         /// The type hash associated with this meta kind.
         type_hash: Hash,
 
-        /// Whether this function has a test annotation
+        /// Whether this function has a `#[test]` annotation
         is_test: bool,
+
+        /// Whether this function has a `#[bench]` annotation.
+        is_bench: bool,
     },
     /// A closure.
     Closure {

--- a/crates/runestick/src/context.rs
+++ b/crates/runestick/src/context.rs
@@ -537,6 +537,7 @@ impl Context {
                 kind: CompileMetaKind::Function {
                     type_hash: hash,
                     is_test: false,
+                    is_bench: false,
                 },
                 source: None,
             },
@@ -639,6 +640,7 @@ impl Context {
                 kind: CompileMetaKind::Function {
                     type_hash: hash,
                     is_test: false,
+                    is_bench: false,
                 },
                 source: None,
             },

--- a/crates/runestick/src/vm.rs
+++ b/crates/runestick/src/vm.rs
@@ -341,8 +341,8 @@ impl Vm {
         Ok(value)
     }
 
-    // Update the instruction pointer to match the function matching the given
-    // name and check that the number of argument matches.
+    /// Update the instruction pointer to match the function matching the given
+    /// name and check that the number of argument matches.
     fn set_entrypoint<N>(&mut self, name: N, count: usize) -> Result<(), VmError>
     where
         N: IntoTypeHash,

--- a/tests/tests/test_attribute.rs
+++ b/tests/tests/test_attribute.rs
@@ -54,3 +54,37 @@ fn deny_nested_use() {
         }  
     }
 }
+
+// We prevent tests from being declared inside of nested items at compile time.
+#[test]
+fn deny_nested_bench() {
+    assert_compile_error! {
+        r#"
+        fn function() {
+            #[bench]
+            fn bench_fn() {
+                assert!(true != true);
+            }
+        }
+        "#,
+        span, NestedBench { nested_span } => {
+            assert_eq!(span, Span::new(37, 71));
+            assert_eq!(nested_span, Span::new(9, 22));
+        }  
+    }
+
+    assert_compile_error! {
+        r#"
+        const ITEM = {
+            #[bench]
+            fn bench_fn() {
+                assert!(true != true);
+            }
+        };
+        "#,
+        span, NestedBench { nested_span } => {
+            assert_eq!(span, Span::new(36, 70));
+            assert_eq!(nested_span, Span::new(9, 19));
+        }  
+    }
+}

--- a/tests/tests/vm_literals.rs
+++ b/tests/tests/vm_literals.rs
@@ -50,7 +50,7 @@ fn test_string_literals() {
     assert_eq!(
         rune!(String => pub fn main() { "\
     a \
-
+\
     b" }),
         "a b"
     );
@@ -73,7 +73,7 @@ fn test_byte_string_literals() {
     assert_eq!(
         rune!(Bytes => pub fn main() { b"\
     a \
-
+\
     b" }),
         b"a b"[..]
     );

--- a/tests/tests/vm_test_from_value_derive.rs
+++ b/tests/tests/vm_test_from_value_derive.rs
@@ -47,6 +47,7 @@ fn test_from_value_tuple_like() {
 fn test_missing_dynamic_field() {
     #[derive(Debug, FromValue)]
     struct ProxyStruct {
+        #[allow(dead_code)]
         missing: u32,
     }
 


### PR DESCRIPTION
This allows for specifying benchmark functions with the `#[bench]` attribute, which uses a similar contract as the same attribute in Rust.

```rust
#[bench]
fn bench_try(b) {
    b.iter(|| {
        Ok(Ok(Ok(Ok(Ok(Ok(42))))))??????
    });
}
```

This can be run with the new `bench` subcommand. It's currently very simple and only reports average and standard deviation after performing a number of warmups and iterations. I expect this to be improved at a later point.

```
> cargo run --release --bin rune -- bench scripts\benches.rn
Found 1 benches...
bench bench_try#0: mean=780.00ns, stddev=50.99, iterations=100
```

I've re-used some of the plumbing introduced with the `#[test]` attribute in 4b4683aea8e2418c2c49f76657b5c900f0b4a952.