### PR TITLE
Fix another capture issue

### DIFF
--- a/crates/rune/src/indexing/index.rs
+++ b/crates/rune/src/indexing/index.rs
@@ -924,8 +924,10 @@ fn local(ast: &mut ast::Local, idx: &mut Indexer<'_>) -> CompileResult<()> {
         return Err(CompileError::msg(span, "attributes are not supported"));
     }
 
-    pat(&mut ast.pat, idx, false)?;
+    // We index the rhs expression first so that it doesn't see it's own
+    // declaration and use that instead of capturing from the outside.
     expr(&mut ast.expr, idx)?;
+    pat(&mut ast.pat, idx, false)?;
     Ok(())
 }
 

--- a/tests/tests/vm_closures.rs
+++ b/tests/tests/vm_closures.rs
@@ -2,19 +2,39 @@ use rune::runtime::{Function, VecTuple};
 use rune::FromValue;
 use rune_tests::*;
 
+/// Test that we don't accidentally capture `a` as part of its own declaration.
 #[test]
 fn test_clobbered_scope() {
     let out: i64 = rune! {
         pub fn main() {
             let a = |b| {
-                let a = 10;
+                let a = 11;
                 a * b
             };
 
-            a(5)
+            a(3)
         }
     };
-    assert_eq!(out, 50);
+    assert_eq!(out, 33);
+}
+
+/// Tests that delcaring `c` doesn't clobber the declaration and that it is
+/// being correctly captured.
+#[test]
+fn test_self_declaration() {
+    let out: i64 = rune! {
+        pub fn main() {
+            let c = 7;
+
+            let c = |b| {
+                let c = c * 11;
+                c * b
+            };
+
+            c(3)
+        }
+    };
+    assert_eq!(out, 231);
 }
 
 #[test]


### PR DESCRIPTION
This is another subtle issue where the rhs of a declaration has to be indexed first to avoid it seeing its own declaration.

Relates to #363