### PR TITLE
Ensure free functions are registered for inst fns

### DIFF
--- a/crates/rune/src/compile/context.rs
+++ b/crates/rune/src/compile/context.rs
@@ -1,7 +1,6 @@
 use crate::collections::{HashMap, HashSet};
 use crate::compile::module::{
-    AssocFn, AssocKind, Function, Module, ModuleFn, ModuleInternalEnum, ModuleMacro, ModuleType,
-    ModuleUnitType,
+    AssocFn, AssocKind, Function, InternalEnum, Macro, Module, ModuleFn, Type, UnitType,
 };
 use crate::compile::{
     ComponentRef, IntoComponent, Item, Meta, Names, PrivMeta, PrivMetaKind, StructMeta, TupleMeta,
@@ -10,7 +9,7 @@ use crate::runtime::{
     ConstValue, FunctionHandler, MacroHandler, Protocol, RuntimeContext, StaticType, TypeCheck,
     TypeInfo, TypeOf, VmError,
 };
-use crate::{Hash, InstFnName};
+use crate::{Hash, InstFnKind};
 use std::fmt;
 use std::sync::Arc;
 use thiserror::Error;
@@ -95,7 +94,7 @@ pub enum ContextSignature {
         /// Path to the instance function.
         item: Item,
         /// Name of the instance function.
-        name: InstFnName,
+        name: InstFnKind,
         /// Arguments.
         args: Option<usize>,
         /// Information on the self type.
@@ -390,7 +389,7 @@ impl Context {
         &mut self,
         module: &Module,
         type_hash: Hash,
-        ty: &ModuleType,
+        ty: &Type,
     ) -> Result<(), ContextError> {
         let item = module.item.extended(&*ty.name);
         let hash = Hash::type_hash(&item);
@@ -494,7 +493,7 @@ impl Context {
         &mut self,
         module: &Module,
         item: &Item,
-        m: &ModuleMacro,
+        m: &Macro,
     ) -> Result<(), ContextError> {
         let item = module.item.join(item);
 
@@ -579,7 +578,7 @@ impl Context {
         //
         // The other alternatives are protocol functions (which are not free)
         // and plain hashes.
-        if let (InstFnName::Instance(name), AssocKind::Instance) = (&assoc.name, kind) {
+        if let (InstFnKind::Instance(name), AssocKind::Instance) = (&assoc.name, kind) {
             let item = info.item.extended(name);
 
             self.constants.insert(
@@ -624,7 +623,7 @@ impl Context {
     fn install_unit_type(
         &mut self,
         module: &Module,
-        unit_type: &ModuleUnitType,
+        unit_type: &UnitType,
     ) -> Result<(), ContextError> {
         let item = module.item.extended(&*unit_type.name);
         let hash = Hash::type_hash(&item);
@@ -647,7 +646,7 @@ impl Context {
     fn install_internal_enum(
         &mut self,
         module: &Module,
-        internal_enum: &ModuleInternalEnum,
+        internal_enum: &InternalEnum,
     ) -> Result<(), ContextError> {
         if !self.internal_enums.insert(internal_enum.static_type) {
             return Err(ContextError::InternalAlreadyPresent {

--- a/crates/rune/src/compile/context.rs
+++ b/crates/rune/src/compile/context.rs
@@ -1,7 +1,7 @@
 use crate::collections::{HashMap, HashSet};
 use crate::compile::module::{
-    Function, Module, ModuleAssociatedFn, ModuleAssociatedKind, ModuleFn, ModuleInternalEnum,
-    ModuleMacro, ModuleType, ModuleUnitType,
+    AssocFn, AssocKind, Function, Module, ModuleFn, ModuleInternalEnum, ModuleMacro, ModuleType,
+    ModuleUnitType,
 };
 use crate::compile::{
     ComponentRef, IntoComponent, Item, Meta, Names, PrivMeta, PrivMetaKind, StructMeta, TupleMeta,
@@ -538,8 +538,8 @@ impl Context {
         &mut self,
         type_hash: Hash,
         hash: Hash,
-        kind: ModuleAssociatedKind,
-        assoc: &ModuleAssociatedFn,
+        kind: AssocKind,
+        assoc: &AssocFn,
     ) -> Result<(), ContextError> {
         let info = match self
             .types_rev
@@ -579,7 +579,7 @@ impl Context {
         //
         // The other alternatives are protocol functions (which are not free)
         // and plain hashes.
-        if let (InstFnName::Instance(name), ModuleAssociatedKind::Instance) = (&assoc.name, kind) {
+        if let (InstFnName::Instance(name), AssocKind::Instance) = (&assoc.name, kind) {
             let item = info.item.extended(name);
 
             self.constants.insert(

--- a/crates/rune/src/compile/mod.rs
+++ b/crates/rune/src/compile/mod.rs
@@ -56,7 +56,7 @@ pub(crate) use self::meta::{
 pub use self::meta::{Meta, MetaKind, MetaRef, SourceMeta};
 
 mod module;
-pub use self::module::{InstallWith, Module};
+pub use self::module::{AssocType, InstallWith, Module};
 
 mod named;
 pub use self::named::Named;

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -223,7 +223,7 @@ pub mod diagnostics;
 pub use self::diagnostics::Diagnostics;
 
 mod hash;
-pub use self::hash::{Hash, InstFnName, InstFnNameHash, IntoTypeHash};
+pub use self::hash::{Hash, InstFnInfo, InstFnName, IntoTypeHash, NamedInstFn};
 
 mod indexing;
 

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -223,7 +223,7 @@ pub mod diagnostics;
 pub use self::diagnostics::Diagnostics;
 
 mod hash;
-pub use self::hash::{Hash, InstFnNameHash, IntoTypeHash};
+pub use self::hash::{Hash, InstFnName, InstFnNameHash, IntoTypeHash};
 
 mod indexing;
 

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -223,7 +223,7 @@ pub mod diagnostics;
 pub use self::diagnostics::Diagnostics;
 
 mod hash;
-pub use self::hash::{Hash, InstFnInfo, InstFnName, IntoTypeHash, NamedInstFn};
+pub use self::hash::{Hash, InstFnInfo, InstFnKind, InstFnName, IntoTypeHash};
 
 mod indexing;
 

--- a/crates/rune/src/modules/int.rs
+++ b/crates/rune/src/modules/int.rs
@@ -10,13 +10,13 @@ pub fn module() -> Result<Module, ContextError> {
     module.ty::<ParseIntError>()?;
 
     module.function(&["parse"], parse)?;
-    module.function(&["max"], i64::max)?;
-    module.function(&["min"], i64::min)?;
-    module.function(&["abs"], i64::abs)?;
-
     module.inst_fn("to_float", to_float)?;
 
+    module.inst_fn("max", i64::max)?;
+    module.inst_fn("min", i64::min)?;
     module.inst_fn("abs", i64::abs)?;
+    module.inst_fn("pow", i64::pow)?;
+
     module.inst_fn("checked_add", i64::checked_add)?;
     module.inst_fn("checked_sub", i64::checked_sub)?;
     module.inst_fn("checked_div", i64::checked_div)?;
@@ -35,7 +35,6 @@ pub fn module() -> Result<Module, ContextError> {
     module.inst_fn("saturating_abs", i64::saturating_abs)?;
     module.inst_fn("saturating_pow", i64::saturating_pow)?;
 
-    module.inst_fn("pow", i64::pow)?;
     Ok(module)
 }
 

--- a/crates/rune/src/runtime/protocol.rs
+++ b/crates/rune/src/runtime/protocol.rs
@@ -1,5 +1,5 @@
 use crate::compile::Item;
-use crate::{Hash, InstFnInfo, InstFnName, IntoTypeHash, NamedInstFn};
+use crate::{Hash, InstFnInfo, InstFnKind, InstFnName, IntoTypeHash};
 use std::cmp;
 use std::fmt;
 use std::hash;
@@ -13,7 +13,7 @@ pub struct Protocol {
     pub hash: Hash,
 }
 
-impl NamedInstFn for Protocol {
+impl InstFnName for Protocol {
     #[inline]
     fn name_hash(self) -> Hash {
         self.hash
@@ -23,7 +23,7 @@ impl NamedInstFn for Protocol {
     fn info(self) -> InstFnInfo {
         InstFnInfo {
             hash: self.hash,
-            name: InstFnName::Protocol(self),
+            kind: InstFnKind::Protocol(self),
         }
     }
 }

--- a/crates/rune/src/runtime/protocol.rs
+++ b/crates/rune/src/runtime/protocol.rs
@@ -1,5 +1,5 @@
 use crate::compile::Item;
-use crate::{Hash, InstFnName, InstFnNameHash, IntoTypeHash};
+use crate::{Hash, InstFnInfo, InstFnName, IntoTypeHash, NamedInstFn};
 use std::cmp;
 use std::fmt;
 use std::hash;
@@ -13,13 +13,18 @@ pub struct Protocol {
     pub hash: Hash,
 }
 
-impl InstFnNameHash for Protocol {
-    fn inst_fn_name_hash(self) -> Hash {
+impl NamedInstFn for Protocol {
+    #[inline]
+    fn name_hash(self) -> Hash {
         self.hash
     }
 
-    fn into_name(self) -> InstFnName {
-        InstFnName::Protocol(self)
+    #[inline]
+    fn info(self) -> InstFnInfo {
+        InstFnInfo {
+            hash: self.hash,
+            name: InstFnName::Protocol(self),
+        }
     }
 }
 

--- a/crates/rune/src/runtime/protocol.rs
+++ b/crates/rune/src/runtime/protocol.rs
@@ -1,5 +1,5 @@
 use crate::compile::Item;
-use crate::{Hash, InstFnNameHash, IntoTypeHash};
+use crate::{Hash, InstFnName, InstFnNameHash, IntoTypeHash};
 use std::cmp;
 use std::fmt;
 use std::hash;
@@ -18,8 +18,8 @@ impl InstFnNameHash for Protocol {
         self.hash
     }
 
-    fn into_name(self) -> Box<str> {
-        <Box<str>>::from(self.name)
+    fn into_name(self) -> InstFnName {
+        InstFnName::Protocol(self)
     }
 }
 
@@ -28,8 +28,8 @@ impl IntoTypeHash for Protocol {
         self.hash
     }
 
-    fn into_item(self) -> Item {
-        Item::with_item(&[self.name])
+    fn into_item(self) -> Option<Item> {
+        None
     }
 }
 

--- a/crates/rune/src/runtime/vm.rs
+++ b/crates/rune/src/runtime/vm.rs
@@ -363,10 +363,11 @@ impl Vm {
         let hash = name.into_type_hash();
 
         let info = self.unit.function(hash).ok_or_else(|| {
-            VmError::from(VmErrorKind::MissingEntry {
-                hash,
-                item: name.into_item(),
-            })
+            if let Some(item) = name.into_item() {
+                VmError::from(VmErrorKind::MissingEntry { hash, item })
+            } else {
+                VmError::from(VmErrorKind::MissingEntryHash { hash })
+            }
         })?;
 
         let offset = match info {

--- a/crates/rune/src/runtime/vm_error.rs
+++ b/crates/rune/src/runtime/vm_error.rs
@@ -188,6 +188,8 @@ pub enum VmErrorKind {
     MissingConst { hash: Hash },
     #[error("missing entry `{item}` with hash `{hash}`")]
     MissingEntry { item: Item, hash: Hash },
+    #[error("missing entry with hash `{hash}`")]
+    MissingEntryHash { hash: Hash },
     #[error("missing function with hash `{hash}`")]
     MissingFunction { hash: Hash },
     #[error("missing instance function `{hash}` for `{instance}`")]

--- a/tests/tests/test_float.rs
+++ b/tests/tests/test_float.rs
@@ -1,0 +1,60 @@
+use rune_tests::*;
+
+#[test]
+fn test_float_fns() {
+    let n: f64 = rune! {
+        pub fn main() {
+            1.0.min(2.0)
+        }
+    };
+    assert_eq!(n, 1.0);
+
+    let n: f64 = rune! {
+        pub fn main() {
+            std::float::min(1.0, 2.0)
+        }
+    };
+    assert_eq!(n, 1.0);
+
+    let n: f64 = rune! {
+        pub fn main() {
+            1.0.max(2.0)
+        }
+    };
+    assert_eq!(n, 2.0);
+
+    let n: f64 = rune! {
+        pub fn main() {
+            std::float::max(1.0, 2.0)
+        }
+    };
+    assert_eq!(n, 2.0);
+
+    let n: f64 = rune! {
+        pub fn main() {
+            (-10.0).abs()
+        }
+    };
+    assert_eq!(n, 10.0);
+
+    let n: f64 = rune! {
+        pub fn main() {
+            std::float::abs(-10.0)
+        }
+    };
+    assert_eq!(n, 10.0);
+
+    let n: f64 = rune! {
+        pub fn main() {
+            (12.0).powf(3.0)
+        }
+    };
+    assert_eq!(n, 1728.0);
+
+    let n: f64 = rune! {
+        pub fn main() {
+            std::float::powf(12.0, 3.0)
+        }
+    };
+    assert_eq!(n, 1728.0);
+}

--- a/tests/tests/test_int.rs
+++ b/tests/tests/test_int.rs
@@ -1,0 +1,60 @@
+use rune_tests::*;
+
+#[test]
+fn test_int_fns() {
+    let n: i64 = rune! {
+        pub fn main() {
+            1.min(2)
+        }
+    };
+    assert_eq!(n, 1);
+
+    let n: i64 = rune! {
+        pub fn main() {
+            std::int::min(1, 2)
+        }
+    };
+    assert_eq!(n, 1);
+
+    let n: i64 = rune! {
+        pub fn main() {
+            1.max(2)
+        }
+    };
+    assert_eq!(n, 2);
+
+    let n: i64 = rune! {
+        pub fn main() {
+            std::int::max(1, 2)
+        }
+    };
+    assert_eq!(n, 2);
+
+    let n: i64 = rune! {
+        pub fn main() {
+            (-10).abs()
+        }
+    };
+    assert_eq!(n, 10);
+
+    let n: i64 = rune! {
+        pub fn main() {
+            std::int::abs(-10)
+        }
+    };
+    assert_eq!(n, 10);
+
+    let n: i64 = rune! {
+        pub fn main() {
+            (12).pow(3)
+        }
+    };
+    assert_eq!(n, 1728);
+
+    let n: i64 = rune! {
+        pub fn main() {
+            std::int::pow(12, 3)
+        }
+    };
+    assert_eq!(n, 1728);
+}


### PR DESCRIPTION
Ensures that function handlers are registered where appropriate for instance functions, and that naming uses a scheme (with an enum) that ensures we won't have ambiguous issues in the future like with `Protocol::NEXT` being automatically named `"next"`.

CC: @tgolsson this is the issue mentioned on Discord.