### PR TITLE
File and module docs

### DIFF
--- a/crates/rune/src/ast/mod.rs
+++ b/crates/rune/src/ast/mod.rs
@@ -196,7 +196,7 @@ pub use self::item_const::ItemConst;
 pub use self::item_enum::{ItemEnum, ItemVariant, ItemVariantBody};
 pub use self::item_fn::ItemFn;
 pub use self::item_impl::ItemImpl;
-pub use self::item_mod::{ItemMod, ItemModBody};
+pub use self::item_mod::{ItemInlineBody, ItemMod, ItemModBody};
 pub use self::item_struct::{Field, ItemStruct, ItemStructBody};
 pub use self::item_use::{ItemUse, ItemUsePath, ItemUseSegment};
 pub use self::label::Label;

--- a/crates/rune/src/compile/compile_visitor.rs
+++ b/crates/rune/src/compile/compile_visitor.rs
@@ -1,5 +1,5 @@
 use crate::ast::Span;
-use crate::compile::MetaRef;
+use crate::compile::{Item, MetaRef};
 use crate::SourceId;
 
 /// A visitor that will be called for every language item compiled.
@@ -16,24 +16,21 @@ pub trait CompileVisitor {
     /// Visit something that is a module.
     fn visit_mod(&mut self, _source_id: SourceId, _span: Span) {}
 
-    /// Visit an item's doc comment attribute.
+    /// Visit anterior `///`-style comments, and interior `//!`-style doc
+    /// comments for an item.
     ///
-    /// This may be called several times for a single item. Each attribute should eventually be
-    /// combined for the full doc string.
+    /// This may be called several times for a single item. Each attribute
+    /// should eventually be combined for the full doc string.
+    ///
+    /// This is always called after [CompileVisitor::visit_meta] for any given item.
     fn visit_doc_comment(
         &mut self,
         _source_id: SourceId,
-        _meta: MetaRef<'_>,
+        _item: &Item,
         _span: Span,
         _docstr: &str,
     ) {
     }
-
-    /// Visit a file's doc comment attribute.
-    ///
-    /// This may be called several times for a single file. Each attribute should eventually be
-    /// combined for the full doc string.
-    fn visit_file_doc_comment(&mut self, _source_id: SourceId, _span: Span, _docstr: &str) {}
 }
 
 /// A [CompileVisitor] which does nothing.

--- a/crates/rune/src/compile/compile_visitor.rs
+++ b/crates/rune/src/compile/compile_visitor.rs
@@ -28,6 +28,12 @@ pub trait CompileVisitor {
         _docstr: &str,
     ) {
     }
+
+    /// Visit a file's doc comment attribute.
+    ///
+    /// This may be called several times for a single file. Each attribute should eventually be
+    /// combined for the full doc string.
+    fn visit_file_doc_comment(&mut self, _source_id: SourceId, _span: Span, _docstr: &str) {}
 }
 
 /// A [CompileVisitor] which does nothing.

--- a/crates/rune/src/compile/meta.rs
+++ b/crates/rune/src/compile/meta.rs
@@ -73,6 +73,8 @@ pub enum MetaKind {
     ConstFn,
     /// Item describes an import.
     Import,
+    /// Item describes a module.
+    Module,
 }
 
 impl fmt::Display for Meta {
@@ -119,6 +121,9 @@ impl fmt::Display for Meta {
             }
             MetaKind::Import => {
                 write!(fmt, "import {}", self.item)?;
+            }
+            MetaKind::Module => {
+                write!(fmt, "module {}", self.item)?;
             }
         }
 
@@ -216,6 +221,7 @@ impl PrivMeta {
             PrivMetaKind::Const { .. } => None,
             PrivMetaKind::ConstFn { .. } => None,
             PrivMetaKind::Import { .. } => None,
+            PrivMetaKind::Module => None,
         }
     }
 }
@@ -307,6 +313,8 @@ pub(crate) enum PrivMetaKind {
         /// The imported target.
         target: Item,
     },
+    /// A module.
+    Module,
 }
 
 impl PrivMetaKind {
@@ -354,6 +362,7 @@ impl PrivMetaKind {
             PrivMetaKind::Const { .. } => MetaKind::Const,
             PrivMetaKind::ConstFn { .. } => MetaKind::ConstFn,
             PrivMetaKind::Import { .. } => MetaKind::Import,
+            PrivMetaKind::Module => MetaKind::Module,
         }
     }
 }

--- a/crates/rune/src/compile/meta.rs
+++ b/crates/rune/src/compile/meta.rs
@@ -150,7 +150,7 @@ pub(crate) struct CaptureMeta {
 }
 
 /// Doc content for a compiled item.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct Doc {
     /// The span of the whole doc comment.
     pub(crate) span: Span,
@@ -386,7 +386,7 @@ pub(crate) struct PrivTupleMeta {
 }
 
 /// Item and the module that the item belongs to.
-#[derive(Default, Debug, Clone)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub(crate) struct ItemMeta {
     /// The id of the item.
@@ -399,8 +399,21 @@ pub(crate) struct ItemMeta {
     pub(crate) visibility: Visibility,
     /// The module associated with the item.
     pub(crate) module: Arc<ModMeta>,
-    /// Doc comment attributes, if any.
-    pub(crate) docs: Arc<Vec<Doc>>,
+    /// Anterior doc comment attributes, if any.
+    pub(crate) docs: Arc<[Doc]>,
+}
+
+impl Default for ItemMeta {
+    fn default() -> Self {
+        Self {
+            id: Default::default(),
+            location: Default::default(),
+            item: Default::default(),
+            visibility: Default::default(),
+            module: Default::default(),
+            docs: Arc::from([]),
+        }
+    }
 }
 
 impl ItemMeta {
@@ -418,7 +431,7 @@ impl From<Item> for ItemMeta {
             item,
             visibility: Default::default(),
             module: Default::default(),
-            docs: Arc::new(Vec::new()),
+            docs: Arc::from([]),
         }
     }
 }

--- a/crates/rune/src/compile/unit_builder.rs
+++ b/crates/rune/src/compile/unit_builder.rs
@@ -510,6 +510,7 @@ impl UnitBuilder {
             }
             PrivMetaKind::ConstFn { .. } => (),
             PrivMetaKind::Import { .. } => (),
+            PrivMetaKind::Module { .. } => (),
         }
 
         Ok(())

--- a/crates/rune/src/indexing/index.rs
+++ b/crates/rune/src/indexing/index.rs
@@ -525,7 +525,7 @@ impl<'a> Indexer<'a> {
     fn handle_file_mod(
         &mut self,
         item_mod: &mut ast::ItemMod,
-        docs: Vec<Doc>,
+        docs: Arc<[Doc]>,
     ) -> CompileResult<()> {
         let span = item_mod.span();
         let name = item_mod.name.resolve(resolve_context!(self.q))?;
@@ -549,7 +549,7 @@ impl<'a> Indexer<'a> {
             item_mod.name_span(),
             &self.mod_item,
             visibility,
-            Arc::from(docs),
+            docs,
         )?;
 
         item_mod.id.set(self.items.id());
@@ -633,7 +633,7 @@ fn item_fn(ast: &mut ast::ItemFn, idx: &mut Indexer<'_>) -> CompileResult<()> {
 
     let visibility = ast_to_visibility(&ast.visibility)?;
     let mut attributes = attrs::Attributes::new(ast.attributes.clone());
-    let docs = Arc::new(Doc::collect_from(resolve_context!(idx.q), &mut attributes)?);
+    let docs = Arc::from(Doc::collect_from(resolve_context!(idx.q), &mut attributes)?);
 
     let item = idx.q.insert_new_item(
         &idx.items,
@@ -864,7 +864,7 @@ fn expr_block(ast: &mut ast::ExprBlock, idx: &mut Indexer<'_>) -> CompileResult<
         span,
         &idx.mod_item,
         Visibility::default(),
-        Arc::new(Vec::new()),
+        Arc::from([]),
     )?;
 
     ast.block.id = item.id;
@@ -926,7 +926,7 @@ fn block(ast: &mut ast::Block, idx: &mut Indexer<'_>) -> CompileResult<()> {
         span,
         &idx.mod_item,
         Visibility::Inherited,
-        Arc::new(Vec::new()),
+        Arc::from([]),
     )?;
 
     idx.preprocess_stmts(&mut ast.statements)?;
@@ -1270,7 +1270,7 @@ fn condition(ast: &mut ast::Condition, idx: &mut Indexer<'_>) -> CompileResult<(
 fn item_enum(ast: &mut ast::ItemEnum, idx: &mut Indexer<'_>) -> CompileResult<()> {
     let span = ast.span();
     let mut attrs = Attributes::new(ast.attributes.to_vec());
-    let docs = Arc::new(Doc::collect_from(resolve_context!(idx.q), &mut attrs)?);
+    let docs = Arc::from(Doc::collect_from(resolve_context!(idx.q), &mut attrs)?);
 
     if let Some(first) = attrs.remaining() {
         return Err(CompileError::msg(
@@ -1296,7 +1296,7 @@ fn item_enum(ast: &mut ast::ItemEnum, idx: &mut Indexer<'_>) -> CompileResult<()
 
     for (index, (variant, _)) in ast.variants.iter_mut().enumerate() {
         let mut attrs = Attributes::new(variant.attributes.to_vec());
-        let docs = Arc::new(Doc::collect_from(resolve_context!(idx.q), &mut attrs)?);
+        let docs = Arc::from(Doc::collect_from(resolve_context!(idx.q), &mut attrs)?);
 
         if let Some(first) = attrs.remaining() {
             return Err(CompileError::msg(
@@ -1339,7 +1339,7 @@ fn item_enum(ast: &mut ast::ItemEnum, idx: &mut Indexer<'_>) -> CompileResult<()
 fn item_struct(ast: &mut ast::ItemStruct, idx: &mut Indexer<'_>) -> CompileResult<()> {
     let span = ast.span();
     let mut attrs = Attributes::new(ast.attributes.to_vec());
-    let docs = Arc::new(Doc::collect_from(resolve_context!(idx.q), &mut attrs)?);
+    let docs = Arc::from(Doc::collect_from(resolve_context!(idx.q), &mut attrs)?);
 
     if let Some(first) = attrs.remaining() {
         return Err(CompileError::msg(
@@ -1420,7 +1420,7 @@ fn item_impl(ast: &mut ast::ItemImpl, idx: &mut Indexer<'_>) -> CompileResult<()
 #[instrument]
 fn item_mod(ast: &mut ast::ItemMod, idx: &mut Indexer<'_>) -> CompileResult<()> {
     let mut attrs = Attributes::new(ast.attributes.clone());
-    let docs = Doc::collect_from(resolve_context!(idx.q), &mut attrs)?;
+    let docs = Arc::from(Doc::collect_from(resolve_context!(idx.q), &mut attrs)?);
 
     if let Some(first) = attrs.remaining() {
         return Err(CompileError::msg(
@@ -1446,7 +1446,7 @@ fn item_mod(ast: &mut ast::ItemMod, idx: &mut Indexer<'_>) -> CompileResult<()> 
                 name_span,
                 &idx.mod_item,
                 visibility,
-                Arc::new(docs),
+                docs,
             )?;
 
             ast.id.set(idx.items.id());
@@ -1463,7 +1463,7 @@ fn item_mod(ast: &mut ast::ItemMod, idx: &mut Indexer<'_>) -> CompileResult<()> 
 #[instrument]
 fn item_const(ast: &mut ast::ItemConst, idx: &mut Indexer<'_>) -> CompileResult<()> {
     let mut attrs = Attributes::new(ast.attributes.to_vec());
-    let docs = Arc::new(Doc::collect_from(resolve_context!(idx.q), &mut attrs)?);
+    let docs = Arc::from(Doc::collect_from(resolve_context!(idx.q), &mut attrs)?);
 
     if let Some(first) = attrs.remaining() {
         return Err(CompileError::msg(
@@ -1638,7 +1638,7 @@ fn expr_closure(ast: &mut ast::ExprClosure, idx: &mut Indexer<'_>) -> CompileRes
         span,
         &idx.mod_item,
         Visibility::Inherited,
-        Arc::new(Vec::new()),
+        Arc::from([]),
     )?;
 
     ast.id.set(idx.items.id());

--- a/crates/rune/src/indexing/index.rs
+++ b/crates/rune/src/indexing/index.rs
@@ -586,7 +586,6 @@ impl<'a> Indexer<'a> {
 
 pub(crate) fn file(ast: &mut ast::File, idx: &mut Indexer<'_>) -> CompileResult<()> {
     let mut attrs = Attributes::new(ast.attributes.to_vec());
-    // TODO find a way to hold onto file-level docs?
     attrs.try_parse_collect::<attrs::Doc>(resolve_context!(idx.q))?;
 
     if let Some(first) = attrs.remaining() {

--- a/crates/rune/src/query/mod.rs
+++ b/crates/rune/src/query/mod.rs
@@ -259,7 +259,7 @@ impl<'a> Query<'a> {
         span: Span,
         parent: &Arc<ModMeta>,
         visibility: Visibility,
-        docs: Arc<Vec<Doc>>,
+        docs: Arc<[Doc]>,
     ) -> Result<Arc<ModMeta>, QueryError> {
         let item = self.insert_new_item(items, source_id, span, parent, visibility, docs)?;
 
@@ -329,7 +329,7 @@ impl<'a> Query<'a> {
         spanned: Span,
         module: &Arc<ModMeta>,
         visibility: Visibility,
-        docs: Arc<Vec<Doc>>,
+        docs: Arc<[Doc]>,
     ) -> Result<Arc<ItemMeta>, QueryError> {
         let id = items.id();
         let item = &*items.item();
@@ -809,7 +809,7 @@ impl<'a> Query<'a> {
             span,
             module,
             visibility,
-            Arc::new(Vec::new()),
+            Arc::from([]),
         )?;
 
         // toplevel public uses are re-exported.
@@ -1160,7 +1160,7 @@ impl<'a> Query<'a> {
         span: Span,
         module: &Arc<ModMeta>,
         visibility: Visibility,
-        docs: Arc<Vec<Doc>>,
+        docs: Arc<[Doc]>,
     ) -> Result<Arc<ItemMeta>, QueryError> {
         let query_item = Arc::new(ItemMeta {
             location: Location::new(source_id, span),

--- a/crates/rune/src/query/mod.rs
+++ b/crates/rune/src/query/mod.rs
@@ -273,6 +273,17 @@ impl<'a> Query<'a> {
             .modules
             .insert(item.item.clone(), query_mod.clone());
         self.insert_name(&item.item);
+        self.insert_meta(
+            span,
+            PrivMeta {
+                item,
+                kind: PrivMetaKind::Module,
+                source: Some(SourceMeta {
+                    location: Location::new(source_id, span),
+                    path: self.sources.path(source_id).map(Into::into),
+                }),
+            },
+        )?;
         Ok(query_mod)
     }
 

--- a/crates/rune/src/query/mod.rs
+++ b/crates/rune/src/query/mod.rs
@@ -186,10 +186,11 @@ impl<'a> Query<'a> {
 
         if !meta.item.docs.is_empty() {
             let ctx = resolve_context!(self);
+
             for doc in &*meta.item.docs {
                 self.visitor.visit_doc_comment(
                     meta.item.location.source_id,
-                    mref,
+                    mref.item,
                     doc.span,
                     &*doc.doc_string.resolve(ctx)?,
                 );

--- a/crates/rune/src/worker/mod.rs
+++ b/crates/rune/src/worker/mod.rs
@@ -3,10 +3,12 @@
 use crate::ast;
 use crate::ast::Span;
 use crate::collections::HashMap;
-use crate::compile::{CompileVisitor, Item, Options, Prelude, SourceLoader, UnitBuilder};
+use crate::compile::attrs::Attributes;
+use crate::compile::{CompileVisitor, Doc, Item, Options, Prelude, SourceLoader, UnitBuilder};
 use crate::indexing::index;
 use crate::indexing::{IndexScopes, Indexer};
 use crate::macros::Storage;
+use crate::parse::{ParseError, Resolve};
 use crate::query::{Query, QueryInner};
 use crate::shared::{Consts, Gen, Items};
 use crate::{Context, Diagnostics, SourceId, Sources};
@@ -126,6 +128,25 @@ impl<'a> Worker<'a> {
 
                     if let Err(error) = index::file(&mut file, &mut indexer) {
                         indexer.diagnostics.error(source_id, error);
+                    }
+
+                    let docs_result = || -> Result<(), ParseError> {
+                        let mut attrs = Attributes::new(file.attributes);
+                        let docs = Doc::collect_from(resolve_context!(self.q), &mut attrs)?;
+
+                        for doc in docs {
+                            self.q.visitor.visit_file_doc_comment(
+                                source_id,
+                                doc.span,
+                                &*doc.doc_string.resolve(resolve_context!(self.q))?,
+                            );
+                        }
+
+                        Ok(())
+                    };
+
+                    if let Err(error) = docs_result() {
+                        self.diagnostics.error(source_id, error);
                     }
                 }
                 Task::ExpandImport(import) => {

--- a/tests/tests/compiler_docs.rs
+++ b/tests/tests/compiler_docs.rs
@@ -82,18 +82,20 @@ fn harvest_docs() {
         "Enum::B" => { " Enum variant B.\n" }
         "constant" => { " Top-level constant.\n" }
 
-        // Curiously, the module item itself never get registered. This always fails.
-        // The child items of the module are, though.
-        // "Module" => { " Top-level module.\n" }
-
+        "Module" => { " Top-level module.\n" }
         "Module::Enum" => { " Module enum.\n" }
         "Module::Enum::A" => { " Enum variant A.\n" }
         "Module::Enum::B" => { " Enum variant B.\n" }
+
+        "Module::Module" => { " Module in a module.\n" }
+        "Module::Module::Enum" => { " Module enum.\n" }
+        "Module::Module::Enum::A" => { " Enum variant A.\n" }
+        "Module::Module::Enum::B" => { " Enum variant B.\n" }
     };
 
     let mut sources = sources(r#"
-        //! Mod/crate doc.
-        /*! Multiline mod/crate doc.
+        //! Mod/file doc.
+        /*! Multiline mod/file doc.
          *
          *  Both of these comments disappear; we can't hold onto file-level attributes at the moment..
          */
@@ -125,7 +127,7 @@ fn harvest_docs() {
 
         /// Top-level module.
         mod Module {
-            //! Also module doc.
+            //! Also module doc. Inner attributes don't seem to make it to their items, yet..
 
             /// Module enum.
             enum Enum {
@@ -133,6 +135,17 @@ fn harvest_docs() {
                 A,
                 /// Enum variant B.
                 B,
+            }
+
+            /// Module in a module.
+            mod Module {
+                /// Module enum.
+                enum Enum {
+                    /// Enum variant A.
+                    A,
+                    /// Enum variant B.
+                    B,
+                }
             }
         }
     "#);

--- a/tests/tests/compiler_docs.rs
+++ b/tests/tests/compiler_docs.rs
@@ -82,7 +82,10 @@ fn harvest_docs() {
         "Enum::B" => { " Enum variant B.\n" }
         "constant" => { " Top-level constant.\n" }
 
-        "Module" => { " Top-level module.\n" }
+        "Module" => {
+            " Top-level module.\n"
+            " Also module doc.\n"
+        }
         "Module::Enum" => { " Module enum.\n" }
         "Module::Enum::A" => { " Enum variant A.\n" }
         "Module::Enum::B" => { " Enum variant B.\n" }
@@ -127,7 +130,7 @@ fn harvest_docs() {
 
         /// Top-level module.
         mod Module {
-            //! Also module doc. Inner attributes don't seem to make it to their items, yet..
+            //! Also module doc.
 
             /// Module enum.
             enum Enum {

--- a/tests/tests/compiler_docs.rs
+++ b/tests/tests/compiler_docs.rs
@@ -14,6 +14,10 @@ impl CompileVisitor for DocVisitor {
     fn visit_doc_comment(&mut self, _: SourceId, meta: MetaRef<'_>, _: Span, doc: &str) {
         self.collected.entry(meta.item.to_string()).or_default().push(doc.to_string());
     }
+
+    fn visit_file_doc_comment(&mut self, _: SourceId, _:Span, doc: &str) {
+        self.collected.entry("".to_string()).or_default().push(doc.to_string());
+    }
 }
 
 impl DocVisitor {
@@ -72,6 +76,10 @@ macro_rules! expect_docs {
 fn harvest_docs() {
     let mut diagnostics = Diagnostics::new();
     let mut vis = expect_docs! {
+        "" => {
+            " Mod/file doc.\n"
+            " Multiline mod/file doc.\n         *  :)\n         "
+        }
         "stuff" => { " Top-level function.\n" }
         "Struct" => {
             " Top-level struct.\n"
@@ -99,8 +107,7 @@ fn harvest_docs() {
     let mut sources = sources(r#"
         //! Mod/file doc.
         /*! Multiline mod/file doc.
-         *
-         *  Both of these comments disappear; we can't hold onto file-level attributes at the moment..
+         *  :)
          */
 
         /// Top-level function.


### PR DESCRIPTION
A new meta type is introduced and registered by modules, allowing them to be picked up by the `CompileVisitor::register_meta` function just like any other item.

This also allows doc comments from modules to make their way to `CompileVisitor::visit_doc_comment` (#409). This does **not** include file-level root modules.

File-level doc comments are instead routed to a new function, `CompileVisitor::visit_file_doc_comment`.