### PR TITLE
Reduce memory footprint of debug info and future proof its API

### DIFF
--- a/crates/rune-languageserver/src/state.rs
+++ b/crates/rune-languageserver/src/state.rs
@@ -126,9 +126,11 @@ impl State {
             by_url.insert(url.clone(), Default::default());
 
             let mut sources = rune::Sources::new();
-
-            let mut input = runestick::Source::new(url.to_string(), source.to_string());
-            *input.path_mut() = url.to_file_path().ok();
+            let input = runestick::Source::with_path(
+                url.to_string(),
+                source.to_string(),
+                url.to_file_path().ok(),
+            );
 
             sources.insert(input);
 

--- a/crates/rune/src/compiling/assembly.rs
+++ b/crates/rune/src/compiling/assembly.rs
@@ -28,7 +28,7 @@ pub struct Assembly {
     /// Instructions with spans.
     pub(crate) instructions: Vec<(AssemblyInst, Span)>,
     /// Comments associated with instructions.
-    pub(crate) comments: HashMap<usize, Vec<String>>,
+    pub(crate) comments: HashMap<usize, Vec<Box<str>>>,
     /// The number of labels.
     pub(crate) label_count: usize,
     /// The collection of functions required by this assembly.
@@ -136,7 +136,7 @@ impl Assembly {
         self.comments
             .entry(pos)
             .or_default()
-            .push(comment.as_ref().to_owned());
+            .push(comment.as_ref().into());
 
         self.push(raw, span);
     }

--- a/crates/rune/src/compiling/mod.rs
+++ b/crates/rune/src/compiling/mod.rs
@@ -323,7 +323,7 @@ impl CompileBuildEntry<'_> {
                         args,
                         asm,
                         b.call,
-                        Vec::new(),
+                        Default::default(),
                     )?;
                 }
             }
@@ -386,7 +386,7 @@ impl CompileBuildEntry<'_> {
     }
 }
 
-fn format_fn_args<'a, I>(source: &Source, arguments: I) -> Result<Vec<String>, CompileError>
+fn format_fn_args<'a, I>(source: &Source, arguments: I) -> Result<Box<[Box<str>]>, CompileError>
 where
     I: IntoIterator<Item = &'a ast::FnArg>,
 {
@@ -395,19 +395,19 @@ where
     for arg in arguments {
         match arg {
             ast::FnArg::SelfValue(..) => {
-                args.push(String::from("self"));
+                args.push("self".into());
             }
             ast::FnArg::Pat(pat) => {
                 let span = pat.span();
 
                 if let Some(s) = source.source(span) {
-                    args.push(s.to_owned());
+                    args.push(s.into());
                 } else {
-                    args.push(String::from("*"));
+                    args.push("*".into());
                 }
             }
         }
     }
 
-    Ok(args)
+    Ok(args.into())
 }

--- a/crates/runestick/src/debug.rs
+++ b/crates/runestick/src/debug.rs
@@ -7,6 +7,7 @@ use std::fmt;
 
 /// Debug information about a unit.
 #[derive(Debug, Default, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct DebugInfo {
     /// Debug information on each instruction.
     pub instructions: Vec<DebugInst>,
@@ -32,15 +33,33 @@ impl DebugInfo {
 
 /// Debug information for every instruction.
 #[derive(Debug, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct DebugInst {
     /// The file by id the instruction belongs to.
     pub source_id: usize,
     /// The span of the instruction.
     pub span: Span,
     /// The comment for the line.
-    pub comment: Option<String>,
+    pub comment: Option<Box<str>>,
     /// Label associated with the location.
     pub label: Option<DebugLabel>,
+}
+
+impl DebugInst {
+    /// Construct a new debug instruction.
+    pub fn new(
+        source_id: usize,
+        span: Span,
+        comment: Option<Box<str>>,
+        label: Option<DebugLabel>,
+    ) -> Self {
+        Self {
+            source_id,
+            span,
+            comment,
+            label,
+        }
+    }
 }
 
 /// Debug information on function arguments.
@@ -51,11 +70,12 @@ pub enum DebugArgs {
     /// A tuple, with the given number of arguments.
     TupleArgs(usize),
     /// A collection of named arguments.
-    Named(Vec<String>),
+    Named(Box<[Box<str>]>),
 }
 
 /// A description of a function signature.
 #[derive(Debug, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct DebugSignature {
     /// The path of the function.
     pub path: Item,
@@ -65,11 +85,8 @@ pub struct DebugSignature {
 
 impl DebugSignature {
     /// Construct a new function signature.
-    pub fn new(path: Item, args: Vec<String>) -> Self {
-        Self {
-            path,
-            args: DebugArgs::Named(args),
-        }
+    pub fn new(path: Item, args: DebugArgs) -> Self {
+        Self { path, args }
     }
 }
 

--- a/crates/runestick/src/label.rs
+++ b/crates/runestick/src/label.rs
@@ -1,6 +1,7 @@
 //! A simple label used to jump to a code location.
 
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 use std::fmt;
 
 /// A label that can be jumped to.
@@ -19,7 +20,7 @@ impl Label {
     /// Convert into owned label.
     pub fn into_owned(self) -> DebugLabel {
         DebugLabel {
-            name: self.name.to_owned(),
+            name: self.name.into(),
             id: self.id,
         }
     }
@@ -35,7 +36,7 @@ impl fmt::Display for Label {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct DebugLabel {
     /// The name of the label.
-    name: String,
+    name: Cow<'static, str>,
     /// The id of the label.
     id: usize,
 }


### PR DESCRIPTION
Minor clean up around sources and debug info. Changes `String` to use `Box<str>` since they are immutable, saving a few bytes here and there. Also marks debug info structs as `#[non_exhaustive]` so that they are more future proof (since they have public fields) and adding constructors for how they are used.