### PR TITLE
Add f32/f64 to VmVisitor

### DIFF
--- a/crates/rune/src/runtime/value.rs
+++ b/crates/rune/src/runtime/value.rs
@@ -1481,6 +1481,22 @@ impl<'de> de::Visitor<'de> for VmVisitor {
     }
 
     #[inline]
+    fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Value::Float(v as f64))
+    }
+
+    #[inline]
+    fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Value::Float(v))
+    }
+
+    #[inline]
     fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
     where
         E: de::Error,


### PR DESCRIPTION
I've just stumbled over [this issue](https://github.com/rune-rs/rune/issues/377) myself and took the time to fix.

The VmVisitor must have been copypasted from the KeyVisitor and the floats were left forgotten. 
A macro would actually seem to fit here to avoid all those duplicates.