### PR TITLE
Move InstallWith for Range into module

### DIFF
--- a/crates/rune/src/modules/ops.rs
+++ b/crates/rune/src/modules/ops.rs
@@ -8,8 +8,12 @@ pub fn module() -> Result<Module, ContextError> {
     let mut module = Module::with_crate_item("std", &["ops"]);
     module.ty::<Range>()?;
     module.inst_fn("contains_int", Range::contains_int)?;
+    module.field_fn(Protocol::GET, "start", |r: &Range| r.start.clone())?;
     module.field_fn(Protocol::SET, "start", range_set_start)?;
     module.field_fn(Protocol::SET, "end", range_set_end)?;
+    module.field_fn(Protocol::GET, "end", |r: &Range| r.end.clone())?;
+    module.inst_fn(Protocol::INTO_ITER, Range::into_iterator)?;
+    module.inst_fn("iter", Range::into_iterator)?;
     Ok(module)
 }
 

--- a/crates/rune/src/runtime/range.rs
+++ b/crates/rune/src/runtime/range.rs
@@ -1,7 +1,7 @@
-use crate::compile::{ContextError, InstallWith, Module, Named};
+use crate::compile::{InstallWith, Named};
 use crate::runtime::{
-    FromValue, Iterator, Mut, Panic, Protocol, RawMut, RawRef, RawStr, Ref, ToValue,
-    UnsafeFromValue, Value, Vm, VmError, VmErrorKind,
+    FromValue, Iterator, Mut, Panic, RawMut, RawRef, RawStr, Ref, ToValue, UnsafeFromValue, Value,
+    Vm, VmError, VmErrorKind,
 };
 use std::fmt;
 use std::ops;
@@ -262,12 +262,4 @@ impl Named for Range {
     const BASE_NAME: RawStr = RawStr::from_str("Range");
 }
 
-impl InstallWith for Range {
-    fn install_with(module: &mut Module) -> Result<(), ContextError> {
-        module.field_fn(Protocol::GET, "start", |r: &Range| r.start.clone())?;
-        module.field_fn(Protocol::GET, "end", |r: &Range| r.end.clone())?;
-        module.inst_fn(Protocol::INTO_ITER, Range::into_iterator)?;
-        module.inst_fn("iter", Range::into_iterator)?;
-        Ok(())
-    }
-}
+impl InstallWith for Range {}


### PR DESCRIPTION
This allows for *opting out* of installing specific range-related things if you don't install the `std::ops` module. Otherwise `InstallWith` forces you to include everything in the runtime context even if you don't need it.

This should be the policy going forward, so if we notice further instances where `InstallWith` is used they should be fixed.