### PR TITLE
Make Try and Return more complex and remove Unwrap and IsValue

### DIFF
--- a/crates/rune/src/compiling/assembly.rs
+++ b/crates/rune/src/compiling/assembly.rs
@@ -20,7 +20,7 @@ pub enum AssemblyInst {
 #[derive(Debug, Clone, Default)]
 pub struct Assembly {
     /// The location that caused the assembly.
-    pub(crate) location: Location,
+    location: Location,
     /// Label to offset.
     pub(crate) labels: HashMap<Label, usize>,
     /// Registered label by offset.

--- a/crates/rune/src/compiling/v1/assemble/block.rs
+++ b/crates/rune/src/compiling/v1/assemble/block.rs
@@ -8,7 +8,7 @@ impl AssembleClosure for ast::Block {
         captures: &[CompileMetaCapture],
     ) -> CompileResult<()> {
         let span = self.span();
-        log::trace!("ExprBlock (procedure) => {:?}", c.source.source(span));
+        log::trace!("Block (closure) => {:?}", c.source.source(span));
 
         let guard = c.scopes.push_child(span)?;
 
@@ -16,9 +16,8 @@ impl AssembleClosure for ast::Block {
             c.scopes.new_var(&capture.ident, span)?;
         }
 
-        self.assemble(c, Needs::Value)?.apply(c)?;
-        c.clean_last_scope(span, guard, Needs::Value)?;
-        c.asm.push(Inst::Return, span);
+        c.return_(span, self)?;
+        c.scopes.pop(guard, span)?;
         Ok(())
     }
 }

--- a/crates/rune/src/compiling/v1/assemble/expr_return.rs
+++ b/crates/rune/src/compiling/v1/assemble/expr_return.rs
@@ -13,16 +13,13 @@ impl Assemble for ast::ExprReturn {
             }
         }
 
-        // NB: we actually want total_var_count here since we need to clean up
-        // _every_ variable declared until we reached the current return.
-        let total_var_count = c.scopes.total_var_count(span)?;
-
         if let Some(expr) = &self.expr {
-            expr.assemble(c, Needs::Value)?.apply(c)?;
-            c.locals_clean(total_var_count, span);
-            c.asm.push(Inst::Return, span);
+            c.return_(span, expr)?;
         } else {
-            c.locals_pop(total_var_count, span);
+            // NB: we actually want total_var_count here since we need to clean up
+            // _every_ variable declared until we reached the current return.
+            let clean = c.scopes.total_var_count(span)?;
+            c.locals_pop(clean, span);
             c.asm.push(Inst::ReturnUnit, span);
         }
 

--- a/crates/rune/src/compiling/v1/assemble/expr_try.rs
+++ b/crates/rune/src/compiling/v1/assemble/expr_try.rs
@@ -8,6 +8,7 @@ impl Assemble for ast::ExprTry {
 
         let clean = c.scopes.total_var_count(span)?;
         let address = self.expr.assemble(c, Needs::Value)?.apply_targeted(c)?;
+
         c.asm.push(
             Inst::Try {
                 address,
@@ -16,6 +17,17 @@ impl Assemble for ast::ExprTry {
             },
             span,
         );
+
+        if let InstAddress::Top = address {
+            c.scopes.undecl_anon(span, 1)?;
+        }
+
+        // Why no needs.value() check here to declare another anonymous
+        // variable? Because when these assembling functions were initially
+        // implemented it was decided that the caller that indicates
+        // Needs::Value is responsible for declaring any anonymous variables.
+        //
+        // TODO: This should probably change!
 
         Ok(Asm::top(span))
     }

--- a/crates/rune/src/compiling/v1/assemble/expr_try.rs
+++ b/crates/rune/src/compiling/v1/assemble/expr_try.rs
@@ -6,25 +6,16 @@ impl Assemble for ast::ExprTry {
         let span = self.span();
         log::trace!("ExprTry => {:?}", c.source.source(span));
 
-        let not_error = c.asm.new_label("try_not_error");
-
-        self.expr.assemble(c, Needs::Value)?.apply(c)?;
-        c.asm.push(Inst::Dup, span);
-        c.asm.push(Inst::IsValue, span);
-        c.asm.jump_if(not_error, span);
-
-        // Clean up all locals so far and return from the current function.
-        let total_var_count = c.scopes.total_var_count(span)?;
-        c.locals_clean(total_var_count, span);
-        c.asm.push(Inst::Return, span);
-
-        c.asm.label(not_error)?;
-
-        if needs.value() {
-            c.asm.push(Inst::Unwrap, span);
-        } else {
-            c.asm.push(Inst::Pop, span);
-        }
+        let clean = c.scopes.total_var_count(span)?;
+        let address = self.expr.assemble(c, Needs::Value)?.apply_targeted(c)?;
+        c.asm.push(
+            Inst::Try {
+                address,
+                clean,
+                preserve: needs.value(),
+            },
+            span,
+        );
 
         Ok(Asm::top(span))
     }

--- a/crates/rune/src/compiling/v1/assemble/item_fn.rs
+++ b/crates/rune/src/compiling/v1/assemble/item_fn.rs
@@ -41,11 +41,7 @@ impl AssembleFn for ast::ItemFn {
         }
 
         if !self.body.produces_nothing() {
-            self.body.assemble(c, Needs::Value)?.apply(c)?;
-
-            let total_var_count = c.scopes.total_var_count(span)?;
-            c.locals_clean(total_var_count, span);
-            c.asm.push(Inst::Return, span);
+            c.return_(span, &self.body)?;
         } else {
             self.body.assemble(c, Needs::None)?.apply(c)?;
 

--- a/crates/rune/src/compiling/v1/assemble/prelude.rs
+++ b/crates/rune/src/compiling/v1/assemble/prelude.rs
@@ -6,7 +6,7 @@ pub(crate) use crate::{
     CompileError, CompileErrorKind, CompileResult, ParseErrorKind, Resolve, Spanned,
 };
 pub(crate) use runestick::{
-    CompileMetaCapture, CompileMetaKind, ConstValue, Hash, Inst, InstAssignOp, InstOp,
+    CompileMetaCapture, CompileMetaKind, ConstValue, Hash, Inst, InstAddress, InstAssignOp, InstOp,
     InstRangeLimits, InstTarget, InstVariant, Item, Span,
 };
 pub(crate) use std::convert::TryFrom;

--- a/crates/runestick/src/stack.rs
+++ b/crates/runestick/src/stack.rs
@@ -145,6 +145,15 @@ impl Stack {
         })
     }
 
+    /// Peek the given address without removing it from the stack if it's on the
+    /// top.
+    pub fn address_peek(&mut self, address: InstAddress) -> Result<&Value, StackError> {
+        match address {
+            InstAddress::Top => self.last(),
+            InstAddress::Offset(offset) => self.at_offset(offset),
+        }
+    }
+
     /// Pop the given number of elements from the stack.
     pub fn popn(&mut self, count: usize) -> Result<(), StackError> {
         drop(self.drain_stack_top(count)?);

--- a/crates/runestick/src/stack.rs
+++ b/crates/runestick/src/stack.rs
@@ -145,15 +145,6 @@ impl Stack {
         })
     }
 
-    /// Peek the given address without removing it from the stack if it's on the
-    /// top.
-    pub fn address_peek(&mut self, address: InstAddress) -> Result<&Value, StackError> {
-        match address {
-            InstAddress::Top => self.last(),
-            InstAddress::Offset(offset) => self.at_offset(offset),
-        }
-    }
-
     /// Pop the given number of elements from the stack.
     pub fn popn(&mut self, count: usize) -> Result<(), StackError> {
         drop(self.drain_stack_top(count)?);

--- a/crates/runestick/src/vm.rs
+++ b/crates/runestick/src/vm.rs
@@ -2290,7 +2290,7 @@ impl Vm {
                 Option::None => None,
             },
             other => {
-                return Err(VmError::from(VmErrorKind::UnsupportedIsValueOperand {
+                return Err(VmError::from(VmErrorKind::UnsupportedTryOperand {
                     actual: other.type_info()?,
                 }))
             }
@@ -2694,7 +2694,7 @@ impl Vm {
                 }
             }
             other => {
-                return Err(VmError::from(VmErrorKind::UnsupportedIsValueOperand {
+                return Err(VmError::from(VmErrorKind::UnsupportedIterNextOperand {
                     actual: other.type_info()?,
                 }))
             }

--- a/crates/runestick/src/vm_error.rs
+++ b/crates/runestick/src/vm_error.rs
@@ -279,8 +279,10 @@ pub enum VmErrorKind {
     UnsupportedUnwrapNone,
     #[error("expected Ok value, but got `Err({err})`")]
     UnsupportedUnwrapErr { err: TypeInfo },
-    #[error("expected result or option as value, but got `{actual}`")]
-    UnsupportedIsValueOperand { actual: TypeInfo },
+    #[error("value `{actual}` is not supported as try operand")]
+    UnsupportedTryOperand { actual: TypeInfo },
+    #[error("value `{actual}` is not supported as iter-next operand")]
+    UnsupportedIterNextOperand { actual: TypeInfo },
     /// Trying to resume a generator that has completed.
     #[error("cannot resume a generator that has completed")]
     GeneratorComplete,


### PR DESCRIPTION
This change introduces the `Try` instruction which replaces the use of about 5 other instructions whenever an expression like `expr?` is used.

`Return` has also been extended to be able to process an addressed variable `address` and to `clean` (where `clean` indicates the number of stack elements that should be clean for the current call frame). This allows it to execute more efficiently under some circumstances.

So what happens is that for every try expression, we replace code that is generated like this:

```
  0000 = dup
  0001 = is-value
  0002 = jump-if 1 // label:try_not_error_4
  0003 = return
try_not_error_4:
  0004 = unwrap
```

With this:

```
  0000 = try address=top, clean=0, preserve=true
```

So for every try we save about 4 instructions. This example code goes from being 82 instructions to only be 14:

```
Ok(Ok(Ok(Ok(Ok(Ok(42))))))??????
```

We also avoid the work involved in advancing the Vm across 5 operations and can avoid performing some duplicate work, netting us a performance uplift of about 15% for try expressions.

Another benefit is that this allows us to nuke the `IsValue` and `Unwrap` instructions which were only used in try expressions.