### PR TITLE
Re-use lowering between ExprWhile and ExprLoop

### DIFF
--- a/crates/rune/src/hir/hir.rs
+++ b/crates/rune/src/hir/hir.rs
@@ -98,7 +98,6 @@ pub struct Expr<'hir> {
 pub enum ExprKind<'hir> {
     Path(&'hir Path<'hir>),
     Assign(&'hir ExprAssign<'hir>),
-    While(&'hir ExprWhile<'hir>),
     Loop(&'hir ExprLoop<'hir>),
     For(&'hir ExprFor<'hir>),
     Let(&'hir ExprLet<'hir>),
@@ -207,24 +206,14 @@ pub struct ExprAssign<'hir> {
     pub rhs: &'hir Expr<'hir>,
 }
 
-/// A `while` loop: `while [expr] { ... }`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[non_exhaustive]
-pub struct ExprWhile<'hir> {
-    /// A label for the while loop.
-    pub label: Option<&'hir ast::Label>,
-    /// The name of the binding.
-    pub condition: &'hir Condition<'hir>,
-    /// The body of the while loop.
-    pub body: &'hir Block<'hir>,
-}
-
 /// A `loop` expression: `loop { ... }`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct ExprLoop<'hir> {
     /// A label.
     pub label: Option<&'hir ast::Label>,
+    /// A condition to execute the loop, if a condition is necessary.
+    pub condition: Option<&'hir Condition<'hir>>,
     /// The body of the loop.
     pub body: &'hir Block<'hir>,
 }

--- a/crates/rune/src/hir/lowering.rs
+++ b/crates/rune/src/hir/lowering.rs
@@ -126,13 +126,14 @@ pub fn expr<'hir>(ctx: &Ctx<'hir, '_>, ast: &ast::Expr) -> Result<hir::Expr<'hir
         // TODO: lower all of these loop constructs to the same loop-like
         // representation. We only do different ones here right now since it's
         // easier when refactoring.
-        ast::Expr::While(ast) => hir::ExprKind::While(alloc!(ctx, ast; hir::ExprWhile {
+        ast::Expr::While(ast) => hir::ExprKind::Loop(alloc!(ctx, ast; hir::ExprLoop {
             label: option!(ctx, ast; &ast.label, |(ast, _)| label(ctx, ast)?),
-            condition: alloc!(ctx, ast; condition(ctx, &ast.condition)?),
+            condition: Some(alloc!(ctx, ast; condition(ctx, &ast.condition)?)),
             body: alloc!(ctx, ast; block(ctx, &ast.body)?),
         })),
         ast::Expr::Loop(ast) => hir::ExprKind::Loop(alloc!(ctx, ast; hir::ExprLoop {
             label: option!(ctx, ast; &ast.label, |(ast, _)| label(ctx, ast)?),
+            condition: None,
             body: alloc!(ctx, ast; block(ctx, &ast.body)?),
         })),
         ast::Expr::For(ast) => hir::ExprKind::For(alloc!(ctx, ast; hir::ExprFor {


### PR DESCRIPTION
First improvement stemming from having a separated hir lowering.