### PR TITLE
store and expose public constants in the unit (fixes #316)

### DIFF
--- a/crates/rune-cli/src/main.rs
+++ b/crates/rune-cli/src/main.rs
@@ -628,7 +628,7 @@ async fn run_path(args: &Args, options: &Options, path: &Path) -> Result<ExitCod
                     }
                 }
 
-                if constants.peek().is_some() {
+                if runargs.dump_constants && constants.peek().is_some() {
                     writeln!(out, "# constants")?;
 
                     for constant in constants {

--- a/crates/rune/src/compile/mod.rs
+++ b/crates/rune/src/compile/mod.rs
@@ -299,8 +299,10 @@ impl<'q> CompileBuildEntry<'_, 'q> {
                 }
             }
             Build::Unused => {
-                self.diagnostics
-                    .not_used(location.source_id, location.span, None);
+                if !item.visibility.is_public() {
+                    self.diagnostics
+                        .not_used(location.source_id, location.span, None);
+                }
             }
             Build::Import(import) => {
                 // Issue the import to check access.

--- a/crates/rune/src/compile/unit_builder.rs
+++ b/crates/rune/src/compile/unit_builder.rs
@@ -142,7 +142,6 @@ impl UnitBuilder {
 
             match self.constants.get(&to) {
                 Some(value) => {
-                    eprintln!("xxx");
                     let const_value = value.clone();
                     if self.constants.insert(from, const_value).is_some() {
                         return Err(CompileError::new(

--- a/crates/rune/src/compile/unit_builder.rs
+++ b/crates/rune/src/compile/unit_builder.rs
@@ -495,10 +495,14 @@ impl UnitBuilder {
                     ConstValue::String(meta.item.item.to_string()),
                 );
             }
+
             MetaKind::Function { .. } => (),
             MetaKind::Closure { .. } => (),
             MetaKind::AsyncBlock { .. } => (),
-            MetaKind::Const { .. } => (),
+            MetaKind::Const { const_value } => {
+                self.constants
+                    .insert(Hash::constant(&meta.item.item.to_string()), const_value.clone());
+            }
             MetaKind::ConstFn { .. } => (),
             MetaKind::Import { .. } => (),
         }

--- a/crates/rune/src/compile/unit_builder.rs
+++ b/crates/rune/src/compile/unit_builder.rs
@@ -126,36 +126,31 @@ impl UnitBuilder {
         }
 
         for (from, to) in self.reexports {
-            match self.functions.get(&to) {
-                Some(info) => {
-                    let info = *info;
-                    if self.functions.insert(from, info).is_some() {
-                        return Err(CompileError::new(
-                            span,
-                            CompileErrorKind::FunctionConflictHash { hash: from },
-                        ));
-                    }
-                    continue;
+            if let Some(info) = self.functions.get(&to) {
+                let info = *info;
+                if self.functions.insert(from, info).is_some() {
+                    return Err(CompileError::new(
+                        span,
+                        CompileErrorKind::FunctionConflictHash { hash: from },
+                    ));
                 }
-                None => {}
-            };
+                continue;
+            }
 
-            match self.constants.get(&to) {
-                Some(value) => {
-                    let const_value = value.clone();
-                    if self.constants.insert(from, const_value).is_some() {
-                        return Err(CompileError::new(
-                            span,
-                            CompileErrorKind::ConstantConflict {
-                                item: Item::with_item(&["unknown"]),
-                                hash: from,
-                            },
-                        ));
-                    }
-                    continue;
+            if let Some(value) = self.constants.get(&to) {
+                let const_value = value.clone();
+                if self.constants.insert(from, const_value).is_some() {
+                    return Err(CompileError::new(
+                        span,
+                        CompileErrorKind::ConstantConflict {
+                            item: Item::with_item(&["unknown"]),
+                            hash: from,
+                        },
+                    ));
                 }
-                None => {}
-            };
+                continue;
+            }
+
             return Err(CompileError::new(
                 span,
                 CompileErrorKind::MissingFunctionHash { hash: to },

--- a/crates/rune/src/hash.rs
+++ b/crates/rune/src/hash.rs
@@ -87,6 +87,11 @@ impl Hash {
         Self::of(name)
     }
 
+    /// Get the hash corresponding to a constant.
+    pub fn constant(name: &str) -> Hash {
+        Self::of(name)
+    }
+
     /// Hash the given iterator of object keys.
     pub fn object_keys<I>(keys: I) -> Self
     where

--- a/crates/rune/src/hash.rs
+++ b/crates/rune/src/hash.rs
@@ -87,11 +87,6 @@ impl Hash {
         Self::of(name)
     }
 
-    /// Get the hash corresponding to a constant.
-    pub fn constant(name: &str) -> Hash {
-        Self::of(name)
-    }
-
     /// Hash the given iterator of object keys.
     pub fn object_keys<I>(keys: I) -> Self
     where

--- a/crates/rune/src/runtime/unit.rs
+++ b/crates/rune/src/runtime/unit.rs
@@ -83,6 +83,11 @@ impl Unit {
         self.static_strings.iter()
     }
 
+    /// Iterate over all constants in the unit.
+    pub fn iter_constants(&self) -> impl Iterator<Item = (&Hash, &ConstValue)> + '_ {
+        self.constants.iter()
+    }
+
     /// Iterate over all static object keys in the unit.
     pub fn iter_static_object_keys(&self) -> impl Iterator<Item = (usize, &[String])> + '_ {
         let mut it = self.static_object_keys.iter().enumerate();

--- a/tests/tests/unit_constants.rs
+++ b/tests/tests/unit_constants.rs
@@ -31,11 +31,11 @@ fn test_get_const_re_export() -> rune::Result<()> {
     let mut sources = rune::sources! {
         entry => {
             mod inner {
-		pub const LEET = 1337;
+                pub const LEET = 1337;
             }
 
             pub use inner::LEET;
-	},
+        },
     };
 
     let unit = rune::prepare(&mut sources).with_context(&context).build()?;
@@ -59,9 +59,9 @@ fn test_get_const_nested() -> rune::Result<()> {
     let mut sources = rune::sources! {
         entry => {
             pub mod inner {
-		pub const LEET = 1337;
+                pub const LEET = 1337;
             }
-	},
+        },
     };
 
     let unit = rune::prepare(&mut sources).with_context(&context).build()?;

--- a/tests/tests/unit_constants.rs
+++ b/tests/tests/unit_constants.rs
@@ -1,0 +1,25 @@
+use rune::Hash;
+
+#[test]
+fn test_get_const() -> rune::Result<()> {
+    let context = rune_modules::default_context()?;
+
+    let mut sources = rune::sources! {
+        entry => {
+        pub const LOAD_COUNT = 1337;
+        }
+    };
+
+    let unit = rune::prepare(&mut sources).with_context(&context).build()?;
+
+    assert_eq!(
+        unit.constant(Hash::constant("LOAD_COUNT"))
+            .expect("successful lookup")
+            .clone()
+            .into_value()
+            .into_integer()
+            .expect("the inner value"),
+        1337
+    );
+    Ok(())
+}

--- a/tests/tests/unit_constants.rs
+++ b/tests/tests/unit_constants.rs
@@ -6,14 +6,68 @@ fn test_get_const() -> rune::Result<()> {
 
     let mut sources = rune::sources! {
         entry => {
-        pub const LOAD_COUNT = 1337;
+            pub const LEET = 1337;
         }
     };
 
     let unit = rune::prepare(&mut sources).with_context(&context).build()?;
 
     assert_eq!(
-        unit.constant(Hash::constant("LOAD_COUNT"))
+        unit.constant(Hash::type_hash(&["LEET"]))
+            .expect("successful lookup")
+            .clone()
+            .into_value()
+            .into_integer()
+            .expect("the inner value"),
+        1337
+    );
+    Ok(())
+}
+
+#[test]
+fn test_get_const_re_export() -> rune::Result<()> {
+    let context = rune_modules::default_context()?;
+
+    let mut sources = rune::sources! {
+        entry => {
+            mod inner {
+		pub const LEET = 1337;
+            }
+
+            pub use inner::LEET;
+	},
+    };
+
+    let unit = rune::prepare(&mut sources).with_context(&context).build()?;
+
+    assert_eq!(
+        unit.constant(Hash::type_hash(&["LEET"]))
+            .expect("successful lookup")
+            .clone()
+            .into_value()
+            .into_integer()
+            .expect("the inner value"),
+        1337
+    );
+    Ok(())
+}
+
+#[test]
+fn test_get_const_nested() -> rune::Result<()> {
+    let context = rune_modules::default_context()?;
+
+    let mut sources = rune::sources! {
+        entry => {
+            pub mod inner {
+		pub const LEET = 1337;
+            }
+	},
+    };
+
+    let unit = rune::prepare(&mut sources).with_context(&context).build()?;
+
+    assert_eq!(
+        unit.constant(Hash::type_hash(&["inner", "LEET"]))
             .expect("successful lookup")
             .clone()
             .into_value()


### PR DESCRIPTION
@pkolaczk Please give this branch a try! There's a new `Hash::constant` that can be used to make it clearer, as well.