### PR TITLE
Prioritize removing indexed entries in query_meta

### DIFF
--- a/crates/rune/Cargo.toml
+++ b/crates/rune/Cargo.toml
@@ -46,6 +46,7 @@ relative-path = { version = "1.6.0", optional = true, features = ["serde"] }
 serde-hashkey = { version = "0.4.0", optional = true }
 
 rune-macros = {version = "0.12.0", path = "../rune-macros"}
+linked-hash-map = "0.5.6"
 
 [dev-dependencies]
 tokio = { version = "1.14.0", features = ["macros"] }

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -269,5 +269,6 @@ pub(crate) use rune_macros::__internal_impl_any;
 mod collections {
     pub use hashbrown::{hash_map, HashMap};
     pub use hashbrown::{hash_set, HashSet};
+    pub use linked_hash_map::{self, LinkedHashMap};
     pub use std::collections::{btree_map, BTreeMap};
 }

--- a/crates/rune/src/query/mod.rs
+++ b/crates/rune/src/query/mod.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 use crate::ast;
 use crate::ast::{Span, Spanned};
+use crate::collections::LinkedHashMap;
 use crate::collections::{hash_map, HashMap, HashSet};
 use crate::compile::{
     ir, CaptureMeta, CompileError, CompileErrorKind, CompileVisitor, ComponentRef, Doc, ImportStep,
@@ -100,7 +101,7 @@ pub(crate) struct QueryInner {
     queue: VecDeque<BuildEntry>,
     /// Indexed items that can be queried for, which will queue up for them to
     /// be compiled.
-    indexed: HashMap<ItemBuf, Vec<IndexedEntry>>,
+    indexed: LinkedHashMap<ItemBuf, Vec<IndexedEntry>>,
     /// Compiled constant functions.
     const_fns: HashMap<NonZeroId, Arc<QueryConstFn>>,
     /// Query paths.

--- a/crates/rune/src/query/mod.rs
+++ b/crates/rune/src/query/mod.rs
@@ -411,8 +411,10 @@ impl<'a> Query<'a> {
     }
 
     /// Insert an item and return its Id.
+    #[tracing::instrument(skip_all)]
     fn insert_const_fn(&mut self, item: &Arc<ItemMeta>, ir_fn: ir::IrFn) -> NonZeroId {
         let id = self.gen.next();
+        tracing::trace!(item = ?item.item, id = ?id);
 
         self.inner.const_fns.insert(
             id,
@@ -448,8 +450,9 @@ impl<'a> Query<'a> {
     }
 
     /// Index the given entry. It is not allowed to overwrite other entries.
+    #[tracing::instrument(skip_all)]
     pub(crate) fn index(&mut self, entry: IndexedEntry) {
-        tracing::trace!("index: {}", entry.item.item);
+        tracing::trace!(item = ?entry.item.item);
 
         self.insert_name(&entry.item.item);
         self.inner
@@ -460,13 +463,14 @@ impl<'a> Query<'a> {
     }
 
     /// Index a constant expression.
+    #[tracing::instrument(skip_all)]
     pub(crate) fn index_const<T>(
         &mut self,
         item: &Arc<ItemMeta>,
         value: &T,
         f: fn(&T, &mut IrCompiler) -> Result<ir::Ir, ir::IrError>,
     ) -> Result<(), QueryError> {
-        tracing::trace!("new const: {:?}", item.item);
+        tracing::trace!(item = ?item.item);
 
         let mut c = IrCompiler {
             source_id: item.location.source_id,
@@ -486,12 +490,13 @@ impl<'a> Query<'a> {
     }
 
     /// Index a constant function.
+    #[tracing::instrument(skip_all)]
     pub(crate) fn index_const_fn(
         &mut self,
         item: &Arc<ItemMeta>,
         item_fn: Box<ast::ItemFn>,
     ) -> Result<(), QueryError> {
-        tracing::trace!("new const fn: {:?}", item.item);
+        tracing::trace!(item = ?item.item);
 
         self.index(IndexedEntry {
             item: item.clone(),
@@ -505,8 +510,9 @@ impl<'a> Query<'a> {
     }
 
     /// Add a new enum item.
+    #[tracing::instrument(skip_all)]
     pub(crate) fn index_enum(&mut self, item: &Arc<ItemMeta>) -> Result<(), QueryError> {
-        tracing::trace!("new enum: {:?}", item.item);
+        tracing::trace!(item = ?item.item);
 
         self.index(IndexedEntry {
             item: item.clone(),
@@ -517,12 +523,13 @@ impl<'a> Query<'a> {
     }
 
     /// Add a new struct item that can be queried.
+    #[tracing::instrument(skip_all)]
     pub(crate) fn index_struct(
         &mut self,
         item: &Arc<ItemMeta>,
         ast: Box<ast::ItemStruct>,
     ) -> Result<(), QueryError> {
-        tracing::trace!("new struct: {:?}", item.item);
+        tracing::trace!(item = ?item.item);
 
         self.index(IndexedEntry {
             item: item.clone(),
@@ -533,6 +540,7 @@ impl<'a> Query<'a> {
     }
 
     /// Add a new variant item that can be queried.
+    #[tracing::instrument(skip_all)]
     pub(crate) fn index_variant(
         &mut self,
         item: &Arc<ItemMeta>,
@@ -540,7 +548,7 @@ impl<'a> Query<'a> {
         ast: ast::ItemVariant,
         index: usize,
     ) -> Result<(), QueryError> {
-        tracing::trace!("new variant: {:?}", item.item);
+        tracing::trace!(item = ?item.item);
 
         self.index(IndexedEntry {
             item: item.clone(),
@@ -551,6 +559,7 @@ impl<'a> Query<'a> {
     }
 
     /// Add a new function that can be queried for.
+    #[tracing::instrument(skip_all)]
     pub(crate) fn index_closure(
         &mut self,
         item: &Arc<ItemMeta>,
@@ -559,7 +568,7 @@ impl<'a> Query<'a> {
         call: Call,
         do_move: bool,
     ) -> Result<(), QueryError> {
-        tracing::trace!("new closure: {:?}", item.item);
+        tracing::trace!(item = ?item.item);
 
         self.index(IndexedEntry {
             item: item.clone(),
@@ -575,6 +584,7 @@ impl<'a> Query<'a> {
     }
 
     /// Add a new async block.
+    #[tracing::instrument(skip_all)]
     pub(crate) fn index_async_block(
         &mut self,
         item: &Arc<ItemMeta>,
@@ -583,7 +593,7 @@ impl<'a> Query<'a> {
         call: Call,
         do_move: bool,
     ) -> Result<(), QueryError> {
-        tracing::trace!("new closure: {:?}", item.item);
+        tracing::trace!(item = ?item.item);
 
         self.index(IndexedEntry {
             item: item.clone(),
@@ -601,7 +611,10 @@ impl<'a> Query<'a> {
     /// Remove and queue up unused entries for building.
     ///
     /// Returns boolean indicating if any unused entries were queued up.
+    #[tracing::instrument(skip_all)]
     pub(crate) fn queue_unused_entries(&mut self) -> Result<bool, (SourceId, QueryError)> {
+        tracing::trace!("queue unused");
+
         let unused = self
             .inner
             .indexed
@@ -634,29 +647,34 @@ impl<'a> Query<'a> {
 
     /// Query for the given meta by looking up the reverse of the specified
     /// item.
+    #[tracing::instrument(skip_all)]
     pub(crate) fn query_meta(
         &mut self,
         span: Span,
         item: &Item,
         used: Used,
     ) -> Result<Option<PrivMeta>, QueryError> {
-        if let Some(meta) = self.inner.meta.get(item) {
-            return Ok(Some(meta.clone()));
+        // NB: Prioritise removing indexed entries since this can otherwise end
+        // up spinning during `queue_unused_entries`.
+        if let Some(entry) = self.remove_indexed(span, item)? {
+            let meta = self.build_indexed_entry(span, entry, used)?;
+            self.unit.insert_meta(span, &meta)?;
+            self.insert_meta(span, meta.clone())?;
+
+            tracing::trace!(item = ?item, meta = ?meta, "build");
+            return Ok(Some(meta));
         }
 
-        // See if there's an index entry we can construct and insert.
-        let entry = match self.remove_indexed(span, item)? {
-            Some(entry) => entry,
-            None => return Ok(None),
-        };
-
-        let meta = self.build_indexed_entry(span, entry, used)?;
-        self.unit.insert_meta(span, &meta)?;
-        self.insert_meta(span, meta.clone())?;
-        Ok(Some(meta))
+        Ok(if let Some(meta) = self.inner.meta.get(item) {
+            tracing::trace!(item = ?item, meta = ?meta, "cached");
+            Some(meta.clone())
+        } else {
+            None
+        })
     }
 
     /// Perform a path lookup on the current state of the unit.
+    #[tracing::instrument(skip_all)]
     pub(crate) fn convert_path<'hir>(
         &mut self,
         context: &Context,
@@ -788,6 +806,7 @@ impl<'a> Query<'a> {
     }
 
     /// Declare a new import.
+    #[tracing::instrument(skip_all)]
     pub(crate) fn insert_import(
         &mut self,
         source_id: SourceId,
@@ -799,7 +818,7 @@ impl<'a> Query<'a> {
         alias: Option<ast::Ident>,
         wildcard: bool,
     ) -> Result<(), QueryError> {
-        tracing::trace!("insert_import {}", at);
+        tracing::trace!(at = ?at, target = ?target);
 
         let alias = match alias {
             Some(alias) => Some(alias.resolve(resolve_context!(self))?),

--- a/tests/tests/bug_417.rs
+++ b/tests/tests/bug_417.rs
@@ -1,0 +1,20 @@
+use rune::query::QueryErrorKind::*;
+use rune::span;
+use rune_tests::*;
+
+/// This tests that all items can be successfully queried for when unused (but
+/// be ambiguous as is the case with `Foo::Variant`) and that a module with the
+/// same name as an item causes a meta conflict.
+#[test]
+fn ensure_unambigious_items() {
+    assert_errors! {
+        r#"enum Foo { Variant } mod Foo { struct Variant; }"#,
+        span,
+        QueryError(MetaConflict { .. }) => {
+            assert_eq!(span, span!(0, 20));
+        },
+        QueryError(AmbiguousItem { .. }) => {
+            assert_eq!(span, span!(11, 18));
+        },
+    };
+}

--- a/tests/tests/compiler_docs.rs
+++ b/tests/tests/compiler_docs.rs
@@ -1,8 +1,7 @@
 use std::collections::BTreeMap;
 use rune::compile::{Location, Item, CompileVisitor};
 use rune::{Context, Diagnostics};
-use rune::termcolor::{ColorChoice, StandardStream};
-use rune_tests::{sources};
+use rune_tests::sources;
 
 struct DocVisitor {
     expected: BTreeMap<&'static str, Vec<&'static str>>,
@@ -157,16 +156,12 @@ fn harvest_docs() {
     "#);
 
     let context = Context::default();
+
     let result = rune::prepare(&mut sources)
         .with_context(&context)
         .with_diagnostics(&mut diagnostics)
-        .with_visitor(&mut vis as &mut dyn CompileVisitor)
+        .with_visitor(&mut vis)
         .build();
-
-    if !diagnostics.is_empty() {
-        let mut writer = StandardStream::stderr(ColorChoice::Always);
-        diagnostics.emit(&mut writer, &sources).unwrap();
-    }
 
     result.unwrap();
     vis.assert();


### PR DESCRIPTION
Also add a bit more instrumentation making it easier to follow what exactly is being called where.

Should be a proper fix for the issue mentioned in this [comment chain](https://github.com/rune-rs/rune/pull/415#discussion_r922662866).

Before this change, the following program would spin forever during compilation since modules are eagerly inserted as metadata and enums are lazily indexed so the unused queue would never be exhausted:

```rust
enum Foo {
    /// Hello
    Variant,
}

mod Foo {
    //// Hello
    struct Variant;
}
```