### PR TITLE
Emit doc attributes from doc comments

### DIFF
--- a/crates/rune/src/ast/generated.rs
+++ b/crates/rune/src/ast/generated.rs
@@ -3,7 +3,7 @@ use crate::macros;
 use crate::parse;
 use std::fmt;
 
-/// This file has been generated from `assets\tokens.yaml`
+/// This file has been generated from `assets/tokens.yaml`
 /// DO NOT modify by hand!
 
 /// The `abstract` keyword.
@@ -4333,8 +4333,8 @@ pub enum Kind {
     Eof,
     /// A single-line comment.
     Comment,
-    /// A multiline comment where the boolean indicates if it's been terminated correctly.
-    MultilineComment(bool),
+    /// A multiline comment.
+    MultilineComment,
     /// En error marker.
     Error,
     /// The special initial line of a file shebang.
@@ -4747,7 +4747,7 @@ impl parse::IntoExpectation for Kind {
     fn into_expectation(self) -> parse::Expectation {
         match self {
             Self::Eof => parse::Expectation::Description("eof"),
-            Self::Comment | Self::MultilineComment(..) => parse::Expectation::Comment,
+            Self::Comment | Self::MultilineComment => parse::Expectation::Comment,
             Self::Error => parse::Expectation::Description("error"),
             Self::Shebang { .. } => parse::Expectation::Description("shebang"),
             Self::Ident(..) => parse::Expectation::Description("ident"),

--- a/crates/rune/src/ast/token.rs
+++ b/crates/rune/src/ast/token.rs
@@ -302,6 +302,8 @@ pub enum BuiltIn {
     BuiltIn,
     /// `literal`.
     Literal,
+    /// `doc`.
+    Doc,
 }
 
 impl BuiltIn {
@@ -312,6 +314,7 @@ impl BuiltIn {
             Self::Format => "formatspec",
             Self::BuiltIn => "builtin",
             Self::Literal => "literal",
+            Self::Doc => "doc",
         }
     }
 }

--- a/crates/rune/src/parse/parser.rs
+++ b/crates/rune/src/parse/parser.rs
@@ -293,19 +293,9 @@ impl<'a> Peeker<'a> {
             };
 
             match token.kind {
-                Kind::Comment | Kind::Whitespace => {
+                Kind::Comment | Kind::Whitespace | Kind::MultilineComment => {
                     continue;
-                }
-                Kind::MultilineComment(term) => {
-                    if !term {
-                        return Err(ParseError::new(
-                            token.span,
-                            ParseErrorKind::ExpectedMultilineCommentTerm,
-                        ));
-                    }
-
-                    continue;
-                }
+                },
                 _ => (),
             }
 

--- a/tools/generate/src/main.rs
+++ b/tools/generate/src/main.rs
@@ -259,8 +259,8 @@ fn main() -> Result<()> {
                 Eof,
                 #("/// A single-line comment.")
                 Comment,
-                #("/// A multiline comment where the boolean indicates if it's been terminated correctly.")
-                MultilineComment(bool),
+                #("/// A multiline comment.")
+                MultilineComment,
                 #("/// En error marker.")
                 Error,
                 #("/// The special initial line of a file shebang.")
@@ -335,7 +335,7 @@ fn main() -> Result<()> {
                 fn into_expectation(self) -> #expectation {
                     match self {
                         Self::Eof => #expectation::Description("eof"),
-                        Self::Comment | Self::MultilineComment(..) => #expectation::Comment,
+                        Self::Comment | Self::MultilineComment => #expectation::Comment,
                         Self::Error => #expectation::Description("error"),
                         Self::Shebang { .. } => #expectation::Description("shebang"),
                         Self::Ident(..) => #expectation::Description("ident"),


### PR DESCRIPTION
When encountering comments, the lexer will now attempt to transform them into tokens to later be interpreted as doc attributes should they match the format of Rust's own style of doc comments, as described by [syn::Attribute's doc comments section](https://docs.rs/syn/1.0.98/syn/struct.Attribute.html#doc-comments).