### PR TITLE
Clean up CLI

### DIFF
--- a/crates/rune-cli/Cargo.toml
+++ b/crates/rune-cli/Cargo.toml
@@ -21,7 +21,7 @@ log = "0.4.14"
 env_logger = "0.9.0"
 tokio = { version = "1.14.0", features = ["rt-multi-thread", "net", "fs", "macros"] }
 codespan-reporting = "0.11.1"
-anyhow = "1.0.49"
+anyhow = { version = "1.0.49", features = ["std"] }
 structopt = { version = "0.3.25", default-features = false, features = ["wrap_help", "suggestions", "color"] }
 
 rune = {version = "0.10.0", path = "../rune"}

--- a/crates/rune-cli/src/check.rs
+++ b/crates/rune-cli/src/check.rs
@@ -1,0 +1,61 @@
+use crate::{visitor, ExitCode, SharedFlags};
+use anyhow::{Context, Result};
+use rune::compile::FileSourceLoader;
+use rune::termcolor::StandardStream;
+use rune::{Diagnostics, Options, Source, Sources};
+use std::io::Write;
+use std::path::Path;
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug, Clone)]
+pub(crate) struct Flags {
+    /// Exit with a non-zero exit-code even for warnings
+    #[structopt(long)]
+    warnings_are_errors: bool,
+
+    #[structopt(flatten)]
+    pub(crate) shared: SharedFlags,
+}
+
+pub(crate) fn run(
+    o: &mut StandardStream,
+    flags: &Flags,
+    options: &Options,
+    path: &Path,
+) -> Result<ExitCode> {
+    writeln!(o, "Checking: {}", path.display())?;
+
+    let context = flags.shared.context()?;
+
+    let source =
+        Source::from_path(path).with_context(|| format!("reading file: {}", path.display()))?;
+
+    let mut sources = Sources::new();
+
+    sources.insert(source);
+
+    let mut diagnostics = if flags.shared.warnings || flags.warnings_are_errors {
+        Diagnostics::new()
+    } else {
+        Diagnostics::without_warnings()
+    };
+
+    let mut test_finder = visitor::FunctionVisitor::new(visitor::Attribute::None);
+    let mut source_loader = FileSourceLoader::new();
+
+    let _ = rune::prepare(&mut sources)
+        .with_context(&context)
+        .with_diagnostics(&mut diagnostics)
+        .with_options(options)
+        .with_visitor(&mut test_finder)
+        .with_source_loader(&mut source_loader)
+        .build();
+
+    diagnostics.emit(o, &sources)?;
+
+    if diagnostics.has_error() || flags.warnings_are_errors && diagnostics.has_warning() {
+        Ok(ExitCode::Failure)
+    } else {
+        Ok(ExitCode::Success)
+    }
+}

--- a/crates/rune-cli/src/loader.rs
+++ b/crates/rune-cli/src/loader.rs
@@ -1,0 +1,150 @@
+use crate::{visitor, Args};
+use anyhow::{anyhow, Context as _, Result};
+use rune::compile::FileSourceLoader;
+use rune::compile::Meta;
+use rune::termcolor::StandardStream;
+use rune::Diagnostics;
+use rune::{Context, Hash, Options, Source, Sources, Unit};
+use std::collections::VecDeque;
+use std::ffi::OsStr;
+use std::fs;
+use std::io;
+use std::path::PathBuf;
+use std::{path::Path, sync::Arc};
+
+pub(crate) struct Load {
+    pub(crate) unit: Arc<Unit>,
+    pub(crate) sources: Sources,
+    pub(crate) functions: Vec<(Hash, Meta)>,
+}
+
+/// Load context and code for a given path
+pub(crate) fn load(
+    o: &mut StandardStream,
+    context: &Context,
+    args: &Args,
+    options: &Options,
+    path: &Path,
+    attribute: visitor::Attribute,
+) -> Result<Load> {
+    let shared = args.shared();
+
+    let bytecode_path = path.with_extension("rnc");
+
+    let source =
+        Source::from_path(path).with_context(|| anyhow!("cannot read file: {}", path.display()))?;
+
+    let mut sources = Sources::new();
+    sources.insert(source);
+
+    let use_cache = options.bytecode && should_cache_be_used(path, &bytecode_path)?;
+
+    // TODO: how do we deal with tests discovery for bytecode loading
+    let maybe_unit = if use_cache {
+        let f = fs::File::open(&bytecode_path)?;
+
+        match bincode::deserialize_from::<_, Unit>(f) {
+            Ok(unit) => {
+                log::trace!("using cache: {}", bytecode_path.display());
+                Some(Arc::new(unit))
+            }
+            Err(e) => {
+                log::error!("failed to deserialize: {}: {}", bytecode_path.display(), e);
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    let (unit, functions) = match maybe_unit {
+        Some(unit) => (unit, Default::default()),
+        None => {
+            log::trace!("building file: {}", path.display());
+
+            let mut diagnostics = if shared.warnings {
+                Diagnostics::new()
+            } else {
+                Diagnostics::without_warnings()
+            };
+
+            let mut functions = visitor::FunctionVisitor::new(attribute);
+            let mut source_loader = FileSourceLoader::new();
+
+            let result = rune::prepare(&mut sources)
+                .with_context(context)
+                .with_diagnostics(&mut diagnostics)
+                .with_options(options)
+                .with_visitor(&mut functions)
+                .with_source_loader(&mut source_loader)
+                .build();
+
+            diagnostics.emit(o, &sources)?;
+            let unit = result?;
+
+            if options.bytecode {
+                log::trace!("serializing cache: {}", bytecode_path.display());
+                let f = fs::File::create(&bytecode_path)?;
+                bincode::serialize_into(f, &unit)?;
+            }
+
+            (Arc::new(unit), functions.into_functions())
+        }
+    };
+
+    Ok(Load {
+        unit,
+        sources,
+        functions,
+    })
+}
+
+/// Test if path `a` is newer than path `b`.
+fn should_cache_be_used(source: &Path, cached: &Path) -> io::Result<bool> {
+    let source = fs::metadata(source)?;
+
+    let cached = match fs::metadata(cached) {
+        Ok(cached) => cached,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error),
+    };
+
+    Ok(source.modified()? < cached.modified()?)
+}
+
+pub(crate) fn walk_paths(
+    recursive: bool,
+    paths: Vec<PathBuf>,
+) -> impl Iterator<Item = io::Result<PathBuf>> {
+    let mut queue = paths.into_iter().collect::<VecDeque<_>>();
+
+    std::iter::from_fn(move || loop {
+        let path = queue.pop_front()?;
+
+        if !recursive {
+            return Some(Ok(path));
+        }
+
+        if path.is_file() {
+            if path.extension() == Some(OsStr::new("rn")) {
+                return Some(Ok(path));
+            }
+
+            continue;
+        }
+
+        let d = match fs::read_dir(path) {
+            Ok(d) => d,
+            Err(error) => return Some(Err(error)),
+        };
+
+        for e in d {
+            let e = match e {
+                Ok(e) => e,
+                Err(error) => return Some(Err(error)),
+            };
+
+            queue.push_back(e.path());
+        }
+    })
+}

--- a/crates/rune-cli/src/main.rs
+++ b/crates/rune-cli/src/main.rs
@@ -48,21 +48,20 @@
 //!
 //! [Rune Language]: https://rune-rs.github.io
 //! [rune]: https://github.com/rune-rs/rune
-#![allow(clippy::type_complexity)]
 
-use anyhow::{Context as _, Result};
-use rune::compile::{FileSourceLoader, Meta, ParseOptionError};
-use rune::runtime::{RuntimeContext, Unit, Value, Vm, VmError, VmExecution};
-use rune::termcolor::{ColorChoice, StandardStream};
-use rune::{Context, ContextError, Diagnostics, Hash, Options, Source, Sources};
-use std::fs;
-use std::io;
-use std::io::Write;
+use anyhow::Result;
+use rune::compile::ParseOptionError;
+use rune::termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+use rune::{Context, ContextError, Options};
+use std::error::Error;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use structopt::StructOpt;
 
 mod benches;
+mod check;
+mod loader;
+mod run;
 mod tests;
 mod visitor;
 
@@ -71,16 +70,13 @@ pub const VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/version.txt"))
 #[derive(StructOpt, Debug, Clone)]
 enum Command {
     /// Run checks but do not execute
-    Check(CheckFlags),
-
+    Check(check::Flags),
     /// Run all tests but do not execute
-    Test(TestFlags),
-
+    Test(tests::Flags),
     /// Run the given program as a benchmark
-    Bench(BenchFlags),
-
+    Bench(benches::Flags),
     /// Run the designated script
-    Run(RunFlags),
+    Run(run::Flags),
 }
 
 impl Command {
@@ -94,37 +90,14 @@ impl Command {
                 args.shared.test = true;
             }
             Command::Run(args) => {
-                if args.dump {
-                    args.dump_constants = true;
-                    args.dump_unit = true;
-                    args.dump_stack = true;
-                    args.dump_functions = true;
-                    args.dump_types = true;
-                    args.dump_native_functions = true;
-                    args.dump_native_types = true;
-                }
-
-                if args.dump_unit {
-                    args.dump_unit = true;
-                    args.emit_instructions = true;
-                }
-
-                if args.dump_functions
-                    || args.dump_native_functions
-                    || args.dump_stack
-                    || args.dump_types
-                    || args.dump_constants
-                    || args.emit_instructions
-                {
-                    args.dump_unit = true;
-                }
+                args.propagate_related_flags();
             }
         }
     }
 }
 
 #[derive(StructOpt, Debug, Clone)]
-struct SharedArgs {
+struct SharedFlags {
     /// Enable experimental features.
     ///
     /// This makes the `std::experimental` module available to scripts.
@@ -163,7 +136,7 @@ struct SharedArgs {
     paths: Vec<PathBuf>,
 }
 
-impl SharedArgs {
+impl SharedFlags {
     /// Construct a rune context according to the specified argument.
     fn context(&self) -> Result<Context, ContextError> {
         let mut context = rune_modules::default_context()?;
@@ -178,91 +151,6 @@ impl SharedArgs {
 
         Ok(context)
     }
-}
-
-#[derive(StructOpt, Debug, Clone)]
-struct CheckFlags {
-    /// Exit with a non-zero exit-code even for warnings
-    #[structopt(long)]
-    warnings_are_errors: bool,
-
-    #[structopt(flatten)]
-    shared: SharedArgs,
-}
-
-#[derive(StructOpt, Debug, Clone)]
-pub(crate) struct TestFlags {
-    /// Display one character per test instead of one line
-    #[structopt(short = "q", long)]
-    quiet: bool,
-
-    /// Run all tests regardless of failure
-    #[structopt(long)]
-    no_fail_fast: bool,
-
-    #[structopt(flatten)]
-    shared: SharedArgs,
-}
-
-#[derive(StructOpt, Debug, Clone)]
-pub(crate) struct BenchFlags {
-    /// Rounds of warmup to perform
-    #[structopt(long, default_value = "100")]
-    warmup: u32,
-
-    /// Iterations to run of the benchmark
-    #[structopt(long, default_value = "100")]
-    iterations: u32,
-
-    #[structopt(flatten)]
-    shared: SharedArgs,
-}
-
-#[derive(StructOpt, Debug, Clone)]
-struct RunFlags {
-    /// Provide detailed tracing for each instruction executed.
-    #[structopt(short, long)]
-    trace: bool,
-    /// Dump everything.
-    #[structopt(short, long)]
-    dump: bool,
-    /// Dump default information about unit.
-    #[structopt(long)]
-    dump_unit: bool,
-    /// Dump constants from the unit.
-    #[structopt(long)]
-    dump_constants: bool,
-    /// Dump unit instructions.
-    #[structopt(long)]
-    emit_instructions: bool,
-    /// Dump the state of the stack after completion.
-    ///
-    /// If compiled with `--trace` will dump it after each instruction.
-    #[structopt(long)]
-    dump_stack: bool,
-
-    /// Dump dynamic functions.
-    #[structopt(long)]
-    dump_functions: bool,
-
-    /// Dump dynamic types.
-    #[structopt(long)]
-    dump_types: bool,
-
-    /// Dump native functions.
-    #[structopt(long)]
-    dump_native_functions: bool,
-
-    /// Dump native types.
-    #[structopt(long)]
-    dump_native_types: bool,
-
-    /// Include source code references where appropriate (only available if -O debug-info=true).
-    #[structopt(long)]
-    with_source: bool,
-
-    #[structopt(flatten)]
-    shared: SharedArgs,
 }
 
 #[derive(Debug, Clone, StructOpt)]
@@ -280,7 +168,7 @@ struct Args {
     color: String,
 
     /// The command to execute
-    #[structopt(subcommand)] // Note that we mark a field as a subcommand
+    #[structopt(subcommand)]
     cmd: Command,
 }
 
@@ -306,7 +194,7 @@ impl Args {
     }
 
     /// Access shared arguments.
-    fn shared(&self) -> &SharedArgs {
+    fn shared(&self) -> &SharedFlags {
         match &self.cmd {
             Command::Check(args) => &args.shared,
             Command::Test(args) => &args.shared,
@@ -316,7 +204,7 @@ impl Args {
     }
 
     /// Access shared arguments mutably.
-    fn shared_mut(&mut self) -> &mut SharedArgs {
+    fn shared_mut(&mut self) -> &mut SharedFlags {
         match &mut self.cmd {
             Command::Check(args) => &mut args.shared,
             Command::Test(args) => &mut args.shared,
@@ -335,418 +223,6 @@ const SPECIAL_FILES: &[&str] = &[
     "script/lib.rn",
 ];
 
-async fn try_main() -> Result<ExitCode> {
-    env_logger::init();
-
-    let mut args = Args::from_args();
-    args.cmd.propagate_related_flags();
-
-    let options = args.options()?;
-
-    let shared = args.shared_mut();
-
-    if shared.paths.is_empty() {
-        for file in SPECIAL_FILES {
-            let path = PathBuf::from(file);
-            if path.exists() && path.is_file() {
-                shared.paths.push(path);
-                break;
-            }
-        }
-
-        if shared.paths.is_empty() {
-            println!("Invalid usage: No input path given and no main or lib file found");
-            return Ok(ExitCode::Failure);
-        }
-    }
-
-    let paths = walk_paths(shared.recursive, std::mem::take(&mut shared.paths));
-
-    for path in paths {
-        let path = path?;
-
-        match run_path(&args, &options, &path).await? {
-            ExitCode::Success => (),
-            other => {
-                return Ok(other);
-            }
-        }
-    }
-
-    Ok(ExitCode::Success)
-}
-
-fn walk_paths(recursive: bool, paths: Vec<PathBuf>) -> impl Iterator<Item = io::Result<PathBuf>> {
-    use std::collections::VecDeque;
-    use std::ffi::OsStr;
-
-    let mut queue = paths.into_iter().collect::<VecDeque<_>>();
-
-    std::iter::from_fn(move || loop {
-        let path = queue.pop_front()?;
-
-        if !recursive {
-            return Some(Ok(path));
-        }
-
-        if path.is_file() {
-            if path.extension() == Some(OsStr::new("rn")) {
-                return Some(Ok(path));
-            }
-
-            continue;
-        }
-
-        let d = match fs::read_dir(path) {
-            Ok(d) => d,
-            Err(error) => return Some(Err(error)),
-        };
-
-        for e in d {
-            let e = match e {
-                Ok(e) => e,
-                Err(error) => return Some(Err(error)),
-            };
-
-            queue.push_back(e.path());
-        }
-    })
-}
-
-/// Load context and code for a given path
-fn load_path(
-    out: &mut StandardStream,
-    args: &Args,
-    options: &Options,
-    path: &Path,
-    attribute: visitor::Attribute,
-) -> Result<(
-    Arc<Unit>,
-    Context,
-    Arc<RuntimeContext>,
-    Sources,
-    Vec<(Hash, Meta)>,
-)> {
-    let shared = args.shared();
-    let context = shared.context()?;
-
-    let bytecode_path = path.with_extension("rnc");
-
-    let source =
-        Source::from_path(path).with_context(|| format!("reading file: {}", path.display()))?;
-
-    let runtime = Arc::new(context.runtime());
-    let mut sources = Sources::new();
-
-    sources.insert(source);
-
-    let use_cache = options.bytecode && should_cache_be_used(path, &bytecode_path)?;
-
-    // TODO: how do we deal with tests discovery for bytecode loading
-    let maybe_unit = if use_cache {
-        let f = fs::File::open(&bytecode_path)?;
-
-        match bincode::deserialize_from::<_, Unit>(f) {
-            Ok(unit) => {
-                log::trace!("using cache: {}", bytecode_path.display());
-                Some(Arc::new(unit))
-            }
-            Err(e) => {
-                log::error!("failed to deserialize: {}: {}", bytecode_path.display(), e);
-                None
-            }
-        }
-    } else {
-        None
-    };
-
-    let (unit, functions) = match maybe_unit {
-        Some(unit) => (unit, Default::default()),
-        None => {
-            log::trace!("building file: {}", path.display());
-
-            let mut diagnostics = if shared.warnings {
-                Diagnostics::new()
-            } else {
-                Diagnostics::without_warnings()
-            };
-
-            let mut test_finder = visitor::FunctionVisitor::new(attribute);
-            let mut source_loader = FileSourceLoader::new();
-
-            let result = rune::prepare(&mut sources)
-                .with_context(&context)
-                .with_diagnostics(&mut diagnostics)
-                .with_options(options)
-                .with_visitor(&mut test_finder)
-                .with_source_loader(&mut source_loader)
-                .build();
-
-            diagnostics.emit(out, &sources)?;
-            let unit = result?;
-
-            if options.bytecode {
-                log::trace!("serializing cache: {}", bytecode_path.display());
-                let f = fs::File::create(&bytecode_path)?;
-                bincode::serialize_into(f, &unit)?;
-            }
-
-            (Arc::new(unit), test_finder.into_functions())
-        }
-    };
-
-    Ok((unit, context, runtime, sources, functions))
-}
-
-/// Run a single path.
-async fn run_path(args: &Args, options: &Options, path: &Path) -> Result<ExitCode> {
-    let choice = match args.color.as_str() {
-        "always" => ColorChoice::Always,
-        "ansi" => ColorChoice::AlwaysAnsi,
-        "auto" => {
-            if atty::is(atty::Stream::Stdout) {
-                ColorChoice::Auto
-            } else {
-                ColorChoice::Never
-            }
-        }
-        "never" => ColorChoice::Never,
-        _ => ColorChoice::Auto,
-    };
-
-    let mut out = StandardStream::stdout(choice);
-
-    match &args.cmd {
-        Command::Check(checkargs) => {
-            writeln!(out, "Checking: {}", path.display())?;
-
-            let context = checkargs.shared.context()?;
-
-            let source = Source::from_path(path)
-                .with_context(|| format!("reading file: {}", path.display()))?;
-
-            let mut sources = Sources::new();
-
-            sources.insert(source);
-
-            let mut diagnostics = if checkargs.shared.warnings || checkargs.warnings_are_errors {
-                Diagnostics::new()
-            } else {
-                Diagnostics::without_warnings()
-            };
-
-            let mut test_finder = visitor::FunctionVisitor::new(visitor::Attribute::None);
-            let mut source_loader = FileSourceLoader::new();
-
-            let _ = rune::prepare(&mut sources)
-                .with_context(&context)
-                .with_diagnostics(&mut diagnostics)
-                .with_options(options)
-                .with_visitor(&mut test_finder)
-                .with_source_loader(&mut source_loader)
-                .build();
-
-            diagnostics.emit(&mut out, &sources).unwrap();
-
-            if diagnostics.has_error() || checkargs.warnings_are_errors && diagnostics.has_warning()
-            {
-                Ok(ExitCode::Failure)
-            } else {
-                Ok(ExitCode::Success)
-            }
-        }
-        Command::Test(test_flags) => {
-            match load_path(&mut out, args, options, path, visitor::Attribute::Test) {
-                Ok((unit, _context, runtime, sources, tests)) => {
-                    tests::do_tests(test_flags, out, runtime, unit, sources, tests).await
-                }
-                Err(_) => Ok(ExitCode::Failure),
-            }
-        }
-        Command::Bench(bench_flags) => {
-            match load_path(&mut out, args, options, path, visitor::Attribute::Bench) {
-                Ok((unit, _context, runtime, sources, benches)) => {
-                    benches::do_benches(bench_flags, out, runtime, unit, sources, benches).await
-                }
-                Err(_) => Ok(ExitCode::Failure),
-            }
-        }
-        Command::Run(runargs) => {
-            let (unit, context, runtime, sources, _functions) =
-                match load_path(&mut out, args, options, path, visitor::Attribute::None) {
-                    Ok(v) => v,
-                    Err(_) => return Ok(ExitCode::Failure),
-                };
-
-            if runargs.dump_native_functions {
-                writeln!(out, "# functions")?;
-
-                for (i, (hash, f)) in context.iter_functions().enumerate() {
-                    writeln!(out, "{:04} = {} ({})", i, f, hash)?;
-                }
-            }
-
-            if runargs.dump_native_types {
-                writeln!(out, "# types")?;
-
-                for (i, (hash, ty)) in context.iter_types().enumerate() {
-                    writeln!(out, "{:04} = {} ({})", i, ty, hash)?;
-                }
-            }
-
-            if runargs.dump_unit {
-                if runargs.emit_instructions {
-                    writeln!(out, "# instructions")?;
-                    let mut out = out.lock();
-                    unit.emit_instructions(&mut out, &sources, runargs.with_source)?;
-                }
-
-                let mut functions = unit.iter_functions().peekable();
-                let mut strings = unit.iter_static_strings().peekable();
-                let mut keys = unit.iter_static_object_keys().peekable();
-                let mut constants = unit.iter_constants().peekable();
-
-                if runargs.dump_functions && functions.peek().is_some() {
-                    writeln!(out, "# dynamic functions")?;
-
-                    for (hash, kind) in functions {
-                        if let Some(signature) =
-                            unit.debug_info().and_then(|d| d.functions.get(&hash))
-                        {
-                            writeln!(out, "{} = {}", hash, signature)?;
-                        } else {
-                            writeln!(out, "{} = {}", hash, kind)?;
-                        }
-                    }
-                }
-
-                if strings.peek().is_some() {
-                    writeln!(out, "# strings")?;
-
-                    for string in strings {
-                        writeln!(out, "{} = {:?}", string.hash(), string)?;
-                    }
-                }
-
-                if runargs.dump_constants && constants.peek().is_some() {
-                    writeln!(out, "# constants")?;
-
-                    for constant in constants {
-                        writeln!(out, "{} = {:?}", constant.0, constant.1)?;
-                    }
-                }
-
-                if keys.peek().is_some() {
-                    writeln!(out, "# object keys")?;
-
-                    for (hash, keys) in keys {
-                        writeln!(out, "{} = {:?}", hash, keys)?;
-                    }
-                }
-            }
-            do_run(runargs, out, runtime, unit, sources).await
-        }
-    }
-}
-
-async fn do_run(
-    args: &RunFlags,
-    mut out: StandardStream,
-    runtime: Arc<RuntimeContext>,
-    unit: Arc<Unit>,
-    sources: Sources,
-) -> Result<ExitCode> {
-    let last = std::time::Instant::now();
-
-    let mut vm = Vm::new(runtime, unit.clone());
-    let mut execution: VmExecution<_> = vm.execute(&["main"], ())?;
-    let result = if args.trace {
-        match do_trace(
-            &mut out,
-            &mut execution,
-            &sources,
-            args.dump_stack,
-            args.with_source,
-        )
-        .await
-        {
-            Ok(value) => Ok(value),
-            Err(TraceError::Io(io)) => return Err(io.into()),
-            Err(TraceError::VmError(vm)) => Err(vm),
-        }
-    } else {
-        execution.async_complete().await
-    };
-
-    let errored;
-
-    match result {
-        Ok(result) => {
-            let duration = std::time::Instant::now().duration_since(last);
-            writeln!(out, "== {:?} ({:?})", result, duration)?;
-            errored = None;
-        }
-        Err(error) => {
-            let duration = std::time::Instant::now().duration_since(last);
-            writeln!(out, "== ! ({}) ({:?})", error, duration)?;
-            errored = Some(error);
-        }
-    };
-
-    if args.dump_stack {
-        writeln!(out, "# full stack dump after halting")?;
-
-        let vm = execution.vm();
-
-        let frames = vm.call_frames();
-        let stack = vm.stack();
-
-        let mut it = frames.iter().enumerate().peekable();
-
-        while let Some((count, frame)) = it.next() {
-            let stack_top = match it.peek() {
-                Some((_, next)) => next.stack_bottom(),
-                None => stack.stack_bottom(),
-            };
-
-            let values = stack
-                .get(frame.stack_bottom()..stack_top)
-                .expect("bad stack slice");
-
-            writeln!(out, "  frame #{} (+{})", count, frame.stack_bottom())?;
-
-            if values.is_empty() {
-                writeln!(out, "    *empty*")?;
-            }
-
-            for (n, value) in stack.iter().enumerate() {
-                writeln!(out, "{}+{} = {:?}", frame.stack_bottom(), n, value)?;
-            }
-        }
-
-        // NB: print final frame
-        writeln!(out, "  frame #{} (+{})", frames.len(), stack.stack_bottom())?;
-
-        let values = stack.get(stack.stack_bottom()..).expect("bad stack slice");
-
-        if values.is_empty() {
-            writeln!(out, "    *empty*")?;
-        }
-
-        for (n, value) in values.iter().enumerate() {
-            writeln!(out, "    {}+{} = {:?}", stack.stack_bottom(), n, value)?;
-        }
-    }
-
-    if let Some(error) = errored {
-        let mut writer = StandardStream::stderr(ColorChoice::Always);
-        error.emit(&mut writer, &sources)?;
-        Ok(ExitCode::VmError)
-    } else {
-        Ok(ExitCode::Success)
-    }
-}
-
 // Our own private ExitCode since std::process::ExitCode is nightly only.
 // Note that these numbers are actually meaningful on Windows, but we don't
 // care.
@@ -764,125 +240,163 @@ async fn main() {
             std::process::exit(exit_code as i32);
         }
         Err(error) => {
-            eprintln!("Error: {}", error);
+            let o = std::io::stderr();
+            // ignore error because stdout / stderr might've been closed.
+            let _ = format_errors(o.lock(), &error);
             std::process::exit(-1);
         }
     }
 }
 
-enum TraceError {
-    Io(std::io::Error),
-    VmError(VmError),
-}
-
-impl From<std::io::Error> for TraceError {
-    fn from(error: std::io::Error) -> Self {
-        Self::Io(error)
-    }
-}
-
-/// Perform a detailed trace of the program.
-async fn do_trace<T>(
-    out: &mut StandardStream,
-    execution: &mut VmExecution<T>,
-    sources: &Sources,
-    dump_stack: bool,
-    with_source: bool,
-) -> Result<Value, TraceError>
+/// Format the given error.
+fn format_errors<O>(mut o: O, error: &dyn Error) -> io::Result<()>
 where
-    T: AsMut<Vm> + AsRef<Vm>,
+    O: io::Write,
 {
-    let mut current_frame_len = execution.vm().call_frames().len();
+    writeln!(o, "Error: {}", error)?;
+    let mut source = error.source();
 
-    loop {
-        {
-            let vm = execution.vm();
-            let mut out = out.lock();
-
-            if let Some((hash, signature)) =
-                vm.unit().debug_info().and_then(|d| d.function_at(vm.ip()))
-            {
-                writeln!(out, "fn {} ({}):", signature, hash)?;
-            }
-
-            let debug = vm
-                .unit()
-                .debug_info()
-                .and_then(|d| d.instruction_at(vm.ip()));
-
-            if with_source {
-                let debug_info = debug.and_then(|d| sources.get(d.source_id).map(|s| (s, d.span)));
-                if let Some((source, span)) = debug_info {
-                    source.emit_source_line(&mut out, span)?;
-                }
-            }
-
-            if let Some(label) = debug.and_then(|d| d.label.as_ref()) {
-                writeln!(out, "{}:", label)?;
-            }
-
-            if let Some(inst) = vm.unit().instruction_at(vm.ip()) {
-                write!(out, "  {:04} = {}", vm.ip(), inst)?;
-            } else {
-                write!(out, "  {:04} = *out of bounds*", vm.ip())?;
-            }
-
-            if let Some(comment) = debug.and_then(|d| d.comment.as_ref()) {
-                write!(out, " // {}", comment)?;
-            }
-
-            writeln!(out)?;
-        }
-
-        let result = match execution.async_step().await {
-            Ok(result) => result,
-            Err(e) => return Err(TraceError::VmError(e)),
-        };
-
-        let mut out = out.lock();
-
-        if dump_stack {
-            let vm = execution.vm();
-            let frames = vm.call_frames();
-
-            let stack = vm.stack();
-
-            if current_frame_len != frames.len() {
-                if current_frame_len < frames.len() {
-                    writeln!(out, "=> frame {} ({}):", frames.len(), stack.stack_bottom())?;
-                } else {
-                    writeln!(out, "<= frame {} ({}):", frames.len(), stack.stack_bottom())?;
-                }
-
-                current_frame_len = frames.len();
-            }
-
-            let values = stack.get(stack.stack_bottom()..).expect("bad stack slice");
-
-            if values.is_empty() {
-                writeln!(out, "    *empty*")?;
-            }
-
-            for (n, value) in values.iter().enumerate() {
-                writeln!(out, "    {}+{} = {:?}", stack.stack_bottom(), n, value)?;
-            }
-        }
-
-        if let Some(result) = result {
-            break Ok(result);
-        }
+    while let Some(error) = source.take() {
+        writeln!(o, "Caused by: {}", error)?;
+        source = error.source();
     }
+
+    Ok(())
 }
 
-/// Test if path `a` is newer than path `b`.
-fn should_cache_be_used(source: &Path, cached: &Path) -> io::Result<bool> {
-    let source = fs::metadata(source)?;
+async fn try_main() -> Result<ExitCode, io::Error> {
+    let args = match Args::from_args_safe() {
+        Ok(args) => args,
+        Err(e) => {
+            let code = if e.use_stderr() {
+                let mut o = std::io::stderr();
+                writeln!(o, "{}", e)?;
+                ExitCode::Failure
+            } else {
+                let mut o = std::io::stdout();
+                writeln!(o, "{}", e)?;
+                ExitCode::Success
+            };
 
-    let cached = match fs::metadata(cached) {
-        Ok(cached) => cached,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
-        Err(error) => return Err(error),
+            return Ok(code);
+        }
     };
 
-    Ok(source.modified()? < cached.modified()?)
+    let choice = match args.color.as_str() {
+        "always" => ColorChoice::Always,
+        "ansi" => ColorChoice::AlwaysAnsi,
+        "auto" => {
+            if atty::is(atty::Stream::Stdout) {
+                ColorChoice::Auto
+            } else {
+                ColorChoice::Never
+            }
+        }
+        "never" => ColorChoice::Never,
+        _ => ColorChoice::Auto,
+    };
+
+    let mut o = StandardStream::stdout(choice);
+    env_logger::init();
+
+    match main_with_out(&mut o, args).await {
+        Ok(code) => Ok(code),
+        Err(error) => {
+            o.set_color(ColorSpec::new().set_fg(Some(Color::Red)))?;
+            let result = format_errors(&mut o, error.as_ref());
+            o.set_color(&ColorSpec::new())?;
+            let () = result?;
+            Ok(ExitCode::Failure)
+        }
+    }
+}
+
+async fn main_with_out(o: &mut StandardStream, mut args: Args) -> Result<ExitCode> {
+    args.cmd.propagate_related_flags();
+
+    let shared = args.shared_mut();
+
+    if shared.paths.is_empty() {
+        for file in SPECIAL_FILES {
+            let path = PathBuf::from(file);
+            if path.exists() && path.is_file() {
+                shared.paths.push(path);
+                break;
+            }
+        }
+
+        if shared.paths.is_empty() {
+            writeln!(
+                o,
+                "Invalid usage: No input path given and no main or lib file found"
+            )?;
+            return Ok(ExitCode::Failure);
+        }
+    }
+
+    let paths = loader::walk_paths(shared.recursive, std::mem::take(&mut shared.paths));
+
+    let options = args.options()?;
+
+    for path in paths {
+        let path = path?;
+
+        match run_path(o, &args, &options, &path).await? {
+            ExitCode::Success => (),
+            other => {
+                return Ok(other);
+            }
+        }
+    }
+
+    Ok(ExitCode::Success)
+}
+
+/// Run a single path.
+async fn run_path(
+    o: &mut StandardStream,
+    args: &Args,
+    options: &Options,
+    path: &Path,
+) -> Result<ExitCode> {
+    match &args.cmd {
+        Command::Check(flags) => check::run(o, flags, options, path),
+        Command::Test(flags) => {
+            let context = flags.shared.context()?;
+
+            let load = loader::load(o, &context, args, options, path, visitor::Attribute::Test)?;
+
+            tests::run(
+                o,
+                flags,
+                &context,
+                load.unit,
+                &load.sources,
+                &load.functions,
+            )
+            .await
+        }
+        Command::Bench(flags) => {
+            let context = flags.shared.context()?;
+
+            let load = loader::load(o, &context, args, options, path, visitor::Attribute::Bench)?;
+
+            benches::run(
+                o,
+                flags,
+                &context,
+                load.unit,
+                &load.sources,
+                &load.functions,
+            )
+            .await
+        }
+        Command::Run(flags) => {
+            let context = flags.shared.context()?;
+
+            let load = loader::load(o, &context, args, options, path, visitor::Attribute::None)?;
+
+            run::run(o, flags, &context, load.unit, &load.sources).await
+        }
+    }
 }

--- a/crates/rune-cli/src/run.rs
+++ b/crates/rune-cli/src/run.rs
@@ -1,0 +1,352 @@
+use crate::{ExitCode, SharedFlags};
+use anyhow::Result;
+use rune::runtime::{VmError, VmExecution};
+use rune::termcolor::StandardStream;
+use rune::{Context, Sources, Unit, Value, Vm};
+use std::io::Write;
+use std::sync::Arc;
+use std::time::Instant;
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug, Clone)]
+pub(crate) struct Flags {
+    /// Provide detailed tracing for each instruction executed.
+    #[structopt(short, long)]
+    trace: bool,
+    /// Dump everything.
+    #[structopt(short, long)]
+    dump: bool,
+    /// Dump default information about unit.
+    #[structopt(long)]
+    dump_unit: bool,
+    /// Dump constants from the unit.
+    #[structopt(long)]
+    dump_constants: bool,
+    /// Dump unit instructions.
+    #[structopt(long)]
+    emit_instructions: bool,
+    /// Dump the state of the stack after completion.
+    ///
+    /// If compiled with `--trace` will dump it after each instruction.
+    #[structopt(long)]
+    dump_stack: bool,
+
+    /// Dump dynamic functions.
+    #[structopt(long)]
+    dump_functions: bool,
+
+    /// Dump dynamic types.
+    #[structopt(long)]
+    dump_types: bool,
+
+    /// Dump native functions.
+    #[structopt(long)]
+    dump_native_functions: bool,
+
+    /// Dump native types.
+    #[structopt(long)]
+    dump_native_types: bool,
+
+    /// Include source code references where appropriate (only available if -O debug-info=true).
+    #[structopt(long)]
+    with_source: bool,
+
+    #[structopt(flatten)]
+    pub(crate) shared: SharedFlags,
+}
+
+impl Flags {
+    pub(crate) fn propagate_related_flags(&mut self) {
+        if self.dump {
+            self.dump_constants = true;
+            self.dump_unit = true;
+            self.dump_stack = true;
+            self.dump_functions = true;
+            self.dump_types = true;
+            self.dump_native_functions = true;
+            self.dump_native_types = true;
+        }
+    }
+
+    fn emit_instructions(&self) -> bool {
+        self.dump_unit || self.emit_instructions
+    }
+
+    fn dump_unit(&self) -> bool {
+        self.dump_unit
+            || self.dump_functions
+            || self.dump_native_functions
+            || self.dump_stack
+            || self.dump_types
+            || self.dump_constants
+            || self.emit_instructions
+    }
+}
+
+enum TraceError {
+    Io(std::io::Error),
+    VmError(VmError),
+}
+
+impl From<std::io::Error> for TraceError {
+    fn from(error: std::io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+pub(crate) async fn run(
+    o: &mut StandardStream,
+    args: &Flags,
+    context: &Context,
+    unit: Arc<Unit>,
+    sources: &Sources,
+) -> Result<ExitCode> {
+    if args.dump_native_functions {
+        writeln!(o, "# functions")?;
+
+        for (i, (hash, f)) in context.iter_functions().enumerate() {
+            writeln!(o, "{:04} = {} ({})", i, f, hash)?;
+        }
+    }
+
+    if args.dump_native_types {
+        writeln!(o, "# types")?;
+
+        for (i, (hash, ty)) in context.iter_types().enumerate() {
+            writeln!(o, "{:04} = {} ({})", i, ty, hash)?;
+        }
+    }
+
+    if args.dump_unit() {
+        if args.emit_instructions() {
+            writeln!(o, "# instructions")?;
+            let mut o = o.lock();
+            unit.emit_instructions(&mut o, sources, args.with_source)?;
+        }
+
+        let mut functions = unit.iter_functions().peekable();
+        let mut strings = unit.iter_static_strings().peekable();
+        let mut keys = unit.iter_static_object_keys().peekable();
+        let mut constants = unit.iter_constants().peekable();
+
+        if args.dump_functions && functions.peek().is_some() {
+            writeln!(o, "# dynamic functions")?;
+
+            for (hash, kind) in functions {
+                if let Some(signature) = unit.debug_info().and_then(|d| d.functions.get(&hash)) {
+                    writeln!(o, "{} = {}", hash, signature)?;
+                } else {
+                    writeln!(o, "{} = {}", hash, kind)?;
+                }
+            }
+        }
+
+        if strings.peek().is_some() {
+            writeln!(o, "# strings")?;
+
+            for string in strings {
+                writeln!(o, "{} = {:?}", string.hash(), string)?;
+            }
+        }
+
+        if args.dump_constants && constants.peek().is_some() {
+            writeln!(o, "# constants")?;
+
+            for constant in constants {
+                writeln!(o, "{} = {:?}", constant.0, constant.1)?;
+            }
+        }
+
+        if keys.peek().is_some() {
+            writeln!(o, "# object keys")?;
+
+            for (hash, keys) in keys {
+                writeln!(o, "{} = {:?}", hash, keys)?;
+            }
+        }
+    }
+
+    let runtime = Arc::new(context.runtime());
+
+    let last = Instant::now();
+
+    let mut vm = Vm::new(runtime, unit);
+    let mut execution: VmExecution<_> = vm.execute(&["main"], ())?;
+    let result = if args.trace {
+        match do_trace(
+            o,
+            &mut execution,
+            sources,
+            args.dump_stack,
+            args.with_source,
+        )
+        .await
+        {
+            Ok(value) => Ok(value),
+            Err(TraceError::Io(io)) => return Err(io.into()),
+            Err(TraceError::VmError(vm)) => Err(vm),
+        }
+    } else {
+        execution.async_complete().await
+    };
+
+    let errored;
+
+    match result {
+        Ok(result) => {
+            let duration = Instant::now().duration_since(last);
+            writeln!(o, "== {:?} ({:?})", result, duration)?;
+            errored = None;
+        }
+        Err(error) => {
+            let duration = Instant::now().duration_since(last);
+            writeln!(o, "== ! ({}) ({:?})", error, duration)?;
+            errored = Some(error);
+        }
+    };
+
+    if args.dump_stack {
+        writeln!(o, "# full stack dump after halting")?;
+
+        let vm = execution.vm();
+
+        let frames = vm.call_frames();
+        let stack = vm.stack();
+
+        let mut it = frames.iter().enumerate().peekable();
+
+        while let Some((count, frame)) = it.next() {
+            let stack_top = match it.peek() {
+                Some((_, next)) => next.stack_bottom(),
+                None => stack.stack_bottom(),
+            };
+
+            let values = stack
+                .get(frame.stack_bottom()..stack_top)
+                .expect("bad stack slice");
+
+            writeln!(o, "  frame #{} (+{})", count, frame.stack_bottom())?;
+
+            if values.is_empty() {
+                writeln!(o, "    *empty*")?;
+            }
+
+            for (n, value) in stack.iter().enumerate() {
+                writeln!(o, "{}+{} = {:?}", frame.stack_bottom(), n, value)?;
+            }
+        }
+
+        // NB: print final frame
+        writeln!(o, "  frame #{} (+{})", frames.len(), stack.stack_bottom())?;
+
+        let values = stack.get(stack.stack_bottom()..).expect("bad stack slice");
+
+        if values.is_empty() {
+            writeln!(o, "    *empty*")?;
+        }
+
+        for (n, value) in values.iter().enumerate() {
+            writeln!(o, "    {}+{} = {:?}", stack.stack_bottom(), n, value)?;
+        }
+    }
+
+    if let Some(error) = errored {
+        error.emit(o, sources)?;
+        Ok(ExitCode::VmError)
+    } else {
+        Ok(ExitCode::Success)
+    }
+}
+
+/// Perform a detailed trace of the program.
+async fn do_trace<T>(
+    o: &mut StandardStream,
+    execution: &mut VmExecution<T>,
+    sources: &Sources,
+    dump_stack: bool,
+    with_source: bool,
+) -> Result<Value, TraceError>
+where
+    T: AsMut<Vm> + AsRef<Vm>,
+{
+    let mut current_frame_len = execution.vm().call_frames().len();
+
+    loop {
+        {
+            let vm = execution.vm();
+            let mut o = o.lock();
+
+            if let Some((hash, signature)) =
+                vm.unit().debug_info().and_then(|d| d.function_at(vm.ip()))
+            {
+                writeln!(o, "fn {} ({}):", signature, hash)?;
+            }
+
+            let debug = vm
+                .unit()
+                .debug_info()
+                .and_then(|d| d.instruction_at(vm.ip()));
+
+            if with_source {
+                let debug_info = debug.and_then(|d| sources.get(d.source_id).map(|s| (s, d.span)));
+                if let Some((source, span)) = debug_info {
+                    source.emit_source_line(&mut o, span)?;
+                }
+            }
+
+            if let Some(label) = debug.and_then(|d| d.label.as_ref()) {
+                writeln!(o, "{}:", label)?;
+            }
+
+            if let Some(inst) = vm.unit().instruction_at(vm.ip()) {
+                write!(o, "  {:04} = {}", vm.ip(), inst)?;
+            } else {
+                write!(o, "  {:04} = *o of bounds*", vm.ip())?;
+            }
+
+            if let Some(comment) = debug.and_then(|d| d.comment.as_ref()) {
+                write!(o, " // {}", comment)?;
+            }
+
+            writeln!(o)?;
+        }
+
+        let result = match execution.async_step().await {
+            Ok(result) => result,
+            Err(e) => return Err(TraceError::VmError(e)),
+        };
+
+        let mut o = o.lock();
+
+        if dump_stack {
+            let vm = execution.vm();
+            let frames = vm.call_frames();
+
+            let stack = vm.stack();
+
+            if current_frame_len != frames.len() {
+                if current_frame_len < frames.len() {
+                    writeln!(o, "=> frame {} ({}):", frames.len(), stack.stack_bottom())?;
+                } else {
+                    writeln!(o, "<= frame {} ({}):", frames.len(), stack.stack_bottom())?;
+                }
+
+                current_frame_len = frames.len();
+            }
+
+            let values = stack.get(stack.stack_bottom()..).expect("bad stack slice");
+
+            if values.is_empty() {
+                writeln!(o, "    *empty*")?;
+            }
+
+            for (n, value) in values.iter().enumerate() {
+                writeln!(o, "    {}+{} = {:?}", stack.stack_bottom(), n, value)?;
+            }
+        }
+
+        if let Some(result) = result {
+            break Ok(result);
+        }
+    }
+}

--- a/crates/rune-modules/Cargo.toml
+++ b/crates/rune-modules/Cargo.toml
@@ -15,7 +15,7 @@ Native modules for Rune, an embeddable dynamic programming language for Rust.
 """
 
 [features]
-default = ["test", "core", "io", "fmt", "macros"]
+default = ["test", "core", "io", "fmt", "macros", "disable-io"]
 full = ["time", "http", "json", "toml", "fs", "process", "signal", "rand", "io", "fmt", "macros"]
 time = ["tokio", "tokio/time"]
 fs = ["tokio", "tokio/fs"]
@@ -26,6 +26,7 @@ signal = ["tokio/signal"]
 rand = ["nanorand"]
 experiments = []
 capture-io = ["parking_lot"]
+disable-io = []
 test = []
 core = []
 io = []

--- a/crates/rune-modules/src/disable_io.rs
+++ b/crates/rune-modules/src/disable_io.rs
@@ -1,0 +1,32 @@
+//! I/O module ignoring everything written to output.
+//!
+//! ```
+//! use rune::{Context, ContextError};
+//! use rune_modules::disable_io;
+//!
+//! # fn main() -> Result<(), ContextError> {
+//! let mut c = rune_modules::with_config(false)?;
+//! c.install(&disable_io::module()?)?;
+//! # Ok(()) }
+//! ```
+
+use rune::runtime::Stack;
+use rune::{ContextError, Module};
+
+/// Provide a bunch of `std::io` functions which will cause any output to be ignored.
+pub fn module() -> Result<Module, ContextError> {
+    let mut module = Module::with_crate_item("std", &["io"]);
+
+    module.function(&["print"], move |_: &str| {})?;
+
+    module.function(&["println"], move |_: &str| {})?;
+
+    module.raw_fn(&["dbg"], move |stack: &mut Stack, args: usize| {
+        // NB: still need to maintain the stack.
+        drop(stack.drain(args)?);
+        stack.push(());
+        Ok(())
+    })?;
+
+    Ok(module)
+}

--- a/crates/rune-modules/src/lib.rs
+++ b/crates/rune-modules/src/lib.rs
@@ -103,6 +103,9 @@ pub mod experiments;
 #[cfg(feature = "capture-io")]
 pub mod capture_io;
 
+#[cfg(feature = "disable-io")]
+pub mod disable_io;
+
 macro_rules! modules {
     ($($ident:ident, $name:literal),* $(,)?) => {
         $(

--- a/crates/rune/src/build.rs
+++ b/crates/rune/src/build.rs
@@ -9,7 +9,8 @@ use thiserror::Error;
 ///
 /// Look at the passed in [Diagnostics] instance for details.
 #[derive(Debug, Error)]
-#[error("failed to load sources (see `errors` for details)")]
+#[error("failed to build rune sources (see diagnostics for details)")]
+#[non_exhaustive]
 pub struct BuildError;
 
 /// Entry point to building [Sources] of Rune.

--- a/crates/rune/src/diagnostics/emit.rs
+++ b/crates/rune/src/diagnostics/emit.rs
@@ -108,6 +108,7 @@ impl VmError {
                 return Ok(());
             }
         };
+
         let debug_inst = match debug_info.instruction_at(ip) {
             Some(debug_inst) => debug_inst,
             None => {


### PR DESCRIPTION
This makes sure all subcommands get their own module to clean up organization a bit and changes how `load_path` (now `loader::load`) works.

Also adds capture for outputs using `CaptureIo` for tests and benches.