### PR TITLE
Remove the need for two lifetimes when referencing the Query engine

### DIFF
--- a/crates/rune-modules/src/core.rs
+++ b/crates/rune-modules/src/core.rs
@@ -35,7 +35,7 @@ pub fn module(_stdio: bool) -> Result<Module, ContextError> {
 
 /// Implementation for the `stringify!` macro.
 pub(crate) fn stringify_macro(
-    ctx: &mut MacroContext<'_, '_>,
+    ctx: &mut MacroContext<'_>,
     stream: &TokenStream,
 ) -> rune::Result<TokenStream> {
     let lit = ctx.stringify(stream).to_string();
@@ -44,7 +44,7 @@ pub(crate) fn stringify_macro(
 }
 
 pub(crate) fn panic_macro(
-    ctx: &mut MacroContext<'_, '_>,
+    ctx: &mut MacroContext<'_>,
     stream: &TokenStream,
 ) -> rune::Result<TokenStream> {
     let mut p = Parser::from_token_stream(stream, ctx.stream_span());

--- a/crates/rune-modules/src/experiments/mod.rs
+++ b/crates/rune-modules/src/experiments/mod.rs
@@ -38,18 +38,12 @@ pub fn module(_stdio: bool) -> Result<Module, ContextError> {
 }
 
 /// Implementation for the `passthrough!` macro.
-fn passthrough_impl(
-    _: &mut MacroContext<'_, '_>,
-    stream: &TokenStream,
-) -> rune::Result<TokenStream> {
+fn passthrough_impl(_: &mut MacroContext<'_>, stream: &TokenStream) -> rune::Result<TokenStream> {
     Ok(stream.clone())
 }
 
 /// Implementation for the `make_function!` macro.
-fn make_function(
-    ctx: &mut MacroContext<'_, '_>,
-    stream: &TokenStream,
-) -> rune::Result<TokenStream> {
+fn make_function(ctx: &mut MacroContext<'_>, stream: &TokenStream) -> rune::Result<TokenStream> {
     let mut parser = Parser::from_token_stream(stream, ctx.stream_span());
 
     let ident = parser.parse::<ast::Ident>()?;

--- a/crates/rune-modules/src/experiments/stringy_math_macro.rs
+++ b/crates/rune-modules/src/experiments/stringy_math_macro.rs
@@ -5,7 +5,7 @@ use rune::parse::Parser;
 
 /// Implementation for the `stringy_math!` macro.
 pub(crate) fn stringy_math(
-    ctx: &mut MacroContext<'_, '_>,
+    ctx: &mut MacroContext<'_>,
     stream: &TokenStream,
 ) -> rune::Result<TokenStream> {
     let mut parser = Parser::from_token_stream(stream, ctx.stream_span());

--- a/crates/rune-modules/src/fmt.rs
+++ b/crates/rune-modules/src/fmt.rs
@@ -32,7 +32,7 @@ pub fn module(_stdio: bool) -> Result<Module, ContextError> {
 }
 
 /// Implementation for the `format!` macro.
-pub(crate) fn format_macro(ctx: &mut MacroContext<'_, '_>, stream: &TokenStream) -> rune::Result<TokenStream> {
+pub(crate) fn format_macro(ctx: &mut MacroContext<'_>, stream: &TokenStream) -> rune::Result<TokenStream> {
     let mut p = Parser::from_token_stream(stream, ctx.stream_span());
     let args = p.parse::<FormatArgs>()?;
     p.eof()?;

--- a/crates/rune-modules/src/io.rs
+++ b/crates/rune-modules/src/io.rs
@@ -32,7 +32,7 @@ pub fn module(_stdio: bool) -> Result<Module, ContextError> {
 }
 
 /// Implementation for the `println!` macro.
-pub(crate) fn println_macro(ctx: &mut MacroContext<'_, '_>, stream: &TokenStream) -> rune::Result<TokenStream> {
+pub(crate) fn println_macro(ctx: &mut MacroContext<'_>, stream: &TokenStream) -> rune::Result<TokenStream> {
     let mut p = Parser::from_token_stream(stream, ctx.stream_span());
     let args = p.parse_all::<FormatArgs>()?;
     let expanded = args.expand(ctx)?;

--- a/crates/rune-modules/src/macros.rs
+++ b/crates/rune-modules/src/macros.rs
@@ -41,7 +41,7 @@ pub fn module(_unused: bool) -> Result<Module, ContextError> {
 }
 
 /// Implementation for the `line!()` macro
-pub(crate) fn emit_line(ctx: &mut MacroContext<'_, '_>, stream: &TokenStream) -> rune::Result<TokenStream> {
+pub(crate) fn emit_line(ctx: &mut MacroContext<'_>, stream: &TokenStream) -> rune::Result<TokenStream> {
     let mut parser = Parser::from_token_stream(stream, ctx.stream_span());
     parser.eof()?;
 
@@ -49,7 +49,7 @@ pub(crate) fn emit_line(ctx: &mut MacroContext<'_, '_>, stream: &TokenStream) ->
 }
 
 /// Implementation for the `file!()` macro
-pub(crate) fn emit_file(ctx: &mut MacroContext<'_, '_>, stream: &TokenStream) -> rune::Result<TokenStream> {
+pub(crate) fn emit_file(ctx: &mut MacroContext<'_>, stream: &TokenStream) -> rune::Result<TokenStream> {
     let mut parser = Parser::from_token_stream(stream, ctx.stream_span());
     parser.eof()?;
 

--- a/crates/rune-modules/src/test.rs
+++ b/crates/rune-modules/src/test.rs
@@ -35,7 +35,7 @@ pub fn module(_stdio: bool) -> Result<rune::Module, rune::ContextError> {
 }
 
 /// Implementation for the `assert!` macro.
-pub(crate) fn assert_macro(ctx: &mut MacroContext<'_, '_>, stream: &TokenStream) -> rune::Result<TokenStream> {
+pub(crate) fn assert_macro(ctx: &mut MacroContext<'_>, stream: &TokenStream) -> rune::Result<TokenStream> {
     let mut p = Parser::from_token_stream(stream, ctx.stream_span());
     let expr = p.parse::<ast::Expr>()?;
 
@@ -64,7 +64,7 @@ pub(crate) fn assert_macro(ctx: &mut MacroContext<'_, '_>, stream: &TokenStream)
 }
 
 /// Implementation for the `assert!` macro.
-pub(crate) fn assert_eq_macro(ctx: &mut MacroContext<'_, '_>, stream: &TokenStream) -> rune::Result<TokenStream> {
+pub(crate) fn assert_eq_macro(ctx: &mut MacroContext<'_>, stream: &TokenStream) -> rune::Result<TokenStream> {
     let mut p = Parser::from_token_stream(stream, ctx.stream_span());
     let left = p.parse::<ast::Expr>()?;
     p.parse::<T![,]>()?;

--- a/crates/rune/src/ast/ident.rs
+++ b/crates/rune/src/ast/ident.rs
@@ -15,7 +15,7 @@ impl Ident {
     /// context.
     ///
     /// This constructor must only be used inside of a macro.
-    pub fn new(ctx: &mut MacroContext<'_, '_>, ident: &str) -> Self {
+    pub fn new(ctx: &mut MacroContext<'_>, ident: &str) -> Self {
         Self::new_with(ident, ctx.macro_span(), &mut ctx.q_mut().storage)
     }
 

--- a/crates/rune/src/ast/label.rs
+++ b/crates/rune/src/ast/label.rs
@@ -15,7 +15,7 @@ impl Label {
     /// specified *without* the leading `'`, so `"foo"` instead of `"'foo"`.
     ///
     /// This constructor must only be used inside of a macro.
-    pub fn new(ctx: &mut MacroContext<'_, '_>, label: &str) -> Self {
+    pub fn new(ctx: &mut MacroContext<'_>, label: &str) -> Self {
         Self::new_with(label, ctx.macro_span(), &mut ctx.q_mut().storage)
     }
 

--- a/crates/rune/src/ast/lit.rs
+++ b/crates/rune/src/ast/lit.rs
@@ -32,7 +32,7 @@ impl Lit {
     ///     assert!(matches!(lit, ast::Lit::Str(..)))
     /// });
     /// ```
-    pub fn new<T>(ctx: &mut MacroContext<'_, '_>, lit: T) -> Self
+    pub fn new<T>(ctx: &mut MacroContext<'_>, lit: T) -> Self
     where
         T: IntoLit,
     {

--- a/crates/rune/src/ast/lit_char.rs
+++ b/crates/rune/src/ast/lit_char.rs
@@ -12,7 +12,7 @@ pub struct LitChar {
 
 impl LitChar {
     /// Construct a new literal character.
-    pub fn new(ctx: &mut MacroContext<'_, '_>, c: char) -> Self {
+    pub fn new(ctx: &mut MacroContext<'_>, c: char) -> Self {
         Self {
             token: ast::Token {
                 kind: ast::Kind::Char(ast::CopySource::Inline(c)),

--- a/crates/rune/src/ast/token.rs
+++ b/crates/rune/src/ast/token.rs
@@ -166,7 +166,7 @@ impl Token {
 }
 
 impl ToTokens for Token {
-    fn to_tokens(&self, _: &mut MacroContext<'_, '_>, stream: &mut TokenStream) {
+    fn to_tokens(&self, _: &mut MacroContext<'_>, stream: &mut TokenStream) {
         stream.push(*self);
     }
 }

--- a/crates/rune/src/compile/mod.rs
+++ b/crates/rune/src/compile/mod.rs
@@ -5,9 +5,10 @@
 
 use crate::ast;
 use crate::ast::{Span, Spanned};
+use crate::macros::Storage;
 use crate::parse::Resolve;
 use crate::query::{Build, BuildEntry, Query};
-use crate::shared::Gen;
+use crate::shared::{Consts, Gen};
 use crate::worker::{LoadFileKind, Task, Worker};
 use crate::{Diagnostics, Sources};
 
@@ -65,10 +66,15 @@ pub(crate) fn compile(
 ) -> Result<(), ()> {
     // Shared id generator.
     let gen = Gen::new();
+    let mut consts = Consts::default();
+    let mut storage = Storage::default();
+    let mut inner = Default::default();
 
     // The worker queue.
     let mut worker = Worker::new(
         context,
+        &mut consts,
+        &mut storage,
         sources,
         options,
         unit,
@@ -76,6 +82,7 @@ pub(crate) fn compile(
         visitor,
         source_loader,
         &gen,
+        &mut inner,
     );
 
     // Queue up the initial sources to be loaded.

--- a/crates/rune/src/compile/module.rs
+++ b/crates/rune/src/compile/module.rs
@@ -489,7 +489,7 @@ impl Module {
         M: 'static
             + Send
             + Sync
-            + Fn(&mut MacroContext<'_, '_>, &TokenStream) -> crate::Result<TokenStream>,
+            + Fn(&mut MacroContext<'_>, &TokenStream) -> crate::Result<TokenStream>,
         N: IntoIterator,
         N::Item: IntoComponent,
     {

--- a/crates/rune/src/compile/v1/mod.rs
+++ b/crates/rune/src/compile/v1/mod.rs
@@ -900,7 +900,7 @@ impl<'a, 'q> Compiler<'a, 'q> {
             ));
         }
 
-        let mut compiler = IrCompiler { q: self.q };
+        let mut compiler = IrCompiler { q: self.q.borrow() };
 
         let mut compiled = Vec::new();
 
@@ -914,7 +914,7 @@ impl<'a, 'q> Compiler<'a, 'q> {
             scopes: Default::default(),
             module: from.module.clone(),
             item: from.item.clone(),
-            q: self.q,
+            q: self.q.borrow(),
         };
 
         for (ir, name) in compiled {

--- a/crates/rune/src/ir/eval/ir.rs
+++ b/crates/rune/src/ir/eval/ir.rs
@@ -6,7 +6,7 @@ impl IrEval for ir::Ir {
 
     fn eval(
         &self,
-        interp: &mut IrInterpreter<'_, '_>,
+        interp: &mut IrInterpreter<'_>,
         used: Used,
     ) -> Result<Self::Output, IrEvalOutcome> {
         interp.budget.take(self)?;

--- a/crates/rune/src/ir/eval/ir_assign.rs
+++ b/crates/rune/src/ir/eval/ir_assign.rs
@@ -5,7 +5,7 @@ impl IrEval for ir::IrAssign {
 
     fn eval(
         &self,
-        interp: &mut IrInterpreter<'_, '_>,
+        interp: &mut IrInterpreter<'_>,
         used: Used,
     ) -> Result<Self::Output, IrEvalOutcome> {
         interp.budget.take(self)?;

--- a/crates/rune/src/ir/eval/ir_binary.rs
+++ b/crates/rune/src/ir/eval/ir_binary.rs
@@ -5,7 +5,7 @@ impl IrEval for ir::IrBinary {
 
     fn eval(
         &self,
-        interp: &mut IrInterpreter<'_, '_>,
+        interp: &mut IrInterpreter<'_>,
         used: Used,
     ) -> Result<Self::Output, IrEvalOutcome> {
         use std::ops::{Add, Mul, Shl, Shr, Sub};

--- a/crates/rune/src/ir/eval/ir_branches.rs
+++ b/crates/rune/src/ir/eval/ir_branches.rs
@@ -5,7 +5,7 @@ impl IrEval for ir::IrBranches {
 
     fn eval(
         &self,
-        interp: &mut IrInterpreter<'_, '_>,
+        interp: &mut IrInterpreter<'_>,
         used: Used,
     ) -> Result<Self::Output, IrEvalOutcome> {
         for (ir_condition, branch) in &self.branches {

--- a/crates/rune/src/ir/eval/ir_break.rs
+++ b/crates/rune/src/ir/eval/ir_break.rs
@@ -3,7 +3,7 @@ use crate::ir::eval::prelude::*;
 impl IrEval for ir::IrBreak {
     type Output = ();
 
-    fn eval(&self, interp: &mut IrInterpreter<'_, '_>, used: Used) -> Result<(), IrEvalOutcome> {
+    fn eval(&self, interp: &mut IrInterpreter<'_>, used: Used) -> Result<(), IrEvalOutcome> {
         let span = self.span();
         interp.budget.take(span)?;
 

--- a/crates/rune/src/ir/eval/ir_call.rs
+++ b/crates/rune/src/ir/eval/ir_call.rs
@@ -5,7 +5,7 @@ impl IrEval for ir::IrCall {
 
     fn eval(
         &self,
-        interp: &mut IrInterpreter<'_, '_>,
+        interp: &mut IrInterpreter<'_>,
         used: Used,
     ) -> Result<Self::Output, IrEvalOutcome> {
         let mut args = Vec::new();

--- a/crates/rune/src/ir/eval/ir_condition.rs
+++ b/crates/rune/src/ir/eval/ir_condition.rs
@@ -5,7 +5,7 @@ impl IrEval for ir::IrCondition {
 
     fn eval(
         &self,
-        interp: &mut IrInterpreter<'_, '_>,
+        interp: &mut IrInterpreter<'_>,
         used: Used,
     ) -> Result<Self::Output, IrEvalOutcome> {
         match self {

--- a/crates/rune/src/ir/eval/ir_decl.rs
+++ b/crates/rune/src/ir/eval/ir_decl.rs
@@ -5,7 +5,7 @@ impl IrEval for ir::IrDecl {
 
     fn eval(
         &self,
-        interp: &mut IrInterpreter<'_, '_>,
+        interp: &mut IrInterpreter<'_>,
         used: Used,
     ) -> Result<Self::Output, IrEvalOutcome> {
         interp.budget.take(self)?;

--- a/crates/rune/src/ir/eval/ir_loop.rs
+++ b/crates/rune/src/ir/eval/ir_loop.rs
@@ -3,11 +3,7 @@ use crate::ir::eval::prelude::*;
 impl IrEval for ir::IrLoop {
     type Output = IrValue;
 
-    fn eval(
-        &self,
-        interp: &mut IrInterpreter<'_, '_>,
-        used: Used,
-    ) -> Result<IrValue, IrEvalOutcome> {
+    fn eval(&self, interp: &mut IrInterpreter<'_>, used: Used) -> Result<IrValue, IrEvalOutcome> {
         let span = self.span();
         interp.budget.take(span)?;
 

--- a/crates/rune/src/ir/eval/ir_object.rs
+++ b/crates/rune/src/ir/eval/ir_object.rs
@@ -6,7 +6,7 @@ impl IrEval for ir::IrObject {
 
     fn eval(
         &self,
-        interp: &mut IrInterpreter<'_, '_>,
+        interp: &mut IrInterpreter<'_>,
         used: Used,
     ) -> Result<Self::Output, IrEvalOutcome> {
         let mut object = HashMap::with_capacity(self.assignments.len());

--- a/crates/rune/src/ir/eval/ir_scope.rs
+++ b/crates/rune/src/ir/eval/ir_scope.rs
@@ -5,7 +5,7 @@ impl IrEval for ir::IrScope {
 
     fn eval(
         &self,
-        interp: &mut IrInterpreter<'_, '_>,
+        interp: &mut IrInterpreter<'_>,
         used: Used,
     ) -> Result<Self::Output, IrEvalOutcome> {
         interp.budget.take(self)?;

--- a/crates/rune/src/ir/eval/ir_set.rs
+++ b/crates/rune/src/ir/eval/ir_set.rs
@@ -5,7 +5,7 @@ impl IrEval for ir::IrSet {
 
     fn eval(
         &self,
-        interp: &mut IrInterpreter<'_, '_>,
+        interp: &mut IrInterpreter<'_>,
         used: Used,
     ) -> Result<Self::Output, IrEvalOutcome> {
         interp.budget.take(self)?;

--- a/crates/rune/src/ir/eval/ir_template.rs
+++ b/crates/rune/src/ir/eval/ir_template.rs
@@ -6,7 +6,7 @@ impl IrEval for &ir::IrTemplate {
 
     fn eval(
         &self,
-        interp: &mut IrInterpreter<'_, '_>,
+        interp: &mut IrInterpreter<'_>,
         used: Used,
     ) -> Result<Self::Output, IrEvalOutcome> {
         interp.budget.take(self)?;

--- a/crates/rune/src/ir/eval/ir_tuple.rs
+++ b/crates/rune/src/ir/eval/ir_tuple.rs
@@ -5,7 +5,7 @@ impl IrEval for &ir::IrTuple {
 
     fn eval(
         &self,
-        interp: &mut IrInterpreter<'_, '_>,
+        interp: &mut IrInterpreter<'_>,
         used: Used,
     ) -> Result<Self::Output, IrEvalOutcome> {
         let mut items = Vec::with_capacity(self.items.len());

--- a/crates/rune/src/ir/eval/ir_vec.rs
+++ b/crates/rune/src/ir/eval/ir_vec.rs
@@ -5,7 +5,7 @@ impl IrEval for ir::IrVec {
 
     fn eval(
         &self,
-        interp: &mut IrInterpreter<'_, '_>,
+        interp: &mut IrInterpreter<'_>,
         used: Used,
     ) -> Result<Self::Output, IrEvalOutcome> {
         let mut vec = Vec::with_capacity(self.items.len());

--- a/crates/rune/src/ir/eval/mod.rs
+++ b/crates/rune/src/ir/eval/mod.rs
@@ -27,25 +27,21 @@ pub trait IrEval {
     /// Evaluate the given type.
     fn eval(
         &self,
-        interp: &mut IrInterpreter<'_, '_>,
+        interp: &mut IrInterpreter<'_>,
         used: Used,
     ) -> Result<Self::Output, IrEvalOutcome>;
 }
 
 pub(crate) trait ConstAs {
     /// Process constant value as a boolean.
-    fn as_bool(
-        &self,
-        interp: &mut IrInterpreter<'_, '_>,
-        used: Used,
-    ) -> Result<bool, IrEvalOutcome>;
+    fn as_bool(&self, interp: &mut IrInterpreter<'_>, used: Used) -> Result<bool, IrEvalOutcome>;
 }
 
 pub(crate) trait Matches {
     /// Test if the current trait matches the given value.
     fn matches<S>(
         &self,
-        compiler: &mut IrInterpreter<'_, '_>,
+        compiler: &mut IrInterpreter<'_>,
         value: IrValue,
         used: Used,
         spanned: S,
@@ -59,11 +55,7 @@ where
     T: IrEval<Output = IrValue>,
     T: Spanned,
 {
-    fn as_bool(
-        &self,
-        interp: &mut IrInterpreter<'_, '_>,
-        used: Used,
-    ) -> Result<bool, IrEvalOutcome> {
+    fn as_bool(&self, interp: &mut IrInterpreter<'_>, used: Used) -> Result<bool, IrEvalOutcome> {
         let span = self.span();
 
         let value = self
@@ -78,7 +70,7 @@ where
 impl Matches for IrPat {
     fn matches<S>(
         &self,
-        interp: &mut IrInterpreter<'_, '_>,
+        interp: &mut IrInterpreter<'_>,
         value: IrValue,
         _used: Used,
         spanned: S,

--- a/crates/rune/src/ir/ir_interpreter.rs
+++ b/crates/rune/src/ir/ir_interpreter.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 pub(crate) type IrScopes = crate::shared::Scopes<IrValue>;
 
 /// The interpreter that executed [Ir][crate::ir::Ir].
-pub struct IrInterpreter<'a, 'q> {
+pub struct IrInterpreter<'a> {
     /// A budget associated with the compiler, for how many expressions it's
     /// allowed to evaluate.
     pub(crate) budget: IrBudget,
@@ -23,10 +23,10 @@ pub struct IrInterpreter<'a, 'q> {
     /// Constant scopes.
     pub(crate) scopes: IrScopes,
     /// Query engine to look for constant expressions.
-    pub(crate) q: &'a mut Query<'q>,
+    pub(crate) q: Query<'a>,
 }
 
-impl IrInterpreter<'_, '_> {
+impl IrInterpreter<'_> {
     /// Evaluate the given target.
     pub(crate) fn eval<T>(&mut self, target: &T, used: Used) -> Result<T::Output, IrEvalOutcome>
     where

--- a/crates/rune/src/macros/format_args.rs
+++ b/crates/rune/src/macros/format_args.rs
@@ -24,7 +24,7 @@ pub struct FormatArgs {
 
 impl FormatArgs {
     /// Expand the format specification.
-    pub fn expand(&self, ctx: &mut MacroContext<'_, '_>) -> Result<Quote<'_>, SpannedError> {
+    pub fn expand(&self, ctx: &mut MacroContext<'_>) -> Result<Quote<'_>, SpannedError> {
         let format = ctx.eval(&self.format)?;
 
         let mut pos = Vec::new();
@@ -155,7 +155,7 @@ impl Parse for FormatArg {
 }
 
 fn expand_format_spec<'a>(
-    ctx: &mut MacroContext<'_, '_>,
+    ctx: &mut MacroContext<'_>,
     span: Span,
     input: &str,
     pos: &[&'a ast::Expr],
@@ -326,7 +326,7 @@ fn expand_format_spec<'a>(
 
     /// Parse a single expansion group.
     fn parse_group<'a>(
-        ctx: &mut MacroContext<'_, '_>,
+        ctx: &mut MacroContext<'_>,
         span: Span,
         iter: &mut Iter<'_>,
         count: &mut usize,

--- a/crates/rune/src/macros/macro_compiler.rs
+++ b/crates/rune/src/macros/macro_compiler.rs
@@ -58,7 +58,7 @@ impl MacroCompiler<'_, '_> {
                 macro_span: macro_call.span(),
                 stream_span: macro_call.stream_span(),
                 item: self.item.clone(),
-                q: self.query,
+                q: self.query.borrow(),
             };
 
             handler(&mut macro_context, input_stream)

--- a/crates/rune/src/macros/quote_fn.rs
+++ b/crates/rune/src/macros/quote_fn.rs
@@ -1,12 +1,12 @@
 use crate::macros::{MacroContext, ToTokens, TokenStream};
 use std::fmt;
 
-type EncodeFn<'a> = dyn Fn(&mut MacroContext<'_, '_>, &mut TokenStream) + Send + Sync + 'a;
+type EncodeFn<'a> = dyn Fn(&mut MacroContext<'_>, &mut TokenStream) + Send + Sync + 'a;
 
 /// Construct a token stream from a function.
 pub fn quote_fn<'a, T>(f: T) -> Quote<'a>
 where
-    T: 'a + Fn(&mut MacroContext<'_, '_>, &mut TokenStream) + Send + Sync,
+    T: 'a + Fn(&mut MacroContext<'_>, &mut TokenStream) + Send + Sync,
 {
     Quote(Box::new(f))
 }
@@ -20,7 +20,7 @@ impl<'a> Quote<'a> {
     /// # Panics
     ///
     /// This panics if called outside of a macro context.
-    pub fn into_token_stream(self, ctx: &mut MacroContext<'_, '_>) -> TokenStream {
+    pub fn into_token_stream(self, ctx: &mut MacroContext<'_>) -> TokenStream {
         let mut stream = TokenStream::new();
         self.to_tokens(ctx, &mut stream);
         stream
@@ -28,7 +28,7 @@ impl<'a> Quote<'a> {
 }
 
 impl<'a> ToTokens for Quote<'a> {
-    fn to_tokens(&self, context: &mut MacroContext<'_, '_>, stream: &mut TokenStream) {
+    fn to_tokens(&self, context: &mut MacroContext<'_>, stream: &mut TokenStream) {
         (self.0)(context, stream)
     }
 }

--- a/crates/rune/src/macros/storage.rs
+++ b/crates/rune/src/macros/storage.rs
@@ -17,11 +17,6 @@ pub struct Storage {
 }
 
 impl Storage {
-    /// Construct a new empty storage.
-    pub(crate) fn new() -> Self {
-        Self::default()
-    }
-
     /// Construct a new number.
     ///
     /// The number will be stored in this storage, and will be synthetic

--- a/crates/rune/src/macros/token_stream.rs
+++ b/crates/rune/src/macros/token_stream.rs
@@ -104,14 +104,14 @@ impl IntoIterator for TokenStream {
 /// Trait for things that can be turned into tokens.
 pub trait ToTokens: Sized {
     /// Turn the current item into tokens.
-    fn to_tokens(&self, context: &mut MacroContext<'_, '_>, stream: &mut TokenStream);
+    fn to_tokens(&self, context: &mut MacroContext<'_>, stream: &mut TokenStream);
 }
 
 impl<T> ToTokens for Box<T>
 where
     T: ToTokens,
 {
-    fn to_tokens(&self, context: &mut MacroContext<'_, '_>, stream: &mut TokenStream) {
+    fn to_tokens(&self, context: &mut MacroContext<'_>, stream: &mut TokenStream) {
         (**self).to_tokens(context, stream);
     }
 }
@@ -120,7 +120,7 @@ impl<T> ToTokens for &T
 where
     T: ToTokens,
 {
-    fn to_tokens(&self, context: &mut MacroContext<'_, '_>, stream: &mut TokenStream) {
+    fn to_tokens(&self, context: &mut MacroContext<'_>, stream: &mut TokenStream) {
         ToTokens::to_tokens(*self, context, stream)
     }
 }
@@ -129,7 +129,7 @@ impl<T> ToTokens for Option<T>
 where
     T: ToTokens,
 {
-    fn to_tokens(&self, context: &mut MacroContext<'_, '_>, stream: &mut TokenStream) {
+    fn to_tokens(&self, context: &mut MacroContext<'_>, stream: &mut TokenStream) {
         if let Some(this) = self {
             this.to_tokens(context, stream);
         }
@@ -140,7 +140,7 @@ impl<T> ToTokens for Vec<T>
 where
     T: ToTokens,
 {
-    fn to_tokens(&self, context: &mut MacroContext<'_, '_>, stream: &mut TokenStream) {
+    fn to_tokens(&self, context: &mut MacroContext<'_>, stream: &mut TokenStream) {
         for item in self {
             item.to_tokens(context, stream);
         }
@@ -152,7 +152,7 @@ where
     A: ToTokens,
     B: ToTokens,
 {
-    fn to_tokens(&self, context: &mut MacroContext<'_, '_>, stream: &mut TokenStream) {
+    fn to_tokens(&self, context: &mut MacroContext<'_>, stream: &mut TokenStream) {
         self.0.to_tokens(context, stream);
         self.1.to_tokens(context, stream);
     }
@@ -164,7 +164,7 @@ where
     B: ToTokens,
     C: ToTokens,
 {
-    fn to_tokens(&self, context: &mut MacroContext<'_, '_>, stream: &mut TokenStream) {
+    fn to_tokens(&self, context: &mut MacroContext<'_>, stream: &mut TokenStream) {
         self.0.to_tokens(context, stream);
         self.1.to_tokens(context, stream);
         self.2.to_tokens(context, stream);
@@ -172,7 +172,7 @@ where
 }
 
 impl ToTokens for TokenStream {
-    fn to_tokens(&self, context: &mut MacroContext<'_, '_>, stream: &mut TokenStream) {
+    fn to_tokens(&self, context: &mut MacroContext<'_>, stream: &mut TokenStream) {
         self.stream.to_tokens(context, stream);
     }
 }

--- a/crates/rune/src/worker/mod.rs
+++ b/crates/rune/src/worker/mod.rs
@@ -5,8 +5,9 @@ use crate::ast::Span;
 use crate::collections::HashMap;
 use crate::compile::{CompileVisitor, Item, Options, SourceLoader, UnitBuilder};
 use crate::indexing::{Index, IndexScopes, Indexer};
-use crate::query::Query;
-use crate::shared::{Gen, Items};
+use crate::macros::Storage;
+use crate::query::{Query, QueryInner};
+use crate::shared::{Consts, Gen, Items};
 use crate::{Context, Diagnostics, SourceId, Sources};
 use std::collections::VecDeque;
 
@@ -37,6 +38,8 @@ impl<'a> Worker<'a> {
     /// Construct a new worker.
     pub(crate) fn new(
         context: &'a Context,
+        consts: &'a mut Consts,
+        storage: &'a mut Storage,
         sources: &'a mut Sources,
         options: &'a Options,
         unit: &'a mut UnitBuilder,
@@ -44,13 +47,14 @@ impl<'a> Worker<'a> {
         visitor: &'a mut dyn CompileVisitor,
         source_loader: &'a mut dyn SourceLoader,
         gen: &'a Gen,
+        inner: &'a mut QueryInner,
     ) -> Self {
         Self {
             context,
             options,
             diagnostics,
             source_loader,
-            q: Query::new(unit, sources, visitor, gen),
+            q: Query::new(unit, consts, storage, sources, visitor, gen, inner),
             gen,
             loaded: HashMap::new(),
             queue: VecDeque::new(),


### PR DESCRIPTION
This is achieved by having `Query` borrow its own internals, allowing it to reborrow itself through `Query::borrow`.