### PR TITLE
Support parsing of a shebang (fixes #270)

### DIFF
--- a/crates/rune/src/ast/attribute.rs
+++ b/crates/rune/src/ast/attribute.rs
@@ -174,9 +174,9 @@ mod tests {
         ];
 
         for s in TEST_STRINGS.iter() {
-            parse_all::<ast::Attribute>(s, SourceId::empty()).expect(s);
+            parse_all::<ast::Attribute>(s, SourceId::empty(), false).expect(s);
             let withbang = s.replacen("#[", "#![", 1);
-            parse_all::<ast::Attribute>(&withbang, SourceId::empty()).expect(&withbang);
+            parse_all::<ast::Attribute>(&withbang, SourceId::empty(), false).expect(&withbang);
         }
     }
 }

--- a/crates/rune/src/ast/generated.rs
+++ b/crates/rune/src/ast/generated.rs
@@ -4206,6 +4206,7 @@ macro_rules! T {
 /// Helper macro to reference a specific token kind, or short sequence of kinds.
 #[macro_export]
 macro_rules! K {
+    (#!($($tt:tt)*)) => { $crate::ast::Kind::Shebang($($tt)*) };
     (ident) => { $crate::ast::Kind::Ident(..) };
     (ident ($($tt:tt)*)) => { $crate::ast::Kind::Ident($($tt)*) };
     ('label) => { $crate::ast::Kind::Label(..) };
@@ -4336,6 +4337,8 @@ pub enum Kind {
     MultilineComment(bool),
     /// En error marker.
     Error,
+    /// The special initial line of a file shebang.
+    Shebang(ast::LitSource),
     /// A close delimiter: `)`, `}`, or `]`.
     Close(ast::Delimiter),
     /// An open delimiter: `(`, `{`, or `[`.
@@ -4744,6 +4747,7 @@ impl parse::IntoExpectation for Kind {
             Self::Eof => parse::Expectation::Description("eof"),
             Self::Comment | Self::MultilineComment(..) => parse::Expectation::Comment,
             Self::Error => parse::Expectation::Description("error"),
+            Self::Shebang { .. } => parse::Expectation::Description("shebang"),
             Self::Ident(..) => parse::Expectation::Description("ident"),
             Self::Label(..) => parse::Expectation::Description("label"),
             Self::Byte { .. } => parse::Expectation::Description("byte"),

--- a/crates/rune/src/ast/item_fn.rs
+++ b/crates/rune/src/ast/item_fn.rs
@@ -11,7 +11,7 @@ use crate::ast::prelude::*;
 /// use rune::testing;
 ///
 /// testing::roundtrip::<ast::ItemFn>("async fn hello() {}");
-/// assert!(parse_all::<ast::ItemFn>("fn async hello() {}", SourceId::empty()).is_err());
+/// assert!(parse_all::<ast::ItemFn>("fn async hello() {}", SourceId::EMPTY, false).is_err());
 ///
 /// let item = testing::roundtrip::<ast::ItemFn>("fn hello() {}");
 /// assert_eq!(item.args.len(), 0);

--- a/crates/rune/src/ast/mod.rs
+++ b/crates/rune/src/ast/mod.rs
@@ -188,7 +188,7 @@ pub use self::expr_unary::{ExprUnary, UnOp};
 pub use self::expr_vec::ExprVec;
 pub use self::expr_while::ExprWhile;
 pub use self::expr_yield::ExprYield;
-pub use self::file::File;
+pub use self::file::{File, Shebang};
 pub use self::fn_arg::FnArg;
 pub use self::force_semi::ForceSemi;
 pub use self::grouped::{AngleBracketed, Braced, Bracketed, Parenthesized};

--- a/crates/rune/src/macros/macro_context.rs
+++ b/crates/rune/src/macros/macro_context.rs
@@ -233,7 +233,7 @@ impl<'a> MacroContext<'a> {
             )
         })?;
 
-        crate::parse::parse_all(source.as_str(), id)
+        crate::parse::parse_all(source.as_str(), id, false)
     }
 
     /// The span of the macro call including the name of the macro.

--- a/crates/rune/src/parse/expectation.rs
+++ b/crates/rune/src/parse/expectation.rs
@@ -20,6 +20,8 @@ pub enum Expectation {
     Literal,
     /// An expression.
     Expression,
+    /// A shebang.
+    Shebang,
     /// A comment.
     Comment,
 }
@@ -35,6 +37,7 @@ impl fmt::Display for Expectation {
             Expectation::Boolean => write!(f, "true or false"),
             Expectation::Literal => write!(f, r#"literal like `"a string"` or 42"#),
             Expectation::Expression => write!(f, "expression"),
+            Expectation::Shebang => write!(f, "shebang"),
             Expectation::Comment => write!(f, "comment"),
         }
     }

--- a/crates/rune/src/parse/mod.rs
+++ b/crates/rune/src/parse/mod.rs
@@ -14,7 +14,7 @@ mod resolve;
 pub use self::expectation::Expectation;
 pub(crate) use self::expectation::IntoExpectation;
 pub use self::id::{Id, NonZeroId};
-pub use self::lexer::{Lexer, LexerMode};
+pub(crate) use self::lexer::{Lexer, LexerMode};
 pub(crate) use self::opaque::Opaque;
 pub use self::parse::Parse;
 pub use self::parse_error::{ParseError, ParseErrorKind};
@@ -26,12 +26,16 @@ use crate::SourceId;
 
 /// Parse the given input as the given type that implements
 /// [Parse][crate::parse::Parse]. The specified `source_id` will be used when
-/// referencing any parsed elements.
-pub fn parse_all<T>(source: &str, source_id: SourceId) -> Result<T, ParseError>
+/// referencing any parsed elements. `shebang` indicates if the parser should
+/// try to parse a shebang or not.
+///
+/// This will raise an error through [Parser::eof] if the specified `source` is
+/// not fully consumed by the parser.
+pub fn parse_all<T>(source: &str, source_id: SourceId, shebang: bool) -> Result<T, ParseError>
 where
     T: Parse,
 {
-    let mut parser = Parser::new(source, source_id);
+    let mut parser = Parser::new(source, source_id, shebang);
     let ast = parser.parse::<T>()?;
     parser.eof()?;
     Ok(ast)

--- a/crates/rune/src/parse/parser.rs
+++ b/crates/rune/src/parse/parser.rs
@@ -15,8 +15,10 @@ use std::ops;
 /// use rune::SourceId;
 /// use rune::parse::Parser;
 ///
-/// let mut parser = Parser::new("fn foo() {}", SourceId::empty());
-/// parser.parse::<ast::ItemFn>().unwrap();
+/// # fn main() -> rune::Result<()> {
+/// let mut parser = Parser::new("fn foo() {}", SourceId::empty(), false);
+/// let ast = parser.parse::<ast::ItemFn>()?;
+/// # Ok(()) }
 /// ```
 #[derive(Debug)]
 pub struct Parser<'a> {
@@ -25,10 +27,12 @@ pub struct Parser<'a> {
 
 impl<'a> Parser<'a> {
     /// Construct a new parser around the given source.
-    pub fn new(source: &'a str, source_id: SourceId) -> Self {
+    ///
+    /// `shebang` indicates if the parser should try and parse a shebang or not.
+    pub fn new(source: &'a str, source_id: SourceId, shebang: bool) -> Self {
         Self::with_source(
             Source {
-                inner: SourceInner::Lexer(Lexer::new(source, source_id)),
+                inner: SourceInner::Lexer(Lexer::new(source, source_id, shebang)),
             },
             Span::new(0u32, source.len()),
         )

--- a/crates/rune/src/testing.rs
+++ b/crates/rune/src/testing.rs
@@ -16,7 +16,7 @@ where
 {
     let source_id = SourceId::empty();
 
-    let mut parser = Parser::new(source, source_id);
+    let mut parser = Parser::new(source, source_id, false);
     let ast = parser.parse::<T>().expect("first parse");
     parser.eof().expect("first parse eof");
 

--- a/crates/rune/src/worker/mod.rs
+++ b/crates/rune/src/worker/mod.rs
@@ -86,14 +86,17 @@ impl<'a> Worker<'a> {
                         }
                     };
 
-                    let mut file =
-                        match crate::parse::parse_all::<ast::File>(source.as_str(), source_id) {
-                            Ok(file) => file,
-                            Err(error) => {
-                                self.diagnostics.error(source_id, error);
-                                continue;
-                            }
-                        };
+                    let mut file = match crate::parse::parse_all::<ast::File>(
+                        source.as_str(),
+                        source_id,
+                        true,
+                    ) {
+                        Ok(file) => file,
+                        Err(error) => {
+                            self.diagnostics.error(source_id, error);
+                            continue;
+                        }
+                    };
 
                     let root = match kind {
                         LoadFileKind::Root => source.path().map(ToOwned::to_owned),

--- a/tools/generate/src/main.rs
+++ b/tools/generate/src/main.rs
@@ -199,6 +199,7 @@ fn main() -> Result<()> {
             #("/// Helper macro to reference a specific token kind, or short sequence of kinds.")
             #[macro_export]
             macro_rules! K {
+                (#!($($tt:tt)*)) => { $crate::ast::Kind::Shebang($($tt)*) };
                 (ident) => { $crate::ast::Kind::Ident(..) };
                 (ident ($($tt:tt)*)) => { $crate::ast::Kind::Ident($($tt)*) };
                 ('label) => { $crate::ast::Kind::Label(..) };
@@ -238,6 +239,8 @@ fn main() -> Result<()> {
                 MultilineComment(bool),
                 #("/// En error marker.")
                 Error,
+                #("/// The special initial line of a file shebang.")
+                Shebang(#lit_source),
                 #("/// A close delimiter: `)`, `}`, or `]`.")
                 Close(#delimiter),
                 #("/// An open delimiter: `(`, `{`, or `[`.")
@@ -310,6 +313,7 @@ fn main() -> Result<()> {
                         Self::Eof => #expectation::Description("eof"),
                         Self::Comment | Self::MultilineComment(..) => #expectation::Comment,
                         Self::Error => #expectation::Description("error"),
+                        Self::Shebang { .. } => #expectation::Description("shebang"),
                         Self::Ident(..) => #expectation::Description("ident"),
                         Self::Label(..) => #expectation::Description("label"),
                         Self::Byte { .. } => #expectation::Description("byte"),


### PR DESCRIPTION
This adds support in the parser so that it ignores shebangs which are on the first input character when parsing files.

The shebang is also captured and made available in `ast::File`, all though parsing of it is disabled by default (e.g. `MacroContext::parse_source`).

One thing of note is that shebangs currently are not formatted with `stringify!`, since a token stream is not whitespace aware and the result would run the risk of not making much sense to parses of it.

With this, it should now be possible to write rune scripts without the hack proposed in #270, like this:

```rust
#!/usr/bin/rune run

pub fn main() {
    println!("Hello Rune!");
}
```