### PR TITLE
Add template literals in an empty group (fixes #326)

### DIFF
--- a/crates/rune/src/ast/expr_empty.rs
+++ b/crates/rune/src/ast/expr_empty.rs
@@ -1,0 +1,20 @@
+use crate::ast::prelude::*;
+
+/// A prioritized expression group without delimiters `<expr>`.
+///
+/// These groups are only produced during internal desugaring. Most notably
+/// through the use of template literals.
+#[derive(Debug, Clone, PartialEq, Eq, ToTokens, Spanned)]
+pub struct ExprEmpty {
+    /// Attributes associated with expression.
+    #[rune(iter)]
+    pub attributes: Vec<ast::Attribute>,
+    /// The open parenthesis.
+    pub open: ast::OpenEmpty,
+    /// The grouped expression.
+    pub expr: ast::Expr,
+    /// The close parenthesis.
+    pub close: ast::CloseEmpty,
+}
+
+expr_parse!(Empty, ExprEmpty, "empty group expression");

--- a/crates/rune/src/ast/file.rs
+++ b/crates/rune/src/ast/file.rs
@@ -97,7 +97,7 @@ impl Parse for File {
         let mut item_visibility = p.parse()?;
         let mut path = p.parse::<Option<ast::Path>>()?;
 
-        while path.is_some() || ast::Item::peek_as_item(p.peeker(), path.as_ref()) {
+        while path.is_some() || ast::Item::peek_as_item(p.peeker()) {
             let item: ast::Item =
                 ast::Item::parse_with_meta_path(p, item_attributes, item_visibility, path.take())?;
 

--- a/crates/rune/src/ast/item.rs
+++ b/crates/rune/src/ast/item.rs
@@ -64,12 +64,7 @@ impl Item {
     }
 
     /// Test if declaration is suitable inside of a file.
-    pub fn peek_as_item(p: &mut Peeker<'_>, path: Option<&ast::Path>) -> bool {
-        if path.is_some() {
-            // Macro call.
-            return matches!(p.nth(0), K![!]);
-        }
-
+    pub fn peek_as_item(p: &mut Peeker<'_>) -> bool {
         match p.nth(0) {
             K![use] => true,
             K![enum] => true,

--- a/crates/rune/src/ast/mod.rs
+++ b/crates/rune/src/ast/mod.rs
@@ -100,6 +100,7 @@ mod expr_break;
 mod expr_call;
 mod expr_closure;
 mod expr_continue;
+mod expr_empty;
 mod expr_field_access;
 mod expr_for;
 mod expr_group;
@@ -165,6 +166,7 @@ pub use self::expr_break::{ExprBreak, ExprBreakValue};
 pub use self::expr_call::ExprCall;
 pub use self::expr_closure::ExprClosure;
 pub use self::expr_continue::ExprContinue;
+pub use self::expr_empty::ExprEmpty;
 pub use self::expr_field_access::{ExprField, ExprFieldAccess};
 pub use self::expr_for::ExprFor;
 pub use self::expr_group::ExprGroup;
@@ -269,7 +271,9 @@ decl_tokens! {
     (CloseBrace, "An closing brace `}`.", "closing brace", Kind::Close(Delimiter::Brace)),
     (CloseBracket, "An open bracket `]`.", "closing bracket", Kind::Close(Delimiter::Bracket)),
     (CloseParen, "An closing parenthesis `)`.", "closing parenthesis", Kind::Close(Delimiter::Parenthesis)),
+    (CloseEmpty, "An empty closing marker.", "closing marker", Kind::Close(Delimiter::Empty)),
     (OpenBrace, "An opening brace `{`.", "opening brace", Kind::Open(Delimiter::Brace)),
     (OpenBracket, "An open bracket `[`.", "opening bracket", Kind::Open(Delimiter::Bracket)),
     (OpenParen, "An opening parenthesis `(`.", "opening parenthesis", Kind::Open(Delimiter::Parenthesis)),
+    (OpenEmpty, "An empty opening marker.", "opening marker", Kind::Open(Delimiter::Empty)),
 }

--- a/crates/rune/src/ast/token.rs
+++ b/crates/rune/src/ast/token.rs
@@ -431,6 +431,8 @@ pub enum Delimiter {
     Brace,
     /// A bracket delimiter `[` and `]`.
     Bracket,
+    /// An empty group delimiter.
+    Empty,
 }
 
 impl Delimiter {
@@ -440,6 +442,7 @@ impl Delimiter {
             Self::Parenthesis => "(",
             Self::Brace => "{",
             Self::Bracket => "[",
+            Self::Empty => "",
         }
     }
 
@@ -449,6 +452,7 @@ impl Delimiter {
             Self::Parenthesis => ")",
             Self::Brace => "}",
             Self::Bracket => "]",
+            Self::Empty => "",
         }
     }
 }

--- a/crates/rune/src/compile/ir/ir_compiler.rs
+++ b/crates/rune/src/compile/ir/ir_compiler.rs
@@ -90,6 +90,7 @@ impl IrCompile for ast::Expr {
                 ir::Ir::new(expr_object.span(), expr_object.compile(c)?)
             }
             ast::Expr::Group(expr_group) => expr_group.expr.compile(c)?,
+            ast::Expr::Empty(expr_empty) => expr_empty.expr.compile(c)?,
             ast::Expr::Binary(expr_binary) => expr_binary.compile(c)?,
             ast::Expr::Assign(expr_assign) => expr_assign.compile(c)?,
             ast::Expr::Call(expr_call) => ir::Ir::new(self.span(), expr_call.compile(c)?),

--- a/crates/rune/src/compile/v1/assemble.rs
+++ b/crates/rune/src/compile/v1/assemble.rs
@@ -1088,6 +1088,7 @@ fn expr(ast: &ast::Expr, c: &mut Assembler<'_>, needs: Needs) -> CompileResult<A
         ast::Expr::Loop(e) => expr_loop(e, c, needs)?,
         ast::Expr::Let(e) => expr_let(e, c, needs)?,
         ast::Expr::Group(e) => expr(&e.expr, c, needs)?,
+        ast::Expr::Empty(e) => expr(&e.expr, c, needs)?,
         ast::Expr::Unary(e) => expr_unary(e, c, needs)?,
         ast::Expr::Assign(e) => expr_assign(e, c, needs)?,
         ast::Expr::Binary(e) => expr_binary(e, c, needs)?,

--- a/crates/rune/src/indexing/index.rs
+++ b/crates/rune/src/indexing/index.rs
@@ -1036,6 +1036,9 @@ fn expr(ast: &mut ast::Expr, idx: &mut Indexer<'_>) -> CompileResult<()> {
         ast::Expr::Group(e) => {
             expr(&mut e.expr, idx)?;
         }
+        ast::Expr::Empty(e) => {
+            expr(&mut e.expr, idx)?;
+        }
         ast::Expr::If(e) => {
             expr_if(e, idx)?;
         }

--- a/crates/rune/src/parse/lexer.rs
+++ b/crates/rune/src/parse/lexer.rs
@@ -439,6 +439,11 @@ impl<'a> Lexer<'a> {
                         span: self.iter.span_from(start),
                     });
 
+                    self.buffer.push_back(ast::Token {
+                        kind: ast::Kind::Close(ast::Delimiter::Empty),
+                        span: self.iter.span_from(start),
+                    });
+
                     let expressions = *expressions;
                     self.modes
                         .pop(&self.iter, LexerMode::Template(expressions))?;
@@ -674,6 +679,11 @@ impl<'a> Lexer<'a> {
                     }
                     '`' => {
                         let span = self.iter.span_from(start);
+
+                        self.buffer.push_back(ast::Token {
+                            kind: ast::Kind::Open(ast::Delimiter::Empty),
+                            span,
+                        });
 
                         self.emit_builtin_attribute(span);
 
@@ -1067,6 +1077,10 @@ mod tests {
         test_lexer! {
             "`foo ${bar} \\` baz`",
             ast::Token {
+                kind: ast::Kind::Open(ast::Delimiter::Empty),
+                span: span!(0, 1),
+            },
+            ast::Token {
                 kind: K![#],
                 span: span!(0, 1),
             },
@@ -1138,6 +1152,10 @@ mod tests {
                 kind: K![')'],
                 span: span!(18, 19),
             },
+            ast::Token {
+                kind: ast::Kind::Close(ast::Delimiter::Empty),
+                span: span!(18, 19),
+            },
         };
     }
 
@@ -1145,6 +1163,10 @@ mod tests {
     fn test_template_literals_multi() {
         test_lexer! {
             "`foo ${bar} ${baz}`",
+            ast::Token {
+                kind: ast::Kind::Open(ast::Delimiter::Empty),
+                span: span!(0, 1),
+            },
             ast::Token {
                 kind: K![#],
                 span: span!(0, 1),
@@ -1223,6 +1245,10 @@ mod tests {
             },
             ast::Token {
                 kind: K![')'],
+                span: span!(18, 19),
+            },
+            ast::Token {
+                kind: ast::Kind::Close(ast::Delimiter::Empty),
                 span: span!(18, 19),
             },
         };

--- a/tests/tests/bug_326.rs
+++ b/tests/tests/bug_326.rs
@@ -1,0 +1,52 @@
+use rune::{ContextError, Module, Source, Sources, Vm};
+use std::sync::Arc;
+
+/// Cannot call instance functions on template literals.
+/// https://github.com/rune-rs/rune/issues/326
+#[test]
+fn bug_326() -> rune::Result<()> {
+    let mut context = rune_modules::default_context()?;
+    context.install(&trim_module()?)?;
+
+    let runtime = Arc::new(context.runtime());
+
+    let mut sources = Sources::new();
+    sources.insert(Source::new(
+        "script",
+        r#"
+        pub fn test_multiline_template() {
+            let age = 35;
+
+            let template_runtime_failure =
+                `Hello, I am ${age} years old.
+                  How old are you?`.trim_indent();
+
+            println(template_runtime_failure);
+        }
+        "#,
+    ));
+
+    let result = rune::prepare(&mut sources)
+        .with_context(&context)
+        .build();
+
+    let unit = result?;
+    let mut vm = Vm::new(runtime, Arc::new(unit));
+
+    vm.call(&["test_multiline_template"], ())?;
+    Ok(())
+}
+
+fn trim_module() -> Result<Module, ContextError> {
+    let mut m = Module::with_item(&["mymodule"]);
+    m.inst_fn("trim_indent", trim_indent)?;
+    Ok(m)
+}
+
+fn trim_indent(string: String) -> String {
+    string
+        .lines()
+        .map(|s| s.trim_start())
+        .collect::<Vec<&str>>()
+        .join("\n")
+}


### PR DESCRIPTION
This causes template literal desugaring (which happens during lexing) to be desugared into an empty group so that attributes are associated with the internal `template!` macro call rather than the chained expression.

Thanks @Steven0351 for finding and reporting the issue!