### PR TITLE
Fix language server

### DIFF
--- a/crates/rune-languageserver/Cargo.toml
+++ b/crates/rune-languageserver/Cargo.toml
@@ -15,21 +15,21 @@ Language server for Rune.
 """
 
 [dependencies]
-tokio = { version = "1.14.0", features = ["full"] }
-tokio-util = { version = "0.6.9", features = ["codec"] }
-lsp = { version = "0.91.1", package = "lsp-types" }
-futures-core = "0.3.0"
-anyhow = "1.0.49"
-serde = { version = "1.0.130", features = ["derive"] }
-serde_json = "1.0.72"
-hashbrown = "0.11.2"
-tracing = "0.1.29"
-tracing-appender = "0.2.0"
-tracing-subscriber = "0.3.3"
-ropey = "1.3.1"
+tokio = { version = "1.20.1", features = ["full"] }
+tokio-util = { version = "0.7.3", features = ["codec"] }
+lsp = { version = "0.93.0", package = "lsp-types" }
+futures-core = "0.3.21"
+anyhow = "1.0.60"
+serde = { version = "1.0.143", features = ["derive"] }
+serde_json = "1.0.83"
+hashbrown = "0.12.3"
+tracing = "0.1.36"
+tracing-appender = "0.2.2"
+tracing-subscriber = "0.3.15"
+ropey = "1.5.0"
 
 rune = {version = "0.12.0", path = "../rune"}
 rune-modules = {version = "0.12.0", path = "../rune-modules", features = ["full", "experiments"]}
 
 [build-dependencies]
-anyhow = "1.0.49"
+anyhow = "1.0.60"

--- a/crates/rune-languageserver/src/server.rs
+++ b/crates/rune-languageserver/src/server.rs
@@ -55,6 +55,7 @@ impl Server {
         use lsp::request::Request as _;
 
         let method = std::mem::take(&mut incoming.method);
+        tracing::trace!("incoming message: method = `{}`", method);
 
         // If server is not initialized, reject incoming requests.
         if !self.state.is_initialized() && method != lsp::request::Initialize::METHOD {


### PR DESCRIPTION
Currently the language server iterates over a previously cleared vector of source files, this renders the language server useless.

Only tested with my WiP rework of the vscode extension, but this fix should work with the current extension as well.