### PR TITLE
Parse multiline comments

### DIFF
--- a/crates/rune/src/ast/generated.rs
+++ b/crates/rune/src/ast/generated.rs
@@ -4330,6 +4330,10 @@ macro_rules! K {
 pub enum Kind {
     /// En end-of-file marker.
     Eof,
+    /// A single-line comment.
+    Comment,
+    /// A multiline comment where the boolean indicates if it's been terminated correctly.
+    MultilineComment(bool),
     /// En error marker.
     Error,
     /// A close delimiter: `)`, `}`, or `]`.
@@ -4738,6 +4742,7 @@ impl parse::IntoExpectation for Kind {
     fn into_expectation(self) -> parse::Expectation {
         match self {
             Self::Eof => parse::Expectation::Description("eof"),
+            Self::Comment | Self::MultilineComment(..) => parse::Expectation::Comment,
             Self::Error => parse::Expectation::Description("error"),
             Self::Ident(..) => parse::Expectation::Description("ident"),
             Self::Label(..) => parse::Expectation::Description("label"),

--- a/crates/rune/src/parse/expectation.rs
+++ b/crates/rune/src/parse/expectation.rs
@@ -20,6 +20,8 @@ pub enum Expectation {
     Literal,
     /// An expression.
     Expression,
+    /// A comment.
+    Comment,
 }
 
 impl fmt::Display for Expectation {
@@ -33,6 +35,7 @@ impl fmt::Display for Expectation {
             Expectation::Boolean => write!(f, "true or false"),
             Expectation::Literal => write!(f, r#"literal like `"a string"` or 42"#),
             Expectation::Expression => write!(f, "expression"),
+            Expectation::Comment => write!(f, "comment"),
         }
     }
 }

--- a/crates/rune/src/parse/parse_error.rs
+++ b/crates/rune/src/parse/parse_error.rs
@@ -111,4 +111,6 @@ pub enum ParseErrorKind {
     MultipleMatchingAttributes { name: &'static str },
     #[error("missing source id `{source_id}`")]
     MissingSourceId { source_id: SourceId },
+    #[error("expected multiline comment to be terminated with a `*/`")]
+    ExpectedMultilineCommentTerm,
 }

--- a/crates/rune/src/parse/parser.rs
+++ b/crates/rune/src/parse/parser.rs
@@ -290,6 +290,21 @@ impl<'a> Peeker<'a> {
                 None => break,
             };
 
+            match token.kind {
+                Kind::Comment => continue,
+                Kind::MultilineComment(term) => {
+                    if !term {
+                        return Err(ParseError::new(
+                            token.span,
+                            ParseErrorKind::ExpectedMultilineCommentTerm,
+                        ));
+                    }
+
+                    continue;
+                }
+                _ => (),
+            }
+
             self.last = Some(token.span);
             self.buf.push_back(token);
         }

--- a/tests/tests/comments.rs
+++ b/tests/tests/comments.rs
@@ -1,0 +1,33 @@
+use rune::parse::ParseErrorKind::*;
+use rune::span;
+use rune_tests::*;
+
+#[test]
+fn test_non_terminated_multiline_comments() {
+    assert_parse_error! {
+        r#"/* foo"#,
+        span, ExpectedMultilineCommentTerm => {
+            assert_eq!(span, span!(0, 6));
+        }
+    };
+
+    assert_parse_error! {
+        r#"/*
+        foo
+        bar"#,
+        span, ExpectedMultilineCommentTerm => {
+            assert_eq!(span, span!(0, 26));
+        }
+    };
+
+    assert_parse_error! {
+        r#"
+        foo
+        /*
+        foo
+        bar"#,
+        span, ExpectedMultilineCommentTerm => {
+            assert_eq!(span, span!(21, 47));
+        }
+    };
+}

--- a/tools/generate/src/main.rs
+++ b/tools/generate/src/main.rs
@@ -232,6 +232,10 @@ fn main() -> Result<()> {
             pub enum Kind {
                 #("/// En end-of-file marker.")
                 Eof,
+                #("/// A single-line comment.")
+                Comment,
+                #("/// A multiline comment where the boolean indicates if it's been terminated correctly.")
+                MultilineComment(bool),
                 #("/// En error marker.")
                 Error,
                 #("/// A close delimiter: `)`, `}`, or `]`.")
@@ -304,6 +308,7 @@ fn main() -> Result<()> {
                 fn into_expectation(self) -> #expectation {
                     match self {
                         Self::Eof => #expectation::Description("eof"),
+                        Self::Comment | Self::MultilineComment(..) => #expectation::Comment,
                         Self::Error => #expectation::Description("error"),
                         Self::Ident(..) => #expectation::Description("ident"),
                         Self::Label(..) => #expectation::Description("label"),


### PR DESCRIPTION
This also changes so that we create tokens out of comments in anticipation of one day switching to non-destructive parsing. But by that point erroneous comments would also receive their own token instead of using a `bool` to indicate if it's terminated or not.