### PR TITLE
Support registering new sources in macros and parsing in macros

### DIFF
--- a/crates/rune/src/ast/attribute.rs
+++ b/crates/rune/src/ast/attribute.rs
@@ -168,8 +168,8 @@ fn test_parse_attribute() {
     ];
 
     for s in TEST_STRINGS.iter() {
-        crate::parse_all::<ast::Attribute>(s).expect(s);
+        crate::parse_all_without_source::<ast::Attribute>(s).expect(s);
         let withbang = s.replacen("#[", "#![", 1);
-        crate::parse_all::<ast::Attribute>(&withbang).expect(&withbang);
+        crate::parse_all_without_source::<ast::Attribute>(&withbang).expect(&withbang);
     }
 }

--- a/crates/rune/src/ast/expr_object.rs
+++ b/crates/rune/src/ast/expr_object.rs
@@ -1,9 +1,8 @@
 use crate::ast;
 use crate::{
-    Parse, ParseError, Parser, Peek, Peeker, Resolve, ResolveError, ResolveOwned, Spanned, Storage,
-    ToTokens,
+    Parse, ParseError, Parser, Peek, Peeker, Resolve, ResolveError, ResolveOwned, Sources, Spanned,
+    Storage, ToTokens,
 };
-use runestick::Source;
 use std::borrow::Cow;
 
 /// Parse an object expression.
@@ -139,9 +138,13 @@ impl Peek for AnonExprObject {
 impl<'a> Resolve<'a> for ObjectKey {
     type Output = Cow<'a, str>;
 
-    fn resolve(&self, storage: &Storage, source: &'a Source) -> Result<Self::Output, ResolveError> {
+    fn resolve(
+        &self,
+        storage: &Storage,
+        sources: &'a Sources,
+    ) -> Result<Self::Output, ResolveError> {
         Ok(match self {
-            Self::LitStr(lit_str) => lit_str.resolve(storage, source)?,
+            Self::LitStr(lit_str) => lit_str.resolve(storage, sources)?,
             Self::Path(path) => {
                 let ident = match path.try_as_ident() {
                     Some(ident) => ident,
@@ -150,7 +153,7 @@ impl<'a> Resolve<'a> for ObjectKey {
                     }
                 };
 
-                ident.resolve(storage, source)?
+                ident.resolve(storage, sources)?
             }
         })
     }
@@ -162,8 +165,8 @@ impl ResolveOwned for ObjectKey {
     fn resolve_owned(
         &self,
         storage: &Storage,
-        source: &Source,
+        sources: &Sources,
     ) -> Result<Self::Owned, ResolveError> {
-        Ok(self.resolve(storage, source)?.into_owned())
+        Ok(self.resolve(storage, sources)?.into_owned())
     }
 }

--- a/crates/rune/src/ast/item_fn.rs
+++ b/crates/rune/src/ast/item_fn.rs
@@ -7,10 +7,10 @@ use runestick::Span;
 /// # Examples
 ///
 /// ```rust
-/// use rune::{testing, ast, parse_all};
+/// use rune::{testing, ast, parse_all_without_source};
 ///
 /// testing::roundtrip::<ast::ItemFn>("async fn hello() {}");
-/// assert!(parse_all::<ast::ItemFn>("fn async hello() {}").is_err());
+/// assert!(parse_all_without_source::<ast::ItemFn>("fn async hello() {}").is_err());
 ///
 /// let item = testing::roundtrip::<ast::ItemFn>("fn hello() {}");
 /// assert_eq!(item.args.len(), 0);

--- a/crates/rune/src/ast/lit_byte_str.rs
+++ b/crates/rune/src/ast/lit_byte_str.rs
@@ -1,9 +1,9 @@
 use crate::ast;
 use crate::{
-    Parse, ParseError, Parser, Resolve, ResolveError, ResolveErrorKind, ResolveOwned, Spanned,
-    Storage, ToTokens,
+    Parse, ParseError, Parser, Resolve, ResolveError, ResolveErrorKind, ResolveOwned, Sources,
+    Spanned, Storage, ToTokens,
 };
-use runestick::{Source, Span};
+use runestick::Span;
 use std::borrow::Cow;
 
 /// A string literal.
@@ -76,7 +76,7 @@ impl<'a> Resolve<'a> for LitByteStr {
     fn resolve(
         &self,
         storage: &Storage,
-        source: &'a Source,
+        sources: &'a Sources,
     ) -> Result<Cow<'a, [u8]>, ResolveError> {
         let span = self.token.span();
 
@@ -98,8 +98,8 @@ impl<'a> Resolve<'a> for LitByteStr {
         };
 
         let span = span.trim_start(2).trim_end(1);
-        let string = source
-            .source(span)
+        let string = sources
+            .source(text.source_id, span)
             .ok_or_else(|| ResolveError::new(span, ResolveErrorKind::BadSlice))?;
 
         Ok(if text.escaped {
@@ -116,8 +116,8 @@ impl ResolveOwned for LitByteStr {
     fn resolve_owned(
         &self,
         storage: &Storage,
-        source: &Source,
+        sources: &Sources,
     ) -> Result<Self::Owned, ResolveError> {
-        Ok(self.resolve(storage, source)?.into_owned())
+        Ok(self.resolve(storage, sources)?.into_owned())
     }
 }

--- a/crates/rune/src/ast/lit_number.rs
+++ b/crates/rune/src/ast/lit_number.rs
@@ -1,9 +1,9 @@
 use crate::ast;
 use crate::{
-    Parse, ParseError, Parser, Resolve, ResolveError, ResolveErrorKind, ResolveOwned, Spanned,
-    Storage, ToTokens,
+    Parse, ParseError, Parser, Resolve, ResolveError, ResolveErrorKind, ResolveOwned, Sources,
+    Spanned, Storage, ToTokens,
 };
-use runestick::{Source, Span};
+use runestick::Span;
 
 /// A number literal.
 #[derive(Debug, Clone, PartialEq, Eq, ToTokens, Spanned)]
@@ -41,7 +41,11 @@ impl Parse for LitNumber {
 impl<'a> Resolve<'a> for LitNumber {
     type Output = ast::Number;
 
-    fn resolve(&self, storage: &Storage, source: &'a Source) -> Result<ast::Number, ResolveError> {
+    fn resolve(
+        &self,
+        storage: &Storage,
+        sources: &'a Sources,
+    ) -> Result<ast::Number, ResolveError> {
         use num::Num as _;
         use std::str::FromStr as _;
 
@@ -60,8 +64,8 @@ impl<'a> Resolve<'a> for LitNumber {
             ast::NumberSource::Text(text) => text,
         };
 
-        let string = source
-            .source(span)
+        let string = sources
+            .source(text.source_id, span)
             .ok_or_else(|| ResolveError::new(span, ResolveErrorKind::BadSlice))?;
 
         if text.is_fractional {
@@ -91,8 +95,8 @@ impl ResolveOwned for LitNumber {
     fn resolve_owned(
         &self,
         storage: &Storage,
-        source: &Source,
+        sources: &Sources,
     ) -> Result<Self::Owned, ResolveError> {
-        self.resolve(storage, source)
+        self.resolve(storage, sources)
     }
 }

--- a/crates/rune/src/ast/mod.rs
+++ b/crates/rune/src/ast/mod.rs
@@ -217,24 +217,24 @@ decl_tokens! {
 
 #[cfg(test)]
 mod tests {
-    use crate::{ast, parse_all};
+    use crate::{ast, parse_all_without_source};
 
     #[test]
     fn test_expr() {
-        parse_all::<ast::Expr>("foo[\"foo\"]").unwrap();
-        parse_all::<ast::Expr>("foo.bar()").unwrap();
-        parse_all::<ast::Expr>("var()").unwrap();
-        parse_all::<ast::Expr>("var").unwrap();
-        parse_all::<ast::Expr>("42").unwrap();
-        parse_all::<ast::Expr>("1 + 2 / 3 - 4 * 1").unwrap();
-        parse_all::<ast::Expr>("foo[\"bar\"]").unwrap();
-        parse_all::<ast::Expr>("let var = 42").unwrap();
-        parse_all::<ast::Expr>("let var = \"foo bar\"").unwrap();
-        parse_all::<ast::Expr>("var[\"foo\"] = \"bar\"").unwrap();
-        parse_all::<ast::Expr>("let var = objects[\"foo\"] + 1").unwrap();
-        parse_all::<ast::Expr>("var = 42").unwrap();
+        parse_all_without_source::<ast::Expr>("foo[\"foo\"]").unwrap();
+        parse_all_without_source::<ast::Expr>("foo.bar()").unwrap();
+        parse_all_without_source::<ast::Expr>("var()").unwrap();
+        parse_all_without_source::<ast::Expr>("var").unwrap();
+        parse_all_without_source::<ast::Expr>("42").unwrap();
+        parse_all_without_source::<ast::Expr>("1 + 2 / 3 - 4 * 1").unwrap();
+        parse_all_without_source::<ast::Expr>("foo[\"bar\"]").unwrap();
+        parse_all_without_source::<ast::Expr>("let var = 42").unwrap();
+        parse_all_without_source::<ast::Expr>("let var = \"foo bar\"").unwrap();
+        parse_all_without_source::<ast::Expr>("var[\"foo\"] = \"bar\"").unwrap();
+        parse_all_without_source::<ast::Expr>("let var = objects[\"foo\"] + 1").unwrap();
+        parse_all_without_source::<ast::Expr>("var = 42").unwrap();
 
-        let expr = parse_all::<ast::Expr>(
+        let expr = parse_all_without_source::<ast::Expr>(
             r#"
             if 1 { } else { if 2 { } else { } }
         "#,
@@ -247,10 +247,10 @@ mod tests {
         }
 
         // Chained function calls.
-        parse_all::<ast::Expr>("foo.bar.baz()").unwrap();
-        parse_all::<ast::Expr>("foo[0][1][2]").unwrap();
-        parse_all::<ast::Expr>("foo.bar()[0].baz()[1]").unwrap();
+        parse_all_without_source::<ast::Expr>("foo.bar.baz()").unwrap();
+        parse_all_without_source::<ast::Expr>("foo[0][1][2]").unwrap();
+        parse_all_without_source::<ast::Expr>("foo.bar()[0].baz()[1]").unwrap();
 
-        parse_all::<ast::Expr>("42 is int::int").unwrap();
+        parse_all_without_source::<ast::Expr>("42 is int::int").unwrap();
     }
 }

--- a/crates/rune/src/ast/path.rs
+++ b/crates/rune/src/ast/path.rs
@@ -2,8 +2,8 @@ use crate::ast;
 use crate::parsing::Opaque;
 use crate::shared::Description;
 use crate::{
-    Id, Parse, ParseError, Parser, Peek, Peeker, Resolve, ResolveError, ResolveOwned, Spanned,
-    ToTokens,
+    Id, Parse, ParseError, Parser, Peek, Peeker, Resolve, ResolveError, ResolveOwned, Sources,
+    Spanned, Storage, ToTokens,
 };
 
 /// A path, where each element is separated by a `::`.
@@ -116,8 +116,8 @@ impl<'a> Resolve<'a> for Path {
 
     fn resolve(
         &self,
-        storage: &crate::Storage,
-        source: &'a runestick::Source,
+        storage: &Storage,
+        sources: &'a Sources,
     ) -> Result<Self::Output, ResolveError> {
         let mut buf = String::new();
 
@@ -133,7 +133,7 @@ impl<'a> Resolve<'a> for Path {
                 buf.push_str("self");
             }
             PathSegment::Ident(ident) => {
-                buf.push_str(ident.resolve(storage, source)?.as_ref());
+                buf.push_str(ident.resolve(storage, sources)?.as_ref());
             }
             PathSegment::Crate(_) => {
                 buf.push_str("crate");
@@ -157,7 +157,7 @@ impl<'a> Resolve<'a> for Path {
                     buf.push_str("self");
                 }
                 PathSegment::Ident(ident) => {
-                    buf.push_str(ident.resolve(storage, source)?.as_ref());
+                    buf.push_str(ident.resolve(storage, sources)?.as_ref());
                 }
                 PathSegment::Crate(_) => {
                     buf.push_str("crate");
@@ -184,10 +184,10 @@ impl ResolveOwned for Path {
 
     fn resolve_owned(
         &self,
-        storage: &crate::Storage,
-        source: &runestick::Source,
+        storage: &Storage,
+        sources: &Sources,
     ) -> Result<Self::Owned, ResolveError> {
-        self.resolve(storage, source)
+        self.resolve(storage, sources)
     }
 }
 

--- a/crates/rune/src/attrs/mod.rs
+++ b/crates/rune/src/attrs/mod.rs
@@ -1,7 +1,6 @@
 mod attributes;
 use crate::ast;
-use crate::{Parse, ParseError, Resolve as _, Storage};
-use runestick::Source;
+use crate::{Parse, ParseError, Resolve as _, Sources, Storage};
 
 pub(crate) use self::attributes::Attributes;
 
@@ -25,13 +24,13 @@ impl BuiltIn {
     pub(crate) fn args(
         &self,
         storage: &Storage,
-        source: &Source,
+        sources: &Sources,
     ) -> Result<BuiltInArgs, ParseError> {
         let mut out = BuiltInArgs::default();
 
         if let Some(args) = &self.args {
             for (ident, _) in args {
-                match ident.resolve(storage, source)?.as_ref() {
+                match ident.resolve(storage, sources)?.as_ref() {
                     "literal" => {
                         out.literal = true;
                     }

--- a/crates/rune/src/compiling/assembly.rs
+++ b/crates/rune/src/compiling/assembly.rs
@@ -2,7 +2,7 @@
 
 use crate::collections::HashMap;
 use crate::compiling::{CompileError, CompileErrorKind};
-use runestick::{Hash, Inst, Label, Location, Span};
+use runestick::{Hash, Inst, Label, Location, SourceId, Span};
 
 #[derive(Debug, Clone)]
 pub enum AssemblyInst {
@@ -32,7 +32,7 @@ pub struct Assembly {
     /// The number of labels.
     pub(crate) label_count: usize,
     /// The collection of functions required by this assembly.
-    pub(crate) required_functions: HashMap<Hash, Vec<(Span, usize)>>,
+    pub(crate) required_functions: HashMap<Hash, Vec<(Span, SourceId)>>,
 }
 
 impl Assembly {

--- a/crates/rune/src/compiling/compile_error.rs
+++ b/crates/rune/src/compiling/compile_error.rs
@@ -302,6 +302,8 @@ pub enum CompileErrorKind {
     NestedTest { nested_span: Span },
     #[error("#[bench] attributes are not supported on nested items")]
     NestedBench { nested_span: Span },
+    #[error("missing source id `{source_id}`")]
+    MissingSourceId { source_id: SourceId },
 }
 
 /// A single stap as an import entry.

--- a/crates/rune/src/compiling/unit_builder.rs
+++ b/crates/rune/src/compiling/unit_builder.rs
@@ -9,8 +9,8 @@ use crate::{CompileError, CompileErrorKind, Diagnostics};
 use runestick::debug::{DebugArgs, DebugSignature};
 use runestick::{
     Call, CompileMeta, CompileMetaKind, ConstValue, Context, DebugInfo, DebugInst, Hash, Inst,
-    IntoComponent, Item, Label, Location, Protocol, Rtti, Span, StaticString, Unit, UnitFn,
-    VariantRtti,
+    IntoComponent, Item, Label, Location, Protocol, Rtti, SourceId, Span, StaticString, Unit,
+    UnitFn, VariantRtti,
 };
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -579,7 +579,7 @@ impl UnitBuilder {
         for (hash, spans) in &inner.required_functions {
             if inner.functions.get(hash).is_none() && context.lookup(*hash).is_none() {
                 diagnostics.error(
-                    0,
+                    SourceId::empty(),
                     LinkerError::MissingFunction {
                         hash: *hash,
                         spans: spans.clone(),
@@ -599,7 +599,7 @@ pub enum LinkerError {
         /// Hash of the function.
         hash: Hash,
         /// Spans where the function is used.
-        spans: Vec<(Span, usize)>,
+        spans: Vec<(Span, SourceId)>,
     },
 }
 
@@ -639,7 +639,7 @@ struct Inner {
     /// The current label count.
     label_count: usize,
     /// A collection of required function hashes.
-    required_functions: HashMap<Hash, Vec<(Span, usize)>>,
+    required_functions: HashMap<Hash, Vec<(Span, SourceId)>>,
     /// Debug info if available for unit.
     debug: Option<Box<DebugInfo>>,
 

--- a/crates/rune/src/compiling/v1/assemble/builtin_template.rs
+++ b/crates/rune/src/compiling/v1/assemble/builtin_template.rs
@@ -18,7 +18,7 @@ impl Assemble for BuiltInTemplate {
                     ..
                 } = &**expr_lit
                 {
-                    let s = s.resolve_template_string(c.storage, &c.source)?;
+                    let s = s.resolve_template_string(c.storage, c.sources)?;
                     size_hint += s.len();
 
                     let slot = c.unit.new_static_string(span, &s)?;

--- a/crates/rune/src/compiling/v1/assemble/expr_assign.rs
+++ b/crates/rune/src/compiling/v1/assemble/expr_assign.rs
@@ -15,7 +15,7 @@ impl Assemble for ast::ExprAssign {
                     .first
                     .try_as_ident()
                     .ok_or_else(|| CompileError::msg(path, "unsupported path"))?;
-                let ident = segment.resolve(c.storage, &*c.source)?;
+                let ident = segment.resolve(c.storage, c.sources)?;
                 let var = c.scopes.get_var(&*ident, c.source_id, span)?;
                 c.asm.push(Inst::Replace { offset: var.offset }, span);
                 true
@@ -28,7 +28,7 @@ impl Assemble for ast::ExprAssign {
                 match &field_access.expr_field {
                     ast::ExprField::Path(path) => {
                         if let Some(ident) = path.try_as_ident() {
-                            let slot = ident.resolve(c.storage, &*c.source)?;
+                            let slot = ident.resolve(c.storage, c.sources)?;
                             let slot = c.unit.new_static_string(ident.span(), slot.as_ref())?;
 
                             self.rhs.assemble(c, Needs::Value)?.apply(c)?;
@@ -45,7 +45,7 @@ impl Assemble for ast::ExprAssign {
                         }
                     }
                     ast::ExprField::LitNumber(field) => {
-                        let number = field.resolve(c.storage, &*c.source)?;
+                        let number = field.resolve(c.storage, c.sources)?;
                         let index = number.as_tuple_index().ok_or_else(|| {
                             CompileError::new(
                                 span,

--- a/crates/rune/src/compiling/v1/assemble/expr_binary.rs
+++ b/crates/rune/src/compiling/v1/assemble/expr_binary.rs
@@ -146,7 +146,7 @@ fn compile_assign_binop(
                 .try_as_ident()
                 .ok_or_else(|| CompileError::msg(path, "unsupported path segment"))?;
 
-            let ident = segment.resolve(c.storage, &*c.source)?;
+            let ident = segment.resolve(c.storage, c.sources)?;
             let var = c.scopes.get_var(&*ident, c.source_id, span)?;
 
             Some(InstTarget::Offset(var.offset))
@@ -160,7 +160,7 @@ fn compile_assign_binop(
             match &field_access.expr_field {
                 ast::ExprField::Path(path) => {
                     if let Some(ident) = path.try_as_ident() {
-                        let n = ident.resolve(c.storage, &*c.source)?;
+                        let n = ident.resolve(c.storage, c.sources)?;
                         let n = c.unit.new_static_string(path.span(), n.as_ref())?;
 
                         Some(InstTarget::Field(n))
@@ -171,7 +171,7 @@ fn compile_assign_binop(
                 ast::ExprField::LitNumber(field) => {
                     let span = field.span();
 
-                    let number = field.resolve(c.storage, &*c.source)?;
+                    let number = field.resolve(c.storage, c.sources)?;
                     let index = number.as_tuple_index().ok_or_else(|| {
                         CompileError::new(span, CompileErrorKind::UnsupportedTupleIndex { number })
                     })?;

--- a/crates/rune/src/compiling/v1/assemble/expr_break.rs
+++ b/crates/rune/src/compiling/v1/assemble/expr_break.rs
@@ -26,7 +26,7 @@ impl Assemble for ast::ExprBreak {
                 }
                 ast::ExprBreakValue::Label(label) => {
                     let (last_loop, to_drop) =
-                        c.loops.walk_until_label(c.storage, &*c.source, *label)?;
+                        c.loops.walk_until_label(c.storage, c.sources, *label)?;
                     (last_loop, to_drop, false)
                 }
             }

--- a/crates/rune/src/compiling/v1/assemble/expr_call.rs
+++ b/crates/rune/src/compiling/v1/assemble/expr_call.rs
@@ -38,7 +38,7 @@ impl Assemble for ast::ExprCall {
                                 c.scopes.decl_anon(span)?;
                             }
 
-                            let ident = ident.resolve(c.storage, &*c.source)?;
+                            let ident = ident.resolve(c.storage, c.sources)?;
                             let hash = Hash::instance_fn_name(ident.as_ref());
                             c.asm.push(Inst::CallInstance { hash, args }, span);
                             false

--- a/crates/rune/src/compiling/v1/assemble/expr_closure.rs
+++ b/crates/rune/src/compiling/v1/assemble/expr_closure.rs
@@ -56,7 +56,10 @@ impl Assemble for ast::ExprClosure {
         let item = c.query.item_for(self)?;
         let hash = Hash::type_hash(&item.item);
 
-        let meta = match c.query.query_meta(span, &item.item, Default::default())? {
+        let meta = match c
+            .query
+            .query_meta(c.sources, span, &item.item, Default::default())?
+        {
             Some(meta) => meta,
             None => {
                 return Err(CompileError::new(

--- a/crates/rune/src/compiling/v1/assemble/expr_continue.rs
+++ b/crates/rune/src/compiling/v1/assemble/expr_continue.rs
@@ -17,7 +17,7 @@ impl Assemble for ast::ExprContinue {
         };
 
         let last_loop = if let Some(label) = &self.label {
-            let (last_loop, _) = c.loops.walk_until_label(c.storage, &*c.source, *label)?;
+            let (last_loop, _) = c.loops.walk_until_label(c.storage, c.sources, *label)?;
             last_loop
         } else {
             current_loop

--- a/crates/rune/src/compiling/v1/assemble/expr_field_access.rs
+++ b/crates/rune/src/compiling/v1/assemble/expr_field_access.rs
@@ -24,7 +24,7 @@ impl Assemble for ast::ExprFieldAccess {
 
         match &self.expr_field {
             ast::ExprField::LitNumber(n) => {
-                if let Some(index) = n.resolve(c.storage, &*c.source)?.as_tuple_index() {
+                if let Some(index) = n.resolve(c.storage, c.sources)?.as_tuple_index() {
                     c.asm.push(Inst::TupleIndexGet { index }, span);
 
                     if !needs.value() {
@@ -37,7 +37,7 @@ impl Assemble for ast::ExprFieldAccess {
             }
             ast::ExprField::Path(path) => {
                 if let Some(ident) = path.try_as_ident() {
-                    let field = ident.resolve(c.storage, &*c.source)?;
+                    let field = ident.resolve(c.storage, c.sources)?;
                     let slot = c.unit.new_static_string(span, field.as_ref())?;
 
                     c.asm.push(Inst::ObjectIndexGet { slot }, span);
@@ -68,9 +68,9 @@ fn try_immediate_field_access_optimization(
         None => return Ok(false),
     };
 
-    let ident = ident.resolve(this.storage, &*this.source)?;
+    let ident = ident.resolve(this.storage, this.sources)?;
 
-    let index = match n.resolve(this.storage, &*this.source)? {
+    let index = match n.resolve(this.storage, this.sources)? {
         ast::Number::Integer(n) => n,
         _ => return Ok(false),
     };

--- a/crates/rune/src/compiling/v1/assemble/expr_object.rs
+++ b/crates/rune/src/compiling/v1/assemble/expr_object.rs
@@ -15,7 +15,7 @@ impl Assemble for ast::ExprObject {
 
         for (assign, _) in &self.assignments {
             let span = assign.span();
-            let key = assign.key.resolve(c.storage, &*c.source)?;
+            let key = assign.key.resolve(c.storage, c.sources)?;
             keys.push(key.as_ref().into());
             check_keys.push((key.as_ref().into(), assign.key.span()));
 
@@ -36,7 +36,7 @@ impl Assemble for ast::ExprObject {
             if let Some((_, expr)) = &assign.assign {
                 expr.assemble(c, Needs::Value)?.apply(c)?;
             } else {
-                let key = assign.key.resolve(c.storage, &*c.source)?;
+                let key = assign.key.resolve(c.storage, c.sources)?;
                 let var = c.scopes.get_var(&*key, c.source_id, span)?;
                 var.copy(&mut c.asm, span, format!("name `{}`", key));
             }

--- a/crates/rune/src/compiling/v1/assemble/expr_unary.rs
+++ b/crates/rune/src/compiling/v1/assemble/expr_unary.rs
@@ -13,7 +13,7 @@ impl Assemble for ast::ExprUnary {
 
         if let (ast::UnOp::Neg, ast::Expr::Lit(expr_lit)) = (self.op, &self.expr) {
             if let ast::Lit::Number(n) = &expr_lit.lit {
-                match n.resolve(c.storage, &*c.source)? {
+                match n.resolve(c.storage, c.sources)? {
                     ast::Number::Float(n) => {
                         c.asm.push(Inst::float(-n), span);
                     }

--- a/crates/rune/src/compiling/v1/assemble/lit_byte.rs
+++ b/crates/rune/src/compiling/v1/assemble/lit_byte.rs
@@ -12,7 +12,7 @@ impl Assemble for ast::LitByte {
             return Ok(Asm::top(span));
         }
 
-        let b = self.resolve(c.storage, &*c.source)?;
+        let b = self.resolve(c.storage, c.sources)?;
         c.asm.push(Inst::byte(b), span);
         Ok(Asm::top(span))
     }

--- a/crates/rune/src/compiling/v1/assemble/lit_byte_str.rs
+++ b/crates/rune/src/compiling/v1/assemble/lit_byte_str.rs
@@ -12,7 +12,7 @@ impl Assemble for ast::LitByteStr {
             return Ok(Asm::top(span));
         }
 
-        let bytes = self.resolve(c.storage, &*c.source)?;
+        let bytes = self.resolve(c.storage, c.sources)?;
         let slot = c.unit.new_static_bytes(span, &*bytes)?;
         c.asm.push(Inst::Bytes { slot }, span);
         Ok(Asm::top(span))

--- a/crates/rune/src/compiling/v1/assemble/lit_char.rs
+++ b/crates/rune/src/compiling/v1/assemble/lit_char.rs
@@ -12,7 +12,7 @@ impl Assemble for ast::LitChar {
             return Ok(Asm::top(span));
         }
 
-        let ch = self.resolve(c.storage, &*c.source)?;
+        let ch = self.resolve(c.storage, c.sources)?;
         c.asm.push(Inst::char(ch), span);
         Ok(Asm::top(span))
     }

--- a/crates/rune/src/compiling/v1/assemble/lit_number.rs
+++ b/crates/rune/src/compiling/v1/assemble/lit_number.rs
@@ -14,7 +14,7 @@ impl Assemble for ast::LitNumber {
             return Ok(Asm::top(span));
         }
 
-        let number = self.resolve(c.storage, &*c.source)?;
+        let number = self.resolve(c.storage, c.sources)?;
 
         match number {
             ast::Number::Float(number) => {

--- a/crates/rune/src/compiling/v1/assemble/lit_str.rs
+++ b/crates/rune/src/compiling/v1/assemble/lit_str.rs
@@ -12,7 +12,7 @@ impl Assemble for ast::LitStr {
             return Ok(Asm::top(span));
         }
 
-        let string = self.resolve(c.storage, &*c.source)?;
+        let string = self.resolve(c.storage, c.sources)?;
         let slot = c.unit.new_static_string(span, &*string)?;
         c.asm.push(Inst::String { slot }, span);
         Ok(Asm::top(span))

--- a/crates/rune/src/compiling/v1/loops.rs
+++ b/crates/rune/src/compiling/v1/loops.rs
@@ -1,7 +1,7 @@
 use crate::ast;
 use crate::compiling::v1::Needs;
-use crate::{CompileError, CompileErrorKind, CompileResult, Spanned as _, Storage};
-use runestick::{Label, Source};
+use crate::{CompileError, CompileErrorKind, CompileResult, Sources, Spanned as _, Storage};
+use runestick::Label;
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -65,13 +65,13 @@ impl Loops {
     pub(crate) fn walk_until_label(
         &self,
         storage: &Storage,
-        source: &Source,
+        sources: &Sources,
         expected: ast::Label,
     ) -> CompileResult<(Loop, Vec<usize>)> {
         use crate::parsing::Resolve as _;
 
         let span = expected.span();
-        let expected = expected.resolve(storage, source)?;
+        let expected = expected.resolve(storage, sources)?;
         let mut to_drop = Vec::new();
 
         for l in self.loops.borrow().iter().rev() {
@@ -84,7 +84,7 @@ impl Loops {
                 }
             };
 
-            let label = label.resolve(storage, source)?;
+            let label = label.resolve(storage, sources)?;
 
             if expected == label {
                 return Ok((*l, to_drop));

--- a/crates/rune/src/diagnostics/mod.rs
+++ b/crates/rune/src/diagnostics/mod.rs
@@ -82,12 +82,12 @@ impl Diagnostics {
     ///
     /// ```rust
     /// use rune::{Diagnostic, Diagnostics};
-    /// use runestick::Span;
+    /// use runestick::{SourceId, Span};
     ///
     /// let mut diagnostics = Diagnostics::without_warnings();
     /// assert!(diagnostics.is_empty());
     ///
-    /// diagnostics.not_used(0, Span::empty(), None);
+    /// diagnostics.not_used(SourceId::empty(), Span::empty(), None);
     ///
     /// assert!(diagnostics.is_empty());
     /// let warning = diagnostics.into_diagnostics().into_iter().next();
@@ -103,12 +103,12 @@ impl Diagnostics {
     ///
     /// ```rust
     /// use rune::{Diagnostic, Diagnostics, Warning, WarningKind};
-    /// use runestick::Span;
+    /// use runestick::{SourceId, Span};
     ///
     /// let mut diagnostics = Diagnostics::new();
     /// assert!(diagnostics.is_empty());
     ///
-    /// diagnostics.not_used(0, Span::empty(), None);
+    /// diagnostics.not_used(SourceId::empty(), Span::empty(), None);
     ///
     /// assert!(!diagnostics.is_empty());
     ///
@@ -155,14 +155,19 @@ impl Diagnostics {
     }
 
     /// Indicate that a value is produced but never used.
-    pub fn not_used(&mut self, source_id: usize, span: Span, context: Option<Span>) {
+    pub fn not_used(&mut self, source_id: SourceId, span: Span, context: Option<Span>) {
         self.warning(source_id, WarningKind::NotUsed { span, context });
     }
 
     /// Indicate that a binding pattern might panic.
     ///
     /// Like `let (a, b) = value`.
-    pub fn let_pattern_might_panic(&mut self, source_id: usize, span: Span, context: Option<Span>) {
+    pub fn let_pattern_might_panic(
+        &mut self,
+        source_id: SourceId,
+        span: Span,
+        context: Option<Span>,
+    ) {
         self.warning(
             source_id,
             WarningKind::LetPatternMightPanic { span, context },
@@ -175,7 +180,7 @@ impl Diagnostics {
     /// Like `` `Hello` ``.
     pub fn template_without_expansions(
         &mut self,
-        source_id: usize,
+        source_id: SourceId,
         span: Span,
         context: Option<Span>,
     ) {
@@ -191,7 +196,7 @@ impl Diagnostics {
     /// Like `None()`.
     pub fn remove_tuple_call_parens(
         &mut self,
-        source_id: usize,
+        source_id: SourceId,
         span: Span,
         variant: Span,
         context: Option<Span>,
@@ -207,7 +212,7 @@ impl Diagnostics {
     }
 
     /// Add a warning about an unecessary semi-colon.
-    pub fn uneccessary_semi_colon(&mut self, source_id: usize, span: Span) {
+    pub fn uneccessary_semi_colon(&mut self, source_id: SourceId, span: Span) {
         self.warning(source_id, WarningKind::UnecessarySemiColon { span });
     }
 

--- a/crates/rune/src/indexing/index_local.rs
+++ b/crates/rune/src/indexing/index_local.rs
@@ -13,7 +13,7 @@ pub(crate) trait IndexLocal {
 impl IndexLocal for ast::Pat {
     fn index_local(&mut self, idx: &mut Indexer<'_>) -> CompileResult<()> {
         let span = self.span();
-        log::trace!("Pat => {:?}", idx.source.source(span));
+        log::trace!("Pat => {:?}", idx.sources.source(idx.source_id, span));
 
         match self {
             ast::Pat::PatPath(pat_path) => {
@@ -43,7 +43,7 @@ impl IndexLocal for ast::Pat {
 impl IndexLocal for ast::PatPath {
     fn index_local(&mut self, idx: &mut Indexer<'_>) -> CompileResult<()> {
         let span = self.span();
-        log::trace!("Ident => {:?}", idx.source.source(span));
+        log::trace!("Ident => {:?}", idx.sources.source(idx.source_id, span));
         self.path.index_local(idx)?;
         Ok(())
     }
@@ -52,7 +52,7 @@ impl IndexLocal for ast::PatPath {
 impl IndexLocal for ast::Path {
     fn index_local(&mut self, idx: &mut Indexer<'_>) -> CompileResult<()> {
         let span = self.span();
-        log::trace!("Ident => {:?}", idx.source.source(span));
+        log::trace!("Ident => {:?}", idx.sources.source(idx.source_id, span));
 
         let id = idx
             .query
@@ -70,10 +70,10 @@ impl IndexLocal for ast::Path {
 impl IndexLocal for ast::Ident {
     fn index_local(&mut self, idx: &mut Indexer<'_>) -> CompileResult<()> {
         let span = self.span();
-        log::trace!("Ident => {:?}", idx.source.source(span));
+        log::trace!("Ident => {:?}", idx.sources.source(idx.source_id, span));
 
         let span = self.span();
-        let ident = self.resolve(&idx.storage, &*idx.source)?;
+        let ident = self.resolve(&idx.storage, idx.sources)?;
         idx.scopes.declare(ident.as_ref(), span)?;
         Ok(())
     }
@@ -82,7 +82,7 @@ impl IndexLocal for ast::Ident {
 impl IndexLocal for ast::PatObject {
     fn index_local(&mut self, idx: &mut Indexer<'_>) -> CompileResult<()> {
         let span = self.span();
-        log::trace!("PatObject => {:?}", idx.source.source(span));
+        log::trace!("PatObject => {:?}", idx.sources.source(idx.source_id, span));
 
         match &mut self.ident {
             ast::ObjectIdent::Anonymous(_) => {}
@@ -102,7 +102,7 @@ impl IndexLocal for ast::PatObject {
 impl IndexLocal for ast::PatVec {
     fn index_local(&mut self, idx: &mut Indexer<'_>) -> CompileResult<()> {
         let span = self.span();
-        log::trace!("PatVec => {:?}", idx.source.source(span));
+        log::trace!("PatVec => {:?}", idx.sources.source(idx.source_id, span));
 
         for (pat, _) in &mut self.items {
             pat.index_local(idx)?;
@@ -115,7 +115,7 @@ impl IndexLocal for ast::PatVec {
 impl IndexLocal for ast::PatTuple {
     fn index_local(&mut self, idx: &mut Indexer<'_>) -> CompileResult<()> {
         let span = self.span();
-        log::trace!("PatTuple => {:?}", idx.source.source(span));
+        log::trace!("PatTuple => {:?}", idx.sources.source(idx.source_id, span));
 
         if let Some(path) = &mut self.path {
             path.index_local(idx)?;
@@ -132,7 +132,10 @@ impl IndexLocal for ast::PatTuple {
 impl IndexLocal for ast::PatBinding {
     fn index_local(&mut self, idx: &mut Indexer<'_>) -> CompileResult<()> {
         let span = self.span();
-        log::trace!("PatBinding => {:?}", idx.source.source(span));
+        log::trace!(
+            "PatBinding => {:?}",
+            idx.sources.source(idx.source_id, span)
+        );
         self.pat.index_local(idx)?;
         Ok(())
     }

--- a/crates/rune/src/ir/ir_compiler.rs
+++ b/crates/rune/src/ir/ir_compiler.rs
@@ -1,17 +1,15 @@
+use crate::ast;
 use crate::ir;
 use crate::query::BuiltInMacro;
 use crate::query::BuiltInTemplate;
-use crate::{IrErrorKind, Resolve, Spanned, Storage};
-use runestick::{Bytes, ConstValue, Source};
-use std::sync::Arc;
-
-use crate::ast;
 use crate::IrError;
+use crate::{IrErrorKind, Resolve, Sources, Spanned, Storage};
+use runestick::{Bytes, ConstValue};
 
 /// A c that compiles AST into Rune IR.
 pub struct IrCompiler<'a> {
     pub(crate) storage: Storage,
-    pub(crate) source: Arc<Source>,
+    pub(crate) sources: &'a Sources,
     pub(crate) query: &'a mut dyn ir::IrQuery,
 }
 
@@ -29,7 +27,7 @@ impl IrCompiler<'_> {
     where
         T: Resolve<'s>,
     {
-        Ok(value.resolve(&self.storage, &*self.source)?)
+        Ok(value.resolve(&self.storage, self.sources)?)
     }
 
     /// Resolve an ir target from an expression.
@@ -500,7 +498,7 @@ impl IrCompile for BuiltInTemplate {
                     ..
                 } = &**expr_lit
                 {
-                    let s = s.resolve_template_string(&c.storage, &c.source)?;
+                    let s = s.resolve_template_string(&c.storage, c.sources)?;
 
                     components.push(ir::IrTemplateComponent::String(
                         s.into_owned().into_boxed_str(),

--- a/crates/rune/src/ir/ir_query.rs
+++ b/crates/rune/src/ir/ir_query.rs
@@ -1,5 +1,6 @@
 use crate::parsing::Id;
 use crate::query::{BuiltInMacro, QueryConstFn, QueryError, Used};
+use crate::Sources;
 use runestick::{CompileMeta, Item, Span};
 use std::sync::Arc;
 
@@ -8,6 +9,7 @@ pub(crate) trait IrQuery {
     /// Query for the given meta.
     fn query_meta(
         &mut self,
+        sources: &Sources,
         span: Span,
         item: &Item,
         used: Used,

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -230,13 +230,27 @@ pub use rune_macros::quote;
 pub(crate) use rune_macros::{OptionSpanned, Parse, Spanned, ToTokens};
 
 /// Parse the given input as the given type that implements
-/// [Parse][crate::parsing::Parse].
-pub fn parse_all<T>(source: &str) -> Result<T, ParseError>
+/// [Parse][crate::parsing::Parse]. The specified `source_id` will be used when
+/// referencing any parsed elements.
+pub fn parse_all<T>(source: &str, source_id: runestick::SourceId) -> Result<T, ParseError>
 where
     T: crate::parsing::Parse,
 {
-    let mut parser = Parser::new(source);
+    let mut parser = Parser::new(source, source_id);
     let ast = parser.parse::<T>()?;
     parser.eof()?;
     Ok(ast)
+}
+
+/// Parse the given input as the given type that implements
+/// [Parse][crate::parsing::Parse].
+///
+/// This uses an empty [SourceId][runestick::SourceId] and is therefore not
+/// appropriate to use beyond testing that a certain type parses.
+#[doc(hidden)]
+pub fn parse_all_without_source<T>(source: &str) -> Result<T, ParseError>
+where
+    T: crate::parsing::Parse,
+{
+    parse_all(source, runestick::SourceId::empty())
 }

--- a/crates/rune/src/load/mod.rs
+++ b/crates/rune/src/load/mod.rs
@@ -1,6 +1,6 @@
 use crate::compiling;
 use crate::{Diagnostics, Options};
-use runestick::{Context, Unit};
+use runestick::{Context, SourceId, Unit};
 use std::rc::Rc;
 use thiserror::Error;
 
@@ -120,7 +120,7 @@ pub fn load_sources_with_visitor<'a>(
     match unit.build() {
         Ok(unit) => Ok(unit),
         Err(error) => {
-            diagnostics.error(0, error);
+            diagnostics.error(SourceId::empty(), error);
             Err(LoadSourcesError)
         }
     }

--- a/crates/rune/src/load/sources.rs
+++ b/crates/rune/src/load/sources.rs
@@ -1,4 +1,8 @@
-use runestick::{Source, SourceId};
+#[cfg(feature = "codespan-reporting")]
+use codespan_reporting::files;
+use runestick::{Source, SourceId, Span};
+use std::convert::TryFrom;
+use std::path::Path;
 use std::sync::Arc;
 
 /// A collection of source files, and a queue of things to compile.
@@ -18,7 +22,7 @@ impl Sources {
 
     /// Get the source at the given source id.
     pub fn source_at(&self, source_id: SourceId) -> Option<&Arc<Source>> {
-        self.sources.get(source_id)
+        self.sources.get(source_id.into_index())
     }
 
     /// Insert a source to be built and return its id.
@@ -29,23 +33,74 @@ impl Sources {
 
     /// Insert a source to be built and return its id.
     pub fn insert(&mut self, source: Source) -> SourceId {
-        let source_id = self.sources.len();
+        let source_id =
+            SourceId::try_from(self.sources.len()).expect("could not build a source identifier");
         self.sources.push(Arc::new(source));
         source_id
     }
 
+    /// Fetch name for the given source id.
+    pub fn name(&self, source_id: SourceId) -> Option<&str> {
+        let source = self.sources.get(source_id.into_index())?;
+        Some(source.name())
+    }
+
+    /// Fetch source for the given span.
+    pub fn source(&self, source_id: SourceId, span: Span) -> Option<&str> {
+        let source = self.sources.get(source_id.into_index())?;
+        source.source(span)
+    }
+
+    /// Access the optional path of the given source id.
+    pub fn path(&self, source_id: SourceId) -> Option<&Path> {
+        let source = self.sources.get(source_id.into_index())?;
+        source.path()
+    }
+
     /// Get the source matching the given source id.
-    pub fn get(&self, source_id: usize) -> Option<&Arc<Source>> {
-        self.sources.get(source_id)
+    pub fn get(&self, source_id: SourceId) -> Option<&Arc<Source>> {
+        self.sources.get(source_id.into_index())
     }
 
     /// Get all available source ids.
     pub(crate) fn source_ids(&self) -> impl Iterator<Item = SourceId> {
-        0..self.sources.len()
+        (0..self.sources.len()).map(|index| SourceId::new(index as u32))
+    }
+}
+
+#[cfg(feature = "codespan-reporting")]
+impl<'a> files::Files<'a> for Sources {
+    type FileId = SourceId;
+    type Name = &'a str;
+    type Source = &'a str;
+
+    fn name(&'a self, file_id: SourceId) -> Result<Self::Name, files::Error> {
+        let source = self.get(file_id).ok_or_else(|| files::Error::FileMissing)?;
+        Ok(source.name())
     }
 
-    /// Iterate over all sources in order by index.
-    pub(crate) fn iter(&self) -> impl Iterator<Item = &Source> {
-        self.sources.iter().map(|s| &**s)
+    fn source(&'a self, file_id: SourceId) -> Result<Self::Source, files::Error> {
+        let source = self.get(file_id).ok_or_else(|| files::Error::FileMissing)?;
+        Ok(source.as_str())
+    }
+
+    fn line_index(&self, file_id: SourceId, byte_index: usize) -> Result<usize, files::Error> {
+        let source = self.get(file_id).ok_or_else(|| files::Error::FileMissing)?;
+        Ok(source.line_index(byte_index))
+    }
+
+    fn line_range(
+        &self,
+        file_id: SourceId,
+        line_index: usize,
+    ) -> Result<std::ops::Range<usize>, files::Error> {
+        let source = self.get(file_id).ok_or_else(|| files::Error::FileMissing)?;
+        let range = source
+            .line_range(line_index)
+            .ok_or_else(|| files::Error::LineTooLarge {
+                given: line_index,
+                max: source.line_count(),
+            })?;
+        Ok(range)
     }
 }

--- a/crates/rune/src/macros/mod.rs
+++ b/crates/rune/src/macros/mod.rs
@@ -9,11 +9,11 @@ mod storage;
 mod token_stream;
 
 pub use self::format_args::FormatArgs;
-pub use self::functions::{eval, resolve, stringify, to_tokens};
+pub use self::functions::{eval, parse_all, resolve, stringify, to_tokens};
 pub use self::macro_context::{with_context, IntoLit, MacroContext};
 pub use self::quote_fn::{quote_fn, Quote};
 pub use self::storage::Storage;
 pub use self::token_stream::{ToTokens, TokenStream, TokenStreamIter};
 
 pub(crate) use self::macro_compiler::MacroCompiler;
-pub(crate) use self::macro_context::{current_context, current_stream_span};
+pub(crate) use self::macro_context::{current_context, current_context_mut, current_stream_span};

--- a/crates/rune/src/parsing/parse_error.rs
+++ b/crates/rune/src/parsing/parse_error.rs
@@ -2,7 +2,7 @@ use crate::ast;
 use crate::parsing::{LexerMode, ResolveError, ResolveErrorKind};
 use crate::shared::Description;
 use crate::Spanned;
-use runestick::SpannedError;
+use runestick::{SourceId, SpannedError};
 
 use thiserror::Error;
 
@@ -110,4 +110,6 @@ pub enum ParseErrorKind {
     BadNumber,
     #[error("can only specify one attribute named `{name}`")]
     MultipleMatchingAttributes { name: &'static str },
+    #[error("missing source id `{source_id}`")]
+    MissingSourceId { source_id: SourceId },
 }

--- a/crates/rune/src/parsing/parser.rs
+++ b/crates/rune/src/parsing/parser.rs
@@ -2,7 +2,7 @@ use crate::ast::{Kind, Token};
 use crate::macros::{TokenStream, TokenStreamIter};
 use crate::parsing::{Lexer, Parse, ParseError, ParseErrorKind, Peek};
 use crate::OptionSpanned as _;
-use runestick::Span;
+use runestick::{SourceId, Span};
 use std::collections::VecDeque;
 use std::fmt;
 use std::ops;
@@ -13,8 +13,9 @@ use std::ops;
 ///
 /// ```rust
 /// use rune::{ast, Parser};
+/// use runestick::SourceId;
 ///
-/// let mut parser = Parser::new("fn foo() {}");
+/// let mut parser = Parser::new("fn foo() {}", SourceId::empty());
 /// parser.parse::<ast::ItemFn>().unwrap();
 /// ```
 #[derive(Debug)]
@@ -26,9 +27,9 @@ pub struct Parser<'a> {
 
 impl<'a> Parser<'a> {
     /// Construct a new parser around the given source.
-    pub fn new(source: &'a str) -> Self {
+    pub fn new(source: &'a str, source_id: SourceId) -> Self {
         Self::with_source(Source {
-            inner: SourceInner::Lexer(Lexer::new(source)),
+            inner: SourceInner::Lexer(Lexer::new(source, source_id)),
         })
     }
 

--- a/crates/rune/src/parsing/resolve.rs
+++ b/crates/rune/src/parsing/resolve.rs
@@ -1,7 +1,7 @@
 use crate::macros::Storage;
 use crate::shared::Description;
-use crate::Spanned;
-use runestick::{Source, SpannedError};
+use crate::{Sources, Spanned};
+use runestick::SpannedError;
 use thiserror::Error;
 
 error! {
@@ -80,7 +80,11 @@ pub trait Resolve<'a>: ResolveOwned {
     type Output: 'a;
 
     /// Resolve the value from parsed AST.
-    fn resolve(&self, storage: &Storage, source: &'a Source) -> Result<Self::Output, ResolveError>;
+    fn resolve(
+        &self,
+        storage: &Storage,
+        sources: &'a Sources,
+    ) -> Result<Self::Output, ResolveError>;
 }
 
 /// Trait for resolving a token into an owned value.
@@ -92,6 +96,6 @@ pub trait ResolveOwned {
     fn resolve_owned(
         &self,
         storage: &Storage,
-        source: &Source,
+        sources: &Sources,
     ) -> Result<Self::Owned, ResolveError>;
 }

--- a/crates/rune/src/shared/mod.rs
+++ b/crates/rune/src/shared/mod.rs
@@ -6,6 +6,7 @@ mod items;
 mod scopes;
 #[cfg(compiler_v2)]
 mod with_span;
+mod x_or_owned;
 
 pub(crate) use self::consts::Consts;
 pub(crate) use self::custom::Custom;
@@ -16,3 +17,4 @@ pub(crate) use self::scopes::Scopes;
 pub use self::scopes::{ScopeError, ScopeErrorKind};
 #[cfg(compiler_v2)]
 pub(crate) use self::with_span::{ResultExt, WithSpan};
+pub(crate) use self::x_or_owned::{MutOrOwned, RefOrOwned};

--- a/crates/rune/src/shared/x_or_owned.rs
+++ b/crates/rune/src/shared/x_or_owned.rs
@@ -1,0 +1,97 @@
+use std::ptr;
+
+/// An unsafe container that can either unsafely hold a reference through an
+/// unsafe API or an owned type.
+#[repr(transparent)]
+pub(crate) struct RefOrOwned<T> {
+    kind: RefOrOwnedKind<T>,
+}
+
+enum RefOrOwnedKind<T> {
+    Ptr(ptr::NonNull<T>),
+    Owned(T),
+}
+
+impl<T> RefOrOwned<T> {
+    /// Construct from an owned value.
+    pub(crate) fn from_owned(value: T) -> Self {
+        Self {
+            kind: RefOrOwnedKind::Owned(value),
+        }
+    }
+
+    /// Construct from a reference.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure that this struct is not used after the data it's
+    /// pointing to has been freed.
+    pub(crate) unsafe fn from_ref(value: &T) -> Self {
+        Self {
+            kind: RefOrOwnedKind::Ptr(value.into()),
+        }
+    }
+
+    /// Get as reference.
+    pub(crate) fn as_ref(&self) -> &T {
+        // SAFETY: This is a private enum and can only safely be constructed in
+        // contexts where we tightly control the lifetime of Storage.
+        match &self.kind {
+            RefOrOwnedKind::Ptr(ptr) => unsafe { ptr.as_ref() },
+            RefOrOwnedKind::Owned(value) => value,
+        }
+    }
+}
+
+/// An unsafe container that can either unsafely hold an exlusive reference
+/// through an unsafe API or an owned type.
+#[repr(transparent)]
+pub(crate) struct MutOrOwned<T> {
+    kind: MutOrOwnedKind<T>,
+}
+
+enum MutOrOwnedKind<T> {
+    Ptr(ptr::NonNull<T>),
+    Owned(T),
+}
+
+impl<T> MutOrOwned<T> {
+    /// Construct from an owned value.
+    pub(crate) fn from_owned(value: T) -> Self {
+        Self {
+            kind: MutOrOwnedKind::Owned(value),
+        }
+    }
+
+    /// Construct from a mutable reference.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure that this struct is not used after the data it's
+    /// pointing to has been freed.
+    pub(crate) unsafe fn from_mut(value: &mut T) -> Self {
+        Self {
+            kind: MutOrOwnedKind::Ptr(value.into()),
+        }
+    }
+
+    /// Get as reference.
+    pub(crate) fn as_ref(&self) -> &T {
+        // SAFETY: This is a private enum and can only safely be constructed in
+        // contexts where we tightly control the lifetime of Storage.
+        match &self.kind {
+            MutOrOwnedKind::Ptr(ptr) => unsafe { ptr.as_ref() },
+            MutOrOwnedKind::Owned(value) => value,
+        }
+    }
+
+    /// Get as mutable reference.
+    pub(crate) fn as_mut(&mut self) -> &mut T {
+        // SAFETY: This is a private enum and can only safely be constructed in
+        // contexts where we tightly control the lifetime of Storage.
+        match &mut self.kind {
+            MutOrOwnedKind::Ptr(ptr) => unsafe { ptr.as_mut() },
+            MutOrOwnedKind::Owned(value) => value,
+        }
+    }
+}

--- a/crates/rune/src/testing.rs
+++ b/crates/rune/src/testing.rs
@@ -1,3 +1,5 @@
+use runestick::SourceId;
+
 /// Function used during parse testing to take the source, parse it as the given
 /// type, tokenize it using [ToTokens][crate::macros::ToTokens], and parse the
 /// token stream.
@@ -7,7 +9,9 @@ pub fn roundtrip<T>(source: &str) -> T
 where
     T: crate::parsing::Parse + crate::macros::ToTokens + PartialEq + Eq + std::fmt::Debug,
 {
-    let mut parser = crate::parsing::Parser::new(source);
+    let source_id = SourceId::empty();
+
+    let mut parser = crate::parsing::Parser::new(source, source_id);
     let ast = parser.parse::<T>().expect("first parse");
     parser.eof().expect("first parse eof");
 

--- a/crates/rune/src/worker/wildcard_import.rs
+++ b/crates/rune/src/worker/wildcard_import.rs
@@ -1,6 +1,6 @@
 use crate::query::Query;
 use crate::{CompileError, CompileErrorKind, CompileResult};
-use runestick::{CompileMod, Context, Item, Source, SourceId, Span, Visibility};
+use runestick::{CompileMod, Context, Item, SourceId, Span, Visibility};
 use std::sync::Arc;
 
 #[derive(Debug)]
@@ -9,7 +9,6 @@ pub(crate) struct WildcardImport {
     pub(crate) from: Item,
     pub(crate) name: Item,
     pub(crate) source_id: SourceId,
-    pub(crate) source: Arc<Source>,
     pub(crate) span: Span,
     pub(crate) module: Arc<CompileMod>,
     pub(crate) found: bool,
@@ -24,7 +23,6 @@ impl WildcardImport {
                 query.insert_import(
                     self.source_id,
                     self.span,
-                    &self.source,
                     &self.module,
                     self.visibility,
                     self.from.clone(),
@@ -48,7 +46,6 @@ impl WildcardImport {
                 query.insert_import(
                     self.source_id,
                     self.span,
-                    &self.source,
                     &self.module,
                     self.visibility,
                     self.from.clone(),

--- a/crates/runestick/src/compile_meta.rs
+++ b/crates/runestick/src/compile_meta.rs
@@ -1,7 +1,7 @@
 use crate::collections::HashSet;
-use crate::{ConstValue, Hash, Id, Item, Location, SourceId, Span, Visibility};
+use crate::{ConstValue, Hash, Id, Item, Location, Visibility};
 use std::fmt;
-use std::path::PathBuf;
+use std::path::Path;
 use std::sync::Arc;
 
 /// Metadata about a closure.
@@ -25,12 +25,10 @@ pub struct CompileMeta {
 /// Information on a compile sourc.
 #[derive(Debug, Clone)]
 pub struct CompileSource {
-    /// The source id where the compile meta is defined.
-    pub source_id: SourceId,
-    /// The span where the meta is declared.
-    pub span: Span,
+    /// The location of the compile source.
+    pub location: Location,
     /// The optional source id where the meta is declared.
-    pub path: Option<PathBuf>,
+    pub path: Option<Box<Path>>,
 }
 
 impl CompileMeta {

--- a/crates/runestick/src/debug.rs
+++ b/crates/runestick/src/debug.rs
@@ -1,7 +1,7 @@
 //! Debug information for units.
 
 use crate::collections::HashMap;
-use crate::{DebugLabel, Hash, Item, Span};
+use crate::{DebugLabel, Hash, Item, SourceId, Span};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -36,7 +36,7 @@ impl DebugInfo {
 #[non_exhaustive]
 pub struct DebugInst {
     /// The file by id the instruction belongs to.
-    pub source_id: usize,
+    pub source_id: SourceId,
     /// The span of the instruction.
     pub span: Span,
     /// The comment for the line.
@@ -48,7 +48,7 @@ pub struct DebugInst {
 impl DebugInst {
     /// Construct a new debug instruction.
     pub fn new(
-        source_id: usize,
+        source_id: SourceId,
         span: Span,
         comment: Option<Box<str>>,
         label: Option<DebugLabel>,

--- a/crates/runestick/src/lib.rs
+++ b/crates/runestick/src/lib.rs
@@ -100,6 +100,7 @@ mod runtime_context;
 mod select;
 mod shared;
 mod source;
+mod source_id;
 mod span;
 mod spanned_error;
 mod stack;
@@ -143,9 +144,6 @@ macro_rules! span {
         }
     };
 }
-
-/// The identifier of a source file.
-pub type SourceId = usize;
 
 /// Exported result type for convenience.
 pub type Result<T, E = anyhow::Error> = std::result::Result<T, E>;
@@ -214,6 +212,7 @@ pub use crate::panic::Panic;
 pub use crate::protocol::Protocol;
 pub use crate::range::{Range, RangeLimits};
 pub use crate::shared::{Mut, RawMut, RawRef, Ref, Shared, SharedPointerGuard};
+pub use crate::source_id::SourceId;
 pub use crate::stack::{Stack, StackError};
 pub use crate::type_of::TypeOf;
 pub use crate::unit::{Unit, UnitFn};

--- a/crates/runestick/src/source_id.rs
+++ b/crates/runestick/src/source_id.rs
@@ -1,0 +1,71 @@
+use std::convert::TryFrom;
+use std::fmt;
+
+/// The identifier of a source file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct SourceId {
+    index: u32,
+}
+
+impl SourceId {
+    /// The empty source identifier.
+    pub const EMPTY: Self = Self::empty();
+
+    /// Construct a source identifier from an index.
+    pub const fn new(index: u32) -> Self {
+        Self { index }
+    }
+
+    /// Define an empty source identifier that cannot reference a source.
+    pub const fn empty() -> Self {
+        Self { index: u32::MAX }
+    }
+
+    /// Access the source identifier as an index.
+    pub fn into_index(self) -> usize {
+        self.index as usize
+    }
+}
+
+impl fmt::Display for SourceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.index.fmt(f)
+    }
+}
+
+impl Default for SourceId {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl TryFrom<usize> for SourceId {
+    type Error = std::num::TryFromIntError;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        Ok(Self {
+            index: u32::try_from(value)?,
+        })
+    }
+}
+
+impl serde::Serialize for SourceId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.index.serialize(serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for SourceId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(Self {
+            index: u32::deserialize(deserializer)?,
+        })
+    }
+}

--- a/examples/examples/parsing_in_macro.rs
+++ b/examples/examples/parsing_in_macro.rs
@@ -1,0 +1,54 @@
+use rune::{ast, macros, Diagnostics, Options, Parser, Sources};
+use runestick::{Context, FromValue, Module, Source, Vm};
+use std::sync::Arc;
+
+pub fn main() -> runestick::Result<()> {
+    let mut m = Module::default();
+
+    let string = "1 + 2 + 13 * 3";
+
+    m.macro_(&["string_as_code"], move |_: &macros::TokenStream| {
+        let expr = macros::parse_all::<ast::Expr>(&string)?;
+        Ok(rune::quote!(#expr).into_token_stream())
+    })?;
+
+    m.macro_(&["string_as_code_from_arg"], |stream| {
+        let mut p = Parser::from_token_stream(stream);
+        let s = p.parse_all::<ast::LitStr>()?;
+        let s = macros::resolve(s)?;
+        let expr = macros::parse_all::<ast::Expr>(&s)?;
+        Ok(rune::quote!(#expr).into_token_stream())
+    })?;
+
+    let mut context = Context::with_default_modules()?;
+    context.install(&m)?;
+
+    let mut sources = Sources::new();
+
+    sources.insert(Source::new(
+        "test",
+        r#"
+        pub fn main() {
+            let a = string_as_code!();
+            let b = string_as_code_from_arg!("1 + 2 + 13 * 3");
+            (a, b)
+        }
+        "#,
+    ));
+
+    let mut diagnostics = Diagnostics::new();
+
+    let unit = rune::load_sources(
+        &context,
+        &Options::default(),
+        &mut sources,
+        &mut diagnostics,
+    )?;
+
+    let mut vm = Vm::new(Arc::new(context.runtime()), Arc::new(unit));
+    let output = vm.execute(&["main"], ())?.complete()?;
+    let output = <(u32, u32)>::from_value(output)?;
+
+    assert_eq!(output, (42, 42));
+    Ok(())
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -12,7 +12,7 @@ pub use runestick::{
     Bytes, CompileMeta, CompileMetaKind, ContextError, FromValue, Function, IntoComponent, Span,
     ToValue, Value, VecTuple, VmError,
 };
-use runestick::{Item, Source, Unit};
+use runestick::{Item, Source, SourceId, Unit};
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -60,7 +60,7 @@ fn internal_compile_source(
     let unit = match unit.build() {
         Ok(unit) => unit,
         Err(error) => {
-            diagnostics.error(0, error);
+            diagnostics.error(SourceId::empty(), error);
             return Err(diagnostics);
         }
     };

--- a/tests/tests/custom_macros.rs
+++ b/tests/tests/custom_macros.rs
@@ -1,0 +1,55 @@
+use rune::{ast, macros, Diagnostics, Options, Parser, Sources};
+use runestick::{Context, FromValue, Module, Source, Vm};
+use std::sync::Arc;
+
+#[test]
+fn test_parse_in_macro() -> runestick::Result<()> {
+    let mut m = Module::default();
+
+    let string = "1 + 2 + 13 * 3";
+
+    m.macro_(&["string_as_code"], move |_: &macros::TokenStream| {
+        let expr = macros::parse_all::<ast::Expr>(&string)?;
+        Ok(rune::quote!(#expr).into_token_stream())
+    })?;
+
+    m.macro_(&["string_as_code_from_arg"], |stream| {
+        let mut p = Parser::from_token_stream(stream);
+        let s = p.parse_all::<ast::LitStr>()?;
+        let s = macros::resolve(s)?;
+        let expr = macros::parse_all::<ast::Expr>(&s)?;
+        Ok(rune::quote!(#expr).into_token_stream())
+    })?;
+
+    let mut context = Context::with_default_modules()?;
+    context.install(&m)?;
+
+    let mut sources = Sources::new();
+
+    sources.insert(Source::new(
+        "test",
+        r#"
+        pub fn main() {
+            let a = string_as_code!();
+            let b = string_as_code_from_arg!("1 + 2 + 13 * 3");
+            (a, b)
+        }
+        "#,
+    ));
+
+    let mut diagnostics = Diagnostics::new();
+
+    let unit = rune::load_sources(
+        &context,
+        &Options::default(),
+        &mut sources,
+        &mut diagnostics,
+    )?;
+
+    let mut vm = Vm::new(Arc::new(context.runtime()), Arc::new(unit));
+    let output = vm.execute(&["main"], ())?.complete()?;
+    let output = <(u32, u32)>::from_value(output)?;
+
+    assert_eq!(output, (42, 42));
+    Ok(())
+}


### PR DESCRIPTION
Almost all of the changes presented in here follow from these requirements:
* All the necessary tokens that need to refer to a piece of source includes a `SourceId` and the lexer has been modified to include it where appropriate.
* The `Resolve` macro now takes the full collection of `Sources` instead of a single *implicit* `Source`.
* A mutable `Sources` is propagated into the macro context so that it can be modified during macro expansion.

Due to all of these, we can now implement `macros::parse_all` allowing to parse a string into a correctly behaving `TokenStream`.

Fixed #302