### PR TITLE
More clippy stuff

### DIFF
--- a/crates/rune-wasm/src/lib.rs
+++ b/crates/rune-wasm/src/lib.rs
@@ -369,7 +369,7 @@ async fn inner_compile(input: String, config: JsValue) -> Result<WasmCompileResu
 
             let (unit, ip, _frames) = match unwound {
                 Some((unit, ip, frames)) => (unit, ip, frames),
-                None => (vm.unit(), vm.ip(), vm.call_frames().to_owned()),
+                None => (vm.unit(), vm.ip(), vm.call_frames()),
             };
 
             // NB: emit diagnostics if debug info is available.

--- a/crates/rune/src/ast/condition.rs
+++ b/crates/rune/src/ast/condition.rs
@@ -7,7 +7,7 @@ pub enum Condition {
     /// A regular expression.
     Expr(ast::Expr),
     /// A pattern match.
-    ExprLet(Box<ast::ExprLet>),
+    ExprLet(ast::ExprLet),
 }
 
 /// Parse a condition.
@@ -23,7 +23,7 @@ pub enum Condition {
 impl Parse for Condition {
     fn parse(p: &mut Parser) -> Result<Self, ParseError> {
         Ok(match p.nth(0)? {
-            K![let] => Self::ExprLet(Box::new(ast::ExprLet::parse_without_eager_brace(p)?)),
+            K![let] => Self::ExprLet(ast::ExprLet::parse_without_eager_brace(p)?),
             _ => Self::Expr(ast::Expr::parse_without_eager_brace(p)?),
         })
     }

--- a/crates/rune/src/ast/expr.rs
+++ b/crates/rune/src/ast/expr.rs
@@ -67,8 +67,6 @@ impl ops::Deref for Callable {
 pub enum Expr {
     /// An path expression.
     Path(Box<ast::Path>),
-    /// A declaration.
-    Item(Box<ast::Item>),
     /// An assign expression.
     Assign(Box<ast::ExprAssign>),
     /// A while loop.
@@ -132,80 +130,10 @@ pub enum Expr {
 }
 
 impl Expr {
-    /// Indicates if an expression needs a semicolon or must be last in a block.
-    pub fn needs_semi(&self) -> bool {
-        match self {
-            Self::While(_) => false,
-            Self::Loop(_) => false,
-            Self::For(_) => false,
-            Self::If(_) => false,
-            Self::Match(_) => false,
-            Self::Block(_) => false,
-            Self::Select(_) => false,
-            Self::MacroCall(macro_call) => macro_call.needs_semi(),
-            Self::ForceSemi(force_semi) => force_semi.needs_semi,
-            _ => true,
-        }
-    }
-
-    /// Indicates if an expression is callable unless it's permitted by an
-    /// override.
-    pub fn is_callable(&self, callable: bool) -> bool {
-        match self {
-            Self::While(_) => false,
-            Self::Loop(_) => callable,
-            Self::For(_) => false,
-            Self::If(_) => callable,
-            Self::Match(_) => callable,
-            Self::Select(_) => callable,
-            Self::ForceSemi(expr) => expr.expr.is_callable(callable),
-            _ => true,
-        }
-    }
-
-    /// Take the attributes from the expression.
-    pub fn take_attributes(&mut self) -> Vec<ast::Attribute> {
-        match self {
-            Self::Path(_) => Vec::new(),
-            Self::Item(item) => item.take_attributes(),
-            Self::Break(expr) => take(&mut expr.attributes),
-            Self::Continue(expr) => take(&mut expr.attributes),
-            Self::Yield(expr) => take(&mut expr.attributes),
-            Self::Block(expr) => take(&mut expr.attributes),
-            Self::Return(expr) => take(&mut expr.attributes),
-            Self::Closure(expr) => take(&mut expr.attributes),
-            Self::Match(expr) => take(&mut expr.attributes),
-            Self::While(expr) => take(&mut expr.attributes),
-            Self::Loop(expr) => take(&mut expr.attributes),
-            Self::For(expr) => take(&mut expr.attributes),
-            Self::Let(expr) => take(&mut expr.attributes),
-            Self::If(expr) => take(&mut expr.attributes),
-            Self::Select(expr) => take(&mut expr.attributes),
-            Self::Lit(expr) => take(&mut expr.attributes),
-            Self::Assign(expr) => take(&mut expr.attributes),
-            Self::Binary(expr) => take(&mut expr.attributes),
-            Self::Call(expr) => take(&mut expr.attributes),
-            Self::FieldAccess(expr) => take(&mut expr.attributes),
-            Self::Group(expr) => take(&mut expr.attributes),
-            Self::Empty(expr) => take(&mut expr.attributes),
-            Self::Unary(expr) => take(&mut expr.attributes),
-            Self::Index(expr) => take(&mut expr.attributes),
-            Self::Await(expr) => take(&mut expr.attributes),
-            Self::Try(expr) => take(&mut expr.attributes),
-            Self::ForceSemi(expr) => expr.expr.take_attributes(),
-            Self::Object(expr) => take(&mut expr.attributes),
-            Self::Range(expr) => take(&mut expr.attributes),
-            Self::Vec(expr) => take(&mut expr.attributes),
-            Self::Tuple(expr) => take(&mut expr.attributes),
-            Self::MacroCall(expr) => take(&mut expr.attributes),
-        }
-    }
-
     /// Access the attributes of the expression.
     pub fn attributes(&self) -> &[ast::Attribute] {
         match self {
             Self::Path(_) => &[],
-            Self::Item(expr) => expr.attributes(),
             Self::Break(expr) => &expr.attributes,
             Self::Continue(expr) => &expr.attributes,
             Self::Yield(expr) => &expr.attributes,
@@ -239,12 +167,80 @@ impl Expr {
         }
     }
 
+    /// Indicates if an expression needs a semicolon or must be last in a block.
+    pub(crate) fn needs_semi(&self) -> bool {
+        match self {
+            Self::While(_) => false,
+            Self::Loop(_) => false,
+            Self::For(_) => false,
+            Self::If(_) => false,
+            Self::Match(_) => false,
+            Self::Block(_) => false,
+            Self::Select(_) => false,
+            Self::MacroCall(macro_call) => macro_call.needs_semi(),
+            Self::ForceSemi(force_semi) => force_semi.needs_semi,
+            _ => true,
+        }
+    }
+
+    /// Indicates if an expression is callable unless it's permitted by an
+    /// override.
+    pub(crate) fn is_callable(&self, callable: bool) -> bool {
+        match self {
+            Self::While(_) => false,
+            Self::Loop(_) => callable,
+            Self::For(_) => false,
+            Self::If(_) => callable,
+            Self::Match(_) => callable,
+            Self::Select(_) => callable,
+            Self::ForceSemi(expr) => expr.expr.is_callable(callable),
+            _ => true,
+        }
+    }
+
+    /// Take the attributes from the expression.
+    pub(crate) fn take_attributes(&mut self) -> Vec<ast::Attribute> {
+        match self {
+            Self::Path(_) => Vec::new(),
+            Self::Break(expr) => take(&mut expr.attributes),
+            Self::Continue(expr) => take(&mut expr.attributes),
+            Self::Yield(expr) => take(&mut expr.attributes),
+            Self::Block(expr) => take(&mut expr.attributes),
+            Self::Return(expr) => take(&mut expr.attributes),
+            Self::Closure(expr) => take(&mut expr.attributes),
+            Self::Match(expr) => take(&mut expr.attributes),
+            Self::While(expr) => take(&mut expr.attributes),
+            Self::Loop(expr) => take(&mut expr.attributes),
+            Self::For(expr) => take(&mut expr.attributes),
+            Self::Let(expr) => take(&mut expr.attributes),
+            Self::If(expr) => take(&mut expr.attributes),
+            Self::Select(expr) => take(&mut expr.attributes),
+            Self::Lit(expr) => take(&mut expr.attributes),
+            Self::Assign(expr) => take(&mut expr.attributes),
+            Self::Binary(expr) => take(&mut expr.attributes),
+            Self::Call(expr) => take(&mut expr.attributes),
+            Self::FieldAccess(expr) => take(&mut expr.attributes),
+            Self::Group(expr) => take(&mut expr.attributes),
+            Self::Empty(expr) => take(&mut expr.attributes),
+            Self::Unary(expr) => take(&mut expr.attributes),
+            Self::Index(expr) => take(&mut expr.attributes),
+            Self::Await(expr) => take(&mut expr.attributes),
+            Self::Try(expr) => take(&mut expr.attributes),
+            Self::ForceSemi(expr) => expr.expr.take_attributes(),
+            Self::Object(expr) => take(&mut expr.attributes),
+            Self::Range(expr) => take(&mut expr.attributes),
+            Self::Vec(expr) => take(&mut expr.attributes),
+            Self::Tuple(expr) => take(&mut expr.attributes),
+            Self::MacroCall(expr) => take(&mut expr.attributes),
+        }
+    }
+
     /// Check if this expression is a literal expression.
     ///
     /// There are exactly two kinds of literal expressions:
     /// * Ones that are ExprLit
     /// * Unary expressions which are the negate operation.
-    pub fn is_lit(&self) -> bool {
+    pub(crate) fn is_lit(&self) -> bool {
         match self {
             Self::Lit(..) => return true,
             Self::Unary(expr_unary) => {
@@ -262,6 +258,14 @@ impl Expr {
         }
 
         false
+    }
+
+    /// Internal function to construct a literal expression.
+    pub(crate) fn from_lit(lit: ast::Lit) -> Self {
+        Self::Lit(Box::new(ast::ExprLit {
+            attributes: Vec::new(),
+            lit,
+        }))
     }
 
     /// Try to coerce into item if applicable.
@@ -388,14 +392,6 @@ impl Expr {
         let lhs = parse_chain(p, lhs, callable)?;
         let lookahead = ast::BinOp::from_peeker(p.peeker());
         parse_binary(p, lhs, lookahead, 0, EagerBrace(true))
-    }
-
-    /// Internal function to construct a literal expression.
-    pub(crate) fn from_lit(lit: ast::Lit) -> Self {
-        Self::Lit(Box::new(ast::ExprLit {
-            attributes: Vec::new(),
-            lit,
-        }))
     }
 }
 

--- a/crates/rune/src/ast/expr_assign.rs
+++ b/crates/rune/src/ast/expr_assign.rs
@@ -8,11 +8,11 @@ pub struct ExprAssign {
     #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,
     /// The expression being awaited.
-    pub lhs: ast::Expr,
+    pub lhs: Box<ast::Expr>,
     /// The equals sign `=`.
     pub eq: T![=],
     /// The value.
-    pub rhs: ast::Expr,
+    pub rhs: Box<ast::Expr>,
 }
 
 expr_parse!(Assign, ExprAssign, "assign expression");

--- a/crates/rune/src/ast/expr_await.rs
+++ b/crates/rune/src/ast/expr_await.rs
@@ -18,7 +18,7 @@ pub struct ExprAwait {
     #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,
     /// The expression being awaited.
-    pub expr: ast::Expr,
+    pub expr: Box<ast::Expr>,
     /// The dot separating the expression.
     pub dot: T![.],
     /// The await token.

--- a/crates/rune/src/ast/expr_binary.rs
+++ b/crates/rune/src/ast/expr_binary.rs
@@ -9,11 +9,11 @@ pub struct ExprBinary {
     #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,
     /// The left-hand side of a binary operation.
-    pub lhs: ast::Expr,
+    pub lhs: Box<ast::Expr>,
     /// The operator.
     pub op: BinOp,
     /// The right-hand side of a binary operation.
-    pub rhs: ast::Expr,
+    pub rhs: Box<ast::Expr>,
 }
 
 expr_parse!(Binary, ExprBinary, "binary expression");

--- a/crates/rune/src/ast/expr_break.rs
+++ b/crates/rune/src/ast/expr_break.rs
@@ -20,7 +20,7 @@ pub struct ExprBreak {
     pub break_token: T![break],
     /// An optional expression to break with.
     #[rune(iter)]
-    pub expr: Option<ExprBreakValue>,
+    pub expr: Option<Box<ExprBreakValue>>,
 }
 
 expr_parse!(Break, ExprBreak, "break expression");

--- a/crates/rune/src/ast/expr_call.rs
+++ b/crates/rune/src/ast/expr_call.rs
@@ -19,7 +19,7 @@ pub struct ExprCall {
     #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,
     /// The name of the function being called.
-    pub expr: ast::Expr,
+    pub expr: Box<ast::Expr>,
     /// The arguments of the function call.
     pub args: ast::Parenthesized<ast::Expr, T![,]>,
 }
@@ -27,7 +27,7 @@ pub struct ExprCall {
 impl ExprCall {
     /// Get the target of the call expression.
     pub(crate) fn target(&self) -> &ast::Expr {
-        if let ast::Expr::FieldAccess(access) = &self.expr {
+        if let ast::Expr::FieldAccess(access) = &*self.expr {
             return &access.expr;
         }
 

--- a/crates/rune/src/ast/expr_closure.rs
+++ b/crates/rune/src/ast/expr_closure.rs
@@ -38,7 +38,7 @@ pub struct ExprClosure {
     /// Arguments to the closure.
     pub args: ExprClosureArgs,
     /// The body of the closure.
-    pub body: ast::Expr,
+    pub body: Box<ast::Expr>,
 }
 
 impl ExprClosure {

--- a/crates/rune/src/ast/expr_empty.rs
+++ b/crates/rune/src/ast/expr_empty.rs
@@ -13,7 +13,7 @@ pub struct ExprEmpty {
     /// The open parenthesis.
     pub open: ast::OpenEmpty,
     /// The grouped expression.
-    pub expr: ast::Expr,
+    pub expr: Box<ast::Expr>,
     /// The close parenthesis.
     pub close: ast::CloseEmpty,
 }

--- a/crates/rune/src/ast/expr_field_access.rs
+++ b/crates/rune/src/ast/expr_field_access.rs
@@ -18,7 +18,7 @@ pub struct ExprFieldAccess {
     #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,
     /// The expr where the field is being accessed.
-    pub expr: ast::Expr,
+    pub expr: Box<ast::Expr>,
     /// The parsed dot separator.
     pub dot: T![.],
     /// The field being accessed.

--- a/crates/rune/src/ast/expr_for.rs
+++ b/crates/rune/src/ast/expr_for.rs
@@ -29,7 +29,7 @@ pub struct ExprFor {
     /// The `in` keyword.
     pub in_: T![in],
     /// Expression producing the iterator.
-    pub iter: ast::Expr,
+    pub iter: Box<ast::Expr>,
     /// The body of the loop.
     pub body: Box<ast::Block>,
 }
@@ -47,7 +47,7 @@ impl ExprFor {
             for_token: parser.parse()?,
             binding: parser.parse()?,
             in_: parser.parse()?,
-            iter: ast::Expr::parse_without_eager_brace(parser)?,
+            iter: Box::new(ast::Expr::parse_without_eager_brace(parser)?),
             body: parser.parse()?,
         })
     }

--- a/crates/rune/src/ast/expr_group.rs
+++ b/crates/rune/src/ast/expr_group.rs
@@ -19,7 +19,7 @@ pub struct ExprGroup {
     /// The open parenthesis.
     pub open: ast::OpenParen,
     /// The grouped expression.
-    pub expr: ast::Expr,
+    pub expr: Box<ast::Expr>,
     /// The close parenthesis.
     pub close: ast::CloseParen,
 }

--- a/crates/rune/src/ast/expr_if.rs
+++ b/crates/rune/src/ast/expr_if.rs
@@ -23,7 +23,7 @@ pub struct ExprIf {
     /// The `if` token.
     pub if_: T![if],
     /// The condition to the if statement.
-    pub condition: ast::Condition,
+    pub condition: Box<ast::Condition>,
     /// The body of the if statement.
     pub block: Box<ast::Block>,
     /// Else if branches.
@@ -45,7 +45,7 @@ pub struct ExprElseIf {
     /// The `if` token.
     pub if_: T![if],
     /// The condition for the branch.
-    pub condition: ast::Condition,
+    pub condition: Box<ast::Condition>,
     /// The body of the else statement.
     pub block: Box<ast::Block>,
 }

--- a/crates/rune/src/ast/expr_index.rs
+++ b/crates/rune/src/ast/expr_index.rs
@@ -8,11 +8,11 @@ pub struct ExprIndex {
     #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,
     /// The target of the index set.
-    pub target: ast::Expr,
+    pub target: Box<ast::Expr>,
     /// The opening bracket.
     pub open: T!['['],
     /// The indexing expression.
-    pub index: ast::Expr,
+    pub index: Box<ast::Expr>,
     /// The closening bracket.
     pub close: T![']'],
 }

--- a/crates/rune/src/ast/expr_let.rs
+++ b/crates/rune/src/ast/expr_let.rs
@@ -23,7 +23,7 @@ pub struct ExprLet {
     /// The equality keyword.
     pub eq: T![=],
     /// The expression the binding is assigned to.
-    pub expr: ast::Expr,
+    pub expr: Box<ast::Expr>,
 }
 
 impl ExprLet {
@@ -37,7 +37,7 @@ impl ExprLet {
             let_token: parser.parse()?,
             pat: parser.parse()?,
             eq: parser.parse()?,
-            expr: ast::Expr::parse_without_eager_brace(parser)?,
+            expr: Box::new(ast::Expr::parse_without_eager_brace(parser)?),
         })
     }
 
@@ -48,7 +48,7 @@ impl ExprLet {
             let_token: parser.parse()?,
             pat: parser.parse()?,
             eq: parser.parse()?,
-            expr: ast::Expr::parse_without_eager_brace(parser)?,
+            expr: Box::new(ast::Expr::parse_without_eager_brace(parser)?),
         })
     }
 }

--- a/crates/rune/src/ast/expr_match.rs
+++ b/crates/rune/src/ast/expr_match.rs
@@ -20,7 +20,7 @@ pub struct ExprMatch {
     /// The `match` token.
     pub match_: T![match],
     /// The expression who's result we match over.
-    pub expr: ast::Expr,
+    pub expr: Box<ast::Expr>,
     /// The open brace of the match.
     pub open: T!['{'],
     /// Branches.
@@ -58,7 +58,7 @@ impl ExprMatch {
         Ok(ExprMatch {
             attributes,
             match_,
-            expr,
+            expr: Box::new(expr),
             open,
             branches,
             close,

--- a/crates/rune/src/ast/expr_range.rs
+++ b/crates/rune/src/ast/expr_range.rs
@@ -16,12 +16,12 @@ pub struct ExprRange {
     pub attributes: Vec<ast::Attribute>,
     /// Start of range.
     #[rune(iter)]
-    pub from: Option<ast::Expr>,
+    pub from: Option<Box<ast::Expr>>,
     /// `..`.
     pub limits: ExprRangeLimits,
     /// End of range.
     #[rune(iter)]
-    pub to: Option<ast::Expr>,
+    pub to: Option<Box<ast::Expr>>,
 }
 
 /// The limits of the specified range.

--- a/crates/rune/src/ast/expr_return.rs
+++ b/crates/rune/src/ast/expr_return.rs
@@ -20,7 +20,7 @@ pub struct ExprReturn {
     pub return_token: T![return],
     /// An optional expression to return.
     #[rune(iter)]
-    pub expr: Option<ast::Expr>,
+    pub expr: Option<Box<ast::Expr>>,
 }
 
 expr_parse!(Return, ExprReturn, "return expression");

--- a/crates/rune/src/ast/expr_try.rs
+++ b/crates/rune/src/ast/expr_try.rs
@@ -8,7 +8,7 @@ pub struct ExprTry {
     #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,
     /// The expression being awaited.
-    pub expr: ast::Expr,
+    pub expr: Box<ast::Expr>,
     /// The try operator `?`.
     pub try_token: T![?],
 }

--- a/crates/rune/src/ast/expr_unary.rs
+++ b/crates/rune/src/ast/expr_unary.rs
@@ -24,7 +24,7 @@ pub struct ExprUnary {
     /// The operation to apply.
     pub op: UnOp,
     /// The expression of the operation.
-    pub expr: ast::Expr,
+    pub expr: Box<ast::Expr>,
 }
 
 impl ExprUnary {
@@ -37,12 +37,12 @@ impl ExprUnary {
         Ok(Self {
             attributes,
             op: p.parse()?,
-            expr: ast::Expr::parse_with(
+            expr: Box::new(ast::Expr::parse_with(
                 p,
                 eager_brace,
                 ast::expr::NOT_EAGER_BINARY,
                 ast::expr::CALLABLE,
-            )?,
+            )?),
         })
     }
 }

--- a/crates/rune/src/ast/expr_while.rs
+++ b/crates/rune/src/ast/expr_while.rs
@@ -24,7 +24,7 @@ pub struct ExprWhile {
     /// The `while` keyword.
     pub while_token: T![while],
     /// The name of the binding.
-    pub condition: ast::Condition,
+    pub condition: Box<ast::Condition>,
     /// The body of the while loop.
     pub body: Box<ast::Block>,
 }

--- a/crates/rune/src/ast/expr_yield.rs
+++ b/crates/rune/src/ast/expr_yield.rs
@@ -22,7 +22,7 @@ pub struct ExprYield {
     pub yield_token: T![yield],
     /// An optional expression to yield.
     #[rune(iter)]
-    pub expr: Option<ast::Expr>,
+    pub expr: Option<Box<ast::Expr>>,
 }
 
 expr_parse!(Yield, ExprYield, "yield expression");

--- a/crates/rune/src/ast/force_semi.rs
+++ b/crates/rune/src/ast/force_semi.rs
@@ -9,7 +9,7 @@ pub struct ForceSemi {
     /// Whether or not the expressions needs a semi.
     pub needs_semi: bool,
     /// The expression to override the policy for.
-    pub expr: ast::Expr,
+    pub expr: Box<ast::Expr>,
 }
 
 impl Spanned for ForceSemi {

--- a/crates/rune/src/ast/item.rs
+++ b/crates/rune/src/ast/item.rs
@@ -5,22 +5,22 @@ use crate::ast::prelude::*;
 #[non_exhaustive]
 pub enum Item {
     /// A use declaration.
-    Use(Box<ast::ItemUse>),
+    Use(ast::ItemUse),
     /// A function declaration.
     // large variant, so boxed
-    Fn(Box<ast::ItemFn>),
+    Fn(ast::ItemFn),
     /// An enum declaration.
-    Enum(Box<ast::ItemEnum>),
+    Enum(ast::ItemEnum),
     /// A struct declaration.
-    Struct(Box<ast::ItemStruct>),
+    Struct(ast::ItemStruct),
     /// An impl declaration.
-    Impl(Box<ast::ItemImpl>),
+    Impl(ast::ItemImpl),
     /// A module declaration.
-    Mod(Box<ast::ItemMod>),
+    Mod(ast::ItemMod),
     /// A const declaration.
-    Const(Box<ast::ItemConst>),
+    Const(ast::ItemConst),
     /// A macro call expanding into an item.
-    MacroCall(Box<ast::MacroCall>),
+    MacroCall(ast::MacroCall),
 }
 
 impl Item {
@@ -89,55 +89,55 @@ impl Item {
         use std::mem::take;
 
         let item = if let Some(path) = path {
-            Self::MacroCall(Box::new(ast::MacroCall::parse_with_meta_path(
+            Self::MacroCall(ast::MacroCall::parse_with_meta_path(
                 p,
                 take(&mut attributes),
                 path,
-            )?))
+            )?)
         } else {
             let mut const_token = p.parse::<Option<T![const]>>()?;
             let mut async_token = p.parse::<Option<T![async]>>()?;
 
             let item = match p.nth(0)? {
-                K![use] => Self::Use(Box::new(ast::ItemUse::parse_with_meta(
+                K![use] => Self::Use(ast::ItemUse::parse_with_meta(
                     p,
                     take(&mut attributes),
                     take(&mut visibility),
-                )?)),
-                K![enum] => Self::Enum(Box::new(ast::ItemEnum::parse_with_meta(
+                )?),
+                K![enum] => Self::Enum(ast::ItemEnum::parse_with_meta(
                     p,
                     take(&mut attributes),
                     take(&mut visibility),
-                )?)),
-                K![struct] => Self::Struct(Box::new(ast::ItemStruct::parse_with_meta(
+                )?),
+                K![struct] => Self::Struct(ast::ItemStruct::parse_with_meta(
                     p,
                     take(&mut attributes),
                     take(&mut visibility),
-                )?)),
-                K![impl] => Self::Impl(Box::new(ast::ItemImpl::parse_with_attributes(
+                )?),
+                K![impl] => Self::Impl(ast::ItemImpl::parse_with_attributes(
                     p,
                     take(&mut attributes),
-                )?)),
-                K![fn] => Self::Fn(Box::new(ast::ItemFn::parse_with_meta(
+                )?),
+                K![fn] => Self::Fn(ast::ItemFn::parse_with_meta(
                     p,
                     take(&mut attributes),
                     take(&mut visibility),
                     take(&mut const_token),
                     take(&mut async_token),
-                )?)),
-                K![mod] => Self::Mod(Box::new(ast::ItemMod::parse_with_meta(
+                )?),
+                K![mod] => Self::Mod(ast::ItemMod::parse_with_meta(
                     p,
                     take(&mut attributes),
                     take(&mut visibility),
-                )?)),
+                )?),
                 K![ident] => {
                     if let Some(const_token) = const_token.take() {
-                        Self::Const(Box::new(ast::ItemConst::parse_with_meta(
+                        Self::Const(ast::ItemConst::parse_with_meta(
                             p,
                             take(&mut attributes),
                             take(&mut visibility),
                             const_token,
-                        )?))
+                        )?)
                     } else {
                         Self::MacroCall(p.parse()?)
                     }

--- a/crates/rune/src/ast/macro_call.rs
+++ b/crates/rune/src/ast/macro_call.rs
@@ -34,11 +34,11 @@ impl MacroCall {
     /// of the macro call.
     pub fn adjust_expr_semi(&self, expr: ast::Expr) -> ast::Expr {
         if self.needs_semi() != expr.needs_semi() {
-            ast::Expr::ForceSemi(Box::new(ast::ForceSemi {
+            ast::Expr::ForceSemi(ast::ForceSemi {
                 needs_semi: self.needs_semi(),
                 span: self.span(),
-                expr,
-            }))
+                expr: Box::new(expr),
+            })
         } else {
             expr
         }

--- a/crates/rune/src/ast/mod.rs
+++ b/crates/rune/src/ast/mod.rs
@@ -67,7 +67,7 @@ macro_rules! expr_parse {
                 let t = p.tok_at(0)?;
 
                 match $crate::ast::Expr::parse(p)? {
-                    $crate::ast::Expr::$ty(expr) => Ok(*expr),
+                    $crate::ast::Expr::$ty(expr) => Ok(expr),
                     _ => Err($crate::parse::ParseError::expected(t, $expected)),
                 }
             }
@@ -82,7 +82,7 @@ macro_rules! item_parse {
                 let t = p.tok_at(0)?;
 
                 match $crate::ast::Item::parse(p)? {
-                    $crate::ast::Item::$ty(item) => Ok(*item),
+                    $crate::ast::Item::$ty(item) => Ok(item),
                     _ => Err($crate::parse::ParseError::expected(t, $expected)),
                 }
             }

--- a/crates/rune/src/ast/pat.rs
+++ b/crates/rune/src/ast/pat.rs
@@ -50,25 +50,25 @@ impl Parse for Pat {
             K![byte] => {
                 return Ok(Self::PatLit(PatLit {
                     attributes,
-                    expr: ast::Expr::from_lit(ast::Lit::Byte(p.parse()?)),
+                    expr: Box::new(ast::Expr::from_lit(ast::Lit::Byte(p.parse()?))),
                 }));
             }
             K![char] => {
                 return Ok(Self::PatLit(PatLit {
                     attributes,
-                    expr: ast::Expr::from_lit(ast::Lit::Char(p.parse()?)),
+                    expr: Box::new(ast::Expr::from_lit(ast::Lit::Char(p.parse()?))),
                 }));
             }
             K![bytestr] => {
                 return Ok(Self::PatLit(PatLit {
                     attributes,
-                    expr: ast::Expr::from_lit(ast::Lit::ByteStr(p.parse()?)),
+                    expr: Box::new(ast::Expr::from_lit(ast::Lit::ByteStr(p.parse()?))),
                 }));
             }
             K![true] | K![false] => {
                 return Ok(Self::PatLit(PatLit {
                     attributes,
-                    expr: ast::Expr::from_lit(ast::Lit::Bool(p.parse()?)),
+                    expr: Box::new(ast::Expr::from_lit(ast::Lit::Bool(p.parse()?))),
                 }));
             }
             K![str] => {
@@ -81,14 +81,14 @@ impl Parse for Pat {
                     }),
                     _ => Self::PatLit(PatLit {
                         attributes,
-                        expr: ast::Expr::from_lit(ast::Lit::Str(p.parse()?)),
+                        expr: Box::new(ast::Expr::from_lit(ast::Lit::Str(p.parse()?))),
                     }),
                 });
             }
             K![number] => {
                 return Ok(Self::PatLit(PatLit {
                     attributes,
-                    expr: ast::Expr::from_lit(ast::Lit::Number(p.parse()?)),
+                    expr: Box::new(ast::Expr::from_lit(ast::Lit::Number(p.parse()?))),
                 }));
             }
             K![..] => {
@@ -125,7 +125,10 @@ impl Parse for Pat {
                 let expr: ast::Expr = p.parse()?;
 
                 if expr.is_lit() {
-                    return Ok(Self::PatLit(PatLit { attributes, expr }));
+                    return Ok(Self::PatLit(PatLit {
+                        attributes,
+                        expr: Box::new(expr),
+                    }));
                 }
             }
             K![_] => {
@@ -188,7 +191,7 @@ pub struct PatLit {
     #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,
     /// The literal expression.
-    pub expr: ast::Expr,
+    pub expr: Box<ast::Expr>,
 }
 
 /// The rest pattern `..` and associated attributes.

--- a/crates/rune/src/ast/stmt.rs
+++ b/crates/rune/src/ast/stmt.rs
@@ -11,6 +11,7 @@ use std::mem::take;
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, ToTokens, Spanned)]
 #[non_exhaustive]
+#[allow(clippy::large_enum_variant)]
 pub enum Stmt {
     /// A local declaration.
     Local(Box<ast::Local>),

--- a/crates/rune/src/compile/ir/mod.rs
+++ b/crates/rune/src/compile/ir/mod.rs
@@ -353,7 +353,7 @@ impl IrBreak {
     fn compile_ast(ast: &ast::ExprBreak, c: &mut IrCompiler<'_>) -> Result<Self, IrError> {
         let span = ast.span();
 
-        let kind = match &ast.expr {
+        let kind = match ast.expr.as_deref() {
             Some(expr) => match expr {
                 ast::ExprBreakValue::Expr(expr) => ir::IrBreakKind::Ir(Box::new(expr.compile(c)?)),
                 ast::ExprBreakValue::Label(label) => {

--- a/crates/rune/src/compile/v1/assemble.rs
+++ b/crates/rune/src/compile/v1/assemble.rs
@@ -1122,18 +1122,6 @@ fn expr(ast: &ast::Expr, c: &mut Assembler<'_>, needs: Needs) -> CompileResult<A
                 BuiltInMacro::File(file) => lit_str(&file.value, c, needs)?,
             }
         }
-        // NB: declarations are not used in this compilation stage.
-        // They have been separately indexed and will be built when queried
-        // for.
-        ast::Expr::Item(decl) => {
-            let span = decl.span();
-
-            if needs.value() {
-                c.asm.push(Inst::unit(), span);
-            }
-
-            Asm::top(span)
-        }
     };
 
     Ok(asm)

--- a/crates/rune/src/compile/v1/loops.rs
+++ b/crates/rune/src/compile/v1/loops.rs
@@ -69,7 +69,7 @@ impl Loops {
         &self,
         storage: &Storage,
         sources: &Sources,
-        expected: ast::Label,
+        expected: &ast::Label,
     ) -> CompileResult<(Loop, Vec<usize>)> {
         use crate::parse::Resolve;
 

--- a/crates/rune/src/indexing/index.rs
+++ b/crates/rune/src/indexing/index.rs
@@ -390,7 +390,7 @@ impl<'a> Indexer<'a> {
                         module: self.mod_item.clone(),
                         item: self.items.item().clone(),
                         source_id: self.source_id,
-                        ast: item_use,
+                        ast: Box::new(item_use),
                     };
 
                     let queue = &mut self.queue;
@@ -442,7 +442,7 @@ impl<'a> Indexer<'a> {
                         module: self.mod_item.clone(),
                         item: self.items.item().clone(),
                         source_id: self.source_id,
-                        ast: item_use,
+                        ast: Box::new(item_use),
                     };
 
                     let queue = &mut self.queue;
@@ -1125,7 +1125,7 @@ fn expr(ast: &mut ast::Expr, idx: &mut Indexer<'_>) -> CompileResult<()> {
                 }
             } else {
                 // Assert that the built-in macro has been expanded.
-                idx.q.builtin_macro_for(&**macro_call)?;
+                idx.q.builtin_macro_for(&*macro_call)?;
                 attributes.drain();
             }
         }
@@ -1434,7 +1434,7 @@ fn item(ast: &mut ast::Item, idx: &mut Indexer<'_>) -> CompileResult<()> {
             // engine.
 
             // Assert that the built-in macro has been expanded.
-            idx.q.builtin_macro_for(&**macro_call)?;
+            idx.q.builtin_macro_for(&*macro_call)?;
 
             // NB: macros are handled during pre-processing.
             attributes.drain();
@@ -1570,7 +1570,7 @@ fn expr_index(ast: &mut ast::ExprIndex, idx: &mut Indexer<'_>) -> CompileResult<
 
 #[instrument]
 fn expr_break(ast: &mut ast::ExprBreak, idx: &mut Indexer<'_>) -> CompileResult<()> {
-    if let Some(e) = &mut ast.expr {
+    if let Some(e) = ast.expr.as_deref_mut() {
         match e {
             ast::ExprBreakValue::Expr(e) => {
                 expr(e, idx)?;

--- a/crates/rune/src/indexing/index.rs
+++ b/crates/rune/src/indexing/index.rs
@@ -1044,9 +1044,6 @@ fn expr(ast: &mut ast::Expr, idx: &mut Indexer<'_>) -> CompileResult<()> {
         ast::Expr::Match(e) => {
             expr_match(e, idx)?;
         }
-        ast::Expr::Item(e) => {
-            item(e, idx)?;
-        }
         ast::Expr::Closure(e) => {
             expr_closure(e, idx)?;
         }

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -165,7 +165,6 @@
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::should_implement_trait)]
 #![allow(clippy::branches_sharing_code)]
-#![allow(clippy::result_unit_err)]
 #![allow(clippy::match_like_matches_macro)]
 #![allow(clippy::type_complexity)]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/crates/rune/src/runtime/vm_error.rs
+++ b/crates/rune/src/runtime/vm_error.rs
@@ -65,7 +65,7 @@ impl VmError {
     }
 
     /// Convert into an unwinded vm error.
-    pub fn into_unwinded(self, unit: &Arc<Unit>, ip: usize, frames: Vec<CallFrame>) -> Self {
+    pub(crate) fn into_unwinded(self, unit: &Arc<Unit>, ip: usize, frames: Vec<CallFrame>) -> Self {
         if let VmErrorKind::Unwound { .. } = &*self.kind {
             return self;
         }
@@ -79,14 +79,14 @@ impl VmError {
     }
 
     /// Unpack an unwinded error, if it is present.
-    pub fn as_unwound(&self) -> (&VmErrorKind, Option<(&Arc<Unit>, usize, Vec<CallFrame>)>) {
+    pub fn as_unwound(&self) -> (&VmErrorKind, Option<(&Arc<Unit>, usize, &[CallFrame])>) {
         match &*self.kind {
             VmErrorKind::Unwound {
                 kind,
                 unit,
                 ip,
                 frames,
-            } => (&*kind, Some((unit, *ip, frames.clone()))),
+            } => (&*kind, Some((unit, *ip, frames))),
             kind => (kind, None),
         }
     }
@@ -109,7 +109,7 @@ impl VmError {
 
     /// Unsmuggles the vm error, returning Ok(Self) in case the error is
     /// critical and should be propagated unaltered.
-    pub fn unpack_critical(self) -> Result<Self, Self> {
+    pub(crate) fn unpack_critical(self) -> Result<Self, Self> {
         if self.is_critical() {
             Err(self)
         } else {


### PR DESCRIPTION
Since every token has shrunk significantly clippy will no longer complain if we stop boxing everything in `ast::Expr`.