### PR TITLE
Support documentation for fields in structs / struct variants.

### DIFF
--- a/crates/rune/src/compile/compile_visitor.rs
+++ b/crates/rune/src/compile/compile_visitor.rs
@@ -24,10 +24,21 @@ pub trait CompileVisitor {
     ///
     /// This can be called in any order, before or after
     /// [CompileVisitor::visit_meta] for any given item.
-    ///
-    /// This may also be called for fields in structs and enum variants
-    /// (though fields themselves are not considered items).
     fn visit_doc_comment(&mut self, _location: Location, _item: &Item, _docstr: &str) {}
+
+    /// Visit anterior `///`-style comments, and interior `//!`-style doc
+    /// comments for a field contained in a struct / enum variant struct.
+    ///
+    /// This may be called several times for a single field. Each attribute
+    /// should eventually be combined for the full doc string.
+    fn visit_field_doc_comment(
+        &mut self,
+        _location: Location,
+        _item: &Item,
+        _field: &str,
+        _docstr: &str,
+    ) {
+    }
 }
 
 /// A [CompileVisitor] which does nothing.

--- a/crates/rune/src/compile/compile_visitor.rs
+++ b/crates/rune/src/compile/compile_visitor.rs
@@ -24,6 +24,9 @@ pub trait CompileVisitor {
     ///
     /// This can be called in any order, before or after
     /// [CompileVisitor::visit_meta] for any given item.
+    ///
+    /// This may also be called for fields in structs and enum variants
+    /// (though fields themselves are not considered items).
     fn visit_doc_comment(&mut self, _location: Location, _item: &Item, _docstr: &str) {}
 }
 

--- a/crates/rune/src/query/mod.rs
+++ b/crates/rune/src/query/mod.rs
@@ -248,7 +248,7 @@ impl<'a> Query<'a> {
         visibility: Visibility,
         docs: &[Doc],
     ) -> Result<Arc<ModMeta>, QueryError> {
-        let item = self.insert_new_item(items, location, parent, visibility, docs)?;
+        let item = self.insert_new_item(items, location, parent, visibility, docs, &[])?;
 
         let query_mod = Arc::new(ModMeta {
             location,
@@ -316,10 +316,11 @@ impl<'a> Query<'a> {
         module: &Arc<ModMeta>,
         visibility: Visibility,
         docs: &[Doc],
+        child_docs: &[(String, Vec<Doc>)],
     ) -> Result<Arc<ItemMeta>, QueryError> {
         let id = items.id();
         let item = &*items.item();
-        self.insert_new_item_with(id, item, location, module, visibility, docs)
+        self.insert_new_item_with(id, item, location, module, visibility, docs, child_docs)
     }
 
     /// Insert a new item with the given newly allocated identifier and complete
@@ -332,17 +333,31 @@ impl<'a> Query<'a> {
         module: &Arc<ModMeta>,
         visibility: Visibility,
         docs: &[Doc],
+        child_docs: &[(String, Vec<Doc>)],
     ) -> Result<Arc<ItemMeta>, QueryError> {
         // Emit documentation comments for the given item.
-        if !docs.is_empty() {
-            let ctx = resolve_context!(self);
+        let ctx = resolve_context!(self);
+        macro_rules! visit_docs {
+            ($array:expr, $item:expr) => {
+                for doc in $array {
+                    self.visitor.visit_doc_comment(
+                        Location::new(location.source_id, doc.span),
+                        $item,
+                        doc.doc_string.resolve(ctx)?.as_ref(),
+                    );
+                }
+            };
+        }
 
-            for doc in docs {
-                self.visitor.visit_doc_comment(
-                    Location::new(location.source_id, doc.span),
-                    item,
-                    doc.doc_string.resolve(ctx)?.as_ref(),
-                );
+        if !docs.is_empty() {
+            visit_docs!(docs, item);
+        }
+
+        if !child_docs.is_empty() {
+            for (child, docs) in child_docs {
+                let mut item = ItemBuf::with_item(item);
+                item.push(child);
+                visit_docs!(docs, &item);
             }
         }
 
@@ -842,7 +857,7 @@ impl<'a> Query<'a> {
         };
 
         let id = self.gen.next();
-        let item = self.insert_new_item_with(id, &item, location, module, visibility, &[])?;
+        let item = self.insert_new_item_with(id, &item, location, module, visibility, &[], &[])?;
 
         // toplevel public uses are re-exported.
         if item.is_public() {

--- a/scripts/doc.rn
+++ b/scripts/doc.rn
@@ -1,5 +1,11 @@
 /// Foo documentation.
 struct Foo {
+    /// Struct field.
+    /// Field A.
+    a,
+    /// Struct field.
+    /// Field B.
+    b,
 }
 
 /// Test
@@ -17,6 +23,13 @@ mod foo {
         /// This is another test.
         Hello,
         /// This is a test.
-        World,
+        World {
+            /// Variant struct field.
+            /// Field A.
+            a,
+            /// Variant struct field.
+            /// Field B.
+            b,
+        },
     }
 }

--- a/tests/tests/compiler_docs.rs
+++ b/tests/tests/compiler_docs.rs
@@ -15,7 +15,7 @@ impl CompileVisitor for DocVisitor {
 
     fn visit_field_doc_comment(&mut self, _: Location, item: &Item, field: &str, doc: &str) {
         let mut field_item = item.to_string();
-        field_item.push_str("::");
+        field_item.push_str(".");
         field_item.push_str(field);
         self.collected.entry(field_item).or_default().push(doc.to_string());
     }
@@ -87,13 +87,13 @@ fn harvest_docs() {
             " Top-level struct.\n"
             " Second line!\n"
         }
-        "Struct::a" => { " Struct field A.\n" }
-        "Struct::b" => { " Struct field B.\n" }
+        "Struct.a" => { " Struct field A.\n" }
+        "Struct.b" => { " Struct field B.\n" }
         "Enum" => { "\n         * Top-level enum.\n         " }
         "Enum::A" => { " Enum variant A.\n" }
         "Enum::B" => { " Enum variant B.\n" }
-        "Enum::B::a" => { " Enum struct variant B field A.\n" }
-        "Enum::B::b" => { " Enum struct variant B field B.\n" }
+        "Enum::B.a" => { " Enum struct variant B field A.\n" }
+        "Enum::B.b" => { " Enum struct variant B field B.\n" }
         "CONSTANT" => { " Top-level constant.\n" }
 
         "module" => {

--- a/tests/tests/compiler_docs.rs
+++ b/tests/tests/compiler_docs.rs
@@ -12,6 +12,13 @@ impl CompileVisitor for DocVisitor {
     fn visit_doc_comment(&mut self, _: Location, item: &Item, doc: &str) {
         self.collected.entry(item.to_string()).or_default().push(doc.to_string());
     }
+
+    fn visit_field_doc_comment(&mut self, _: Location, item: &Item, field: &str, doc: &str) {
+        let mut field_item = item.to_string();
+        field_item.push_str("::");
+        field_item.push_str(field);
+        self.collected.entry(field_item).or_default().push(doc.to_string());
+    }
 }
 
 impl DocVisitor {

--- a/tests/tests/compiler_docs.rs
+++ b/tests/tests/compiler_docs.rs
@@ -80,9 +80,13 @@ fn harvest_docs() {
             " Top-level struct.\n"
             " Second line!\n"
         }
+        "Struct::a" => { " Struct field A.\n" }
+        "Struct::b" => { " Struct field B.\n" }
         "Enum" => { "\n         * Top-level enum.\n         " }
         "Enum::A" => { " Enum variant A.\n" }
         "Enum::B" => { " Enum variant B.\n" }
+        "Enum::B::a" => { " Enum struct variant B field A.\n" }
+        "Enum::B::b" => { " Enum struct variant B field B.\n" }
         "CONSTANT" => { " Top-level constant.\n" }
 
         "module" => {
@@ -111,9 +115,9 @@ fn harvest_docs() {
         /// Top-level struct.
         /// Second line!
         struct Struct {
-            // note: doc comments on struct fields will cause a compile error
-            // currently unsupported
+            /// Struct field A.
             a,
+            /// Struct field B.
             b,
         }
 
@@ -124,7 +128,12 @@ fn harvest_docs() {
             /// Enum variant A.
             A,
             /// Enum variant B.
-            B,
+            B {
+                /// Enum struct variant B field A.
+                a,
+                /// Enum struct variant B field B.
+                b,
+            },
         }
 
         /// Top-level constant.


### PR DESCRIPTION
~~Adds an extra parameter to `insert_new_item` to receive doc comments for child objects contained within the item (targets #413).~~

~~This change assumes that we don't want to treat fields themselves as items, similar to how [Rust itself doesn't.](https://doc.rust-lang.org/reference/items.html)~~

Adds a new callback to `CompileVisitor` specifically for fields.