### PR TITLE
Hide meta items

### DIFF
--- a/crates/rune-cli/src/benches.rs
+++ b/crates/rune-cli/src/benches.rs
@@ -1,5 +1,5 @@
 use crate::{ExitCode, Io, SharedFlags};
-use rune::compile::{Item, Meta};
+use rune::compile::Item;
 use rune::runtime::{Function, Unit, Value};
 use rune::{Any, Context, ContextError, Hash, Module, Sources};
 use rune_modules::capture_io::CaptureIo;
@@ -50,7 +50,7 @@ pub(crate) async fn run(
     capture_io: Option<&CaptureIo>,
     unit: Arc<Unit>,
     sources: &Sources,
-    fns: &[(Hash, Meta)],
+    fns: &[(Hash, Item)],
 ) -> anyhow::Result<ExitCode> {
     let runtime = Arc::new(context.runtime());
     let mut vm = rune::Vm::new(runtime, unit);
@@ -59,8 +59,7 @@ pub(crate) async fn run(
 
     let mut any_error = false;
 
-    for (hash, meta) in fns {
-        let item = &meta.item.item;
+    for (hash, item) in fns {
         let mut bencher = Bencher::default();
 
         if let Err(error) = vm.call(*hash, (&mut bencher,)) {

--- a/crates/rune-cli/src/loader.rs
+++ b/crates/rune-cli/src/loader.rs
@@ -1,7 +1,6 @@
 use crate::{visitor, Args, Io};
 use anyhow::{anyhow, Context as _, Result};
-use rune::compile::FileSourceLoader;
-use rune::compile::Meta;
+use rune::compile::{FileSourceLoader, Item};
 use rune::Diagnostics;
 use rune::{Context, Hash, Options, Source, Sources, Unit};
 use std::collections::VecDeque;
@@ -13,7 +12,7 @@ use std::{path::Path, sync::Arc};
 pub(crate) struct Load {
     pub(crate) unit: Arc<Unit>,
     pub(crate) sources: Sources,
-    pub(crate) functions: Vec<(Hash, Meta)>,
+    pub(crate) functions: Vec<(Hash, Item)>,
 }
 
 /// Load context and code for a given path

--- a/crates/rune-cli/src/visitor.rs
+++ b/crates/rune-cli/src/visitor.rs
@@ -1,4 +1,4 @@
-use rune::compile::{CompileVisitor, Meta, MetaKind};
+use rune::compile::{CompileVisitor, Item, MetaKind, MetaRef};
 use rune::Hash;
 
 /// Attribute to collect.
@@ -15,7 +15,7 @@ pub(crate) enum Attribute {
 /// A compile visitor that collects functions with a specific attribute.
 pub struct FunctionVisitor {
     attribute: Attribute,
-    functions: Vec<(Hash, Meta)>,
+    functions: Vec<(Hash, Item)>,
 }
 
 impl FunctionVisitor {
@@ -27,13 +27,13 @@ impl FunctionVisitor {
     }
 
     /// Convert visitor into test functions.
-    pub(crate) fn into_functions(self) -> Vec<(Hash, Meta)> {
+    pub(crate) fn into_functions(self) -> Vec<(Hash, Item)> {
         self.functions
     }
 }
 
 impl CompileVisitor for FunctionVisitor {
-    fn register_meta(&mut self, meta: &Meta) {
+    fn register_meta(&mut self, meta: MetaRef<'_>) {
         let type_hash = match (self.attribute, &meta.kind) {
             (
                 Attribute::Test,
@@ -52,6 +52,6 @@ impl CompileVisitor for FunctionVisitor {
             _ => return,
         };
 
-        self.functions.push((*type_hash, meta.clone()));
+        self.functions.push((*type_hash, meta.item.clone()));
     }
 }

--- a/crates/rune-languageserver/src/state.rs
+++ b/crates/rune-languageserver/src/state.rs
@@ -6,7 +6,7 @@ use ropey::Rope;
 use rune::ast::{Span, Spanned};
 use rune::compile::{
     CompileError, CompileVisitor, ComponentRef, FileSourceLoader, Item, LinkerError, Location,
-    Meta, MetaKind, SourceMeta,
+    MetaKind, MetaRef, SourceMeta,
 };
 use rune::diagnostics::{Diagnostic, FatalDiagnosticKind};
 use rune::{Context, Options, SourceId};
@@ -585,12 +585,12 @@ impl Visitor {
 }
 
 impl CompileVisitor for Visitor {
-    fn visit_meta(&mut self, source_id: SourceId, meta: &Meta, span: Span) {
+    fn visit_meta(&mut self, source_id: SourceId, meta: MetaRef<'_>, span: Span) {
         if source_id.into_index() != 0 {
             return;
         }
 
-        let source = match meta.source.as_ref() {
+        let source = match meta.source {
             Some(source) => source,
             None => return,
         };

--- a/crates/rune/src/compile/compile_visitor.rs
+++ b/crates/rune/src/compile/compile_visitor.rs
@@ -1,14 +1,14 @@
 use crate::ast::Span;
-use crate::compile::Meta;
+use crate::compile::MetaRef;
 use crate::SourceId;
 
 /// A visitor that will be called for every language item compiled.
 pub trait CompileVisitor {
     /// Called when a meta item is registered.
-    fn register_meta(&mut self, _meta: &Meta) {}
+    fn register_meta(&mut self, _meta: MetaRef<'_>) {}
 
     /// Mark that we've encountered a specific compile meta at the given span.
-    fn visit_meta(&mut self, _source_id: SourceId, _meta: &Meta, _span: Span) {}
+    fn visit_meta(&mut self, _source_id: SourceId, _meta: MetaRef<'_>, _span: Span) {}
 
     /// Visit a variable use.
     fn visit_variable_use(&mut self, _source_id: SourceId, _var_span: Span, _span: Span) {}

--- a/crates/rune/src/compile/ir/ir_interpreter.rs
+++ b/crates/rune/src/compile/ir/ir_interpreter.rs
@@ -1,7 +1,7 @@
 use crate::ast::{Span, Spanned};
 use crate::compile::ir;
 use crate::compile::{
-    IrError, IrErrorKind, IrEval, IrEvalOutcome, IrValue, Item, MetaKind, ModMeta,
+    IrError, IrErrorKind, IrEval, IrEvalOutcome, IrValue, Item, ModMeta, PrivMetaKind,
 };
 use crate::query::{Query, Used};
 use crate::runtime::{ConstValue, Object, Tuple};
@@ -106,11 +106,14 @@ impl IrInterpreter<'_> {
 
             if let Some(meta) = self.q.query_meta(spanned, &item, used)? {
                 match &meta.kind {
-                    MetaKind::Const { const_value, .. } => {
+                    PrivMetaKind::Const { const_value, .. } => {
                         return Ok(IrValue::from_const(const_value));
                     }
                     _ => {
-                        return Err(IrError::new(spanned, IrErrorKind::UnsupportedMeta { meta }));
+                        return Err(IrError::new(
+                            spanned,
+                            IrErrorKind::UnsupportedMeta { meta: meta.info() },
+                        ));
                     }
                 }
             }
@@ -153,11 +156,14 @@ impl IrInterpreter<'_> {
 
             if let Some(meta) = self.q.query_meta(span, &item, used)? {
                 match &meta.kind {
-                    MetaKind::ConstFn { id, .. } => {
+                    PrivMetaKind::ConstFn { id, .. } => {
                         break *id;
                     }
                     _ => {
-                        return Err(IrError::new(span, IrErrorKind::UnsupportedMeta { meta }));
+                        return Err(IrError::new(
+                            span,
+                            IrErrorKind::UnsupportedMeta { meta: meta.info() },
+                        ));
                     }
                 }
             }

--- a/crates/rune/src/compile/mod.rs
+++ b/crates/rune/src/compile/mod.rs
@@ -50,9 +50,10 @@ mod location;
 pub use self::location::Location;
 
 mod meta;
-pub use self::meta::{
-    CaptureMeta, EmptyMeta, ItemMeta, Meta, MetaKind, ModMeta, SourceMeta, StructMeta, TupleMeta,
+pub(crate) use self::meta::{
+    CaptureMeta, EmptyMeta, ItemMeta, ModMeta, PrivMeta, PrivMetaKind, StructMeta, TupleMeta,
 };
+pub use self::meta::{Meta, MetaKind, MetaRef, SourceMeta};
 
 mod module;
 pub use self::module::{InstallWith, Module};
@@ -230,9 +231,9 @@ impl CompileBuildEntry<'_> {
                 let mut c = self.compiler1(location, span, &mut asm);
                 let meta = c.lookup_meta(f.instance_span, &f.impl_item)?;
 
-                let type_hash = meta
-                    .type_hash_of()
-                    .ok_or_else(|| CompileError::expected_meta(span, meta, "instance function"))?;
+                let type_hash = meta.type_hash_of().ok_or_else(|| {
+                    CompileError::expected_meta(span, meta.info(), "instance function")
+                })?;
 
                 assemble::fn_from_item_fn(&f.ast, &mut c, true)?;
 

--- a/crates/rune/src/compile/unit_builder.rs
+++ b/crates/rune/src/compile/unit_builder.rs
@@ -6,8 +6,8 @@
 use crate::ast::Span;
 use crate::collections::HashMap;
 use crate::compile::{
-    Assembly, AssemblyInst, CompileError, CompileErrorKind, IntoComponent, Item, Location, Meta,
-    MetaKind,
+    Assembly, AssemblyInst, CompileError, CompileErrorKind, IntoComponent, Item, Location,
+    PrivMeta, PrivMetaKind,
 };
 use crate::query::{QueryError, QueryErrorKind};
 use crate::runtime::debug::{DebugArgs, DebugSignature};
@@ -315,9 +315,9 @@ impl UnitBuilder {
     }
 
     /// Declare a new struct.
-    pub(crate) fn insert_meta(&mut self, span: Span, meta: &Meta) -> Result<(), QueryError> {
+    pub(crate) fn insert_meta(&mut self, span: Span, meta: &PrivMeta) -> Result<(), QueryError> {
         match &meta.kind {
-            MetaKind::UnitStruct { empty, .. } => {
+            PrivMetaKind::UnitStruct { empty, .. } => {
                 let info = UnitFn::UnitStruct { hash: empty.hash };
 
                 let signature = DebugSignature::new(meta.item.item.clone(), DebugArgs::EmptyArgs);
@@ -352,7 +352,7 @@ impl UnitBuilder {
                     .functions
                     .insert(empty.hash, signature);
             }
-            MetaKind::TupleStruct { tuple, .. } => {
+            PrivMetaKind::TupleStruct { tuple, .. } => {
                 let info = UnitFn::TupleStruct {
                     hash: tuple.hash,
                     args: tuple.args,
@@ -391,7 +391,7 @@ impl UnitBuilder {
                     .functions
                     .insert(tuple.hash, signature);
             }
-            MetaKind::Struct { .. } => {
+            PrivMetaKind::Struct { .. } => {
                 let hash = Hash::type_hash(&meta.item.item);
 
                 let rtti = Arc::new(Rtti {
@@ -411,7 +411,7 @@ impl UnitBuilder {
                     ));
                 }
             }
-            MetaKind::UnitVariant {
+            PrivMetaKind::UnitVariant {
                 enum_item, empty, ..
             } => {
                 let enum_hash = Hash::type_hash(enum_item);
@@ -446,7 +446,7 @@ impl UnitBuilder {
                     .functions
                     .insert(empty.hash, signature);
             }
-            MetaKind::TupleVariant {
+            PrivMetaKind::TupleVariant {
                 enum_item, tuple, ..
             } => {
                 let enum_hash = Hash::type_hash(enum_item);
@@ -485,7 +485,7 @@ impl UnitBuilder {
                     .functions
                     .insert(tuple.hash, signature);
             }
-            MetaKind::StructVariant { enum_item, .. } => {
+            PrivMetaKind::StructVariant { enum_item, .. } => {
                 let hash = Hash::type_hash(&meta.item.item);
                 let enum_hash = Hash::type_hash(enum_item);
 
@@ -502,22 +502,22 @@ impl UnitBuilder {
                     ));
                 }
             }
-            MetaKind::Enum { type_hash } => {
+            PrivMetaKind::Enum { type_hash } => {
                 self.constants.insert(
                     Hash::instance_function(*type_hash, Protocol::INTO_TYPE_NAME),
                     ConstValue::String(meta.item.item.to_string()),
                 );
             }
 
-            MetaKind::Function { .. } => (),
-            MetaKind::Closure { .. } => (),
-            MetaKind::AsyncBlock { .. } => (),
-            MetaKind::Const { const_value } => {
+            PrivMetaKind::Function { .. } => (),
+            PrivMetaKind::Closure { .. } => (),
+            PrivMetaKind::AsyncBlock { .. } => (),
+            PrivMetaKind::Const { const_value } => {
                 self.constants
                     .insert(Hash::type_hash(&meta.item.item), const_value.clone());
             }
-            MetaKind::ConstFn { .. } => (),
-            MetaKind::Import { .. } => (),
+            PrivMetaKind::ConstFn { .. } => (),
+            PrivMetaKind::Import { .. } => (),
         }
 
         Ok(())

--- a/crates/rune/src/indexing/index.rs
+++ b/crates/rune/src/indexing/index.rs
@@ -3,8 +3,8 @@ use crate::ast::{OptionSpanned, Span, Spanned};
 use crate::collections::HashMap;
 use crate::compile::attrs;
 use crate::compile::{
-    CompileError, CompileErrorKind, CompileResult, Item, Location, Meta, MetaKind, ModMeta,
-    Options, SourceLoader, SourceMeta, Visibility,
+    CompileError, CompileErrorKind, CompileResult, Item, Location, ModMeta, Options, PrivMeta,
+    PrivMetaKind, SourceLoader, SourceMeta, Visibility,
 };
 use crate::indexing::locals;
 use crate::indexing::{IndexFnKind, IndexScopes};
@@ -707,6 +707,13 @@ fn item_fn(ast: &mut ast::ItemFn, idx: &mut Indexer<'_>) -> CompileResult<()> {
             ));
         }
 
+        if is_bench {
+            return Err(CompileError::msg(
+                span,
+                "#[bench] is not supported on member functions",
+            ));
+        }
+
         let impl_item = idx.impl_item.as_ref().ok_or_else(|| {
             CompileError::new(span, CompileErrorKind::InstanceFunctionOutsideImpl)
         })?;
@@ -728,13 +735,13 @@ fn item_fn(ast: &mut ast::ItemFn, idx: &mut Indexer<'_>) -> CompileResult<()> {
             used: Used::Used,
         });
 
-        let kind = MetaKind::Function {
+        let kind = PrivMetaKind::Function {
             type_hash: Hash::type_hash(&item.item),
             is_test: false,
             is_bench: false,
         };
 
-        let meta = Meta {
+        let meta = PrivMeta {
             item,
             kind,
             source: Some(SourceMeta {
@@ -753,13 +760,13 @@ fn item_fn(ast: &mut ast::ItemFn, idx: &mut Indexer<'_>) -> CompileResult<()> {
             used: Used::Used,
         });
 
-        let kind = MetaKind::Function {
+        let kind = PrivMetaKind::Function {
             type_hash: Hash::type_hash(&item.item),
             is_test,
             is_bench,
         };
 
-        let meta = Meta {
+        let meta = PrivMeta {
             item,
             kind,
             source: Some(SourceMeta {


### PR DESCRIPTION
And the spirit of constraining the public API of rune as much as possible, this one hides most meta items in favor of instead exporting a very specific and limited version in `MetaInfo` which is used for visitors and errors.