### PR TITLE
More cleanups

### DIFF
--- a/crates/rune/src/compile/context.rs
+++ b/crates/rune/src/compile/context.rs
@@ -3,10 +3,12 @@ use crate::compile::module::{
     Function, Module, ModuleAssociatedFn, ModuleFn, ModuleInternalEnum, ModuleMacro, ModuleType,
     ModuleUnitType,
 };
-use crate::compile::{ComponentRef, IntoComponent, Item, Meta, MetaKind, StructMeta, TupleMeta};
+use crate::compile::{
+    ComponentRef, IntoComponent, Item, Meta, MetaKind, Names, StructMeta, TupleMeta,
+};
 use crate::runtime::{
-    ConstValue, FunctionHandler, MacroHandler, Names, Protocol, RuntimeContext, StaticType,
-    TypeCheck, TypeInfo, TypeOf, VmError,
+    ConstValue, FunctionHandler, MacroHandler, Protocol, RuntimeContext, StaticType, TypeCheck,
+    TypeInfo, TypeOf, VmError,
 };
 use crate::Hash;
 use std::fmt;

--- a/crates/rune/src/compile/mod.rs
+++ b/crates/rune/src/compile/mod.rs
@@ -60,6 +60,9 @@ pub use self::module::{InstallWith, Module};
 mod named;
 pub use self::named::Named;
 
+mod names;
+pub(crate) use self::names::Names;
+
 mod visibility;
 pub(crate) use self::visibility::Visibility;
 

--- a/crates/rune/src/compile/names.rs
+++ b/crates/rune/src/compile/names.rs
@@ -9,25 +9,8 @@ pub struct Names {
 }
 
 impl Names {
-    /// Construct a collection of names.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     /// Insert the given item as an import.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rune::runtime::Names;
-    ///
-    /// let mut names = Names::new();
-    /// assert!(!names.contains(&["test"]));
-    /// assert!(!names.insert(&["test"]));
-    /// assert!(names.contains(&["test"]));
-    /// assert!(names.insert(&["test"]));
-    /// ```
-    pub fn insert<I>(&mut self, iter: I) -> bool
+    pub(crate) fn insert<I>(&mut self, iter: I) -> bool
     where
         I: IntoIterator,
         I::Item: IntoComponent,
@@ -42,19 +25,7 @@ impl Names {
     }
 
     /// Test if the given import exists.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rune::runtime::Names;
-    ///
-    /// let mut names = Names::new();
-    /// assert!(!names.contains(&["test"]));
-    /// assert!(!names.insert(&["test"]));
-    /// assert!(names.contains(&["test"]));
-    /// assert!(names.insert(&["test"]));
-    /// ```
-    pub fn contains<I>(&self, iter: I) -> bool
+    pub(crate) fn contains<I>(&self, iter: I) -> bool
     where
         I: IntoIterator,
         I::Item: IntoComponent,
@@ -63,7 +34,7 @@ impl Names {
     }
 
     /// Test if we contain the given prefix.
-    pub fn contains_prefix<I>(&self, iter: I) -> bool
+    pub(crate) fn contains_prefix<I>(&self, iter: I) -> bool
     where
         I: IntoIterator,
         I::Item: IntoComponent,
@@ -73,7 +44,7 @@ impl Names {
 
     /// Iterate over all known components immediately under the specified `iter`
     /// path.
-    pub fn iter_components<'a, I: 'a>(
+    pub(crate) fn iter_components<'a, I: 'a>(
         &'a self,
         iter: I,
     ) -> impl Iterator<Item = ComponentRef<'a>> + 'a
@@ -134,4 +105,27 @@ struct Node {
     term: bool,
     /// The children of this node.
     children: HashMap<Component, Node>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Names;
+
+    #[test]
+    fn insert() {
+        let mut names = Names::default();
+        assert!(!names.contains(&["test"]));
+        assert!(!names.insert(&["test"]));
+        assert!(names.contains(&["test"]));
+        assert!(names.insert(&["test"]));
+    }
+
+    #[test]
+    fn contains() {
+        let mut names = Names::default();
+        assert!(!names.contains(&["test"]));
+        assert!(!names.insert(&["test"]));
+        assert!(names.contains(&["test"]));
+        assert!(names.insert(&["test"]));
+    }
 }

--- a/crates/rune/src/query/mod.rs
+++ b/crates/rune/src/query/mod.rs
@@ -8,12 +8,13 @@ use crate::compile::ir;
 use crate::compile::{
     CaptureMeta, CompileError, CompileErrorKind, CompileVisitor, ComponentRef, EmptyMeta,
     ImportStep, IntoComponent, IrBudget, IrCompile, IrCompiler, IrInterpreter, Item, ItemMeta,
-    Location, Meta, MetaKind, ModMeta, SourceMeta, StructMeta, TupleMeta, UnitBuilder, Visibility,
+    Location, Meta, MetaKind, ModMeta, Names, SourceMeta, StructMeta, TupleMeta, UnitBuilder,
+    Visibility,
 };
 use crate::macros::Storage;
 use crate::parse::{Id, NonZeroId, Opaque, Resolve, ResolveContext};
 use crate::runtime::format;
-use crate::runtime::{Call, Names};
+use crate::runtime::Call;
 use crate::shared::{Consts, Gen, Items};
 use crate::{Context, Hash, SourceId, Sources};
 use std::collections::VecDeque;

--- a/crates/rune/src/runtime/awaited.rs
+++ b/crates/rune/src/runtime/awaited.rs
@@ -2,7 +2,7 @@ use crate::runtime::{Future, Select, Shared, ToValue, Vm, VmError};
 
 /// A stored await task.
 #[derive(Debug)]
-pub enum Awaited {
+pub(crate) enum Awaited {
     /// A future to be awaited.
     Future(Shared<Future>),
     /// A select to be awaited.

--- a/crates/rune/src/runtime/mod.rs
+++ b/crates/rune/src/runtime/mod.rs
@@ -55,7 +55,7 @@ pub use self::access::{
 };
 pub use self::any_obj::{AnyObj, AnyObjError, AnyObjVtable};
 pub use self::args::Args;
-pub use self::awaited::Awaited;
+pub(crate) use self::awaited::Awaited;
 pub use self::bytes::Bytes;
 pub use self::call::Call;
 pub use self::const_value::ConstValue;

--- a/crates/rune/src/runtime/mod.rs
+++ b/crates/rune/src/runtime/mod.rs
@@ -21,7 +21,6 @@ mod inst;
 mod iterator;
 mod key;
 mod label;
-mod names;
 mod object;
 mod panic;
 mod protocol;
@@ -75,7 +74,6 @@ pub use self::inst::{
 pub use self::iterator::{Iterator, IteratorTrait};
 pub use self::key::Key;
 pub use self::label::{DebugLabel, Label};
-pub use self::names::Names;
 pub use self::object::Object;
 pub use self::panic::Panic;
 pub use self::protocol::Protocol;

--- a/crates/rune/src/runtime/protocol_caller.rs
+++ b/crates/rune/src/runtime/protocol_caller.rs
@@ -37,7 +37,7 @@ impl ProtocolCaller for EnvProtocolCaller {
                 offset,
                 args: expected,
                 call,
-            }) = unit.lookup(hash)
+            }) = unit.function(hash)
             {
                 check_args(count, expected)?;
 
@@ -52,7 +52,7 @@ impl ProtocolCaller for EnvProtocolCaller {
                 return call.call_with_vm(vm);
             }
 
-            let handler = match context.lookup(hash) {
+            let handler = match context.function(hash) {
                 Some(handler) => handler,
                 None => return Err(VmError::from(VmErrorKind::MissingFunction { hash })),
             };

--- a/crates/rune/src/runtime/runtime_context.rs
+++ b/crates/rune/src/runtime/runtime_context.rs
@@ -1,7 +1,6 @@
 use crate::collections::HashMap;
-use crate::compile::Item;
 use crate::macros::{MacroContext, TokenStream};
-use crate::runtime::{ConstValue, Stack, TypeCheck, VmError};
+use crate::runtime::{ConstValue, Stack, VmError};
 use crate::Hash;
 use std::fmt;
 use std::sync::Arc;
@@ -22,26 +21,24 @@ pub(crate) type MacroHandler =
 #[derive(Default)]
 pub struct RuntimeContext {
     /// Registered native function handlers.
-    pub(crate) functions: HashMap<Hash, Arc<FunctionHandler>>,
-    /// Registered types.
-    pub(crate) types: HashMap<Hash, TypeCheck>,
+    functions: HashMap<Hash, Arc<FunctionHandler>>,
     /// Named constant values
-    pub(crate) constants: HashMap<Hash, ConstValue>,
+    constants: HashMap<Hash, ConstValue>,
 }
 
 impl RuntimeContext {
-    /// Construct a new empty collection of functions.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Use the specified type check.
-    pub fn type_check_for(&self, item: &Item) -> Option<TypeCheck> {
-        Some(*self.types.get(&Hash::type_hash(item))?)
+    pub(crate) fn new(
+        functions: HashMap<Hash, Arc<FunctionHandler>>,
+        constants: HashMap<Hash, ConstValue>,
+    ) -> Self {
+        Self {
+            functions,
+            constants,
+        }
     }
 
     /// Lookup the given native function handler in the context.
-    pub fn lookup(&self, hash: Hash) -> Option<&Arc<FunctionHandler>> {
+    pub fn function(&self, hash: Hash) -> Option<&Arc<FunctionHandler>> {
         self.functions.get(&hash)
     }
 

--- a/crates/rune/src/runtime/unit.rs
+++ b/crates/rune/src/runtime/unit.rs
@@ -140,12 +140,12 @@ impl Unit {
         self.variant_rtti.get(&hash)
     }
 
-    /// Lookup information of a function.
-    pub fn lookup(&self, hash: Hash) -> Option<UnitFn> {
+    /// Lookup a function in the unit.
+    pub fn function(&self, hash: Hash) -> Option<UnitFn> {
         self.functions.get(&hash).copied()
     }
 
-    /// Read a constant value from the unit.
+    /// Lookup a constant from the unit.
     pub fn constant(&self, hash: Hash) -> Option<&ConstValue> {
         self.constants.get(&hash)
     }
@@ -153,8 +153,9 @@ impl Unit {
 
 /// The kind and necessary information on registered functions.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum UnitFn {
-    /// Offset to call a "real" function.
+    /// Instruction offset of a function inside of the unit.
     Offset {
         /// Offset of the registered function.
         offset: usize,
@@ -163,24 +164,24 @@ pub enum UnitFn {
         /// The number of arguments the function takes.
         args: usize,
     },
-    /// An empty constructor.
+    /// An empty constructor of the type identified by the given hash.
     UnitStruct {
         /// The type hash of the empty.
         hash: Hash,
     },
-    /// A tuple constructor.
+    /// A tuple constructor of the type identified by the given hash.
     TupleStruct {
         /// The type hash of the tuple.
         hash: Hash,
         /// The number of arguments the tuple takes.
         args: usize,
     },
-    /// A empty variant constructor.
+    /// A unit variant of the type identified by the given hash.
     UnitVariant {
         /// The type hash of the empty variant.
         hash: Hash,
     },
-    /// A tuple variant constructor.
+    /// A tuple variant of the type identified by the given hash.
     TupleVariant {
         /// The type hash of the variant.
         hash: Hash,

--- a/tests/tests/bug_344.rs
+++ b/tests/tests/bug_344.rs
@@ -27,7 +27,7 @@ fn bug_344_function() -> rune::Result<()> {
 
     let hash = Hash::type_hash(&["function"]);
 
-    let function = runtime.lookup(hash).expect("expect function");
+    let function = runtime.function(hash).expect("expect function");
 
     let mut stack = Stack::new();
     stack.push(GuardCheck::new());
@@ -54,7 +54,7 @@ fn bug_344_inst_fn() -> rune::Result<()> {
 
     let hash = Hash::instance_function(<GuardCheck as Any>::type_hash(), "function");
 
-    let function = runtime.lookup(hash).expect("expect function");
+    let function = runtime.function(hash).expect("expect function");
 
     let mut stack = Stack::new();
     stack.push(GuardCheck::new());
@@ -83,7 +83,7 @@ fn bug_344_async_function() -> rune::Result<()> {
 
     let hash = Hash::type_hash(&["function"]);
 
-    let function = runtime.lookup(hash).expect("expect function");
+    let function = runtime.function(hash).expect("expect function");
 
     let mut stack = Stack::new();
     stack.push(GuardCheck::new());
@@ -112,7 +112,7 @@ fn bug_344_async_inst_fn() -> rune::Result<()> {
 
     let hash = Hash::instance_function(<GuardCheck as Any>::type_hash(), "function");
 
-    let function = runtime.lookup(hash).expect("expect function");
+    let function = runtime.function(hash).expect("expect function");
 
     let mut stack = Stack::new();
     stack.push(GuardCheck::new());


### PR DESCRIPTION
Hide more from public API and rename `lookup` to `function` where appropriate.

Also minor adjustments to api docs.