### PR TITLE
Support compile-time metadata for matching over fields

### DIFF
--- a/crates/rune-macros/src/context.rs
+++ b/crates/rune-macros/src/context.rs
@@ -32,6 +32,8 @@ pub(crate) struct FieldAttrs {
     /// `#[rune(copy)]` to indicate that a field is copy and does not need to be
     /// cloned.
     pub(crate) copy: bool,
+    /// Whether this field should be known at compile time or not.
+    pub(crate) field: bool,
 }
 
 impl FieldAttrs {
@@ -69,7 +71,7 @@ pub(crate) struct TypeAttrs {
     pub(crate) parse: ParseKind,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub(crate) struct Generate<'a> {
     pub(crate) tokens: &'a Tokens,
     pub(crate) attrs: &'a FieldAttrs,
@@ -245,6 +247,7 @@ impl Context {
                         attrs.copy = true;
                     }
                     Meta(meta) if meta.path() == GET => {
+                        attrs.field = true;
                         attrs.protocols.push(FieldProtocol {
                             custom: self.parse_field_custom(meta)?,
                             generate: |g| {

--- a/crates/rune/src/compile/meta.rs
+++ b/crates/rune/src/compile/meta.rs
@@ -36,6 +36,8 @@ pub struct MetaRef<'a> {
 #[derive(Debug, Clone, Copy)]
 #[non_exhaustive]
 pub enum MetaKind {
+    /// An unknown type.
+    Unknown,
     /// Item describes a unit structure.
     UnitStruct,
     /// Item describes a tuple structure.
@@ -74,6 +76,9 @@ pub enum MetaKind {
 impl fmt::Display for Meta {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.kind {
+            MetaKind::Unknown => {
+                write!(fmt, "unknown {}", self.item)?;
+            }
             MetaKind::UnitStruct => {
                 write!(fmt, "struct {}", self.item)?;
             }
@@ -174,6 +179,7 @@ impl PrivMeta {
     /// compare them against the enum type.
     pub(crate) fn type_hash_of(&self) -> Option<Hash> {
         match &self.kind {
+            PrivMetaKind::Unknown { type_hash, .. } => Some(*type_hash),
             PrivMetaKind::UnitStruct { type_hash, .. } => Some(*type_hash),
             PrivMetaKind::TupleStruct { type_hash, .. } => Some(*type_hash),
             PrivMetaKind::Struct { type_hash, .. } => Some(*type_hash),
@@ -222,6 +228,9 @@ impl PrivMeta {
 /// Compile-time metadata kind about a unit.
 #[derive(Debug, Clone)]
 pub(crate) enum PrivMetaKind {
+    /// The type is completely opaque. We have no idea about what it is with the
+    /// exception of it having a type hash.
+    Unknown { type_hash: Hash },
     /// Metadata about an object.
     UnitStruct {
         /// The type hash associated with this meta kind.
@@ -329,6 +338,7 @@ impl PrivMetaKind {
     /// Coerce into a [MetaKind].
     pub(crate) fn as_meta_info_kind(&self) -> MetaKind {
         match self {
+            PrivMetaKind::Unknown { .. } => MetaKind::Unknown,
             PrivMetaKind::UnitStruct { .. } => MetaKind::UnitStruct,
             PrivMetaKind::TupleStruct { .. } => MetaKind::TupleStruct,
             PrivMetaKind::Struct { .. } => MetaKind::Struct,

--- a/crates/rune/src/modules/ops.rs
+++ b/crates/rune/src/modules/ops.rs
@@ -8,10 +8,8 @@ pub fn module() -> Result<Module, ContextError> {
     let mut module = Module::with_crate_item("std", &["ops"]);
     module.ty::<Range>()?;
     module.inst_fn("contains_int", Range::contains_int)?;
-    module.field_fn(Protocol::GET, "start", |r: &Range| r.start.clone())?;
     module.field_fn(Protocol::SET, "start", range_set_start)?;
     module.field_fn(Protocol::SET, "end", range_set_end)?;
-    module.field_fn(Protocol::GET, "end", |r: &Range| r.end.clone())?;
     module.inst_fn(Protocol::INTO_ITER, Range::into_iterator)?;
     module.inst_fn("iter", Range::into_iterator)?;
     Ok(module)

--- a/crates/rune/src/runtime/inst.rs
+++ b/crates/rune/src/runtime/inst.rs
@@ -813,6 +813,18 @@ pub enum Inst {
         /// The slot to test against.
         slot: usize,
     },
+    /// Test that the top of the stack has the given type.
+    ///
+    /// # Operation
+    ///
+    /// ```text
+    /// <value>
+    /// => <boolean>
+    /// ```
+    MatchType {
+        /// The type hash to match against.
+        hash: Hash,
+    },
     /// Test that the top of the stack is a tuple with the given length
     /// requirements.
     ///
@@ -841,8 +853,6 @@ pub enum Inst {
     /// => <boolean>
     /// ```
     MatchObject {
-        /// Type constraints that the object must match.
-        type_check: TypeCheck,
         /// The slot of object keys to use.
         slot: usize,
         /// Whether the operation should check exact `true` or minimum length
@@ -1181,6 +1191,9 @@ impl fmt::Display for Inst {
             Self::EqStaticString { slot } => {
                 write!(fmt, "eq-static-string slot={}", slot)?;
             }
+            Self::MatchType { hash } => {
+                write!(fmt, "match-type hash={}", hash,)?;
+            }
             Self::MatchSequence {
                 type_check,
                 len,
@@ -1192,16 +1205,8 @@ impl fmt::Display for Inst {
                     type_check, len, exact
                 )?;
             }
-            Self::MatchObject {
-                type_check,
-                slot,
-                exact,
-            } => {
-                write!(
-                    fmt,
-                    "match-object type_check={}, slot={}, exact={}",
-                    type_check, slot, exact
-                )?;
+            Self::MatchObject { slot, exact } => {
+                write!(fmt, "match-object slot={}, exact={}", slot, exact)?;
             }
             Self::Yield => {
                 write!(fmt, "yield")?;

--- a/crates/rune/src/runtime/range.rs
+++ b/crates/rune/src/runtime/range.rs
@@ -1,8 +1,9 @@
 use crate::compile::{InstallWith, Named};
 use crate::runtime::{
-    FromValue, Iterator, Mut, Panic, RawMut, RawRef, RawStr, Ref, ToValue, UnsafeFromValue, Value,
-    Vm, VmError, VmErrorKind,
+    FromValue, Iterator, Mut, Panic, Protocol, RawMut, RawRef, RawStr, Ref, ToValue,
+    UnsafeFromValue, Value, Vm, VmError, VmErrorKind,
 };
+use crate::Module;
 use std::fmt;
 use std::ops;
 
@@ -262,4 +263,11 @@ impl Named for Range {
     const BASE_NAME: RawStr = RawStr::from_str("Range");
 }
 
-impl InstallWith for Range {}
+impl InstallWith for Range {
+    fn install_with(module: &mut Module) -> Result<(), crate::ContextError> {
+        module.struct_meta::<Self>(&["start", "end"])?;
+        module.field_fn(Protocol::GET, "start", |r: &Range| r.start.clone())?;
+        module.field_fn(Protocol::GET, "end", |r: &Range| r.end.clone())?;
+        Ok(())
+    }
+}

--- a/crates/rune/src/runtime/value.rs
+++ b/crates/rune/src/runtime/value.rs
@@ -882,6 +882,9 @@ impl Value {
     }
 
     /// Get the type hash for the current value.
+    ///
+    /// One notable feature is that the type of a variant is its container
+    /// *enum*, and not the type hash of the variant itself.
     pub fn type_hash(&self) -> Result<Hash, VmError> {
         Ok(match self {
             Self::Unit => crate::runtime::UNIT_TYPE.hash,

--- a/tests/tests/match_external.rs
+++ b/tests/tests/match_external.rs
@@ -1,0 +1,61 @@
+//! Tests for derive(Any) generates the necessary metadata to match over fields.
+
+use rune::{Any, ContextError, Module};
+use rune_tests::*;
+
+#[derive(Any, Clone, Copy)]
+struct External {
+    #[rune(get)]
+    a: u32,
+    #[rune(get)]
+    b: u32,
+}
+
+fn make_module() -> Result<Module, ContextError> {
+    let mut module = Module::new();
+    module.ty::<External>()?;
+    Ok(module)
+}
+
+#[test]
+fn test_external_field_match() {
+    let m = make_module().expect("failed make module");
+
+    let e = External { a: 40, b: 41 };
+
+    assert_eq!(
+        rune_n! {
+            m,
+            (e,),
+            i64 => pub fn main(v) { match v { External { .. } => 2, _ => 0 } }
+        },
+        2
+    );
+
+    assert_eq!(
+        rune_n! {
+            m,
+            (e,),
+            i64 => pub fn main(v) { match v { External { a, .. } => a, _ => 0 } }
+        },
+        40
+    );
+
+    assert_eq!(
+        rune_n! {
+            m,
+            (e,),
+            i64 => pub fn main(v) { match v { External { b, .. } => b, _ => 0 } }
+        },
+        41
+    );
+
+    assert_eq!(
+        rune_n! {
+            m,
+            (e,),
+            i64 => pub fn main(v) { match v { External { a, b } => a + b, _ => 0 } }
+        },
+        81
+    );
+}


### PR DESCRIPTION
This adds support for defining an external type using the `Any` derive. And for each field that is marked with `#[rune(get)]`, it will be possible to match over those fields in Rune.

The internal plumbing is the addition of `Module::struct_meta` which requires you to specify the fields which are available on a given type. Once this is done, the necessary compile meta is then added so that the correct instructions are generated to invoke the getter if the type matches.

This also introduces the `PrivMetaKind::Unknown` metadata - which is what will be used if the metadata is not specified through `Module::struct_meta` (or future) metadata functions like ones for enums.

So if a type like this is defined and registered in Rust:

```rust
#[derive(Any)]
struct External {
    #[rune(get)]
    data: u32,
}
```

It will be possible to do this in Rune:

```rust
pub fn main(e) {
    match e {
        External { data } => data,
    }
}
```

This also **reintroduced** the `match-type` instruction which used to be supported, but was inadvertently deleted making it impossible to match over any external struct objects. This fixes a bug that was found by `imagio` on Discord.

# TODO

After this we still need to populate internal types with calls to `Module::struct_meta` ([as has been done with `Range` in this PR](https://github.com/rune-rs/rune/pull/384/files#diff-88d467d434f39b9b41485557c3171f07826d0822f20e641a0bc0bab5957df84eR268)) - otherwise it won't be possible to pattern match over their fields.

We should also add future support for tuple types (!).