### PR TITLE
Track fields in struct metas.

### DIFF
--- a/crates/rune/src/compile/context.rs
+++ b/crates/rune/src/compile/context.rs
@@ -9,7 +9,7 @@ use crate::compile::module::{
     TypeSpecification, UnitType, VariantKind,
 };
 use crate::compile::{
-    ComponentRef, IntoComponent, Item, ItemBuf, Meta, Names, PrivMeta, PrivMetaKind,
+    ComponentRef, IntoComponent, Item, ItemBuf, ItemMeta, Meta, Names, PrivMeta, PrivMetaKind,
     PrivStructMeta, PrivTupleMeta, PrivVariantMeta,
 };
 use crate::runtime::{
@@ -423,7 +423,22 @@ impl Context {
                 TypeSpecification::Struct(st) => PrivMetaKind::Struct {
                     type_hash,
                     variant: PrivVariantMeta::Struct(PrivStructMeta {
-                        fields: st.fields.clone(),
+                        fields: st
+                            .fields
+                            .clone()
+                            .into_iter()
+                            .map(|it| {
+                                let mut item = item.clone();
+                                item.push(&it);
+                                (
+                                    it,
+                                    Arc::new(ItemMeta {
+                                        item,
+                                        ..ItemMeta::default()
+                                    }),
+                                )
+                            })
+                            .collect(),
                     }),
                 },
                 TypeSpecification::Enum(en) => {
@@ -442,7 +457,22 @@ impl Context {
                             ),
                             VariantKind::Struct(st) => (
                                 PrivVariantMeta::Struct(PrivStructMeta {
-                                    fields: st.fields.clone(),
+                                    fields: st
+                                        .fields
+                                        .clone()
+                                        .into_iter()
+                                        .map(|it| {
+                                            let mut item = item.clone();
+                                            item.push(&it);
+                                            (
+                                                it,
+                                                Arc::new(ItemMeta {
+                                                    item,
+                                                    ..ItemMeta::default()
+                                                }),
+                                            )
+                                        })
+                                        .collect(),
                                 }),
                                 None,
                             ),

--- a/crates/rune/src/compile/meta.rs
+++ b/crates/rune/src/compile/meta.rs
@@ -1,12 +1,12 @@
 //! Compiler metadata for Rune.
 
 use crate::ast::{LitStr, Span};
-use crate::collections::HashSet;
 use crate::compile::attrs::Attributes;
 use crate::compile::{ItemBuf, Location, Visibility};
 use crate::parse::{Id, ParseError, ResolveContext};
 use crate::runtime::ConstValue;
 use crate::Hash;
+use hashbrown::HashMap;
 use std::fmt;
 use std::path::Path;
 use std::sync::Arc;
@@ -372,7 +372,7 @@ impl PrivMetaKind {
 #[non_exhaustive]
 pub(crate) struct PrivStructMeta {
     /// Fields associated with the type.
-    pub(crate) fields: HashSet<Box<str>>,
+    pub(crate) fields: HashMap<Box<str>, Arc<ItemMeta>>,
 }
 
 /// The metadata about a tuple.

--- a/crates/rune/src/compile/v1/assemble.rs
+++ b/crates/rune/src/compile/v1/assemble.rs
@@ -763,10 +763,7 @@ fn pat_object(
             }
 
             if !hir.is_open && !fields.is_empty() {
-                let mut fields = fields
-                    .into_iter()
-                    .map(|it| it.0)
-                    .collect::<Box<[_]>>();
+                let mut fields = fields.into_iter().map(|it| it.0).collect::<Box<[_]>>();
                 fields.sort();
 
                 return Err(CompileError::new(

--- a/crates/rune/src/compile/visibility.rs
+++ b/crates/rune/src/compile/visibility.rs
@@ -1,4 +1,6 @@
-use crate::compile::Item;
+use crate::ast;
+use crate::ast::Spanned;
+use crate::compile::{CompileError, CompileErrorKind, Item};
 use std::fmt;
 
 /// Information on the visibility of an item.
@@ -41,6 +43,23 @@ impl Visibility {
             Visibility::Public => true,
             Visibility::Crate => true,
         }
+    }
+
+    /// Create equivalent visiblity from AST representation.
+    pub(crate) fn from_ast(vis: &ast::Visibility) -> Result<Self, CompileError> {
+        let span = match vis {
+            ast::Visibility::Inherited => return Ok(Visibility::Inherited),
+            ast::Visibility::Public(..) => return Ok(Visibility::Public),
+            ast::Visibility::Crate(..) => return Ok(Visibility::Crate),
+            ast::Visibility::Super(..) => return Ok(Visibility::Super),
+            ast::Visibility::SelfValue(..) => return Ok(Visibility::SelfValue),
+            ast::Visibility::In(restrict) => restrict.span(),
+        };
+
+        Err(CompileError::new(
+            span,
+            CompileErrorKind::UnsupportedVisibility,
+        ))
     }
 }
 

--- a/crates/rune/src/query/mod.rs
+++ b/crates/rune/src/query/mod.rs
@@ -1653,7 +1653,8 @@ fn struct_body_meta(
                 id: Id::default(),
                 location: Location::new(item.location.source_id, field.span()),
                 item: buf,
-                visibility: Visibility::from_ast(&field.visibility).unwrap(),
+                visibility: Visibility::from_ast(&field.visibility)
+                    .map_err(|_| QueryError::msg(field, "unsupported visibility"))?,
                 module: item.module.clone(),
             }),
         );


### PR DESCRIPTION
Introduces more information on fields in `PrivStructMeta` (targets #413).

Field information is largely similar to regular items; this is thus performed by storing `ItemMeta` data for the fields. They are not treated as actual items (the metas don't get registered), [similar to how Rust treats them.](https://doc.rust-lang.org/reference/items.html)

(is this still necessary after #414 / #415?)