### PR TITLE
Start working on manifest loading

### DIFF
--- a/Rune.toml
+++ b/Rune.toml
@@ -1,0 +1,5 @@
+[workspace]
+members = [
+    "benches",
+    "examples",
+]

--- a/benches/Rune.toml
+++ b/benches/Rune.toml
@@ -1,0 +1,3 @@
+[package]
+name = "rune-benches"
+version = "0.0.0"

--- a/crates/rune-cli/Cargo.toml
+++ b/crates/rune-cli/Cargo.toml
@@ -24,8 +24,8 @@ codespan-reporting = "0.11.1"
 anyhow = { version = "1.0.49", features = ["std"] }
 structopt = { version = "0.3.25", default-features = false, features = ["wrap_help", "suggestions", "color"] }
 
-rune = {version = "0.10.0", path = "../rune"}
-rune-modules = {version = "0.10.0", path = "../rune-modules", features = ["full", "experiments"]}
+rune = { version = "0.10.0", path = "../rune", features = ["workspace"] }
+rune-modules = { version = "0.10.0", path = "../rune-modules", features = ["full", "experiments"] }
 
 [build-dependencies]
 anyhow = "1.0.49"

--- a/crates/rune-cli/src/tests.rs
+++ b/crates/rune-cli/src/tests.rs
@@ -1,8 +1,7 @@
-use crate::{ExitCode, SharedFlags};
+use crate::{ExitCode, Io, SharedFlags};
 use anyhow::Result;
 use rune::compile::Meta;
 use rune::runtime::{Unit, Value, Vm, VmError};
-use rune::termcolor::StandardStream;
 use rune::{Context, Hash, Sources};
 use rune_modules::capture_io::CaptureIo;
 use std::io::Write;
@@ -51,13 +50,13 @@ impl<'a> TestCase<'a> {
 
     async fn execute(
         &mut self,
-        o: &mut StandardStream,
+        io: &mut Io<'_>,
         vm: &mut Vm,
         quiet: bool,
-        io: Option<&CaptureIo>,
+        capture_io: Option<&CaptureIo>,
     ) -> Result<bool> {
         if !quiet {
-            write!(o, "Test {:30} ", self.meta.item.item)?;
+            write!(io.stdout, "Test {:30} ", self.meta.item.item)?;
         }
 
         let result = match vm.execute(self.hash, ()) {
@@ -65,8 +64,8 @@ impl<'a> TestCase<'a> {
             Ok(mut execution) => execution.async_complete().await,
         };
 
-        if let Some(io) = io {
-            let _ = io.drain_into(&mut self.buf);
+        if let Some(capture_io) = capture_io {
+            let _ = capture_io.drain_into(&mut self.buf);
         }
 
         self.outcome = match result {
@@ -90,31 +89,31 @@ impl<'a> TestCase<'a> {
         if quiet {
             match &self.outcome {
                 Some(FailureReason::Crash { .. }) => {
-                    write!(o, "F")?;
+                    write!(io.stdout, "F")?;
                 }
                 Some(FailureReason::ReturnedErr { .. }) => {
-                    write!(o, "f")?;
+                    write!(io.stdout, "f")?;
                 }
                 Some(FailureReason::ReturnedNone { .. }) => {
-                    write!(o, "n")?;
+                    write!(io.stdout, "n")?;
                 }
                 None => {
-                    write!(o, ".")?;
+                    write!(io.stdout, ".")?;
                 }
             }
         } else {
             match &self.outcome {
                 Some(FailureReason::Crash { .. }) => {
-                    writeln!(o, "failed")?;
+                    writeln!(io.stdout, "failed")?;
                 }
                 Some(FailureReason::ReturnedErr { .. }) => {
-                    writeln!(o, "returned error")?;
+                    writeln!(io.stdout, "returned error")?;
                 }
                 Some(FailureReason::ReturnedNone { .. }) => {
-                    writeln!(o, "returned none")?;
+                    writeln!(io.stdout, "returned none")?;
                 }
                 None => {
-                    writeln!(o, "passed")?;
+                    writeln!(io.stdout, "passed")?;
                 }
             }
         }
@@ -123,22 +122,22 @@ impl<'a> TestCase<'a> {
         Ok(self.outcome.is_none())
     }
 
-    fn emit(&self, o: &mut StandardStream, sources: &Sources) -> Result<()> {
+    fn emit(&self, io: &mut Io<'_>, sources: &Sources) -> Result<()> {
         if let Some(outcome) = &self.outcome {
             match outcome {
                 FailureReason::Crash(err) => {
-                    writeln!(o, "----------------------------------------")?;
-                    writeln!(o, "Test: {}\n", self.meta.item.item)?;
-                    err.emit(o, sources)?;
+                    writeln!(io.stdout, "----------------------------------------")?;
+                    writeln!(io.stdout, "Test: {}\n", self.meta.item.item)?;
+                    err.emit(io.stdout, sources)?;
                 }
                 FailureReason::ReturnedNone { .. } => {}
                 FailureReason::ReturnedErr { output, error, .. } => {
-                    writeln!(o, "----------------------------------------")?;
-                    writeln!(o, "Test: {}\n", self.meta.item.item)?;
-                    writeln!(o, "Error: {:?}\n", error)?;
-                    writeln!(o, "-- output --")?;
-                    o.write_all(output)?;
-                    writeln!(o, "-- end of output --")?;
+                    writeln!(io.stdout, "----------------------------------------")?;
+                    writeln!(io.stdout, "Test: {}\n", self.meta.item.item)?;
+                    writeln!(io.stdout, "Error: {:?}\n", error)?;
+                    writeln!(io.stdout, "-- output --")?;
+                    io.stdout.write_all(output)?;
+                    writeln!(io.stdout, "-- end of output --")?;
                 }
             }
         }
@@ -148,10 +147,10 @@ impl<'a> TestCase<'a> {
 }
 
 pub(crate) async fn run(
-    o: &mut StandardStream,
+    io: &mut Io<'_>,
     flags: &Flags,
     context: &Context,
-    io: Option<&CaptureIo>,
+    capture_io: Option<&CaptureIo>,
     unit: Arc<Unit>,
     sources: &Sources,
     fns: &[(Hash, Meta)],
@@ -163,7 +162,7 @@ pub(crate) async fn run(
         .map(|v| TestCase::from_parts(v.0, &v.1))
         .collect::<Vec<_>>();
 
-    writeln!(o, "Found {} tests...", cases.len())?;
+    writeln!(io.stdout, "Found {} tests...", cases.len())?;
 
     let start = Instant::now();
     let mut failure_count = 0;
@@ -174,7 +173,7 @@ pub(crate) async fn run(
     for test in &mut cases {
         executed_count += 1;
 
-        let success = test.execute(o, &mut vm, flags.quiet, io).await?;
+        let success = test.execute(io, &mut vm, flags.quiet, capture_io).await?;
 
         if !success {
             failure_count += 1;
@@ -186,18 +185,18 @@ pub(crate) async fn run(
     }
 
     if flags.quiet {
-        writeln!(o)?;
+        writeln!(io.stdout)?;
     }
 
     let elapsed = start.elapsed();
 
     for case in &cases {
-        case.emit(o, sources)?;
+        case.emit(io, sources)?;
     }
 
-    writeln!(o, "====")?;
+    writeln!(io.stdout, "====")?;
     writeln!(
-        o,
+        io.stdout,
         "Executed {} tests with {} failures ({} skipped) in {:.3} seconds",
         executed_count,
         failure_count,

--- a/crates/rune/Cargo.toml
+++ b/crates/rune/Cargo.toml
@@ -18,6 +18,7 @@ An embeddable dynamic programming language for Rust.
 default = ["emit"]
 emit = ["codespan-reporting"]
 bench = []
+workspace = ["toml", "toml-spanned-value", "semver", "relative-path", "serde-hashkey"]
 
 [dependencies]
 thiserror = "1.0.30"
@@ -38,6 +39,11 @@ futures-util = "0.3.18"
 anyhow = "1.0.49"
 twox-hash = { version = "1.6.1", default-features = false }
 num-bigint = "0.4.3"
+toml = { version = "0.5.8", optional = true }
+toml-spanned-value = { version = "0.1.0", optional = true }
+semver = { version = "1.0.4", optional = true, features = ["serde"] }
+relative-path = { version = "1.6.0", optional = true, features = ["serde"] }
+serde-hashkey = { version = "0.4.0", optional = true }
 
 rune-macros = {version = "0.10.0", path = "../rune-macros"}
 

--- a/crates/rune/src/internal_macros.rs
+++ b/crates/rune/src/internal_macros.rs
@@ -33,7 +33,7 @@ macro_rules! error {
             /// broken for some reason.
             pub fn msg<S>(spanned: S, message: &'static str) -> Self
             where
-                S: Spanned,
+                S: $crate::ast::Spanned,
             {
                 Self::new(spanned, $kind::Custom { message })
             }
@@ -69,6 +69,8 @@ macro_rules! error {
 
         impl From<$crate::shared::Custom> for $error_ty {
             fn from(error: $crate::shared::Custom) -> Self {
+                use $crate::ast::Spanned;
+
                 Self::new(
                     error.span(),
                     $kind::Custom {
@@ -159,6 +161,16 @@ macro_rules! cfg_emit {
         $(
             #[cfg(feature = "emit")]
             #[cfg_attr(docsrs, doc(cfg(feature = "emit")))]
+            $item
+        )*
+    }
+}
+
+macro_rules! cfg_workspace {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "workspace")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "workspace")))]
             $item
         )*
     }

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -252,6 +252,10 @@ pub use self::sources::Sources;
 
 mod worker;
 
+cfg_workspace! {
+    pub mod workspace;
+}
+
 #[doc(hidden)]
 pub mod testing;
 

--- a/crates/rune/src/source.rs
+++ b/crates/rune/src/source.rs
@@ -29,8 +29,6 @@ impl Source {
     pub fn from_path(path: &Path) -> io::Result<Self> {
         let name = path.display().to_string();
         let source = fs::read_to_string(&path)?;
-        let path = path.canonicalize()?;
-
         Ok(Self::with_path(name, source, Some(path)))
     }
 

--- a/crates/rune/src/workspace/build.rs
+++ b/crates/rune/src/workspace/build.rs
@@ -1,0 +1,67 @@
+use crate::Sources;
+use crate::workspace::Diagnostics;
+use thiserror::Error;
+use crate::workspace::manifest::{self, Loader, Manifest};
+
+/// Failed to build workspace.
+#[derive(Debug, Error)]
+#[error("failed to load workspace")]
+pub struct BuildError;
+
+/// Prepare a workspace build.
+pub fn prepare(sources: &mut Sources) -> Build<'_> {
+    Build {
+        sources,
+        diagnostics: None,
+    }
+}
+
+/// A prepared build.
+pub struct Build<'a> {
+    sources: &'a mut Sources,
+    diagnostics: Option<&'a mut Diagnostics>,
+}
+
+impl<'a> Build<'a> {
+    /// Associate a specific diagnostic with the build.
+    pub fn with_diagnostics(self, diagnostics: &'a mut Diagnostics) -> Self {
+        Self {
+            diagnostics: Some(diagnostics),
+            ..self
+        }
+    }
+
+    /// Perform the build.
+    pub fn build(self) -> Result<Manifest, BuildError> {
+        let mut diagnostics;
+
+        let diagnostics = match self.diagnostics {
+            Some(diagnostics) => diagnostics,
+            None => {
+                diagnostics = Diagnostics::new();
+                &mut diagnostics
+            }
+        };
+
+        let mut manifest = Manifest {
+            packages: Vec::new(),
+        };
+
+        for id in self.sources.source_ids() {
+            let mut l = Loader {
+                id,
+                sources: self.sources,
+                diagnostics,
+                manifest: &mut manifest,
+            };
+
+            manifest::load_manifest(&mut l);
+        }
+    
+        if diagnostics.has_errors() {
+            return Err(BuildError);
+        }
+    
+        Ok(manifest)
+    }
+}

--- a/crates/rune/src/workspace/diagnostics.rs
+++ b/crates/rune/src/workspace/diagnostics.rs
@@ -1,0 +1,47 @@
+use crate::{SourceId};
+use crate::workspace::WorkspaceError;
+
+/// A reported diagnostic error.
+pub(crate) struct FatalDiagnostic {
+    pub(crate) source_id: SourceId,
+    pub(crate) error: WorkspaceError,
+}
+
+/// A single workspace diagnostic.
+pub(crate) enum Diagnostic {
+    /// An error in a workspace.
+    Fatal(FatalDiagnostic),
+}
+
+/// Diagnostics emitted about a workspace.
+#[derive(Default)]
+pub struct Diagnostics {
+    pub(crate) diagnostics: Vec<Diagnostic>,
+}
+
+impl Diagnostics {
+    /// Report a single workspace error.
+    pub fn fatal(&mut self, source_id: SourceId, error: WorkspaceError) {
+        self.diagnostics.push(Diagnostic::Fatal(FatalDiagnostic {
+            source_id,
+            error,
+        }))
+    }
+
+    /// Test if diagnostics has errors.
+    pub fn has_errors(&self) -> bool {
+        self.diagnostics.iter().any(|e| matches!(e, Diagnostic::Fatal(..)))
+    }
+
+    /// Test if diagnostics is empty.
+    pub fn is_empty(&self) -> bool {
+        self.diagnostics.is_empty()
+    }
+}
+
+impl Diagnostics {
+    /// Construct an empty diagnostics container.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}

--- a/crates/rune/src/workspace/emit.rs
+++ b/crates/rune/src/workspace/emit.rs
@@ -1,0 +1,80 @@
+//! Runtime helpers for loading code and emitting diagnostics.
+
+use crate::{Sources};
+use crate::ast::{Spanned};
+use std::fmt;
+use std::io;
+use thiserror::Error;
+use codespan_reporting::diagnostic as d;
+use codespan_reporting::term;
+use codespan_reporting::term::termcolor::WriteColor;
+pub use codespan_reporting::term::termcolor;
+use crate::workspace::{Diagnostics, Diagnostic, FatalDiagnostic};
+
+/// Errors that can be raised when formatting diagnostics.
+#[derive(Debug, Error)]
+pub enum EmitError {
+    /// Source Error.
+    #[error("I/O error")]
+    Io(#[from] io::Error),
+    /// Source Error.
+    #[error("formatting error")]
+    Fmt(#[from] fmt::Error),
+    /// Codespan reporting error.
+    #[error("codespan reporting error")]
+    CodespanReporting(#[from] codespan_reporting::files::Error),
+}
+
+impl Diagnostics {
+    /// Generate formatted diagnostics capable of referencing source lines and
+    /// hints.
+    ///
+    /// See [prepare][crate::prepare] for how to use.
+    pub fn emit<O>(
+        &self,
+        out: &mut O,
+        sources: &Sources,
+    ) -> Result<(), EmitError>
+    where
+        O: WriteColor,
+    {
+        if self.is_empty() {
+            return Ok(());
+        }
+
+        let config = codespan_reporting::term::Config::default();
+
+        for diagnostic in &self.diagnostics {
+            match diagnostic {
+                Diagnostic::Fatal(e) => {
+                    error_diagnostics_emit(e, out, sources, &config)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Custom shared helper for emitting diagnostics for a single error.
+fn error_diagnostics_emit<O>(
+    this: &FatalDiagnostic,
+    out: &mut O,
+    sources: &Sources,
+    config: &codespan_reporting::term::Config,
+) -> Result<(), EmitError>
+where
+    O: WriteColor,
+{
+    let mut labels = Vec::new();
+
+    let span = this.error.span();
+    labels.push(d::Label::primary(this.source_id, span.range()).with_message(this.error.to_string()));
+
+    let diagnostic = d::Diagnostic::error()
+        .with_message(this.error.to_string())
+        .with_labels(labels);
+
+    term::emit(out, config, sources, &diagnostic)?;
+    Ok(())
+}

--- a/crates/rune/src/workspace/error.rs
+++ b/crates/rune/src/workspace/error.rs
@@ -1,0 +1,49 @@
+use std::path::Path;
+use thiserror::Error;
+use crate::{SourceId};
+use crate::ast::Span;
+
+error! {
+    /// An error raised when interacting with workspaces.
+    #[derive(Debug)]
+    pub struct WorkspaceError {
+        kind: WorkspaceErrorKind,
+    }
+}
+
+impl WorkspaceError {
+    pub(crate) fn missing_field(span: Span, field: &'static str) -> Self {
+        Self::new(span, WorkspaceErrorKind::MissingField { field })
+    }
+
+    pub(crate) fn expected_array(span: Span) -> Self {
+        Self::new(span, WorkspaceErrorKind::ExpectedArray)
+    }
+}
+
+/// A workspace error.
+#[derive(Debug, Error)]
+#[allow(missing_docs)]
+#[non_exhaustive]
+pub enum WorkspaceErrorKind {
+    #[error("manifest deserialization: {error}")]
+    Toml { #[from] #[source] error: toml::de::Error },
+    #[error("manifest serializationo: {error}")]
+    Key { #[from] #[source] error: serde_hashkey::Error },
+    #[error("failed to read `{path}`: {error}")]
+    SourceError { path: Box<Path>, error: std::io::Error },
+    #[error("custom: {message}")]
+    Custom { message: &'static str },
+    #[error("missing source id `{source_id}`")]
+    MissingSourceId { source_id: SourceId },
+    #[error("missing required field `{field}`")]
+    MissingField { field: &'static str },
+    #[error("expected array")]
+    ExpectedArray,
+    #[error("[workspace] elements can only be used in manifests with a valid path")]
+    MissingManifestPath,
+    #[error("expected table")]
+    ExpectedTable,
+    #[error("key not supported")]
+    UnsupportedKey,
+}

--- a/crates/rune/src/workspace/manifest.rs
+++ b/crates/rune/src/workspace/manifest.rs
@@ -1,0 +1,423 @@
+use std::collections::VecDeque;
+use std::mem;
+use std::path::{PathBuf, Path};
+use relative_path::{RelativePathBuf, RelativePath, Component};
+use semver::Version;
+use serde::de::{IntoDeserializer};
+use toml_spanned_value::spanned_value::{ValueKind, Table, Array};
+use crate::{Sources, SourceId, Source};
+use crate::ast::{Span, Spanned};
+use crate::workspace::{MANIFEST_FILE, WorkspaceErrorKind, Diagnostics, WorkspaceError};
+use toml_spanned_value::SpannedValue;
+use serde::Deserialize;
+use serde_hashkey as key;
+use std::io;
+use std::fs;
+use std::ffi::OsStr;
+
+/// A workspace filter which in combination with functions such as
+/// [Manifest::find_bins] can be used to selectively find things in the
+/// workspace.
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+pub enum WorkspaceFilter<'a> {
+    /// Look for one specific named thing.
+    Name(&'a str),
+    /// Look for all things.
+    All,
+}
+
+/// A found item in the workspace.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct Found<'a> {
+    /// A found path that can be built.
+    pub path: Box<Path>,
+    /// The package the found path belongs to.
+    pub package: &'a Package,
+}
+
+impl WorkspaceFilter<'_> {
+    fn matches(self, name: &str) -> bool {
+        match self {
+            WorkspaceFilter::Name(expected) => name == expected,
+            WorkspaceFilter::All => true,
+        }
+    }
+}
+
+impl<T> Spanned for toml::Spanned<T> {
+    fn span(&self) -> Span {
+        let (start, end) = toml::Spanned::span(self);
+        Span::new(start, end)
+    }
+}
+
+/// The manifest of a workspace.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct Manifest {
+    /// List of packages found.
+    pub packages: Vec<Package>,
+}
+
+impl Manifest {
+    fn find_paths(&self, m: WorkspaceFilter<'_>, auto_path: &Path, auto_find: impl Fn(&Package) -> bool) -> io::Result<Vec<Found<'_>>> {
+        let mut output = Vec::new();
+
+        for package in &self.packages {
+            if let (Some(path), true) = (&package.root, auto_find(package)) {
+                let path = path.join(auto_path);
+                let results = find_rune_files(&path)?;
+
+                for result in results {
+                    let (base, path) = result?;
+
+                    if m.matches(&*base) {
+                        output.push(Found { path, package });
+                    }
+                }
+            }
+        }
+
+        Ok(output)
+    }
+
+    /// Find all binaries matching the given name in the workspace.
+    pub fn find_bins(&self, m: WorkspaceFilter<'_>) -> io::Result<Vec<Found<'_>>> {
+        self.find_paths(m, Path::new("bin"), |p| p.auto_bins)
+    }
+
+    /// Find all tests associated with the given base name.
+    pub fn find_tests(&self, m: WorkspaceFilter<'_>) -> io::Result<Vec<Found<'_>>> {
+        self.find_paths(m, Path::new("tests"), |p| p.auto_tests)
+    }
+
+    /// Find all examples matching the given name in the workspace.
+    pub fn find_examples(&self, m: WorkspaceFilter<'_>) -> io::Result<Vec<Found<'_>>> {
+        self.find_paths(m, Path::new("examples"), |p| p.auto_examples)
+    }
+
+    /// Find all benches matching the given name in the workspace.
+    pub fn find_benches(&self, m: WorkspaceFilter<'_>) -> io::Result<Vec<Found<'_>>> {
+        self.find_paths(m, Path::new("benches"), |p| p.auto_benches)
+    }
+}
+
+/// A single package.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct Package {
+    /// The name of the package.
+    pub name: Box<str>,
+    /// The version of the package..
+    pub version: Version,
+    /// The root of the package.
+    pub root: Option<Box<Path>>,
+    /// Automatically detect binaries.
+    pub auto_bins: bool,
+    /// Automatically detect tests.
+    pub auto_tests: bool,
+    /// Automatically detect examples.
+    pub auto_examples: bool,
+    /// Automatically detect benches.
+    pub auto_benches: bool,
+}
+
+pub(crate) struct Loader<'a> {
+    pub(crate) id: SourceId,
+    pub(crate) sources: &'a mut Sources,
+    pub(crate) diagnostics: &'a mut Diagnostics,
+    pub(crate) manifest: &'a mut Manifest,
+}
+
+/// Load a manifest.
+pub(crate) fn load_manifest(l: &mut Loader<'_>) {
+    let (value, root) = match l.sources.get(l.id) {
+        Some(source) => {
+            let root: Option<Box<Path>> = source.path().and_then(|p| p.parent()).map(|p| p.into());
+
+            let value: SpannedValue = match toml::from_str(source.as_str()) {
+                Ok(value) => value,
+                Err(e) => {
+                    let span = Span::new(0, source.len());
+                    l.diagnostics.fatal(l.id, WorkspaceError::new(span, e));
+                    return;
+                }
+            };
+
+            (value, root)
+        }
+        None => {
+            l.diagnostics.fatal(l.id, WorkspaceError::new(Span::empty(), WorkspaceErrorKind::MissingSourceId { source_id: l.id }));
+            return;
+        }
+    };
+
+    if let Some((mut table, _)) = into_table(l, value) {
+        // If manifest is a package, add it here.
+        if let Some(package) = table.remove("package") {
+            if let Some((mut package, span)) = into_table(l, package) {
+                if let Some(package) = load_package(l, &mut package, span, root.as_deref()) {
+                    l.manifest.packages.push(package);
+                }
+
+                ensure_empty(l, package);
+            }
+        }
+
+        // Load the [workspace] section.
+        if let Some(workspace) = table.remove("workspace") {
+            if let Some((mut table, span)) = into_table(l, workspace) {
+                match &root {
+                    Some(root) => {
+                        if let Some(members) = load_members(l, &mut table, root) {
+                            for (span, path) in members {
+                                load_member(l, span, &path);
+                            }
+                        }
+                    },
+                    None => {
+                        l.diagnostics.fatal(l.id, WorkspaceError::new(span, WorkspaceErrorKind::MissingManifestPath));
+                    }
+                }
+
+                ensure_empty(l, table);
+            }
+        }
+
+        ensure_empty(l, table);
+    }
+}
+
+/// Load members from the given workspace configuration.
+fn load_members(l: &mut Loader<'_>, table: &mut Table, root: &Path) -> Option<Vec<(Span, PathBuf)>> {
+    let members = match table.remove("members") {
+        Some(members) => members,
+        None => return None,
+    };
+
+    let (members, _) = into_array(l, members)?;
+    let mut output = Vec::new();
+
+    for value in members {
+        let span = Spanned::span(&value);
+
+        match deserialize::<RelativePathBuf>(value) {
+            Ok(member) => {
+                glob_relative_path(l, &mut output, span, &member, root);
+            }
+            Err(error) => {
+                l.diagnostics.fatal(l.id, error);
+            }
+        };
+    }
+
+    Some(output)
+}
+
+/// Glob a relative path.
+///
+/// Currently only supports expanding `*` and required interacting with the
+/// filesystem.
+fn glob_relative_path(l: &mut Loader<'_>, output: &mut Vec<(Span, PathBuf)>, span: Span, member: &RelativePath, root: &Path) {
+    let mut queue = VecDeque::new();
+    queue.push_back((root.to_owned(), member.components()));
+
+    while let Some((mut path, mut it)) = queue.pop_front() {
+        loop {
+            let c = match it.next() {
+                Some(c) => c,
+                None => {
+                    path.push(MANIFEST_FILE);
+                    output.push((span, path));
+                    break;
+                }
+            };
+
+            match c {
+                Component::CurDir => {},
+                Component::ParentDir => {
+                    path.push("..");
+                },
+                Component::Normal("*") => {
+                    let result = match source_error(l, span, &path, fs::read_dir(&path)) {
+                        Some(result) => result,
+                        None => continue,
+                    };
+
+                    for e in result {
+                        let e = match source_error(l, span, &path, e) {
+                            Some(e) => e,
+                            None => continue,
+                        };
+
+                        let path = e.path();
+
+                        let m = match source_error(l, span, &path, e.metadata()) {
+                            Some(m) => m,
+                            None => continue,
+                        };
+
+                        if m.is_dir() {
+                            queue.push_back((path, it.clone()));
+                        }
+                    }
+
+                    break;
+                },
+                Component::Normal(normal) => {
+                    path.push(normal);
+                },
+            }
+        }
+    }
+}
+
+/// Helper to convert an [io::Error] into a [WorkspaceErrorKind::SourceError].
+fn source_error<T>(l: &mut Loader<'_>, span: Span, path: &Path, result: io::Result<T>) -> Option<T> {
+    match result {
+        Ok(result) => Some(result),
+        Err(error) => {
+            l.diagnostics.fatal(l.id, WorkspaceError::new(span, WorkspaceErrorKind::SourceError {
+                path: path.into(),
+                error,
+            }));
+
+            None
+        }
+    }
+}
+
+/// Try to load the given path as a member in the current manifest.
+fn load_member(l: &mut Loader<'_>, span: Span, path: &Path) {
+    let source = match source_error(l, span, path, Source::from_path(path)) {
+        Some(source) => source,
+        None => return,
+    };
+
+    let id = l.sources.insert(source);
+    let old = mem::replace(&mut l.id, id);
+    load_manifest(l);
+    l.id = old;
+}
+
+/// Load a package from a value.
+fn load_package(l: &mut Loader<'_>, table: &mut Table, span: Span, root: Option<&Path>) -> Option<Package> {
+    let name = field(l, table, span, "name");
+    let version = field(l, table, span, "version");
+
+    Some(Package {
+        name: name?,
+        version: version?,
+        root: root.map(|p| p.into()),
+        auto_bins: true,
+        auto_tests: true,
+        auto_examples: true,
+        auto_benches: true,
+    })
+}
+
+/// Ensure that a table is empty and mark any additional elements as erroneous.
+fn ensure_empty(l: &mut Loader<'_>, table: Table) {
+    for (key, _) in table {
+        let span = Spanned::span(&key);
+        l.diagnostics.fatal(l.id, WorkspaceError::new(span, WorkspaceErrorKind::UnsupportedKey));
+    }
+}
+
+/// Ensure that value is a table.
+fn into_table(l: &mut Loader<'_>, value: SpannedValue) -> Option<(Table, Span)> {
+    let span = Spanned::span(&value);
+
+    match value.into_inner() {
+        ValueKind::Table(table) => Some((table, span)),
+        _ => {
+            let error = WorkspaceError::new(span, WorkspaceErrorKind::ExpectedTable);
+            l.diagnostics.fatal(l.id, error);
+            None
+        }
+    }
+}
+
+/// Coerce into an array or error.
+fn into_array(l: &mut Loader<'_>, value: SpannedValue) -> Option<(Array, Span)> {
+    let span = Spanned::span(&value);
+
+    match value.into_inner() {
+        ValueKind::Array(array) => Some((array, span)),
+        _ => {
+            let error = WorkspaceError::expected_array(span);
+            l.diagnostics.fatal(l.id, error);
+            None
+        }
+    }
+}
+
+/// Helper to load a single field.
+fn field<T>(l: &mut Loader<'_>, table: &mut Table, span: Span, field: &'static str) -> Option<T> where T: for<'de> Deserialize<'de> {
+    match table.remove(field) {
+        Some(value) => {
+            match deserialize(value) {
+                Ok(value) => Some(value),
+                Err(error) => {
+                    l.diagnostics.fatal(l.id, error);
+                    None
+                }
+            }
+        },
+        None => {
+            let error = WorkspaceError::missing_field(span, field);
+            l.diagnostics.fatal(l.id, error);
+            None
+        }
+    }
+}
+
+/// Helper to load a single field.
+fn deserialize<T>(value: SpannedValue) -> Result<T, WorkspaceError> where T: for<'de> Deserialize<'de> {
+    let span = Spanned::span(&value);
+    let f = key::to_key(value.get_ref()).map_err(|e| WorkspaceError::new(span, e))?;
+    let deserializer = f.into_deserializer();
+    let value = T::deserialize(deserializer).map_err(|e| WorkspaceError::new(span, e))?;
+    Ok(value)
+}
+
+/// Find all rune files in the given path.
+fn find_rune_files(path: &Path) -> io::Result<impl Iterator<Item = io::Result<(Box<str>, Box<Path>)>>> {
+    let mut dir = match fs::read_dir(path) {
+        Ok(dir) => Some(dir),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => None,
+        Err(e) => return Err(e),
+    };
+
+    Ok(std::iter::from_fn(move || {
+        loop {
+            let e = dir.as_mut()?.next()?;
+
+            let e = match e {
+                Ok(e) => e,
+                Err(err) => return Some(Err(err)),
+            };
+
+            let m = match e.metadata() {
+                Ok(m) => m,
+                Err(err) => return Some(Err(err)),
+            };
+
+            if !m.is_file() {
+                continue;
+            }
+
+            let path = e.path();
+
+            if let (Some(base), Some(ext)) = (path.file_stem(), path.extension()) {
+                if ext == OsStr::new("rn") {
+                    if let Some(base) = base.to_str() {
+                        return Some(Ok((base.into(), path.into())));
+                    }
+                }
+            }
+        }
+    }))
+}

--- a/crates/rune/src/workspace/mod.rs
+++ b/crates/rune/src/workspace/mod.rs
@@ -1,0 +1,24 @@
+//! Types for dealing with workspaces of rune code.
+
+/// The name of the toplevel manifest `Rune.toml`.
+pub const MANIFEST_FILE: &str = "Rune.toml";
+
+mod build;
+pub use self::build::{prepare, Build, BuildError};
+
+cfg_emit! {
+    mod emit;
+    #[doc(inline)]
+    pub use self::emit::EmitError;
+}
+
+mod error;
+
+pub use self::error::{WorkspaceErrorKind, WorkspaceError};
+
+mod manifest;
+pub use self::manifest::{Manifest, WorkspaceFilter};
+
+mod diagnostics;
+pub use self::diagnostics::{Diagnostics};
+pub(crate) use self::diagnostics::{Diagnostic, FatalDiagnostic};

--- a/examples/Rune.toml
+++ b/examples/Rune.toml
@@ -1,0 +1,3 @@
+[package]
+name = "rune-examples"
+version = "0.0.0"

--- a/examples/examples/test.rn
+++ b/examples/examples/test.rn
@@ -1,0 +1,3 @@
+pub fn main() {
+    println!("A project");
+}


### PR DESCRIPTION
This adds very preliminary support for loading manifests from a `Rune.toml` file in a directory.

This should (eventually) allow for complex project structures such as those permitted through a `Cargo.toml` file in rust.

Right now, what is supported are the following:

```toml
[package]
name = "hello"
version = "0.0.0"

[workspace]
members = [
    "crates/a",
    "crates/b",
]
```

And what rune-cli does is to use this directory structure to autodiscover the following directories:
* `bin` for binary files that can be run with `rune run --bin <name>`.
* `tests` for files expected to contain test cases. If the `--test <name>` argument is omitted it runs all benchmarks by default.
* `examples` for examples that can be run with `rune run --example <name>`.
* `benches` for benchmarks that can be rune with `rune bench --bench <name>`. If the `--bench <name>` argument is omitted it runs all benchmarks by default.

# To do before merging

* [ ] The workspace is currently not validated. So for example multiple packages can have the same name. This is eventually important for when `rune build` is added, which is intended to produce a compacted bytecode package of all rune code with dependencies.
* [x] Wildcards in `members` are not supported.