### PR TITLE
Support more item-based operations to walk collected metadata

### DIFF
--- a/crates/rune/src/compile/item/component_ref.rs
+++ b/crates/rune/src/compile/item/component_ref.rs
@@ -2,6 +2,8 @@ use core::fmt;
 
 use serde::{Deserialize, Serialize};
 
+use crate::compile::Component;
+
 /// A reference to a component of an item.
 ///
 /// All indexes refer to sibling indexes. So two sibling id components could
@@ -22,6 +24,15 @@ impl ComponentRef<'_> {
         match self {
             Self::Id(n) => Some(n),
             _ => None,
+        }
+    }
+
+    /// Coerce this [ComponentRef] into an owned [Component].
+    pub fn to_owned(&self) -> Component {
+        match *self {
+            ComponentRef::Crate(s) => Component::Crate(s.into()),
+            ComponentRef::Str(s) => Component::Str(s.into()),
+            ComponentRef::Id(id) => Component::Id(id),
         }
     }
 }

--- a/crates/rune/src/compile/item/item_buf.rs
+++ b/crates/rune/src/compile/item/item_buf.rs
@@ -210,7 +210,7 @@ impl Deref for ItemBuf {
 
     fn deref(&self) -> &Self::Target {
         // SAFETY: Item ensures that content is valid.
-        unsafe { Item::new(self.content.as_ref()) }
+        unsafe { Item::from_raw(self.content.as_ref()) }
     }
 }
 
@@ -247,18 +247,30 @@ impl<'a> IntoIterator for &'a ItemBuf {
 
 impl PartialEq<Item> for ItemBuf {
     fn eq(&self, other: &Item) -> bool {
-        self.content.as_ref() == &other.content
+        self.content.as_ref() == other.as_bytes()
     }
 }
 
 impl PartialEq<Item> for &ItemBuf {
     fn eq(&self, other: &Item) -> bool {
-        self.content.as_ref() == &other.content
+        self.content.as_ref() == other.as_bytes()
     }
 }
 
 impl PartialEq<&Item> for ItemBuf {
     fn eq(&self, other: &&Item) -> bool {
-        self.content.as_ref() == &other.content
+        self.content.as_ref() == other.as_bytes()
+    }
+}
+
+impl PartialEq<Iter<'_>> for ItemBuf {
+    fn eq(&self, other: &Iter<'_>) -> bool {
+        self == other.as_item()
+    }
+}
+
+impl PartialEq<Iter<'_>> for &ItemBuf {
+    fn eq(&self, other: &Iter<'_>) -> bool {
+        *self == other.as_item()
     }
 }

--- a/crates/rune/src/compile/item/iter.rs
+++ b/crates/rune/src/compile/item/iter.rs
@@ -21,20 +21,23 @@ impl<'a> Iter<'a> {
     }
 
     /// Check if the iterator is empty.
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.content.is_empty()
     }
 
     /// Coerce the iterator into an item.
+    #[inline]
     pub fn as_item(&self) -> &Item {
         // SAFETY: Iterator ensures that content is valid.
-        unsafe { Item::new(self.content) }
+        unsafe { Item::from_raw(self.content) }
     }
 
     /// Coerce the iterator into an item with the lifetime of the iterator.
+    #[inline]
     pub fn into_item(self) -> &'a Item {
         // SAFETY: Iterator ensures that content is valid.
-        unsafe { Item::new(self.content) }
+        unsafe { Item::from_raw(self.content) }
     }
 
     /// Get the next component as a string.
@@ -148,48 +151,12 @@ impl<'a> DoubleEndedIterator for Iter<'a> {
 
 impl PartialEq<ItemBuf> for Iter<'_> {
     fn eq(&self, other: &ItemBuf) -> bool {
-        self.content == other.content.as_ref()
-    }
-}
-
-impl PartialEq<&ItemBuf> for Iter<'_> {
-    fn eq(&self, other: &&ItemBuf) -> bool {
-        self.content == other.content.as_ref()
-    }
-}
-
-impl PartialEq<Iter<'_>> for ItemBuf {
-    fn eq(&self, other: &Iter<'_>) -> bool {
-        self.content.as_ref() == other.content
-    }
-}
-
-impl PartialEq<Iter<'_>> for &ItemBuf {
-    fn eq(&self, other: &Iter<'_>) -> bool {
-        self.content.as_ref() == other.content
+        self.as_item() == other
     }
 }
 
 impl PartialEq<Item> for Iter<'_> {
     fn eq(&self, other: &Item) -> bool {
-        self.content == &other.content
-    }
-}
-
-impl PartialEq<&Item> for Iter<'_> {
-    fn eq(&self, other: &&Item) -> bool {
-        self.content == &other.content
-    }
-}
-
-impl PartialEq<Iter<'_>> for Item {
-    fn eq(&self, other: &Iter<'_>) -> bool {
-        &self.content == other.content
-    }
-}
-
-impl PartialEq<Iter<'_>> for &Item {
-    fn eq(&self, other: &Iter<'_>) -> bool {
-        &self.content == other.content
+        self.as_item() == other
     }
 }

--- a/scripts/doc.rn
+++ b/scripts/doc.rn
@@ -11,3 +11,12 @@ mod module {
     struct Bar {
     }
 }
+
+mod foo {
+    enum Foo {
+        /// This is another test.
+        Hello,
+        /// This is a test.
+        World,
+    }
+}


### PR DESCRIPTION
Further enhances `rune doc` so that it prints walked items in their alphabetical order.

Builds on #411 and the new `Item` / `ItemBuf` separation.

We're currently missing field metadata, which would require an extension to struct `PrivMeta` to include it and each fields' corresponding documentation.
