### PR TITLE
Reject non-exhaustive struct patterns in match arm

### DIFF
--- a/crates/rune/src/compile/compile_error.rs
+++ b/crates/rune/src/compile/compile_error.rs
@@ -281,6 +281,8 @@ pub enum CompileErrorKind {
     MissingFunctionHash { hash: Hash },
     #[error("conflicting function already exists `{hash}`")]
     FunctionConflictHash { hash: Hash },
+    #[error("non-exhaustive pattern for `{item}`")]
+    PatternMissingFields { item: Item, fields: Box<[Box<str>]> },
 }
 
 /// A single step in an import.

--- a/crates/rune/src/compile/context.rs
+++ b/crates/rune/src/compile/context.rs
@@ -413,7 +413,7 @@ impl Context {
             match spec {
                 TypeSpecification::Struct(st) => PrivMetaKind::Struct {
                     type_hash,
-                    object: StructMeta {
+                    st: StructMeta {
                         fields: st.fields.clone(),
                     },
                 },

--- a/crates/rune/src/compile/meta.rs
+++ b/crates/rune/src/compile/meta.rs
@@ -250,7 +250,7 @@ pub(crate) enum PrivMetaKind {
         /// The type hash associated with this meta kind.
         type_hash: Hash,
         /// The underlying object.
-        object: StructMeta,
+        st: StructMeta,
     },
     /// Metadata about an empty variant.
     UnitVariant {
@@ -277,7 +277,7 @@ pub(crate) enum PrivMetaKind {
         /// The item of the enum.
         enum_item: Item,
         /// The underlying object.
-        object: StructMeta,
+        st: StructMeta,
     },
     /// An enum item.
     Enum {

--- a/crates/rune/src/diagnostics/fatal.rs
+++ b/crates/rune/src/diagnostics/fatal.rs
@@ -1,3 +1,4 @@
+use crate::ast::{Span, Spanned};
 use crate::compile::{CompileError, LinkerError};
 use crate::parse::ParseError;
 use crate::query::QueryError;
@@ -30,6 +31,16 @@ impl FatalDiagnostic {
     /// Convert into the kind of the load error.
     pub fn into_kind(self) -> FatalDiagnosticKind {
         *self.kind
+    }
+
+    pub(crate) fn span(&self) -> Option<Span> {
+        match &*self.kind {
+            FatalDiagnosticKind::ParseError(error) => Some(error.span()),
+            FatalDiagnosticKind::CompileError(error) => Some(error.span()),
+            FatalDiagnosticKind::QueryError(error) => Some(error.span()),
+            FatalDiagnosticKind::LinkError(..) => None,
+            FatalDiagnosticKind::Internal(..) => None,
+        }
     }
 }
 

--- a/crates/rune/src/query/mod.rs
+++ b/crates/rune/src/query/mod.rs
@@ -1578,15 +1578,15 @@ fn struct_body_meta(
         fields.insert(name.into());
     }
 
-    let object = StructMeta { fields };
+    let st = StructMeta { fields };
 
     Ok(match enum_item {
         Some(enum_item) => PrivMetaKind::StructVariant {
             type_hash,
             enum_item: enum_item.clone(),
-            object,
+            st,
         },
-        None => PrivMetaKind::Struct { type_hash, object },
+        None => PrivMetaKind::Struct { type_hash, st },
     })
 }
 

--- a/tests/tests/compiler_patterns.rs
+++ b/tests/tests/compiler_patterns.rs
@@ -1,0 +1,34 @@
+use rune::compile::CompileErrorKind::*;
+use rune::span;
+use rune_tests::*;
+
+#[test]
+fn illegal_pattern_in_match() {
+    assert_compile_error! {
+        r#"
+        struct Foo { bar, baz }
+
+        pub fn main() {
+            match () { Foo { } => {} }
+        }
+        "#,
+        span, PatternMissingFields { fields, .. } => {
+            assert_eq!(&fields[..], [Box::from("bar"), Box::from("baz")]);
+            assert_eq!(span, span!(85, 88));
+        }
+    };
+
+    assert_compile_error! {
+        r#"
+        struct Foo { bar, baz }
+
+        pub fn main() {
+            match () { Foo { bar } => {} }
+        }
+        "#,
+        span, PatternMissingFields { fields, .. } => {
+            assert_eq!(&fields[..], [Box::from("baz")]);
+            assert_eq!(span, span!(85, 92));
+        }
+    };
+}


### PR DESCRIPTION
Also adds the following diagnostic:

```
error: compile error
  ┌─ scripts/test.rn:2:45
  │
2 │     let out = match 0..10 { std::ops::Range {} => start, _ => None };
  │                                             ^^
  │                                             │
  │                                             non-exhaustive pattern for `::std::ops::Range`
  │                                             missing fields: end, start
  │
  = You can also make the pattern non-exhaustive by adding `..`

Error: failed to build rune sources (see diagnostics for details)
```