### PR TITLE
A bunch of cleanups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.61.0
           profile: minimal
           components: clippy
           override: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Build
+name: CI
 
 on:
   pull_request: {}

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 <div align="center">
 <a href="https://github.com/rune-rs/rune/actions">
-    <img alt="Build Status" src="https://github.com/rune-rs/rune/workflows/Build/badge.svg">
+    <img alt="Build Status" src="https://github.com/rune-rs/rune/workflows/CI/badge.svg">
 </a>
 
 <a href="https://github.com/rune-rs/rune/actions">

--- a/crates/rune-cli/README.md
+++ b/crates/rune-cli/README.md
@@ -20,7 +20,7 @@
 
 <div align="center">
 <a href="https://github.com/rune-rs/rune/actions">
-    <img alt="Build Status" src="https://github.com/rune-rs/rune/workflows/Build/badge.svg">
+    <img alt="Build Status" src="https://github.com/rune-rs/rune/workflows/CI/badge.svg">
 </a>
 
 <a href="https://github.com/rune-rs/rune/actions">

--- a/crates/rune-cli/src/main.rs
+++ b/crates/rune-cli/src/main.rs
@@ -18,7 +18,7 @@
 //!
 //! <div align="center">
 //! <a href="https://github.com/rune-rs/rune/actions">
-//!     <img alt="Build Status" src="https://github.com/rune-rs/rune/workflows/Build/badge.svg">
+//!     <img alt="Build Status" src="https://github.com/rune-rs/rune/workflows/CI/badge.svg">
 //! </a>
 //!
 //! <a href="https://github.com/rune-rs/rune/actions">

--- a/crates/rune-cli/src/main.rs
+++ b/crates/rune-cli/src/main.rs
@@ -433,7 +433,7 @@ async fn try_main() -> Result<ExitCode, io::Error> {
             o.set_color(ColorSpec::new().set_fg(Some(Color::Red)))?;
             let result = format_errors(&mut o, error.as_ref());
             o.set_color(&ColorSpec::new())?;
-            let () = result?;
+            result?;
             Ok(ExitCode::Failure)
         }
     }

--- a/crates/rune-cli/src/run.rs
+++ b/crates/rune-cli/src/run.rs
@@ -190,9 +190,7 @@ pub(crate) async fn run(
         execution.async_complete().await
     };
 
-    let errored;
-
-    match result {
+    let errored = match result {
         Ok(result) => {
             let duration = Instant::now().duration_since(last);
 
@@ -200,7 +198,7 @@ pub(crate) async fn run(
                 writeln!(io.stderr, "== {:?} ({:?})", result, duration)?;
             }
 
-            errored = None;
+            None
         }
         Err(error) => {
             let duration = Instant::now().duration_since(last);
@@ -209,7 +207,7 @@ pub(crate) async fn run(
                 writeln!(io.stderr, "== ! ({}) ({:?})", error, duration)?;
             }
 
-            errored = Some(error);
+            Some(error)
         }
     };
 

--- a/crates/rune-languageserver/README.md
+++ b/crates/rune-languageserver/README.md
@@ -20,7 +20,7 @@
 
 <div align="center">
 <a href="https://github.com/rune-rs/rune/actions">
-    <img alt="Build Status" src="https://github.com/rune-rs/rune/workflows/Build/badge.svg">
+    <img alt="Build Status" src="https://github.com/rune-rs/rune/workflows/CI/badge.svg">
 </a>
 
 <a href="https://github.com/rune-rs/rune/actions">

--- a/crates/rune-languageserver/src/lib.rs
+++ b/crates/rune-languageserver/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! <div align="center">
 //! <a href="https://github.com/rune-rs/rune/actions">
-//!     <img alt="Build Status" src="https://github.com/rune-rs/rune/workflows/Build/badge.svg">
+//!     <img alt="Build Status" src="https://github.com/rune-rs/rune/workflows/CI/badge.svg">
 //! </a>
 //!
 //! <a href="https://github.com/rune-rs/rune/actions">

--- a/crates/rune-languageserver/src/main.rs
+++ b/crates/rune-languageserver/src/main.rs
@@ -18,7 +18,7 @@
 //!
 //! <div align="center">
 //! <a href="https://github.com/rune-rs/rune/actions">
-//!     <img alt="Build Status" src="https://github.com/rune-rs/rune/workflows/Build/badge.svg">
+//!     <img alt="Build Status" src="https://github.com/rune-rs/rune/workflows/CI/badge.svg">
 //! </a>
 //!
 //! <a href="https://github.com/rune-rs/rune/actions">

--- a/crates/rune-languageserver/src/state.rs
+++ b/crates/rune-languageserver/src/state.rs
@@ -125,11 +125,7 @@ impl State {
             by_url.insert(url.clone(), Default::default());
 
             let mut sources = rune::Sources::new();
-            let input = rune::Source::with_path(
-                url.to_string(),
-                source.to_string(),
-                url.to_file_path().ok(),
-            );
+            let input = rune::Source::with_path(url, source.to_string(), url.to_file_path().ok());
 
             sources.insert(input);
 
@@ -435,7 +431,7 @@ fn report<E, R>(
     R: Fn(lsp::Range, E) -> lsp::Diagnostic,
 {
     let source = match sources.get(source_id) {
-        Some(source) => &*source,
+        Some(source) => source,
         None => return,
     };
 
@@ -447,7 +443,7 @@ fn report<E, R>(
         None => return,
     };
 
-    let range = match span_to_lsp_range(&*source, span) {
+    let range = match span_to_lsp_range(source, span) {
         Some(range) => range,
         None => return,
     };
@@ -714,7 +710,7 @@ impl rune::compile::SourceLoader for SourceLoader {
         if let Some(candidates) = Self::candidates(root, item) {
             for url in candidates.iter() {
                 if let Some(s) = self.sources.get(url) {
-                    return Ok(rune::Source::new(url.to_string(), s.to_string()));
+                    return Ok(rune::Source::new(url, s.to_string()));
                 }
             }
         }

--- a/crates/rune-macros/README.md
+++ b/crates/rune-macros/README.md
@@ -20,7 +20,7 @@
 
 <div align="center">
 <a href="https://github.com/rune-rs/rune/actions">
-    <img alt="Build Status" src="https://github.com/rune-rs/rune/workflows/Build/badge.svg">
+    <img alt="Build Status" src="https://github.com/rune-rs/rune/workflows/CI/badge.svg">
 </a>
 
 <a href="https://github.com/rune-rs/rune/actions">

--- a/crates/rune-macros/src/lib.rs
+++ b/crates/rune-macros/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! <div align="center">
 //! <a href="https://github.com/rune-rs/rune/actions">
-//!     <img alt="Build Status" src="https://github.com/rune-rs/rune/workflows/Build/badge.svg">
+//!     <img alt="Build Status" src="https://github.com/rune-rs/rune/workflows/CI/badge.svg">
 //! </a>
 //!
 //! <a href="https://github.com/rune-rs/rune/actions">

--- a/crates/rune-modules/README.md
+++ b/crates/rune-modules/README.md
@@ -20,7 +20,7 @@
 
 <div align="center">
 <a href="https://github.com/rune-rs/rune/actions">
-    <img alt="Build Status" src="https://github.com/rune-rs/rune/workflows/Build/badge.svg">
+    <img alt="Build Status" src="https://github.com/rune-rs/rune/workflows/CI/badge.svg">
 </a>
 
 <a href="https://github.com/rune-rs/rune/actions">

--- a/crates/rune-modules/src/lib.rs
+++ b/crates/rune-modules/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! <div align="center">
 //! <a href="https://github.com/rune-rs/rune/actions">
-//!     <img alt="Build Status" src="https://github.com/rune-rs/rune/workflows/Build/badge.svg">
+//!     <img alt="Build Status" src="https://github.com/rune-rs/rune/workflows/CI/badge.svg">
 //! </a>
 //!
 //! <a href="https://github.com/rune-rs/rune/actions">

--- a/crates/rune-wasm/README.md
+++ b/crates/rune-wasm/README.md
@@ -20,7 +20,7 @@
 
 <div align="center">
 <a href="https://github.com/rune-rs/rune/actions">
-    <img alt="Build Status" src="https://github.com/rune-rs/rune/workflows/Build/badge.svg">
+    <img alt="Build Status" src="https://github.com/rune-rs/rune/workflows/CI/badge.svg">
 </a>
 
 <a href="https://github.com/rune-rs/rune/actions">

--- a/crates/rune-wasm/src/lib.rs
+++ b/crates/rune-wasm/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! <div align="center">
 //! <a href="https://github.com/rune-rs/rune/actions">
-//!     <img alt="Build Status" src="https://github.com/rune-rs/rune/workflows/Build/badge.svg">
+//!     <img alt="Build Status" src="https://github.com/rune-rs/rune/workflows/CI/badge.svg">
 //! </a>
 //!
 //! <a href="https://github.com/rune-rs/rune/actions">

--- a/crates/rune/README.md
+++ b/crates/rune/README.md
@@ -20,7 +20,7 @@
 
 <div align="center">
 <a href="https://github.com/rune-rs/rune/actions">
-    <img alt="Build Status" src="https://github.com/rune-rs/rune/workflows/Build/badge.svg">
+    <img alt="Build Status" src="https://github.com/rune-rs/rune/workflows/CI/badge.svg">
 </a>
 
 <a href="https://github.com/rune-rs/rune/actions">

--- a/crates/rune/src/ast/condition.rs
+++ b/crates/rune/src/ast/condition.rs
@@ -1,6 +1,6 @@
 use crate::ast::prelude::*;
 
-/// An if condition.
+/// The condition in an if statement.
 ///
 /// # Examples
 ///

--- a/crates/rune/src/ast/expr_assign.rs
+++ b/crates/rune/src/ast/expr_assign.rs
@@ -7,7 +7,7 @@ pub struct ExprAssign {
     /// Attributes associated with the assign expression.
     #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,
-    /// The expression being awaited.
+    /// The expression being assigned to.
     pub lhs: Box<ast::Expr>,
     /// The equals sign `=`.
     pub eq: T![=],

--- a/crates/rune/src/ast/expr_continue.rs
+++ b/crates/rune/src/ast/expr_continue.rs
@@ -16,7 +16,7 @@ pub struct ExprContinue {
     #[rune(iter, meta)]
     pub attributes: Vec<ast::Attribute>,
     /// The return token.
-    pub break_token: T![continue],
+    pub continue_token: T![continue],
     /// An optional label to continue to.
     #[rune(iter)]
     pub label: Option<ast::Label>,

--- a/crates/rune/src/ast/expr_if.rs
+++ b/crates/rune/src/ast/expr_if.rs
@@ -1,6 +1,6 @@
 use crate::ast::prelude::*;
 
-/// An if statement: `if cond { true } else { false }`
+/// An if statement: `if cond { true } else { false }`.
 ///
 /// # Examples
 ///

--- a/crates/rune/src/ast/expr_let.rs
+++ b/crates/rune/src/ast/expr_let.rs
@@ -1,6 +1,6 @@
 use crate::ast::prelude::*;
 
-/// A let expression `let <name> = <expr>;`
+/// A let expression `let <name> = <expr>`
 ///
 /// # Examples
 ///

--- a/crates/rune/src/ast/ident.rs
+++ b/crates/rune/src/ast/ident.rs
@@ -1,6 +1,6 @@
 use crate::ast::prelude::*;
 
-/// An identifier, like `foo` or `Hello`.".
+/// An identifier, like `foo` or `Hello`.
 ///
 /// Custom identifiers are constructed in macros using
 /// [MacroContext::ident][crate::macros::MacroContext::ident].
@@ -30,7 +30,7 @@ use crate::ast::prelude::*;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Spanned)]
 #[non_exhaustive]
 pub struct Ident {
-    /// The kind of the identifier.
+    /// The span of the identifier.
     pub span: Span,
     /// The kind of the identifier.
     #[rune(skip)]

--- a/crates/rune/src/ast/label.rs
+++ b/crates/rune/src/ast/label.rs
@@ -1,6 +1,6 @@
 use crate::ast::prelude::*;
 
-/// A label, like `'foo`
+/// A label, like `'foo`.
 ///
 /// Custom labels are constructed in macros using
 /// [MacroContext::label][crate::macros::MacroContext::label].
@@ -32,7 +32,7 @@ use crate::ast::prelude::*;
 pub struct Label {
     /// The token of the label.
     pub span: Span,
-    /// The kind of the label.
+    /// The source of the label.
     #[rune(skip)]
     pub source: ast::LitSource,
 }

--- a/crates/rune/src/ast/lit.rs
+++ b/crates/rune/src/ast/lit.rs
@@ -18,7 +18,7 @@ use crate::ast::prelude::*;
 ///     assert!(matches!(lit, ast::Lit::Str(..)))
 /// });
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, ToTokens, Spanned)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ToTokens, Spanned)]
 #[non_exhaustive]
 pub enum Lit {
     /// A boolean literal

--- a/crates/rune/src/ast/lit_bool.rs
+++ b/crates/rune/src/ast/lit_bool.rs
@@ -1,7 +1,7 @@
 use crate::ast::prelude::*;
 
 /// The unit literal `()`.
-#[derive(Debug, Clone, PartialEq, Eq, Spanned)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Spanned)]
 #[non_exhaustive]
 pub struct LitBool {
     /// The span corresponding to the literal.

--- a/crates/rune/src/ast/lit_byte.rs
+++ b/crates/rune/src/ast/lit_byte.rs
@@ -1,7 +1,7 @@
 use crate::ast::prelude::*;
 
 /// A byte literal.
-#[derive(Debug, Clone, PartialEq, Eq, Spanned)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Spanned)]
 #[non_exhaustive]
 pub struct LitByte {
     /// The span corresponding to the literal.

--- a/crates/rune/src/ast/lit_byte_str.rs
+++ b/crates/rune/src/ast/lit_byte_str.rs
@@ -2,7 +2,7 @@ use crate::ast::prelude::*;
 use std::borrow::Cow;
 
 /// A string literal.
-#[derive(Debug, Clone, PartialEq, Eq, Spanned)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Spanned)]
 #[non_exhaustive]
 pub struct LitByteStr {
     /// The span corresponding to the literal.

--- a/crates/rune/src/ast/lit_char.rs
+++ b/crates/rune/src/ast/lit_char.rs
@@ -1,7 +1,7 @@
 use crate::ast::prelude::*;
 
 /// A character literal.
-#[derive(Debug, Clone, PartialEq, Eq, Spanned)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Spanned)]
 #[non_exhaustive]
 pub struct LitChar {
     /// The span corresponding to the literal.

--- a/crates/rune/src/ast/lit_number.rs
+++ b/crates/rune/src/ast/lit_number.rs
@@ -3,7 +3,7 @@ use num::Num;
 use std::str::FromStr;
 
 /// A number literal.
-#[derive(Debug, Clone, PartialEq, Eq, Spanned)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Spanned)]
 #[non_exhaustive]
 pub struct LitNumber {
     /// The span corresponding to the literal.

--- a/crates/rune/src/ast/lit_str.rs
+++ b/crates/rune/src/ast/lit_str.rs
@@ -2,7 +2,7 @@ use crate::ast::prelude::*;
 use std::borrow::Cow;
 
 /// A string literal.
-#[derive(Debug, Clone, PartialEq, Eq, Spanned)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Spanned)]
 #[non_exhaustive]
 pub struct LitStr {
     /// The span corresponding to the literal.

--- a/crates/rune/src/ast/pat.rs
+++ b/crates/rune/src/ast/pat.rs
@@ -258,22 +258,22 @@ pub struct PatBinding {
     pub pat: Box<ast::Pat>,
 }
 
-/// A tuple pattern.
+/// A path pattern.
 #[derive(Debug, Clone, PartialEq, Eq, ToTokens, Spanned)]
 #[non_exhaustive]
 pub struct PatPath {
     /// Attributes associate with the path.
     #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,
-    /// The path, if the tuple is typed.
+    /// The path of the pattern.
     pub path: ast::Path,
 }
 
-/// A ignore pattern.
+/// An ignore pattern.
 #[derive(Debug, Clone, PartialEq, Eq, ToTokens, Spanned)]
 #[non_exhaustive]
 pub struct PatIgnore {
-    /// Attributes associate with the path.
+    /// Attributes associate with the pattern.
     #[rune(iter)]
     pub attributes: Vec<ast::Attribute>,
     /// The ignore token`_`.

--- a/crates/rune/src/compile/ir/compile.rs
+++ b/crates/rune/src/compile/ir/compile.rs
@@ -85,7 +85,7 @@ pub(crate) fn expr(ast: &ast::Expr, c: &mut IrCompiler<'_>) -> Result<ir::Ir, Ir
             ir::Ir::new(expr_break, ir::IrBreak::compile_ast(expr_break, c)?)
         }
         ast::Expr::MacroCall(macro_call) => {
-            let internal_macro = c.q.builtin_macro_for(&*macro_call)?;
+            let internal_macro = c.q.builtin_macro_for(macro_call)?;
 
             match &*internal_macro {
                 BuiltInMacro::Template(template) => {

--- a/crates/rune/src/compile/ir/eval.rs
+++ b/crates/rune/src/compile/ir/eval.rs
@@ -241,9 +241,9 @@ fn eval_ir_loop(
 
     loop {
         if let Some(condition) = &ir.condition {
-            interp.scopes.clear_current(&*condition)?;
+            interp.scopes.clear_current(condition)?;
 
-            let value = eval_ir_condition(&*condition, interp, used)?;
+            let value = eval_ir_condition(condition, interp, used)?;
 
             if !as_bool(condition.span(), value)? {
                 break;

--- a/crates/rune/src/compile/item.rs
+++ b/crates/rune/src/compile/item.rs
@@ -407,7 +407,7 @@ impl fmt::Debug for Item {
     }
 }
 
-impl<'a> IntoIterator for Item {
+impl IntoIterator for Item {
     type IntoIter = std::vec::IntoIter<Component>;
     type Item = Component;
 
@@ -609,8 +609,8 @@ impl Component {
     /// Convert into component reference.
     pub fn as_component_ref(&self) -> ComponentRef<'_> {
         match self {
-            Self::Crate(s) => ComponentRef::Crate(&*s),
-            Self::Str(s) => ComponentRef::Str(&*s),
+            Self::Crate(s) => ComponentRef::Crate(s),
+            Self::Str(s) => ComponentRef::Str(s),
             Self::Id(n) => ComponentRef::Id(*n),
         }
     }

--- a/crates/rune/src/compile/v1/assemble.rs
+++ b/crates/rune/src/compile/v1/assemble.rs
@@ -1123,7 +1123,7 @@ fn const_(
             c.asm.push(Inst::String { slot }, span);
         }
         ConstValue::Bytes(b) => {
-            let slot = c.q.unit.new_static_bytes(span, &*b)?;
+            let slot = c.q.unit.new_static_bytes(span, b)?;
             c.asm.push(Inst::Bytes { slot }, span);
         }
         ConstValue::Option(option) => match option {
@@ -1244,7 +1244,7 @@ fn expr_assign(ast: &ast::ExprAssign, c: &mut Assembler<'_>, needs: Needs) -> Co
                 .try_as_ident()
                 .ok_or_else(|| CompileError::msg(path, "unsupported path"))?;
             let ident = segment.resolve(resolve_context!(c.q))?;
-            let var = c.scopes.get_var(c.q.visitor, &*ident, c.source_id, span)?;
+            let var = c.scopes.get_var(c.q.visitor, ident, c.source_id, span)?;
             c.asm.push(Inst::Replace { offset: var.offset }, span);
             true
         }
@@ -1469,7 +1469,7 @@ fn expr_binary(ast: &ast::ExprBinary, c: &mut Assembler<'_>, needs: Needs) -> Co
                     .ok_or_else(|| CompileError::msg(path, "unsupported path segment"))?;
 
                 let ident = segment.resolve(resolve_context!(c.q))?;
-                let var = c.scopes.get_var(c.q.visitor, &*ident, c.source_id, span)?;
+                let var = c.scopes.get_var(c.q.visitor, ident, c.source_id, span)?;
 
                 Some(InstTarget::Offset(var.offset))
             }

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! <div align="center">
 //! <a href="https://github.com/rune-rs/rune/actions">
-//!     <img alt="Build Status" src="https://github.com/rune-rs/rune/workflows/Build/badge.svg">
+//!     <img alt="Build Status" src="https://github.com/rune-rs/rune/workflows/CI/badge.svg">
 //! </a>
 //!
 //! <a href="https://github.com/rune-rs/rune/actions">

--- a/crates/rune/src/query/mod.rs
+++ b/crates/rune/src/query/mod.rs
@@ -909,7 +909,7 @@ impl<'a> Query<'a> {
 
         self.check_access_to(
             span,
-            &*module,
+            module,
             item,
             &entry.item.module,
             entry.item.location,

--- a/crates/rune/src/runtime/iterator.rs
+++ b/crates/rune/src/runtime/iterator.rs
@@ -460,12 +460,10 @@ impl RuneIterator for IterRepr {
 
     fn next_back(&mut self) -> Result<Option<Value>, VmError> {
         match self {
-            Self::Iterator(iter) => {
-                return Err(VmError::panic(format!(
-                    "`{}` is not a double-ended iterator",
-                    iter.name
-                )));
-            }
+            Self::Iterator(iter) => Err(VmError::panic(format!(
+                "`{}` is not a double-ended iterator",
+                iter.name
+            ))),
             Self::DoubleEndedIterator(iter) => iter.iter.next_back(),
             Self::Map(iter) => iter.next_back(),
             Self::FlatMap(iter) => iter.next_back(),

--- a/crates/rune/src/runtime/key.rs
+++ b/crates/rune/src/runtime/key.rs
@@ -262,11 +262,11 @@ impl ser::Serialize for Key {
             Self::Byte(c) => serializer.serialize_u8(*c),
             Self::Integer(integer) => serializer.serialize_i64(*integer),
             Self::String(string) => serializer.serialize_str(string.as_str()),
-            Self::Bytes(bytes) => serializer.serialize_bytes(&*bytes),
+            Self::Bytes(bytes) => serializer.serialize_bytes(bytes),
             Self::Vec(vec) => {
                 let mut serializer = serializer.serialize_seq(Some(vec.len()))?;
 
-                for value in &*vec {
+                for value in vec {
                     serializer.serialize_element(value)?;
                 }
 

--- a/crates/rune/src/runtime/vm.rs
+++ b/crates/rune/src/runtime/vm.rs
@@ -984,7 +984,7 @@ impl Vm {
     }
 
     /// Internal implementation of the instance check.
-    fn is_instance(&mut self, lhs: InstAddress, rhs: InstAddress) -> Result<bool, VmError> {
+    fn test_is_instance(&mut self, lhs: InstAddress, rhs: InstAddress) -> Result<bool, VmError> {
         let b = self.stack.address(rhs)?;
         let a = self.stack.address(lhs)?;
 
@@ -1713,11 +1713,11 @@ impl Vm {
                 self.internal_boolean_op(|a, b| a || b, "||", lhs, rhs)?;
             }
             InstOp::Is => {
-                let is_instance = self.is_instance(lhs, rhs)?;
+                let is_instance = self.test_is_instance(lhs, rhs)?;
                 self.stack.push(is_instance);
             }
             InstOp::IsNot => {
-                let is_instance = self.is_instance(lhs, rhs)?;
+                let is_instance = self.test_is_instance(lhs, rhs)?;
                 self.stack.push(!is_instance);
             }
         }

--- a/crates/rune/src/runtime/vm_error.rs
+++ b/crates/rune/src/runtime/vm_error.rs
@@ -87,7 +87,7 @@ impl VmError {
                 unit,
                 ip,
                 frames,
-            } => (&*kind, Some((unit, *ip, frames))),
+            } => (kind, Some((unit, *ip, frames))),
             kind => (kind, None),
         }
     }
@@ -345,7 +345,7 @@ impl VmErrorKind {
                 unit,
                 ip,
                 frames,
-            } => (&*kind, Some((unit.clone(), *ip, frames.clone()))),
+            } => (kind, Some((unit.clone(), *ip, frames.clone()))),
             kind => (kind, None),
         }
     }

--- a/crates/rune/src/worker/import.rs
+++ b/crates/rune/src/worker/import.rs
@@ -101,7 +101,7 @@ impl Import {
                                 continue;
                             }
 
-                            name = self.lookup_local(context, q, &*ident);
+                            name = self.lookup_local(context, q, ident);
                         }
                         ast::PathSegment::SelfType(self_type) => {
                             return Err(CompileError::new(

--- a/editors/code/README.md
+++ b/editors/code/README.md
@@ -14,7 +14,7 @@
 
 <div align="center">
 <a href="https://github.com/rune-rs/rune/actions">
-    <img alt="Build Status" src="https://github.com/rune-rs/rune/workflows/Build/badge.svg">
+    <img alt="Build Status" src="https://github.com/rune-rs/rune/workflows/CI/badge.svg">
 </a>
 
 <a href="https://github.com/rune-rs/rune/actions">

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -35,7 +35,7 @@ pub fn compile_helper(source: &str, diagnostics: &mut Diagnostics) -> Result<Uni
     let context = self::modules::default_context().expect("setting up default modules");
 
     let mut sources = Sources::new();
-    sources.insert(Source::new("main", source.to_owned()));
+    sources.insert(Source::new("main", source));
 
     let unit = rune::prepare(&mut sources)
         .with_context(&context)
@@ -94,7 +94,7 @@ where
 #[doc(hidden)]
 pub fn sources(source: &str) -> Sources {
     let mut sources = Sources::new();
-    sources.insert(Source::new("main", source.to_owned()));
+    sources.insert(Source::new("main", source));
     sources
 }
 
@@ -107,7 +107,7 @@ where
     T: FromValue,
 {
     let mut sources = Sources::new();
-    sources.insert(Source::new("main", source.to_owned()));
+    sources.insert(Source::new("main", source));
 
     let mut diagnostics = Default::default();
 

--- a/tests/tests/char.rs
+++ b/tests/tests/char.rs
@@ -3,11 +3,11 @@ use rune_tests::*;
 #[test]
 fn test_int_conversion() {
     let result: char = rune! {
-		use std::char;
+        use std::char;
         pub fn main() {
-			let a = 'A';
-			let ai = char::to_int(a);
-			char::from_int(ai).unwrap()
+            let a = 'A';
+            let ai = char::to_int(a);
+            char::from_int(ai).unwrap()
         }
     };
 
@@ -15,8 +15,8 @@ fn test_int_conversion() {
 
     let result: char = rune! {
         pub fn main() {
-			let ai = 0x41;
-			char::from_int(ai).unwrap()
+            let ai = 0x41;
+            char::from_int(ai).unwrap()
         }
     };
 


### PR DESCRIPTION
Rename `Build` workflow to `CI` and pin the Clippy version to use to avoid sporadic build failures. Fix new Clippy lints.

Pull in some AST fixes from the `hir` branch.