### PR TITLE
Always index when introducing compile meta

### DIFF
--- a/crates/rune-cli/src/doc.rs
+++ b/crates/rune-cli/src/doc.rs
@@ -188,11 +188,6 @@ impl CompileVisitor for DocFinder {
         string: &str,
     ) {
         let map = self.field_docs.entry(item.to_owned()).or_default();
-
-        if let Some(docs) = map.get_mut(field) {
-            docs.push(string.to_owned());
-        } else {
-            map.insert(field.into(), vec![string.to_owned()]);
-        }
+        map.entry(field.into()).or_default().push(string.to_owned());
     }
 }

--- a/crates/rune-languageserver/src/state.rs
+++ b/crates/rune-languageserver/src/state.rs
@@ -583,8 +583,8 @@ impl Visitor {
 }
 
 impl CompileVisitor for Visitor {
-    fn visit_meta(&mut self, source_id: SourceId, meta: MetaRef<'_>, span: Span) {
-        if source_id.into_index() != 0 {
+    fn visit_meta(&mut self, location: Location, meta: MetaRef<'_>) {
+        if location.source_id.into_index() != 0 {
             return;
         }
 
@@ -610,7 +610,7 @@ impl CompileVisitor for Visitor {
             source: DefinitionSource::SourceMeta(source.clone()),
         };
 
-        if let Some(d) = self.index.definitions.insert(span, definition) {
+        if let Some(d) = self.index.definitions.insert(location.span, definition) {
             tracing::warn!("replaced definition: {:?}", d.kind)
         }
     }

--- a/crates/rune/src/compile/compile_visitor.rs
+++ b/crates/rune/src/compile/compile_visitor.rs
@@ -7,8 +7,8 @@ pub trait CompileVisitor {
     /// Called when a meta item is registered.
     fn register_meta(&mut self, _meta: MetaRef<'_>) {}
 
-    /// Mark that we've encountered a specific compile meta at the given span.
-    fn visit_meta(&mut self, _source_id: SourceId, _meta: MetaRef<'_>, _span: Span) {}
+    /// Mark that we've resolved a specific compile meta at the given location.
+    fn visit_meta(&mut self, _location: Location, _meta: MetaRef<'_>) {}
 
     /// Visit a variable use.
     fn visit_variable_use(&mut self, _source_id: SourceId, _var_span: Span, _span: Span) {}

--- a/crates/rune/src/compile/meta.rs
+++ b/crates/rune/src/compile/meta.rs
@@ -196,7 +196,7 @@ impl PrivMeta {
     }
 
     /// Get the [MetaRef] which describes this [PrivMeta] object.
-    pub(crate) fn info_ref(&self) -> MetaRef<'_> {
+    pub(crate) fn as_meta_ref(&self) -> MetaRef<'_> {
         MetaRef {
             item: &self.item.item,
             kind: self.kind.as_meta_info_kind(),

--- a/tests/tests/bug_417.rs
+++ b/tests/tests/bug_417.rs
@@ -10,8 +10,8 @@ fn ensure_unambigious_items() {
     assert_errors! {
         r#"enum Foo { Variant } mod Foo { struct Variant; }"#,
         span,
-        QueryError(MetaConflict { .. }) => {
-            assert_eq!(span, span!(0, 20));
+        CompileError(_) => {
+            assert_eq!(span, span!(21, 28));
         },
         QueryError(AmbiguousItem { .. }) => {
             assert_eq!(span, span!(11, 18));

--- a/tests/tests/compiler_docs.rs
+++ b/tests/tests/compiler_docs.rs
@@ -14,10 +14,7 @@ impl CompileVisitor for DocVisitor {
     }
 
     fn visit_field_doc_comment(&mut self, _: Location, item: &Item, field: &str, doc: &str) {
-        let mut field_item = item.to_string();
-        field_item.push_str(".");
-        field_item.push_str(field);
-        self.collected.entry(field_item).or_default().push(doc.to_string());
+        self.collected.entry(format!("{item}.{field}")).or_default().push(doc.to_string());
     }
 }
 


### PR DESCRIPTION
And inconsistency in how the compiler dealt with indexing and metadata registration lead to #417, this change makes `Query::insert_meta` non-public and requires that any meta being inserted must go through the indexing process to ensure that we get consistent diagnostics regardless of the item being indexed.

For the following rune script:

```rust
enum Foo {
    /// Hello
    Variant,
}

mod Foo {
    //// Hello
    struct Variant;
}
```

Before this change we would get a metadata registration conflict when registering meta:
```
error: query error
  ┌─ entry:1:1
  │  
1 │ ╭ enum Foo {
2 │ │     /// Hello
3 │ │     Variant,
4 │ │ }
  │ ╰─^ trying to insert `enum Foo` but conflicting meta `module Foo` already exists

error: query error
  ┌─ entry:3:5
  │
3 │     Variant,
  │     ^^^^^^^
  │     │
  │     `Foo::Variant` can refer to multiple things
  │     here as `Foo::Variant`
  ·
8 │     struct Variant;
  │     -------------- here as `Foo::Variant`
```

After this change, we get this instead:
```
error: compile error
  ┌─ scripts/test.rn:6:1
  │  
1 │ ╭ enum Foo {
2 │ │     /// Hello
3 │ │     Variant,
4 │ │ }
  │ ╰─' here as `Foo`
5 │   
6 │   mod Foo {
  │   ^^^^^^^
  │   │
  │   `Foo` can refer to multiple things
  │   here as `Foo`

error: query error
  ┌─ scripts/test.rn:3:5
  │
3 │     Variant,
  │     ^^^^^^^
  │     │
  │     `Foo::Variant` can refer to multiple things
  │     here as `Foo::Variant`
  ·
8 │     struct Variant;
  │     -------------- here as `Foo::Variant`
```

Note how both errors are treated as errors of ambiguity, rather than one being an error of ambiguity and the other a metadata insertion conflict.