### PR TITLE
Fix shadowed variables being incorrectly captured

### DIFF
--- a/crates/rune/src/indexing/index.rs
+++ b/crates/rune/src/indexing/index.rs
@@ -924,20 +924,20 @@ fn local(ast: &mut ast::Local, idx: &mut Indexer<'_>) -> CompileResult<()> {
         return Err(CompileError::msg(span, "attributes are not supported"));
     }
 
-    pat(&mut ast.pat, idx)?;
+    pat(&mut ast.pat, idx, false)?;
     expr(&mut ast.expr, idx)?;
     Ok(())
 }
 
 #[instrument]
 fn expr_let(ast: &mut ast::ExprLet, idx: &mut Indexer<'_>) -> CompileResult<()> {
-    pat(&mut ast.pat, idx)?;
+    pat(&mut ast.pat, idx, false)?;
     expr(&mut ast.expr, idx)?;
     Ok(())
 }
 
 #[instrument]
-fn ident(ast: &mut ast::Ident, idx: &mut Indexer<'_>) -> CompileResult<()> {
+fn declare(ast: &mut ast::Ident, idx: &mut Indexer<'_>) -> CompileResult<()> {
     let span = ast.span();
 
     let ident = ast.resolve(resolve_context!(idx.q))?;
@@ -946,13 +946,14 @@ fn ident(ast: &mut ast::Ident, idx: &mut Indexer<'_>) -> CompileResult<()> {
 }
 
 #[instrument]
-fn pat(ast: &mut ast::Pat, idx: &mut Indexer<'_>) -> CompileResult<()> {
+fn pat(ast: &mut ast::Pat, idx: &mut Indexer<'_>, is_use: bool) -> CompileResult<()> {
     match ast {
         ast::Pat::PatPath(pat) => {
-            path(&mut pat.path, idx)?;
+            path(&mut pat.path, idx, is_use)?;
 
             if let Some(i) = pat.path.try_as_ident_mut() {
-                ident(i, idx)?;
+                // Treat as a variable declaration going lexically forward.
+                declare(i, idx)?;
             }
         }
         ast::Pat::PatObject(pat) => {
@@ -978,11 +979,12 @@ fn pat(ast: &mut ast::Pat, idx: &mut Indexer<'_>) -> CompileResult<()> {
 #[instrument]
 fn pat_tuple(ast: &mut ast::PatTuple, idx: &mut Indexer<'_>) -> CompileResult<()> {
     if let Some(p) = &mut ast.path {
-        path(p, idx)?;
+        // Not a variable use - just the name of the tuple.
+        path(p, idx, false)?;
     }
 
     for (p, _) in &mut ast.items {
-        pat(p, idx)?;
+        pat(p, idx, false)?;
     }
 
     Ok(())
@@ -990,7 +992,7 @@ fn pat_tuple(ast: &mut ast::PatTuple, idx: &mut Indexer<'_>) -> CompileResult<()
 
 #[instrument]
 fn pat_binding(ast: &mut ast::PatBinding, idx: &mut Indexer<'_>) -> CompileResult<()> {
-    pat(&mut ast.pat, idx)?;
+    pat(&mut ast.pat, idx, false)?;
     Ok(())
 }
 
@@ -999,12 +1001,13 @@ fn pat_object(ast: &mut ast::PatObject, idx: &mut Indexer<'_>) -> CompileResult<
     match &mut ast.ident {
         ast::ObjectIdent::Anonymous(..) => (),
         ast::ObjectIdent::Named(p) => {
-            path(p, idx)?;
+            // Not a variable use - just a name in a pattern match.
+            path(p, idx, false)?;
         }
     }
 
     for (p, _) in &mut ast.items {
-        pat(p, idx)?;
+        pat(p, idx, false)?;
     }
 
     Ok(())
@@ -1013,7 +1016,7 @@ fn pat_object(ast: &mut ast::PatObject, idx: &mut Indexer<'_>) -> CompileResult<
 #[instrument]
 fn pat_vec(ast: &mut ast::PatVec, idx: &mut Indexer<'_>) -> CompileResult<()> {
     for (p, _) in &mut ast.items {
-        pat(p, idx)?;
+        pat(p, idx, false)?;
     }
 
     Ok(())
@@ -1025,7 +1028,7 @@ fn expr(ast: &mut ast::Expr, idx: &mut Indexer<'_>) -> CompileResult<()> {
 
     match ast {
         ast::Expr::Path(e) => {
-            path(e, idx)?;
+            path(e, idx, true)?;
         }
         ast::Expr::Let(e) => {
             expr_let(e, idx)?;
@@ -1186,7 +1189,7 @@ fn expr_match(ast: &mut ast::ExprMatch, idx: &mut Indexer<'_>) -> CompileResult<
         }
 
         let _guard = idx.scopes.push_scope();
-        pat(&mut branch.pat, idx)?;
+        pat(&mut branch.pat, idx, false)?;
         expr(&mut branch.body, idx)?;
     }
 
@@ -1458,21 +1461,23 @@ fn item(ast: &mut ast::Item, idx: &mut Indexer<'_>) -> CompileResult<()> {
 }
 
 #[instrument]
-fn path(ast: &mut ast::Path, idx: &mut Indexer<'_>) -> CompileResult<()> {
+fn path(ast: &mut ast::Path, idx: &mut Indexer<'_>, is_use: bool) -> CompileResult<()> {
     let id = idx
         .q
         .insert_path(&idx.mod_item, idx.impl_item.as_ref(), &*idx.items.item());
     ast.id.set(id);
 
-    match ast.as_kind() {
-        Some(ast::PathKind::SelfValue) => {
-            idx.scopes.mark_use(SELF);
+    if is_use {
+        match ast.as_kind() {
+            Some(ast::PathKind::SelfValue) => {
+                idx.scopes.mark_use(SELF);
+            }
+            Some(ast::PathKind::Ident(ident)) => {
+                let ident = ident.resolve(resolve_context!(idx.q))?;
+                idx.scopes.mark_use(ident);
+            }
+            None => (),
         }
-        Some(ast::PathKind::Ident(ident)) => {
-            let ident = ident.resolve(resolve_context!(idx.q))?;
-            idx.scopes.mark_use(ident);
-        }
-        None => (),
     }
 
     Ok(())
@@ -1499,7 +1504,7 @@ fn expr_for(ast: &mut ast::ExprFor, idx: &mut Indexer<'_>) -> CompileResult<()> 
     expr(&mut ast.iter, idx)?;
 
     let _guard = idx.scopes.push_scope();
-    pat(&mut ast.binding, idx)?;
+    pat(&mut ast.binding, idx, false)?;
     block(&mut ast.body, idx)?;
     Ok(())
 }
@@ -1642,7 +1647,7 @@ fn expr_select(ast: &mut ast::ExprSelect, idx: &mut Indexer<'_>) -> CompileResul
                 expr(&mut p.expr, idx)?;
 
                 let _guard = idx.scopes.push_scope();
-                pat(&mut p.pat, idx)?;
+                pat(&mut p.pat, idx, false)?;
                 expr(&mut p.body, idx)?;
             }
             ast::ExprSelectBranch::Default(def) => {
@@ -1716,7 +1721,8 @@ fn expr_vec(ast: &mut ast::ExprVec, idx: &mut Indexer<'_>) -> CompileResult<()> 
 fn expr_object(ast: &mut ast::ExprObject, idx: &mut Indexer<'_>) -> CompileResult<()> {
     match &mut ast.ident {
         ast::ObjectIdent::Named(p) => {
-            path(p, idx)?;
+            // Not a variable use: Name of the object.
+            path(p, idx, false)?;
         }
         ast::ObjectIdent::Anonymous(..) => (),
     }

--- a/tests/tests/vm_closures.rs
+++ b/tests/tests/vm_closures.rs
@@ -3,6 +3,21 @@ use rune::FromValue;
 use rune_tests::*;
 
 #[test]
+fn test_clobbered_scope() {
+    let out: i64 = rune! {
+        pub fn main() {
+            let a = |b| {
+                let a = 10;
+                a * b
+            };
+
+            a(5)
+        }
+    };
+    assert_eq!(out, 50);
+}
+
+#[test]
 fn test_nested_closures() {
     let out: i64 = rune! {
         pub fn main() {


### PR DESCRIPTION
Capture calculation had two issue in it:
* It treated certain statements as captures such as `a` in `let a = 42` under certain scenarios.
* It missed certain scenarios where a local variable in a closure is declared in the closure itself.

This is fixed by 1) ensuring that not all forms of `path`s are treated as uses and 2) checking if a variable exists in a scope *before* marking it as a capture.