### PR TITLE
Allow constructing Function instances from closures

### DIFF
--- a/crates/rune/src/compile/mod.rs
+++ b/crates/rune/src/compile/mod.rs
@@ -61,7 +61,9 @@ pub(crate) use self::meta::{
 pub use self::meta::{Meta, MetaKind, MetaRef, SourceMeta};
 
 mod module;
-pub use self::module::{AssocType, InstallWith, Module, Variant};
+pub use self::module::{
+    AssocType, AsyncFunction, AsyncInstFn, Function, InstFn, InstallWith, Module, Variant,
+};
 
 mod pool;
 pub(crate) use self::pool::{ItemId, ModId, ModMeta, Pool};

--- a/crates/rune/src/hash.rs
+++ b/crates/rune/src/hash.rs
@@ -25,7 +25,7 @@ pub struct Hash(u64);
 
 impl Hash {
     /// The empty hash.
-    pub(crate) const EMPTY: Self = Self(0);
+    pub const EMPTY: Self = Self(0);
 
     /// Construct a new raw hash.
     pub(crate) const fn new(hash: u64) -> Self {

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -168,6 +168,7 @@
 #![allow(clippy::match_like_matches_macro)]
 #![allow(clippy::type_complexity)]
 #![allow(clippy::module_inception)]
+#![allow(clippy::self_named_constructors)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 /// A macro that can be used to construct a [Span][crate::ast::Span] that can be

--- a/crates/rune/src/runtime/vm.rs
+++ b/crates/rune/src/runtime/vm.rs
@@ -2544,7 +2544,7 @@ impl Vm {
     fn op_load_fn(&mut self, hash: Hash) -> Result<(), VmError> {
         let function = match self.unit.function(hash) {
             Some(info) => match info {
-                UnitFn::Offset { offset, call, args } => Function::from_offset(
+                UnitFn::Offset { offset, call, args } => Function::from_vm_offset(
                     self.context.clone(),
                     self.unit.clone(),
                     offset,
@@ -2614,7 +2614,7 @@ impl Vm {
 
         let environment = self.stack.pop_sequence(count)?.into_boxed_slice();
 
-        let function = Function::from_closure(
+        let function = Function::from_vm_closure(
             self.context.clone(),
             self.unit.clone(),
             offset,


### PR DESCRIPTION
Requested on discord by val3rius.

Two side effects:
* All the `Function` traits are made public, which is just as well because they currently are not which is more confusing [than it is not](https://docs.rs/rune/latest/rune/compile/struct.Module.html#method.function) (Note how the trait is not clickable).
* `Hash::EMPTY` is made public for convenient comparison.

This allows constructing a `rune::runtime::Function` from closures (either `async` or not) through:

```rust
use rune::runtime::Function;

let function1 = Function::function(|value: u32| value + 1);
let function2 = Function::function(some_function);
let function3 = Function::async_function(|value: u32| async move { value + 1 }));
let function4 = Function::async_function(some_async_function);

fn some_function(value: u32) -> u32 {
    value + 1
}

async fn some_async_function(value: u32) -> u32 {
    value + 1
}
```