### PR TITLE
Introduce build for CLI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,27 @@ jobs:
           key: build_benchmarks-${{ runner.os }}-${{ steps.toolchain.outputs.rustc_hash }}
       - run: cargo build --benches
 
+  build_rune_cli:
+    name: Build CLI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        id: toolchain
+        with:
+          toolchain: nightly
+          profile: minimal
+          default: true
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/bin
+            target
+          key: build_rune_cli-${{ runner.os }}-${{ steps.toolchain.outputs.rustc_hash }}
+      - run: cargo build --package rune-cli
+
   check_formatting:
     name: Check Formatting
     runs-on: ubuntu-latest


### PR DESCRIPTION
Relates to #368

This should catch any issues with building rune-cli with default feature flags since this doesn't pull in any other crates as dependencies which might enable them.