### PR TITLE
Don't panic on missing last item id (relates #426)

### DIFF
--- a/crates/rune/src/compile/compile_error.rs
+++ b/crates/rune/src/compile/compile_error.rs
@@ -66,7 +66,7 @@ impl CompileError {
 #[non_exhaustive]
 pub enum CompileErrorKind {
     #[error("{message}")]
-    Custom { message: &'static str },
+    Custom { message: Box<str> },
     #[error("{error}")]
     IrError {
         #[source]

--- a/crates/rune/src/compile/ir/error.rs
+++ b/crates/rune/src/compile/ir/error.rs
@@ -57,7 +57,7 @@ impl From<IrError> for SpannedError {
 #[non_exhaustive]
 pub enum IrErrorKind {
     #[error("{message}")]
-    Custom { message: &'static str },
+    Custom { message: Box<str> },
     /// An access error raised during compilation.
     #[error("access error: {error}")]
     AccessError {

--- a/crates/rune/src/compile/v1/assemble.rs
+++ b/crates/rune/src/compile/v1/assemble.rs
@@ -3052,7 +3052,7 @@ fn expr_tuple(
             let mut it = hir.items.iter();
 
             $(
-            let $var = it.next().ok_or_else(|| CompileError::new($span, CompileErrorKind::Custom { message: "items ended unexpectedly" }))?;
+            let $var = it.next().ok_or_else(|| CompileError::msg($span, "items ended unexpectedly"))?;
             let $var = expr($var, $c, Needs::Value)?.apply_targeted($c)?;
             )*
 

--- a/crates/rune/src/hir/error.rs
+++ b/crates/rune/src/hir/error.rs
@@ -18,7 +18,7 @@ error! {
 #[non_exhaustive]
 pub enum HirErrorKind {
     #[error("{message}")]
-    Custom { message: &'static str },
+    Custom { message: Box<str> },
     #[error("writing arena slice out of bounds for index {index}")]
     ArenaWriteSliceOutOfBounds { index: usize },
     #[error("allocation error for {requested} bytes")]

--- a/crates/rune/src/internal_macros.rs
+++ b/crates/rune/src/internal_macros.rs
@@ -31,11 +31,12 @@ macro_rules! error {
             ///
             /// This should be used for programming invariants of the encoder which are
             /// broken for some reason.
-            pub fn msg<S>(spanned: S, message: &'static str) -> Self
+            pub fn msg<S, M>(spanned: S, message: M) -> Self
             where
                 S: $crate::ast::Spanned,
+                M: ::core::fmt::Display,
             {
-                Self::new(spanned, $kind::Custom { message })
+                Self::new(spanned, $kind::Custom { message: message.to_string().into() })
             }
 
             /// Get the kind of the error.
@@ -72,7 +73,7 @@ macro_rules! error {
                 Self::new(
                     $crate::ast::Spanned::span(&error),
                     $kind::Custom {
-                        message: error.message(),
+                        message: error.message().into(),
                     },
                 )
             }

--- a/crates/rune/src/parse/parse_error.rs
+++ b/crates/rune/src/parse/parse_error.rs
@@ -52,12 +52,12 @@ impl From<ParseError> for SpannedError {
 }
 
 /// Error when parsing.
-#[derive(Debug, Clone, Copy, Error)]
+#[derive(Debug, Clone, Error)]
 #[allow(missing_docs)]
 #[non_exhaustive]
 pub enum ParseErrorKind {
     #[error("{message}")]
-    Custom { message: &'static str },
+    Custom { message: Box<str> },
     #[error("{error}")]
     ResolveError { error: ResolveErrorKind },
     #[error("expected end of file, but got `{actual}`")]

--- a/crates/rune/src/parse/resolve.rs
+++ b/crates/rune/src/parse/resolve.rs
@@ -36,12 +36,12 @@ impl From<ResolveError> for SpannedError {
 }
 
 /// The kind of a resolve error.
-#[derive(Debug, Clone, Copy, Error)]
+#[derive(Debug, Clone, Error)]
 #[allow(missing_docs)]
 #[non_exhaustive]
 pub enum ResolveErrorKind {
     #[error("{message}")]
-    Custom { message: &'static str },
+    Custom { message: Box<str> },
     #[error("expected {expected}, but got {actual}")]
     Expected {
         actual: Expectation,

--- a/crates/rune/src/query/mod.rs
+++ b/crates/rune/src/query/mod.rs
@@ -274,7 +274,7 @@ impl<'a> Query<'a> {
         visibility: Visibility,
         docs: &[Doc],
     ) -> Result<ItemMeta, QueryError> {
-        let id = items.id();
+        let id = items.id().map_err(|e| QueryError::msg(location.span, e))?;
         let item = self.pool.alloc_item(&*items.item());
         self.insert_new_item_with(id, item, location, module, visibility, docs)
     }

--- a/crates/rune/src/query/query_error.rs
+++ b/crates/rune/src/query/query_error.rs
@@ -24,7 +24,7 @@ error! {
 #[non_exhaustive]
 pub enum QueryErrorKind {
     #[error("{message}")]
-    Custom { message: &'static str },
+    Custom { message: Box<str> },
     #[error("{error}")]
     IrError {
         #[source]

--- a/crates/rune/src/shared/items.rs
+++ b/crates/rune/src/shared/items.rs
@@ -2,7 +2,17 @@ use crate::compile::{ComponentRef, Item, ItemBuf};
 use crate::parse::NonZeroId;
 use crate::shared::Gen;
 use std::cell::{Ref, RefCell};
+use std::fmt;
 use std::rc::Rc;
+
+#[non_exhaustive]
+pub(crate) struct MissingLastId;
+
+impl fmt::Display for MissingLastId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "missing last inserted id into the items stack")
+    }
+}
 
 #[derive(Debug)]
 struct Inner<'a> {
@@ -32,8 +42,8 @@ impl<'a> Items<'a> {
     }
 
     /// Access the last added id.
-    pub(crate) fn id(&self) -> NonZeroId {
-        *self.inner.borrow().ids.last().expect("last id not present")
+    pub(crate) fn id(&self) -> Result<NonZeroId, MissingLastId> {
+        self.inner.borrow().ids.last().copied().ok_or(MissingLastId)
     }
 
     /// Get the item for the current state of the path.

--- a/crates/rune/src/shared/mod.rs
+++ b/crates/rune/src/shared/mod.rs
@@ -9,6 +9,6 @@ pub(crate) use self::assert_send::AssertSend;
 pub(crate) use self::consts::Consts;
 pub(crate) use self::custom::Custom;
 pub(crate) use self::gen::Gen;
-pub(crate) use self::items::Items;
+pub(crate) use self::items::{Items, MissingLastId};
 pub(crate) use self::scopes::Scopes;
 pub(crate) use self::scopes::{ScopeError, ScopeErrorKind};

--- a/crates/rune/src/shared/scopes.rs
+++ b/crates/rune/src/shared/scopes.rs
@@ -186,7 +186,7 @@ error! {
 #[non_exhaustive]
 pub enum ScopeErrorKind {
     #[error("{message}")]
-    Custom { message: &'static str },
+    Custom { message: Box<str> },
     #[error("missing local {name}")]
     MissingLocal { name: Box<str> },
 }

--- a/crates/rune/src/workspace/error.rs
+++ b/crates/rune/src/workspace/error.rs
@@ -33,7 +33,7 @@ pub enum WorkspaceErrorKind {
     #[error("failed to read `{path}`: {error}")]
     SourceError { path: Box<Path>, error: std::io::Error },
     #[error("custom: {message}")]
-    Custom { message: &'static str },
+    Custom { message: Box<str> },
     #[error("missing source id `{source_id}`")]
     MissingSourceId { source_id: SourceId },
     #[error("missing required field `{field}`")]

--- a/tests/tests/compiler_attributes.rs
+++ b/tests/tests/compiler_attributes.rs
@@ -7,7 +7,7 @@ fn test_bad_attributes() {
     assert_compile_error! {
         r#"pub fn main() { #[foo] #[bar] let x = 1; }"#,
         span, Custom { message } => {
-            assert_eq!(message, "attributes are not supported");
+            assert_eq!(message.as_ref(), "attributes are not supported");
             assert_eq!(span, span!(16, 29));
         }
     };


### PR DESCRIPTION
This reworks the custom message mechanic so that it can use heap-allocated strings and changes each occurence of `items.id()` from panicking to erroring, with a span indicating where the error happened.

This doesn't fix #426, but ensures that user input that triggers the bug cannot cause the application to panic.