### PR TITLE
Add Clone to Unit and Context

### DIFF
--- a/crates/rune/src/runtime/debug.rs
+++ b/crates/rune/src/runtime/debug.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 
 /// Debug information about a unit.
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct DebugInfo {
     /// Debug information on each instruction.
@@ -35,7 +35,7 @@ impl DebugInfo {
 }
 
 /// Debug information for every instruction.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct DebugInst {
     /// The file by id the instruction belongs to.
@@ -66,7 +66,7 @@ impl DebugInst {
 }
 
 /// Debug information on function arguments.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum DebugArgs {
     /// An empty, with not arguments.
     EmptyArgs,
@@ -77,7 +77,7 @@ pub enum DebugArgs {
 }
 
 /// A description of a function signature.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct DebugSignature {
     /// The path of the function.

--- a/crates/rune/src/runtime/runtime_context.rs
+++ b/crates/rune/src/runtime/runtime_context.rs
@@ -18,7 +18,7 @@ pub(crate) type MacroHandler =
 /// * Declared functions.
 /// * Declared instance functions.
 /// * Built-in type checks.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct RuntimeContext {
     /// Registered native function handlers.
     functions: HashMap<Hash, Arc<FunctionHandler>>,

--- a/crates/rune/src/runtime/unit.rs
+++ b/crates/rune/src/runtime/unit.rs
@@ -13,7 +13,7 @@ use std::fmt;
 use std::sync::Arc;
 
 /// Instructions from a single source file.
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Unit {
     /// The instructions contained in the source file.
     instructions: Vec<Inst>,


### PR DESCRIPTION
On multiprocessor computers, sharing the
same Unit (or Context) behind a single Arc can
be very costly, because the Arc(s) used inside
those structures end up in the
caches of all cores, and each update on
one core invalidates caches of the other cores.

By allowing Unit and Context to be Clone,
the users are able to do deep per-thread copies,
effectively unsharing all the reference counters
and letting each core progress at full
speed independently, at the expense of higher memory use.