### PR TITLE
Fix HashMap INDEX_{SET,GET}

### DIFF
--- a/crates/rune-wasm/Cargo.toml
+++ b/crates/rune-wasm/Cargo.toml
@@ -15,18 +15,18 @@ A WASM module for Rune, an embeddable dynamic programming language for Rust.
 """
 
 [dependencies]
-serde = { version = "1.0.130", features = ["derive"] }
-wasm-bindgen = { version = "0.2.78", features = ["serde-serialize"] }
-wasm-bindgen-futures = "0.4.28"
-js-sys = "0.3.55"
-anyhow = "1.0.49"
+serde = { version = "1.0.136", features = ["derive"] }
+wasm-bindgen = { version = "0.2.79", features = ["serde-serialize"] }
+wasm-bindgen-futures = "0.4.29"
+js-sys = "0.3.56"
+anyhow = "1.0.53"
 
 rune = {version = "0.11.0", path = "../rune", features = []}
 rune-macros = {version = "0.11.0", path = "../rune-macros"}
 rune-modules = {version = "0.11.0", path = "../rune-modules", features = ["core", "test", "json", "toml", "rand", "experiments", "macros", "capture-io", "wasm-bindgen"]}
 
 [dependencies.web-sys]
-version = "0.3.55"
+version = "0.3.56"
 features = ["Request", "Response", "Window", "RequestInit", "RequestMode"]
 
 [lib]

--- a/crates/rune-wasm/src/lib.rs
+++ b/crates/rune-wasm/src/lib.rs
@@ -46,6 +46,7 @@
 
 #![allow(clippy::collapsible_match)]
 #![allow(clippy::single_match)]
+#![allow(clippy::unused_unit)]
 
 use anyhow::Context as _;
 use rune::ast::Spanned;

--- a/crates/rune/src/modules/collections.rs
+++ b/crates/rune/src/modules/collections.rs
@@ -56,6 +56,11 @@ impl HashMap {
     }
 
     #[inline]
+    fn index_set(&mut self, key: Key, value: Value) {
+        let _ = self.map.insert(key, value);
+    }
+
+    #[inline]
     fn insert(&mut self, key: Key, value: Value) -> Option<Value> {
         self.map.insert(key, value)
     }
@@ -66,7 +71,7 @@ impl HashMap {
     }
 
     #[inline]
-    fn fallible_get(&self, key: Key) -> Result<Value, VmError> {
+    fn index_get(&self, key: Key) -> Result<Value, VmError> {
         use crate::runtime::TypeOf;
 
         let value = self.map.get(&key).ok_or_else(|| {
@@ -425,8 +430,8 @@ pub fn module() -> Result<Module, ContextError> {
     module.inst_fn("remove", HashMap::remove)?;
     module.inst_fn("values", HashMap::values)?;
     module.inst_fn(Protocol::INTO_ITER, HashMap::iter)?;
-    module.inst_fn(Protocol::INDEX_SET, HashMap::insert)?;
-    module.inst_fn(Protocol::INDEX_GET, HashMap::fallible_get)?;
+    module.inst_fn(Protocol::INDEX_SET, HashMap::index_set)?;
+    module.inst_fn(Protocol::INDEX_GET, HashMap::index_get)?;
     module.inst_fn(Protocol::STRING_DEBUG, HashMap::string_debug)?;
 
     module.ty::<HashSet>()?;

--- a/tests/tests/collections.rs
+++ b/tests/tests/collections.rs
@@ -13,9 +13,11 @@ fn test_hash_map_tile() {
             let m = HashMap::new();
 
             m.insert((0, 1), Tile::Wall);
+            m[(0, 3)] = 5;
 
             assert_eq!(m.get((0, 1)), Some(Tile::Wall));
             assert_eq!(m.get((0, 2)), None);
+            assert_eq!(m[(0, 3)], 5);
         }
     };
 }


### PR DESCRIPTION
Failing test case illustrating the breakage from #390.

If cherry-picked onto the 0.10.3 tag, it passes without issue.