### PR TITLE
Fix buggy self value

### DIFF
--- a/crates/rune/src/compile/v1/assemble.rs
+++ b/crates/rune/src/compile/v1/assemble.rs
@@ -15,6 +15,9 @@ use crate::{Hash, Protocol};
 use rune_macros::__instrument_ast as instrument;
 use std::convert::TryFrom;
 
+/// `self` variable.
+const SELF: &str = "self";
+
 #[derive(Debug)]
 #[must_use = "must be consumed to make sure the value is realized"]
 struct Asm {
@@ -2555,10 +2558,10 @@ fn path(ast: &ast::Path, c: &mut Assembler<'_>, needs: Needs) -> CompileResult<A
     let span = ast.span();
 
     if let Some(ast::PathKind::SelfValue) = ast.as_kind() {
-        let var = c.scopes.get_var(c.q.visitor, "ast", c.source_id, span)?;
+        let var = c.scopes.get_var(c.q.visitor, SELF, c.source_id, span)?;
 
         if needs.value() {
-            var.copy(c, span, "ast");
+            var.copy(c, span, SELF);
         }
 
         return Ok(Asm::top(span));
@@ -3071,7 +3074,7 @@ pub(crate) fn fn_from_item_fn(
                 }
 
                 let span = s.span();
-                c.scopes.new_var("ast", span)?;
+                c.scopes.new_var(SELF, span)?;
             }
             ast::FnArg::Pat(pat) => {
                 let offset = c.scopes.decl_anon(pat.span())?;

--- a/crates/rune/src/indexing/index.rs
+++ b/crates/rune/src/indexing/index.rs
@@ -25,6 +25,9 @@ use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+/// `self` variable.
+const SELF: &str = "self";
+
 pub(crate) struct Indexer<'a> {
     /// The root URL that the indexed file originated from.
     pub(crate) root: Option<PathBuf>,
@@ -624,7 +627,7 @@ fn item_fn(ast: &mut ast::ItemFn, idx: &mut Indexer<'_>) -> CompileResult<()> {
         match arg {
             ast::FnArg::SelfValue(s) => {
                 let span = s.span();
-                idx.scopes.declare("ast", span)?;
+                idx.scopes.declare(SELF, span)?;
             }
             ast::FnArg::Pat(p) => {
                 locals::pat(p, idx)?;
@@ -1463,7 +1466,7 @@ fn path(ast: &mut ast::Path, idx: &mut Indexer<'_>) -> CompileResult<()> {
 
     match ast.as_kind() {
         Some(ast::PathKind::SelfValue) => {
-            idx.scopes.mark_use("ast");
+            idx.scopes.mark_use(SELF);
         }
         Some(ast::PathKind::Ident(ident)) => {
             let ident = ident.resolve(idx.q.storage(), idx.q.sources)?;

--- a/tests/tests/instance.rs
+++ b/tests/tests/instance.rs
@@ -1,0 +1,44 @@
+use rune_tests::*;
+
+#[test]
+fn test_basic_self() {
+    rune! { () =>
+        struct Foo {
+            value,
+        }
+
+        impl Foo {
+            fn inc(self) {
+                self.value += 1;
+            }
+        }
+
+        pub fn main() {
+            let foo = Foo { value: 42 };
+            assert_eq!(foo.value, 42);
+            foo.inc();
+            assert_eq!(foo.value, 43);
+        }
+    }
+}
+
+#[test]
+fn test_chaining() {
+    rune! { () =>
+        struct Foo {
+            value,
+        }
+
+        impl Foo {
+            fn inc(self) {
+                self.value += 1;
+                self
+            }
+        }
+
+        pub fn main() {
+            let foo = Foo { value: 42 };
+            assert_eq!(foo.inc().inc().inc().value, 45);
+        }
+    }
+}


### PR DESCRIPTION
Accidentally renamed the magic `self` variable to `ast` during a refactoring. It would only cause problem if someone actually used a variable with the identifier `ast` though.