### PR TITLE
Clean up Call and introduce ExecutionState

### DIFF
--- a/crates/rune/src/runtime/call.rs
+++ b/crates/rune/src/runtime/call.rs
@@ -2,9 +2,7 @@ use crate::runtime::{Future, Generator, Stream, Value, Vm, VmError};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-/// How the function is called.
-///
-/// Async functions create a sub-context and immediately return futures.
+/// The calling convention of a function.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum Call {
@@ -15,12 +13,8 @@ pub enum Call {
     Immediate,
     /// Function produces a stream, also known as an async generator.
     Stream,
-    /// A stream which has been resumed.
-    ResumedStream,
     /// Function produces a generator.
     Generator,
-    /// A generator that has been resumed.
-    ResumedGenerator,
 }
 
 impl Call {
@@ -30,8 +24,8 @@ impl Call {
         Ok(match self {
             Call::Stream => Value::from(Stream::new(vm)),
             Call::Generator => Value::from(Generator::new(vm)),
-            Call::ResumedGenerator | Call::Immediate => vm.complete()?,
-            Call::ResumedStream | Call::Async => Value::from(Future::new(vm.async_complete())),
+            Call::Immediate => vm.complete()?,
+            Call::Async => Value::from(Future::new(vm.async_complete())),
         })
     }
 }
@@ -48,14 +42,8 @@ impl fmt::Display for Call {
             Self::Stream => {
                 write!(fmt, "stream")?;
             }
-            Self::ResumedStream => {
-                write!(fmt, "resumed stream")?;
-            }
             Self::Generator => {
                 write!(fmt, "generator")?;
-            }
-            Self::ResumedGenerator => {
-                write!(fmt, "resumed generator")?;
             }
         }
 

--- a/crates/rune/src/runtime/mod.rs
+++ b/crates/rune/src/runtime/mod.rs
@@ -107,6 +107,6 @@ pub use self::vec_tuple::VecTuple;
 pub use self::vm::{CallFrame, Vm};
 pub(crate) use self::vm_call::VmCall;
 pub use self::vm_error::{VmError, VmErrorKind, VmIntegerRepr};
-pub use self::vm_execution::{VmExecution, VmSendExecution};
+pub use self::vm_execution::{ExecutionState, VmExecution, VmSendExecution};
 pub(crate) use self::vm_halt::VmHalt;
 pub use self::vm_halt::VmHaltInfo;

--- a/crates/rune/src/runtime/vm_call.rs
+++ b/crates/rune/src/runtime/vm_call.rs
@@ -3,8 +3,8 @@ use crate::runtime::{Call, Future, Generator, Stream, Value, Vm, VmError, VmExec
 /// An instruction to push a virtual machine to the execution.
 #[derive(Debug)]
 pub(crate) struct VmCall {
-    pub(crate) call: Call,
-    pub(crate) vm: Vm,
+    call: Call,
+    vm: Vm,
 }
 
 impl VmCall {
@@ -19,8 +19,8 @@ impl VmCall {
         T: AsMut<Vm>,
     {
         let value = match self.call {
-            Call::ResumedStream | Call::Async => Value::from(Future::new(self.vm.async_complete())),
-            Call::ResumedGenerator | Call::Immediate => {
+            Call::Async => Value::from(Future::new(self.vm.async_complete())),
+            Call::Immediate => {
                 execution.push_vm(self.vm);
                 return Ok(());
             }

--- a/crates/rune/src/runtime/vm_error.rs
+++ b/crates/rune/src/runtime/vm_error.rs
@@ -1,8 +1,8 @@
 use crate::compile::Item;
 use crate::runtime::panic::BoxedPanic;
 use crate::runtime::{
-    AccessError, Call, CallFrame, Key, Panic, Protocol, StackError, TypeInfo, TypeOf, Unit, Value,
-    VmHaltInfo,
+    AccessError, CallFrame, ExecutionState, Key, Panic, Protocol, StackError, TypeInfo, TypeOf,
+    Unit, Value, VmHaltInfo,
 };
 use crate::Hash;
 use std::fmt;
@@ -325,8 +325,11 @@ pub enum VmErrorKind {
     IndexOutOfBounds,
     #[error("unsupported range")]
     UnsupportedRange,
-    #[error("expected to be a {expected} function, but was an {actual} function")]
-    ExpectedCall { expected: Call, actual: Call },
+    #[error("expected execution to be {expected}, but was {actual}")]
+    ExpectedExecutionState {
+        expected: ExecutionState,
+        actual: ExecutionState,
+    },
 }
 
 impl VmErrorKind {


### PR DESCRIPTION
So I noted that a `VmExecution` only needs to keep track of two states - whether the current execution is `initial`, or whether it is `resumed`. The latter simply means that the function is a generator or a stream that has been called at least once. While every other function is in the `initial` state.

This is necessary to help top level executions to be correctly managed, because resuming a `resumed` execution requires a value to be pushed onto the stack which will be the return value of the yield statement.

As a result this reverts `Call` back into a sparser state.