### PR TITLE
A bit more HIR-related cleanups

### DIFF
--- a/crates/rune/src/build.rs
+++ b/crates/rune/src/build.rs
@@ -137,10 +137,12 @@ impl<'a> Build<'a> {
             }
         };
 
-        let mut unit = if context.has_default_modules() {
-            compile::UnitBuilder::with_default_prelude()
+        let mut unit = compile::UnitBuilder::default();
+
+        let prelude = if context.has_default_modules() {
+            compile::Prelude::with_default_prelude()
         } else {
-            compile::UnitBuilder::default()
+            compile::Prelude::default()
         };
 
         let mut default_diagnostics;
@@ -185,6 +187,7 @@ impl<'a> Build<'a> {
 
         let result = compile::compile(
             &mut unit,
+            &prelude,
             self.sources,
             context,
             diagnostics,

--- a/crates/rune/src/compile/compile_error.rs
+++ b/crates/rune/src/compile/compile_error.rs
@@ -164,8 +164,6 @@ pub enum CompileErrorKind {
     },
     #[error("{meta} is not supported here")]
     UnsupportedPattern { meta: Meta },
-    #[error("`..` is not supported in this location")]
-    UnsupportedPatternRest,
     #[error("this kind of expression is not supported as a pattern")]
     UnsupportedPatternExpr,
     #[error("not a valid binding")]

--- a/crates/rune/src/compile/mod.rs
+++ b/crates/rune/src/compile/mod.rs
@@ -28,6 +28,9 @@ pub(crate) use self::compile_visitor::NoopCompileVisitor;
 pub(crate) mod context;
 pub use self::context::{Context, ContextError, ContextSignature, ContextTypeInfo};
 
+mod prelude;
+pub(crate) use self::prelude::Prelude;
+
 pub(crate) mod ir;
 pub(crate) use self::ir::{IrBudget, IrCompiler, IrEvalContext, IrEvalOutcome, IrInterpreter};
 pub use self::ir::{IrError, IrErrorKind, IrEval, IrValue};
@@ -75,6 +78,7 @@ pub(crate) type CompileResult<T> = ::std::result::Result<T, CompileError>;
 /// Encode the given object into a collection of asm.
 pub(crate) fn compile(
     unit: &mut UnitBuilder,
+    prelude: &Prelude,
     sources: &mut Sources,
     context: &Context,
     diagnostics: &mut Diagnostics,
@@ -96,6 +100,7 @@ pub(crate) fn compile(
         sources,
         options,
         unit,
+        prelude,
         diagnostics,
         visitor,
         source_loader,

--- a/crates/rune/src/compile/prelude.rs
+++ b/crates/rune/src/compile/prelude.rs
@@ -1,0 +1,62 @@
+use crate::collections::HashMap;
+use crate::compile::{IntoComponent, Item};
+
+/// The contents of a prelude.
+#[derive(Default)]
+pub struct Prelude {
+    /// Prelude imports.
+    prelude: HashMap<Box<str>, Item>,
+}
+
+impl Prelude {
+    /// Construct a new unit with the default prelude.
+    pub(crate) fn with_default_prelude() -> Self {
+        let mut this = Self::default();
+
+        this.add_prelude("assert_eq", &["test", "assert_eq"]);
+        this.add_prelude("assert", &["test", "assert"]);
+        this.add_prelude("bool", &["bool"]);
+        this.add_prelude("byte", &["byte"]);
+        this.add_prelude("char", &["char"]);
+        this.add_prelude("dbg", &["io", "dbg"]);
+        this.add_prelude("drop", &["mem", "drop"]);
+        this.add_prelude("Err", &["result", "Result", "Err"]);
+        this.add_prelude("file", &["macros", "builtin", "file"]);
+        this.add_prelude("float", &["float"]);
+        this.add_prelude("format", &["fmt", "format"]);
+        this.add_prelude("int", &["int"]);
+        this.add_prelude("is_readable", &["is_readable"]);
+        this.add_prelude("is_writable", &["is_writable"]);
+        this.add_prelude("line", &["macros", "builtin", "line"]);
+        this.add_prelude("None", &["option", "Option", "None"]);
+        this.add_prelude("Object", &["object", "Object"]);
+        this.add_prelude("Ok", &["result", "Result", "Ok"]);
+        this.add_prelude("Option", &["option", "Option"]);
+        this.add_prelude("panic", &["panic"]);
+        this.add_prelude("print", &["io", "print"]);
+        this.add_prelude("println", &["io", "println"]);
+        this.add_prelude("Result", &["result", "Result"]);
+        this.add_prelude("Some", &["option", "Option", "Some"]);
+        this.add_prelude("String", &["string", "String"]);
+        this.add_prelude("stringify", &["stringify"]);
+        this.add_prelude("unit", &["unit"]);
+        this.add_prelude("Vec", &["vec", "Vec"]);
+
+        this
+    }
+
+    /// Access a value from the prelude.
+    pub(crate) fn get<'a>(&'a self, name: &str) -> Option<&'a Item> {
+        self.prelude.get(name)
+    }
+
+    /// Define a prelude item.
+    fn add_prelude<I>(&mut self, local: &str, path: I)
+    where
+        I: IntoIterator,
+        I::Item: IntoComponent,
+    {
+        self.prelude
+            .insert(local.into(), Item::with_crate_item("std", path));
+    }
+}

--- a/crates/rune/src/compile/unit_builder.rs
+++ b/crates/rune/src/compile/unit_builder.rs
@@ -6,8 +6,8 @@
 use crate::ast::Span;
 use crate::collections::HashMap;
 use crate::compile::{
-    Assembly, AssemblyInst, CompileError, CompileErrorKind, IntoComponent, Item, Location,
-    PrivMeta, PrivMetaKind, PrivVariantMeta,
+    Assembly, AssemblyInst, CompileError, CompileErrorKind, Item, Location, PrivMeta, PrivMetaKind,
+    PrivVariantMeta,
 };
 use crate::query::{QueryError, QueryErrorKind};
 use crate::runtime::debug::{DebugArgs, DebugSignature};
@@ -34,8 +34,6 @@ pub enum LinkerError {
 /// Instructions from a single source file.
 #[derive(Debug, Default)]
 pub(crate) struct UnitBuilder {
-    /// Prelude imports.
-    prelude: HashMap<Box<str>, Item>,
     /// The instructions contained in the source file.
     instructions: Vec<Inst>,
     /// Registered re-exports.
@@ -76,47 +74,6 @@ pub(crate) struct UnitBuilder {
 }
 
 impl UnitBuilder {
-    /// Construct a new unit with the default prelude.
-    pub(crate) fn with_default_prelude() -> Self {
-        let mut this = Self::default();
-
-        this.add_prelude("assert_eq", &["test", "assert_eq"]);
-        this.add_prelude("assert", &["test", "assert"]);
-        this.add_prelude("bool", &["bool"]);
-        this.add_prelude("byte", &["byte"]);
-        this.add_prelude("char", &["char"]);
-        this.add_prelude("dbg", &["io", "dbg"]);
-        this.add_prelude("drop", &["mem", "drop"]);
-        this.add_prelude("Err", &["result", "Result", "Err"]);
-        this.add_prelude("file", &["macros", "builtin", "file"]);
-        this.add_prelude("float", &["float"]);
-        this.add_prelude("format", &["fmt", "format"]);
-        this.add_prelude("int", &["int"]);
-        this.add_prelude("is_readable", &["is_readable"]);
-        this.add_prelude("is_writable", &["is_writable"]);
-        this.add_prelude("line", &["macros", "builtin", "line"]);
-        this.add_prelude("None", &["option", "Option", "None"]);
-        this.add_prelude("Object", &["object", "Object"]);
-        this.add_prelude("Ok", &["result", "Result", "Ok"]);
-        this.add_prelude("Option", &["option", "Option"]);
-        this.add_prelude("panic", &["panic"]);
-        this.add_prelude("print", &["io", "print"]);
-        this.add_prelude("println", &["io", "println"]);
-        this.add_prelude("Result", &["result", "Result"]);
-        this.add_prelude("Some", &["option", "Option", "Some"]);
-        this.add_prelude("String", &["string", "String"]);
-        this.add_prelude("stringify", &["stringify"]);
-        this.add_prelude("unit", &["unit"]);
-        this.add_prelude("Vec", &["vec", "Vec"]);
-
-        this
-    }
-
-    /// Clone the prelude.
-    pub(crate) fn prelude(&self) -> &HashMap<Box<str>, Item> {
-        &self.prelude
-    }
-
     /// Convert into a runtime unit, shedding our build metadata in the process.
     ///
     /// Returns `None` if the builder is still in use.
@@ -316,7 +273,6 @@ impl UnitBuilder {
 
     /// Declare a new struct.
     pub(crate) fn insert_meta(&mut self, span: Span, meta: &PrivMeta) -> Result<(), QueryError> {
-        // TODO: Can someone deduplicate this?
         match &meta.kind {
             PrivMetaKind::Unknown { .. } => {
                 let hash = Hash::type_hash(&meta.item.item);
@@ -689,16 +645,6 @@ impl UnitBuilder {
                 );
             }
         }
-    }
-
-    /// Define a prelude item.
-    fn add_prelude<I>(&mut self, local: &str, path: I)
-    where
-        I: IntoIterator,
-        I::Item: IntoComponent,
-    {
-        self.prelude
-            .insert(local.into(), Item::with_crate_item("std", path));
     }
 
     /// Insert and access debug information.

--- a/crates/rune/src/hir/error.rs
+++ b/crates/rune/src/hir/error.rs
@@ -23,6 +23,8 @@ pub enum HirErrorKind {
     ArenaWriteSliceOutOfBounds { index: usize },
     #[error("allocation error for {requested} bytes")]
     ArenaAllocError { requested: usize },
+    #[error("`..` is not supported in this location")]
+    UnsupportedPatternRest,
     #[error("{error}")]
     QueryError {
         #[source]

--- a/crates/rune/src/hir/hir.rs
+++ b/crates/rune/src/hir/hir.rs
@@ -48,7 +48,7 @@ pub enum PatKind<'hir> {
     /// A literal pattern. This is represented as an expression.
     PatLit(&'hir Expr<'hir>),
     /// A vector pattern.
-    PatVec(&'hir [Pat<'hir>]),
+    PatVec(&'hir PatItems<'hir>),
     /// A tuple pattern.
     PatTuple(&'hir PatItems<'hir>),
     /// An object pattern.
@@ -65,6 +65,10 @@ pub struct PatItems<'hir> {
     pub path: Option<&'hir Path<'hir>>,
     /// The items in the tuple.
     pub items: &'hir [Pat<'hir>],
+    /// If the pattern is open.
+    pub is_open: bool,
+    /// The number of elements in the pattern.
+    pub count: usize,
 }
 
 /// An object item.

--- a/crates/rune/src/macros/macro_context.rs
+++ b/crates/rune/src/macros/macro_context.rs
@@ -3,7 +3,8 @@
 use crate::ast;
 use crate::ast::Span;
 use crate::compile::{
-    IrCompiler, IrError, IrEval, IrEvalContext, IrValue, ItemMeta, NoopCompileVisitor, UnitBuilder,
+    IrCompiler, IrError, IrEval, IrEvalContext, IrValue, ItemMeta, NoopCompileVisitor, Prelude,
+    UnitBuilder,
 };
 use crate::macros::{IntoLit, Storage, ToTokens, TokenStream};
 use crate::parse::{Parse, ParseError, ParseErrorKind, Resolve, ResolveError};
@@ -41,6 +42,7 @@ impl<'a> MacroContext<'a> {
         F: FnOnce(&mut MacroContext<'_>) -> O,
     {
         let mut unit = UnitBuilder::default();
+        let prelude = Prelude::default();
         let gen = Gen::default();
         let mut consts = Consts::default();
         let mut storage = Storage::default();
@@ -50,6 +52,7 @@ impl<'a> MacroContext<'a> {
 
         let mut query = Query::new(
             &mut unit,
+            &prelude,
             &mut consts,
             &mut storage,
             &mut sources,

--- a/crates/rune/src/query/mod.rs
+++ b/crates/rune/src/query/mod.rs
@@ -1,6 +1,11 @@
 //! Lazy query system, used to compile and build items on demand and keep track
 //! of what's being used and not.
 
+use std::collections::VecDeque;
+use std::fmt;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+
 use crate::ast;
 use crate::ast::{Span, Spanned};
 use crate::collections::{HashMap, HashSet};
@@ -18,10 +23,6 @@ use crate::runtime::format;
 use crate::runtime::Call;
 use crate::shared::{Consts, Gen, Items};
 use crate::{Context, Hash, SourceId, Sources};
-use std::collections::VecDeque;
-use std::fmt;
-use std::num::NonZeroUsize;
-use std::sync::Arc;
 
 /// The permitted number of import recursions when constructing a path.
 const IMPORT_RECURSION_LIMIT: usize = 128;

--- a/crates/rune/src/worker/mod.rs
+++ b/crates/rune/src/worker/mod.rs
@@ -3,7 +3,7 @@
 use crate::ast;
 use crate::ast::Span;
 use crate::collections::HashMap;
-use crate::compile::{CompileVisitor, Item, Options, SourceLoader, UnitBuilder};
+use crate::compile::{CompileVisitor, Item, Options, Prelude, SourceLoader, UnitBuilder};
 use crate::indexing::index;
 use crate::indexing::{IndexScopes, Indexer};
 use crate::macros::Storage;
@@ -44,6 +44,7 @@ impl<'a> Worker<'a> {
         sources: &'a mut Sources,
         options: &'a Options,
         unit: &'a mut UnitBuilder,
+        prelude: &'a Prelude,
         diagnostics: &'a mut Diagnostics,
         visitor: &'a mut dyn CompileVisitor,
         source_loader: &'a mut dyn SourceLoader,
@@ -55,7 +56,7 @@ impl<'a> Worker<'a> {
             options,
             diagnostics,
             source_loader,
-            q: Query::new(unit, consts, storage, sources, visitor, gen, inner),
+            q: Query::new(unit, prelude, consts, storage, sources, visitor, gen, inner),
             gen,
             loaded: HashMap::new(),
             queue: VecDeque::new(),


### PR DESCRIPTION
Also separates `Prelude` into its own type for processing.