### PR TITLE
Introduce #[inststrument] macro

### DIFF
--- a/crates/rune-macros/src/instrument.rs
+++ b/crates/rune-macros/src/instrument.rs
@@ -1,0 +1,67 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+
+/// An internal call to the macro.
+pub struct Expander {
+    f: syn::ItemFn,
+}
+
+impl syn::parse::Parse for Expander {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let f: syn::ItemFn = input.parse()?;
+
+        Ok(Self { f })
+    }
+}
+
+impl Expander {
+    pub fn expand(self) -> Result<TokenStream, Vec<syn::Error>> {
+        let f = self.f;
+
+        let mut it = f.sig.inputs.iter();
+
+        let first = match it.next() {
+            Some(syn::FnArg::Typed(ty)) => match &*ty.pat {
+                syn::Pat::Ident(ident) => Some(&ident.ident),
+                _ => None,
+            },
+            _ => None,
+        };
+
+        let second = match it.next() {
+            Some(syn::FnArg::Typed(ty)) => match &*ty.pat {
+                syn::Pat::Ident(ident) => Some(&ident.ident),
+                _ => None,
+            },
+            _ => None,
+        };
+
+        let ident = &f.sig.ident;
+
+        let log = match (first, second) {
+            (Some(a), Some(b)) => {
+                let ident = syn::LitStr::new(&ident.to_string(), ident.span());
+
+                Some(quote! {
+                    if let Some(source) = #b.q.sources.source(#b.source_id, #a.span()) {
+                        log::trace!("{} => {:?}", #ident, source);
+                    } else {
+                        log::trace!("{}", #ident);
+                    }
+                })
+            }
+            _ => None,
+        };
+
+        let vis = &f.vis;
+        let stmts = &f.block.stmts;
+        let sig = &f.sig;
+
+        Ok(quote! {
+            #vis #sig {
+                #log
+                #(#stmts)*
+            }
+        })
+    }
+}

--- a/crates/rune-macros/src/lib.rs
+++ b/crates/rune-macros/src/lib.rs
@@ -48,6 +48,7 @@ extern crate proc_macro;
 mod any;
 mod context;
 mod from_value;
+mod instrument;
 mod internals;
 mod option_spanned;
 mod parse;
@@ -241,6 +242,20 @@ pub fn any(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 #[doc(hidden)]
 pub fn __internal_impl_any(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let internal_call = syn::parse_macro_input!(input as any::InternalCall);
+    internal_call
+        .expand()
+        .unwrap_or_else(to_compile_errors)
+        .into()
+}
+
+/// Internal macro to instrument a function which is threading AST.
+#[proc_macro_attribute]
+#[doc(hidden)]
+pub fn __instrument_ast(
+    _attr: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let internal_call = syn::parse_macro_input!(item as instrument::Expander);
     internal_call
         .expand()
         .unwrap_or_else(to_compile_errors)

--- a/crates/rune/src/indexing/locals.rs
+++ b/crates/rune/src/indexing/locals.rs
@@ -4,11 +4,10 @@ use crate::ast::Spanned;
 use crate::compile::CompileResult;
 use crate::indexing::Indexer;
 use crate::parse::Resolve;
+use rune_macros::__instrument_ast as instrument;
 
+#[instrument]
 pub(crate) fn pat(ast: &mut ast::Pat, idx: &mut Indexer<'_>) -> CompileResult<()> {
-    let span = ast.span();
-    log::trace!("Pat => {:?}", idx.q.sources.source(idx.source_id, span));
-
     match ast {
         ast::Pat::PatPath(p) => {
             pat_path(p, idx)?;
@@ -33,17 +32,14 @@ pub(crate) fn pat(ast: &mut ast::Pat, idx: &mut Indexer<'_>) -> CompileResult<()
     Ok(())
 }
 
+#[instrument]
 fn pat_path(ast: &mut ast::PatPath, idx: &mut Indexer<'_>) -> CompileResult<()> {
-    let span = ast.span();
-    log::trace!("Ident => {:?}", idx.q.sources.source(idx.source_id, span));
     path(&mut ast.path, idx)?;
     Ok(())
 }
 
+#[instrument]
 fn path(ast: &mut ast::Path, idx: &mut Indexer<'_>) -> CompileResult<()> {
-    let span = ast.span();
-    log::trace!("Ident => {:?}", idx.q.sources.source(idx.source_id, span));
-
     let id = idx
         .q
         .insert_path(&idx.mod_item, idx.impl_item.as_ref(), &*idx.items.item());
@@ -56,23 +52,16 @@ fn path(ast: &mut ast::Path, idx: &mut Indexer<'_>) -> CompileResult<()> {
     Ok(())
 }
 
+#[instrument]
 fn ident(ast: &mut ast::Ident, idx: &mut Indexer<'_>) -> CompileResult<()> {
-    let span = ast.span();
-    log::trace!("Ident => {:?}", idx.q.sources.source(idx.source_id, span));
-
     let span = ast.span();
     let ident = ast.resolve(idx.q.storage(), idx.q.sources)?;
     idx.scopes.declare(ident.as_ref(), span)?;
     Ok(())
 }
 
+#[instrument]
 fn pat_object(ast: &mut ast::PatObject, idx: &mut Indexer<'_>) -> CompileResult<()> {
-    let span = ast.span();
-    log::trace!(
-        "PatObject => {:?}",
-        idx.q.sources.source(idx.source_id, span)
-    );
-
     match &mut ast.ident {
         ast::ObjectIdent::Anonymous(_) => {}
         ast::ObjectIdent::Named(p) => {
@@ -87,10 +76,8 @@ fn pat_object(ast: &mut ast::PatObject, idx: &mut Indexer<'_>) -> CompileResult<
     Ok(())
 }
 
+#[instrument]
 fn pat_vec(ast: &mut ast::PatVec, idx: &mut Indexer<'_>) -> CompileResult<()> {
-    let span = ast.span();
-    log::trace!("PatVec => {:?}", idx.q.sources.source(idx.source_id, span));
-
     for (p, _) in &mut ast.items {
         pat(p, idx)?;
     }
@@ -98,13 +85,8 @@ fn pat_vec(ast: &mut ast::PatVec, idx: &mut Indexer<'_>) -> CompileResult<()> {
     Ok(())
 }
 
+#[instrument]
 fn pat_tuple(ast: &mut ast::PatTuple, idx: &mut Indexer<'_>) -> CompileResult<()> {
-    let span = ast.span();
-    log::trace!(
-        "PatTuple => {:?}",
-        idx.q.sources.source(idx.source_id, span)
-    );
-
     if let Some(p) = &mut ast.path {
         path(p, idx)?;
     }
@@ -116,12 +98,8 @@ fn pat_tuple(ast: &mut ast::PatTuple, idx: &mut Indexer<'_>) -> CompileResult<()
     Ok(())
 }
 
+#[instrument]
 fn pat_binding(ast: &mut ast::PatBinding, idx: &mut Indexer<'_>) -> CompileResult<()> {
-    let span = ast.span();
-    log::trace!(
-        "PatBinding => {:?}",
-        idx.q.sources.source(idx.source_id, span)
-    );
     pat(&mut ast.pat, idx)?;
     Ok(())
 }

--- a/crates/rune/src/query/mod.rs
+++ b/crates/rune/src/query/mod.rs
@@ -43,6 +43,12 @@ pub(crate) struct BuiltInTemplate {
     pub(crate) exprs: Vec<ast::Expr>,
 }
 
+impl Spanned for BuiltInTemplate {
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
 /// An internal format specification.
 pub(crate) struct BuiltInFormat {
     pub(crate) span: Span,
@@ -62,6 +68,12 @@ pub(crate) struct BuiltInFormat {
     pub(crate) value: ast::Expr,
 }
 
+impl Spanned for BuiltInFormat {
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
 /// Macro data for `file!()`
 pub(crate) struct BuiltInFile {
     /// The span of the built-in-file
@@ -70,12 +82,24 @@ pub(crate) struct BuiltInFile {
     pub(crate) value: ast::LitStr,
 }
 
+impl Spanned for BuiltInFile {
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
 /// Macro data for `line!()`
 pub(crate) struct BuiltInLine {
     /// The span of the built-in-file
     pub(crate) span: Span,
     /// The line number
     pub(crate) value: ast::LitNumber,
+}
+
+impl Spanned for BuiltInLine {
+    fn span(&self) -> Span {
+        self.span
+    }
 }
 
 #[derive(Default)]


### PR DESCRIPTION
Very simple helper macro that adds the necessary tracing for internal compiler functions.

It's currently limited to trace log every function call, but could eventually be expanded to use `tracing` and spans.