### PR TITLE
Support generic functions

### DIFF
--- a/benches/benches/aoc_2020_11a.rs
+++ b/benches/benches/aoc_2020_11a.rs
@@ -56,7 +56,7 @@ fn aoc_2020_11a(b: &mut Bencher) -> rune::Result<()> {
 
             fn add(self, row) {
 
-                let row = row.collect_vec();
+                let row = row.collect::<Vec>();
                 if self.grid_world.len() == 0 {
                     self.height = 1;
                     self.grid_world.extend(row.iter().map(|_| CellState::Floor));
@@ -74,8 +74,8 @@ fn aoc_2020_11a(b: &mut Bencher) -> rune::Result<()> {
             fn complete(self, scanfunc) {
                 self.height += 1;
                 self.grid_world.extend((0..self.width).iter().map(|_| CellState::Floor));
-                self.backbuffer = self.grid_world.iter().collect_vec();
-                self.n1 = self.grid_world.iter().collect_vec();
+                self.backbuffer = self.grid_world.iter().collect::<Vec>();
+                self.n1 = self.grid_world.iter().collect::<Vec>();
                 for y in 0..self.height  {
                     for x in 0..self.width {
                         let idx = x + y * self.width;
@@ -199,7 +199,7 @@ fn aoc_2020_11a(b: &mut Bencher) -> rune::Result<()> {
                 .map(scan_line)
                 .fold(Map::new(), Map::add);
 
-            waiting_hall.complete(|m, x, y| m.slopes.iter().map(|(dx, dy)| (x + dx) + (y + dy) * m.width).collect_vec());
+            waiting_hall.complete(|m, x, y| m.slopes.iter().map(|(dx, dy)| (x + dx) + (y + dy) * m.width).collect::<Vec>());
 
 
             for i in (0..2).iter() {

--- a/benches/benches/aoc_2020_1a.rs
+++ b/benches/benches/aoc_2020_1a.rs
@@ -24,7 +24,7 @@ fn aoc_2020_1a(b: &mut Bencher) -> rune::Result<()> {
         struct NoSolution;
 
         fn part1(v, target) {
-            v.sort_int();
+            v.sort::<int>();
 
             let a = 0;
             let b = v.len() - 1;
@@ -41,7 +41,7 @@ fn aoc_2020_1a(b: &mut Bencher) -> rune::Result<()> {
         }
 
         fn part2(v, target) {
-            v.sort_int();
+            v.sort::<int>();
 
             let a = 0;
             let c = v.len() - 1;

--- a/benches/benches/aoc_2020_1b.rs
+++ b/benches/benches/aoc_2020_1b.rs
@@ -55,7 +55,7 @@ fn aoc_2020_1b(b: &mut Bencher) -> rune::Result<()> {
         }
 
         pub fn main(lines) {
-            lines.sort_int();
+            lines.sort::<int>();
             (filter_inner(iter::all_pairs(lines)), filter_inner(iter::all_triples(lines)))
         }
     };

--- a/benches/benches/primes.rn
+++ b/benches/benches/primes.rn
@@ -1,0 +1,32 @@
+const MAX_NUMBER_TO_CHECK = 1000;
+
+#[bench]
+fn find_primes(b) {
+    let prime_mask = [];
+
+    for n in 0..MAX_NUMBER_TO_CHECK {
+        prime_mask.push(true);
+    }
+
+    prime_mask[0] = false;
+    prime_mask[1] = false;
+
+    b.iter(|| {
+        let prime_mask = prime_mask.clone();
+        let total_primes_found = 0;
+
+        for p in 2..MAX_NUMBER_TO_CHECK {
+            if prime_mask[p] {
+                total_primes_found += 1;
+                let i = 2 * p;
+
+                while i < MAX_NUMBER_TO_CHECK {
+                    prime_mask[i] = false;
+                    i += p;
+                }
+            }
+        }
+
+        total_primes_found
+    });
+}

--- a/crates/rune/src/ast/path.rs
+++ b/crates/rune/src/ast/path.rs
@@ -60,6 +60,28 @@ impl Path {
         }
     }
 
+    /// Borrow ident and generics at the same time.
+    pub(crate) fn try_as_ident_generics(
+        &self,
+    ) -> Option<(
+        &ast::Ident,
+        Option<&ast::AngleBracketed<PathSegmentExpr, T![,]>>,
+    )> {
+        if self.trailing.is_none() && self.global.is_none() {
+            if let Some(ident) = self.first.try_as_ident() {
+                let generics = if let [(_, PathSegment::Generics(generics))] = &self.rest[..] {
+                    Some(generics)
+                } else {
+                    None
+                };
+
+                return Some((ident, generics));
+            }
+        }
+
+        None
+    }
+
     /// Borrow as an identifier used for field access calls.
     ///
     /// This is only allowed if there are no other path components

--- a/crates/rune/src/compile/compile_error.rs
+++ b/crates/rune/src/compile/compile_error.rs
@@ -204,6 +204,8 @@ pub enum CompileErrorKind {
     UnsupportedSuper,
     #[error("`super` can't be used in paths starting with `Self`")]
     UnsupportedSuperInSelfType,
+    #[error("path component cannot follow a generic argument")]
+    UnsupportedAfterGeneric,
     #[error("another segment can't follow wildcard `*` or group imports")]
     IllegalUseSegment,
     #[error("use aliasing is not supported for wildcard `*` or group imports")]

--- a/crates/rune/src/compile/compile_error.rs
+++ b/crates/rune/src/compile/compile_error.rs
@@ -269,7 +269,7 @@ pub enum CompileErrorKind {
     NoSuchBuiltInMacro { name: Box<str> },
     #[error("variable moved")]
     VariableMoved { moved_at: Span },
-    #[error("unsupported generic arguments")]
+    #[error("unsupported generic argument")]
     UnsupportedGenerics,
     #[error("#[test] attributes are not supported on nested items")]
     NestedTest { nested_span: Span },

--- a/crates/rune/src/compile/module.rs
+++ b/crates/rune/src/compile/module.rs
@@ -135,6 +135,7 @@ pub(crate) struct AssocFn {
 pub(crate) struct AssocKey {
     pub(crate) type_hash: Hash,
     pub(crate) hash: Hash,
+    pub(crate) parameters: Hash,
     pub(crate) kind: AssocKind,
 }
 
@@ -697,6 +698,7 @@ impl Module {
             type_hash: ty.hash,
             hash: name.hash,
             kind,
+            parameters: name.parameters,
         };
 
         if self.associated_functions.contains_key(&key) {

--- a/crates/rune/src/compile/v1/assemble.rs
+++ b/crates/rune/src/compile/v1/assemble.rs
@@ -5,6 +5,7 @@ use crate::compile::v1::{Assembler, Loop, Needs, Scope, Var};
 use crate::compile::{
     CaptureMeta, CompileError, CompileErrorKind, CompileResult, Item, PrivMeta, PrivMetaKind,
 };
+use crate::hash::ParametersBuilder;
 use crate::parse::{Id, ParseErrorKind, Resolve};
 use crate::query::{BuiltInFormat, BuiltInTemplate, Named};
 use crate::runtime::{
@@ -1604,7 +1605,7 @@ fn generics_parameters(
     generics: &ast::AngleBracketed<ast::PathSegmentExpr, T![,]>,
     c: &mut Assembler<'_>,
 ) -> Result<Hash, CompileError> {
-    let mut parameters = Vec::with_capacity(generics.len());
+    let mut parameters = ParametersBuilder::new();
 
     for (param, _) in generics {
         let path = match &param.expr {
@@ -1632,10 +1633,10 @@ fn generics_parameters(
             }
         };
 
-        parameters.push(hash);
+        parameters.add(hash);
     }
 
-    Ok(Hash::parameters(parameters))
+    Ok(parameters.finish())
 }
 
 enum Call {

--- a/crates/rune/src/compile/v1/mod.rs
+++ b/crates/rune/src/compile/v1/mod.rs
@@ -121,7 +121,10 @@ impl<'a> Assembler<'a> {
     }
 
     /// Convert an [ast::Path] into a [Named] item.
-    pub(crate) fn convert_path(&mut self, path: &ast::Path) -> CompileResult<Named> {
+    pub(crate) fn convert_path<'ast>(
+        &mut self,
+        path: &'ast ast::Path,
+    ) -> CompileResult<Named<'ast>> {
         self.q.convert_path(self.context, path)
     }
 

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -223,7 +223,7 @@ pub mod diagnostics;
 pub use self::diagnostics::Diagnostics;
 
 mod hash;
-pub use self::hash::{Hash, InstFnInfo, InstFnKind, InstFnName, IntoTypeHash};
+pub use self::hash::{Hash, InstFnInfo, InstFnKind, InstFnName, IntoTypeHash, Params};
 
 mod indexing;
 

--- a/crates/rune/src/modules/iter.rs
+++ b/crates/rune/src/modules/iter.rs
@@ -1,7 +1,7 @@
 //! The `std::iter` module.
 
-use crate::runtime::{FromValue, Iterator, Object, Protocol, Tuple, Value, Vec, VmError};
-use crate::{ContextError, Module};
+use crate::runtime::{FromValue, Iterator, Object, Protocol, Tuple, TypeOf, Value, Vec, VmError};
+use crate::{ContextError, Module, Params};
 
 /// Construct the `std::iter` module.
 pub fn module() -> Result<Module, ContextError> {
@@ -10,9 +10,9 @@ pub fn module() -> Result<Module, ContextError> {
 
     // Sorted for ease of finding
     module.inst_fn("chain", Iterator::chain)?;
-    module.inst_fn("collect_object", collect_object)?;
-    module.inst_fn("collect_vec", collect_vec)?;
-    module.inst_fn("collect_tuple", collect_tuple)?;
+    module.inst_fn(Params("collect", [Object::type_hash()]), collect_object)?;
+    module.inst_fn(Params("collect", [Vec::type_hash()]), collect_vec)?;
+    module.inst_fn(Params("collect", [Tuple::type_hash()]), collect_tuple)?;
     module.inst_fn("enumerate", Iterator::enumerate)?;
     module.inst_fn("filter", Iterator::filter)?;
     module.inst_fn("find", Iterator::find)?;

--- a/crates/rune/src/modules/vec.rs
+++ b/crates/rune/src/modules/vec.rs
@@ -1,7 +1,7 @@
 //! The `std::vec` module.
 
-use crate::runtime::{Function, Protocol, Value, Vec};
-use crate::{ContextError, Module};
+use crate::runtime::{Function, Protocol, TypeOf, Value, Vec};
+use crate::{ContextError, Module, Params};
 
 /// Construct the `std::vec` module.
 pub fn module() -> Result<Module, ContextError> {
@@ -25,8 +25,7 @@ pub fn module() -> Result<Module, ContextError> {
     module.inst_fn(Protocol::INDEX_SET, Vec::set)?;
 
     // TODO: parameterize with generics.
-    module.inst_fn("sort_int", sort_int)?;
-
+    module.inst_fn(Params("sort", [i64::type_hash()]), sort_int)?;
     Ok(module)
 }
 
@@ -47,6 +46,6 @@ fn sort_by(vec: &mut Vec, comparator: &Function) {
     vec.sort_by(|a, b| {
         comparator
             .call::<_, std::cmp::Ordering>((a, b))
-            .expect("an ordering")
+            .unwrap_or(std::cmp::Ordering::Equal)
     })
 }

--- a/crates/rune/src/runtime/protocol.rs
+++ b/crates/rune/src/runtime/protocol.rs
@@ -24,6 +24,7 @@ impl InstFnName for Protocol {
         InstFnInfo {
             hash: self.hash,
             kind: InstFnKind::Protocol(self),
+            parameters: Hash::EMPTY,
         }
     }
 }
@@ -35,6 +36,13 @@ impl IntoTypeHash for Protocol {
 
     fn into_item(self) -> Option<Item> {
         None
+    }
+
+    fn hash<H>(self, hasher: &mut H)
+    where
+        H: hash::Hasher,
+    {
+        self.hash.hash(hasher);
     }
 }
 

--- a/scripts/book/objects/json.rn
+++ b/scripts/book/objects/json.rn
@@ -7,12 +7,12 @@ async fn get_commits(repo, limit) {
     let text = response.text().await?;
     let json = json::from_string(text)?;
 
-    let commits = json.iter().take(limit).map(|e| e.sha).collect_vec();
+    let commits = json.iter().take(limit).map(|e| e.sha).collect::<Vec>();
     Ok(commits)
 }
 
 pub async fn main() {
     for commit in get_commits("rune-rs/rune", Some(5)).await? {
-        println(commit);
+        println!("{}", commit);
     }
 }

--- a/site/content/posts/2020-10-19-tmir1.md
+++ b/site/content/posts/2020-10-19-tmir1.md
@@ -389,7 +389,7 @@ pub fn main() {
 }
 {% end %}
 
-We've also added two collect functions, `collect_vec` and `collect_object`.
+We've also added two collect functions: `collect::<Vec>` and `collect::<Object>`.
 
 {% rune(footnote = "Apply filter to an iterator and collecting the result") %}
 struct Foo {
@@ -399,7 +399,7 @@ struct Foo {
 pub fn main() {
     let values = [1, "foo", Foo { value: 42 }];
 
-    values.iter().filter(|v| v is Foo).collect_vec()
+    values.iter().filter(|v| v is Foo).collect::<Vec>()
 }
 {% end %}
 

--- a/tests/tests/generics.rs
+++ b/tests/tests/generics.rs
@@ -2,7 +2,7 @@ use rune_tests::*;
 use std::collections::HashMap;
 
 #[test]
-fn test_collect() {
+fn test_collect_vec() {
     let values: Vec<i64> = rune! {
         pub fn main() {
             let it = [4, 3, 2, 1].iter();
@@ -11,10 +11,71 @@ fn test_collect() {
     };
     assert_eq!(values, vec![4, 3, 2, 1]);
 
+    let values: Vec<i64> = rune! {
+        use std::iter::Iterator;
+
+        pub fn main() {
+            let it = [4, 3, 2, 1].iter();
+            Iterator::collect::<Vec>(it)
+        }
+    };
+    assert_eq!(values, vec![4, 3, 2, 1]);
+
+    let values: Vec<i64> = rune! {
+        use std::iter::Iterator;
+
+        pub fn main() {
+            let it = [4, 3, 2, 1].iter();
+            let c = Iterator::collect::<Vec>;
+            c(it)
+        }
+    };
+    assert_eq!(values, vec![4, 3, 2, 1]);
+}
+
+#[test]
+fn test_collect_object() {
     let values: HashMap<String, i64> = rune! {
         pub fn main() {
             let it = [("a", 4), ("b", 3), ("c", 2), ("d", 1)].iter();
             it.collect::<Object>()
+        }
+    };
+    let expected = [
+        (String::from("a"), 4),
+        (String::from("b"), 3),
+        (String::from("c"), 2),
+        (String::from("d"), 1),
+    ]
+    .into_iter()
+    .collect::<HashMap<_, _>>();
+    assert_eq!(values, expected);
+
+    let values: HashMap<String, i64> = rune! {
+        use std::iter::Iterator;
+
+        pub fn main() {
+            let it = [("a", 4), ("b", 3), ("c", 2), ("d", 1)].iter();
+            Iterator::collect::<Object>(it)
+        }
+    };
+    let expected = [
+        (String::from("a"), 4),
+        (String::from("b"), 3),
+        (String::from("c"), 2),
+        (String::from("d"), 1),
+    ]
+    .into_iter()
+    .collect::<HashMap<_, _>>();
+    assert_eq!(values, expected);
+
+    let values: HashMap<String, i64> = rune! {
+        use std::iter::Iterator;
+
+        pub fn main() {
+            let it = [("a", 4), ("b", 3), ("c", 2), ("d", 1)].iter();
+            let c = Iterator::collect::<Object>;
+            c(it)
         }
     };
     let expected = [
@@ -34,6 +95,25 @@ fn test_sort() {
         pub fn main() {
             let vec = [4, 3, 2, 1];
             vec.sort::<int>();
+            vec
+        }
+    };
+    assert_eq!(values, vec![1, 2, 3, 4]);
+
+    let values: Vec<i64> = rune! {
+        pub fn main() {
+            let vec = [4, 3, 2, 1];
+            Vec::sort::<int>(vec);
+            vec
+        }
+    };
+    assert_eq!(values, vec![1, 2, 3, 4]);
+
+    let values: Vec<i64> = rune! {
+        pub fn main() {
+            let vec = [4, 3, 2, 1];
+            let f = Vec::sort::<int>;
+            f(vec);
             vec
         }
     };

--- a/tests/tests/generics.rs
+++ b/tests/tests/generics.rs
@@ -1,0 +1,41 @@
+use rune_tests::*;
+use std::collections::HashMap;
+
+#[test]
+fn test_collect() {
+    let values: Vec<i64> = rune! {
+        pub fn main() {
+            let it = [4, 3, 2, 1].iter();
+            it.collect::<Vec>()
+        }
+    };
+    assert_eq!(values, vec![4, 3, 2, 1]);
+
+    let values: HashMap<String, i64> = rune! {
+        pub fn main() {
+            let it = [("a", 4), ("b", 3), ("c", 2), ("d", 1)].iter();
+            it.collect::<Object>()
+        }
+    };
+    let expected = [
+        (String::from("a"), 4),
+        (String::from("b"), 3),
+        (String::from("c"), 2),
+        (String::from("d"), 1),
+    ]
+    .into_iter()
+    .collect::<HashMap<_, _>>();
+    assert_eq!(values, expected);
+}
+
+#[test]
+fn test_sort() {
+    let values: Vec<i64> = rune! {
+        pub fn main() {
+            let vec = [4, 3, 2, 1];
+            vec.sort::<int>();
+            vec
+        }
+    };
+    assert_eq!(values, vec![1, 2, 3, 4]);
+}

--- a/tests/tests/iterator.rs
+++ b/tests/tests/iterator.rs
@@ -7,7 +7,7 @@ fn test_range_iter() {
         use std::iter::range;
 
         pub fn main() {
-            range(0, 100).map(|n| n * 2).filter(|n| n % 3 == 0).collect_vec()
+            range(0, 100).map(|n| n * 2).filter(|n| n % 3 == 0).collect::<Vec>()
         }
     };
 
@@ -26,7 +26,7 @@ fn test_rev() {
         use std::iter::range;
 
         pub fn main() {
-            range(0, 100).map(|n| n * 2).filter(|n| n % 3 == 0).rev().collect_vec()
+            range(0, 100).map(|n| n * 2).filter(|n| n % 3 == 0).rev().collect::<Vec>()
         }
     };
 
@@ -71,7 +71,7 @@ fn test_object_rev_error() {
 fn test_chain() {
     let values: Vec<i64> = rune! {
         pub fn main() {
-            [1, 2].iter().rev().chain([3, 4].iter()).collect_vec()
+            [1, 2].iter().rev().chain([3, 4].iter()).collect::<Vec>()
         }
     };
 
@@ -84,7 +84,7 @@ fn test_enumerate() {
         pub fn main() {
             let it = [1, 2].iter().rev().chain([3, 4].iter()).enumerate();
             assert_eq!(it.next_back(), Some((3, 4)));
-            it.collect_vec()
+            it.collect::<Vec>()
         }
     };
 
@@ -95,7 +95,7 @@ fn test_enumerate() {
 fn test_option_iter() {
     let values: Vec<i64> = rune! {
         pub fn main() {
-            Some(1).iter().chain(None.iter()).chain(Some(3).iter()).collect_vec()
+            Some(1).iter().chain(None.iter()).chain(Some(3).iter()).collect::<Vec>()
         }
     };
 

--- a/tests/tests/test_range.rs
+++ b/tests/tests/test_range.rs
@@ -29,15 +29,15 @@ fn test_range() {
 fn test_range_iter() {
     let _: () = rune! {
         pub fn main() {
-            assert_eq!((1..4).iter().collect_vec(), [1, 2, 3]);
-            assert_eq!((1..4).iter().rev().collect_vec(), [3, 2, 1]);
-            assert_eq!((1..=4).iter().collect_vec(), [1, 2, 3, 4]);
-            assert_eq!((1..=4).iter().rev().collect_vec(), [4, 3, 2, 1]);
-            assert_eq!((0..10).iter().rev().take(3).collect_vec(), [9, 8, 7]);
-            assert_eq!((0..).iter().take(3).collect_vec(), [0, 1, 2]);
+            assert_eq!((1..4).iter().collect::<Vec>(), [1, 2, 3]);
+            assert_eq!((1..4).iter().rev().collect::<Vec>(), [3, 2, 1]);
+            assert_eq!((1..=4).iter().collect::<Vec>(), [1, 2, 3, 4]);
+            assert_eq!((1..=4).iter().rev().collect::<Vec>(), [4, 3, 2, 1]);
+            assert_eq!((0..10).iter().rev().take(3).collect::<Vec>(), [9, 8, 7]);
+            assert_eq!((0..).iter().take(3).collect::<Vec>(), [0, 1, 2]);
 
             let n = 1;
-            assert_eq!((n + 1..).iter().take(3).collect_vec(), [2, 3, 4]);
+            assert_eq!((n + 1..).iter().take(3).collect::<Vec>(), [2, 3, 4]);
         }
     };
 }


### PR DESCRIPTION
So this might *seem* kinda weird. Isn't Rune a dynamic programming language?

Well yes. But we also have a problem where functions that behave similarly but needs to be *parameterized* in some way need to be named. With this PR we can now call for example `Iterator::collect` like this:

```rust
let it = [1, 2, 3, 4].iter();
let vec = it.collect::<Vec>(); // Note: used to be `collect_vec`.

// These would work as well:
use std::iter::Iterator;
Iterator::collect::<Vec>(it);
let f = Iterator::collect::<Vec>;
f(it);
```

Note that there's no additional runtime overhead for calling functions like this. From a runtime perspective they are exactly the same.

The current approach is to add a "type suffix" to the function name itself. Like `collect_vec` and `collect_object`. This obviously runs the problem of polluting the namespace, and it's also *really poor* for providing good diagnostics. Like what do you do if `collect_map` doesn't exist? If we instead were to use a generic parameter to the collect fn to determine which implementation to use we could simply tell the user if they're trying to use an implementation which doesn't exist:

```
it.collect::<HashMap>()
   ^^^^^^^- no implementation available for `collect::<HashMap>`.

Note: Available implementations are `collect::<Vec>` and `collect::<Object>`.
```

Now we're not there yet. Currently it will simply complains that the corresponding instance hash is missing. In fact a bit more runtime data would need to be conveyed in order to support this properly. But this would be the vision long term.

Missing pieces in this PR:
* We might not want to use the `Params` struct to define generic names.