### PR TITLE
Immediately emit doc comments instead of associating them with build meta

### DIFF
--- a/crates/rune-cli/src/doc.rs
+++ b/crates/rune-cli/src/doc.rs
@@ -3,12 +3,10 @@ use std::io::{self, Write};
 use std::{collections::HashMap, path::Path};
 
 use anyhow::Context;
-use rune::compile::{Component, MetaKind};
-use rune::{
-    ast::Span,
-    compile::{CompileVisitor, FileSourceLoader, Item, ItemBuf, MetaRef},
-    Diagnostics, Options, Source, SourceId, Sources,
+use rune::compile::{
+    CompileVisitor, Component, FileSourceLoader, Item, ItemBuf, Location, MetaKind, MetaRef,
 };
+use rune::{Diagnostics, Options, Source, Sources};
 use structopt::StructOpt;
 
 use crate::{Config, ExitCode, Io, SharedFlags};
@@ -154,7 +152,7 @@ impl CompileVisitor for DocFinder {
         }
     }
 
-    fn visit_doc_comment(&mut self, _source_id: SourceId, item: &Item, _span: Span, string: &str) {
+    fn visit_doc_comment(&mut self, _location: Location, item: &Item, string: &str) {
         self.docs
             .entry(item.to_owned())
             .or_default()

--- a/crates/rune/src/compile/compile_visitor.rs
+++ b/crates/rune/src/compile/compile_visitor.rs
@@ -1,5 +1,5 @@
 use crate::ast::Span;
-use crate::compile::{Item, MetaRef};
+use crate::compile::{Item, Location, MetaRef};
 use crate::SourceId;
 
 /// A visitor that will be called for every language item compiled.
@@ -22,15 +22,9 @@ pub trait CompileVisitor {
     /// This may be called several times for a single item. Each attribute
     /// should eventually be combined for the full doc string.
     ///
-    /// This is always called after [CompileVisitor::visit_meta] for any given item.
-    fn visit_doc_comment(
-        &mut self,
-        _source_id: SourceId,
-        _item: &Item,
-        _span: Span,
-        _docstr: &str,
-    ) {
-    }
+    /// This can be called in any order, before or after
+    /// [CompileVisitor::visit_meta] for any given item.
+    fn visit_doc_comment(&mut self, _location: Location, _item: &Item, _docstr: &str) {}
 }
 
 /// A [CompileVisitor] which does nothing.

--- a/crates/rune/src/compile/location.rs
+++ b/crates/rune/src/compile/location.rs
@@ -15,7 +15,7 @@ pub struct Location {
 
 impl Location {
     /// Construct a new location.
-    pub fn new(source_id: SourceId, span: Span) -> Self {
+    pub const fn new(source_id: SourceId, span: Span) -> Self {
         Self { source_id, span }
     }
 }

--- a/crates/rune/src/compile/meta.rs
+++ b/crates/rune/src/compile/meta.rs
@@ -386,7 +386,7 @@ pub(crate) struct PrivTupleMeta {
 }
 
 /// Item and the module that the item belongs to.
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 #[non_exhaustive]
 pub(crate) struct ItemMeta {
     /// The id of the item.
@@ -399,21 +399,6 @@ pub(crate) struct ItemMeta {
     pub(crate) visibility: Visibility,
     /// The module associated with the item.
     pub(crate) module: Arc<ModMeta>,
-    /// Anterior doc comment attributes, if any.
-    pub(crate) docs: Arc<[Doc]>,
-}
-
-impl Default for ItemMeta {
-    fn default() -> Self {
-        Self {
-            id: Default::default(),
-            location: Default::default(),
-            item: Default::default(),
-            visibility: Default::default(),
-            module: Default::default(),
-            docs: Arc::from([]),
-        }
-    }
 }
 
 impl ItemMeta {
@@ -431,7 +416,6 @@ impl From<ItemBuf> for ItemMeta {
             item,
             visibility: Default::default(),
             module: Default::default(),
-            docs: Arc::from([]),
         }
     }
 }

--- a/tests/tests/compiler_docs.rs
+++ b/tests/tests/compiler_docs.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
-use rune::compile::{Item, CompileVisitor};
-use rune::{Context, Diagnostics, SourceId};
-use rune::ast::Span;
+use rune::compile::{Location, Item, CompileVisitor};
+use rune::{Context, Diagnostics};
 use rune::termcolor::{ColorChoice, StandardStream};
 use rune_tests::{sources};
 
@@ -11,7 +10,7 @@ struct DocVisitor {
 }
 
 impl CompileVisitor for DocVisitor {
-    fn visit_doc_comment(&mut self, _: SourceId, item: &Item, _:Span, doc: &str) {
+    fn visit_doc_comment(&mut self, _: Location, item: &Item, doc: &str) {
         self.collected.entry(item.to_string()).or_default().push(doc.to_string());
     }
 }


### PR DESCRIPTION
This reduces the amount of build meta and paves the door to reduce the number of allocations needed to store documentation. I.e. it should now be possible to use a single vector during indexing to store all parsed doc comments.

Might interfere with #413