### PR TITLE
Attempt FALLBACK_SET/GET on failure to find field via SET/GET

### DIFF
--- a/crates/rune/src/runtime/protocol.rs
+++ b/crates/rune/src/runtime/protocol.rs
@@ -82,14 +82,14 @@ impl Protocol {
     };
 
     /// The function to access a field by name when Protocol::GET fails.
-    pub const GET_FALLBACK: Protocol = Protocol {
-        name: "get_fallback",
+    pub const FALLBACK_GET: Protocol = Protocol {
+        name: "fallback_get",
         hash: Hash::new(0x6dda58b140dfeaf9),
     };
 
     /// The function to set a field by name when Protocol::SET fails.
-    pub const SET_FALLBACK: Protocol = Protocol {
-        name: "set_fallback",
+    pub const FALLBACK_SET: Protocol = Protocol {
+        name: "fallback_set",
         hash: Hash::new(0xbe28c02896ca0b64),
     };
 

--- a/crates/rune/src/runtime/protocol.rs
+++ b/crates/rune/src/runtime/protocol.rs
@@ -81,6 +81,18 @@ impl Protocol {
         hash: Hash::new(0x418f5becbf885806),
     };
 
+    /// The function to access a field by name when Protocol::GET fails.
+    pub const GET_FALLBACK: Protocol = Protocol {
+        name: "get_fallback",
+        hash: Hash::new(0x6dda58b140dfeaf9),
+    };
+
+    /// The function to set a field by name when Protocol::SET fails.
+    pub const SET_FALLBACK: Protocol = Protocol {
+        name: "set_fallback",
+        hash: Hash::new(0xbe28c02896ca0b64),
+    };
+
     /// The function to access a field.
     pub const GET: Protocol = Protocol {
         name: "get",

--- a/crates/rune/src/runtime/vm.rs
+++ b/crates/rune/src/runtime/vm.rs
@@ -931,7 +931,7 @@ impl Vm {
                     .call_field_fn(Protocol::GET, target, index.hash(), ())?
                     {
                         CallResult::Ok(()) => return Ok(CallResult::Ok(self.stack.pop()?)),
-                        CallResult::Unsupported(target) => match self.call_instance_fn(target, Protocol::INDEX_GET, (index,))? {
+                        CallResult::Unsupported(target) => match self.call_instance_fn(target, Protocol::GET_FALLBACK, (index,))? {
                             CallResult::Ok(()) => CallResult::Ok(self.stack.pop()?),
                             CallResult::Unsupported(target) => CallResult::Unsupported(target),
                         },
@@ -996,7 +996,7 @@ impl Vm {
                             CallResult::Ok(())
                         }
                         CallResult::Unsupported(target) => {
-                            match self.call_instance_fn(target, Protocol::INDEX_SET, (index, value))? {
+                            match self.call_instance_fn(target, Protocol::SET_FALLBACK, (index, value))? {
                                 CallResult::Ok(()) => {
                                     self.stack.pop()?;
                                     CallResult::Ok(())

--- a/crates/rune/src/runtime/vm.rs
+++ b/crates/rune/src/runtime/vm.rs
@@ -927,15 +927,17 @@ impl Vm {
             }
             target => {
                 let index = index.clone();
-                return Ok(match self
-                    .call_field_fn(Protocol::GET, target, index.hash(), ())?
-                    {
+                return Ok(
+                    match self.call_field_fn(Protocol::GET, target, index.hash(), ())? {
                         CallResult::Ok(()) => return Ok(CallResult::Ok(self.stack.pop()?)),
-                        CallResult::Unsupported(target) => match self.call_instance_fn(target, Protocol::FALLBACK_GET, (index,))? {
-                            CallResult::Ok(()) => CallResult::Ok(self.stack.pop()?),
-                            CallResult::Unsupported(target) => CallResult::Unsupported(target),
-                        },
-                    });
+                        CallResult::Unsupported(target) => {
+                            match self.call_instance_fn(target, Protocol::FALLBACK_GET, (index,))? {
+                                CallResult::Ok(()) => CallResult::Ok(self.stack.pop()?),
+                                CallResult::Unsupported(target) => CallResult::Unsupported(target),
+                            }
+                        }
+                    },
+                );
             }
         }
 
@@ -988,15 +990,23 @@ impl Vm {
             }
             target => {
                 let index = field.clone();
-                return Ok(match self
-                    .call_field_fn(Protocol::SET, target, index.hash(), (value.clone(),))?
-                    {
+                return Ok(
+                    match self.call_field_fn(
+                        Protocol::SET,
+                        target,
+                        index.hash(),
+                        (value.clone(),),
+                    )? {
                         CallResult::Ok(()) => {
                             self.stack.pop()?;
                             CallResult::Ok(())
                         }
                         CallResult::Unsupported(target) => {
-                            match self.call_instance_fn(target, Protocol::FALLBACK_SET, (index, value))? {
+                            match self.call_instance_fn(
+                                target,
+                                Protocol::FALLBACK_SET,
+                                (index, value),
+                            )? {
                                 CallResult::Ok(()) => {
                                     self.stack.pop()?;
                                     CallResult::Ok(())
@@ -1004,7 +1014,8 @@ impl Vm {
                                 CallResult::Unsupported(target) => CallResult::Unsupported(target),
                             }
                         }
-                    });
+                    },
+                );
             }
         })
     }

--- a/crates/rune/src/runtime/vm.rs
+++ b/crates/rune/src/runtime/vm.rs
@@ -533,6 +533,28 @@ impl Vm {
         Ok(CallResult::Unsupported(target))
     }
 
+    /// Helper to call a field function which has been prechecked to exist.
+    #[inline(always)]
+    fn call_field_fn_prechecked<A>(
+        &mut self,
+        target: Value,
+        handler: &Arc<dyn Fn(&mut Stack, usize) -> Result<(), VmError> + Send + Sync>,
+        args: A,
+    ) -> Result<CallResult<()>, VmError>
+    where
+        A: Args,
+    {
+        let count = args.count();
+        let full_count = count + 1;
+
+        self.stack.push(target);
+        args.into_stack(&mut self.stack)?;
+
+        handler(&mut self.stack, full_count)?;
+
+        Ok(CallResult::Ok(()))
+    }
+
     /// Helper to call an index function.
     #[inline(always)]
     fn call_index_fn<A>(
@@ -927,10 +949,26 @@ impl Vm {
             }
             target => {
                 let hash = index.hash();
-
-                return Ok(match self.call_field_fn(Protocol::GET, target, hash, ())? {
-                    CallResult::Ok(()) => CallResult::Ok(self.stack.pop()?),
-                    CallResult::Unsupported(target) => CallResult::Unsupported(target),
+                let type_hash =
+                    Hash::field_fn(Protocol::GET, target.type_hash()?, hash.into_type_hash());
+                return Ok(if let Some(handler) = self.context.function(type_hash) {
+                    match unsafe {
+                        //Unsafe block required to avoid cloning index if it isn't needed.
+                        (self as *const Self as *mut Self)
+                            .as_mut()
+                            .unwrap_unchecked()
+                    }
+                    .call_field_fn_prechecked(target, handler, ())?
+                    {
+                        CallResult::Ok(()) => return Ok(CallResult::Ok(self.stack.pop()?)),
+                        CallResult::Unsupported(target) => CallResult::Unsupported(target),
+                    }
+                } else {
+                    let index = index.clone();
+                    match self.call_instance_fn(target, Protocol::INDEX_GET, (index,))? {
+                        CallResult::Ok(()) => CallResult::Ok(self.stack.pop()?),
+                        CallResult::Unsupported(target) => CallResult::Unsupported(target),
+                    }
                 });
             }
         }
@@ -984,14 +1022,33 @@ impl Vm {
             }
             target => {
                 let hash = field.hash();
-
-                match self.call_field_fn(Protocol::SET, target, hash, (value,))? {
-                    CallResult::Ok(()) => {
-                        self.stack.pop()?;
-                        CallResult::Ok(())
+                let type_hash =
+                    Hash::field_fn(Protocol::SET, target.type_hash()?, hash.into_type_hash());
+                return Ok(if let Some(handler) = self.context.function(type_hash) {
+                    match unsafe {
+                        //Unsafe block required to avoid cloning index if it isn't needed.
+                        (self as *const Self as *mut Self)
+                            .as_mut()
+                            .unwrap_unchecked()
                     }
-                    result => result,
-                }
+                    .call_field_fn_prechecked(target, handler, (value,))?
+                    {
+                        CallResult::Ok(()) => {
+                            self.stack.pop()?;
+                            return Ok(CallResult::Ok(()));
+                        }
+                        CallResult::Unsupported(target) => CallResult::Unsupported(target),
+                    }
+                } else {
+                    let index = field.clone();
+                    match self.call_instance_fn(target, Protocol::INDEX_SET, (index, value))? {
+                        CallResult::Ok(()) => {
+                            self.stack.pop()?;
+                            CallResult::Ok(())
+                        }
+                        CallResult::Unsupported(target) => CallResult::Unsupported(target),
+                    }
+                });
             }
         })
     }

--- a/crates/rune/src/runtime/vm.rs
+++ b/crates/rune/src/runtime/vm.rs
@@ -931,7 +931,7 @@ impl Vm {
                     .call_field_fn(Protocol::GET, target, index.hash(), ())?
                     {
                         CallResult::Ok(()) => return Ok(CallResult::Ok(self.stack.pop()?)),
-                        CallResult::Unsupported(target) => match self.call_instance_fn(target, Protocol::GET_FALLBACK, (index,))? {
+                        CallResult::Unsupported(target) => match self.call_instance_fn(target, Protocol::FALLBACK_GET, (index,))? {
                             CallResult::Ok(()) => CallResult::Ok(self.stack.pop()?),
                             CallResult::Unsupported(target) => CallResult::Unsupported(target),
                         },
@@ -996,7 +996,7 @@ impl Vm {
                             CallResult::Ok(())
                         }
                         CallResult::Unsupported(target) => {
-                            match self.call_instance_fn(target, Protocol::SET_FALLBACK, (index, value))? {
+                            match self.call_instance_fn(target, Protocol::FALLBACK_SET, (index, value))? {
                                 CallResult::Ok(()) => {
                                     self.stack.pop()?;
                                     CallResult::Ok(())


### PR DESCRIPTION
I made it possible to fallback to ~~`Protocol::INDEX_GET`~~`Protocol::FALLBACK_GET` with `StaticString`/`String` key on failure to find a field via `Protocol::GET`, the same applies to ~~`Protocol::INDEX_SET`~~`Protocol::FALLBACK_SET` and `Protocol::SET`.

## Reasoning
Sometimes it is desired for user readability to pretend a specific custom type has fields and instead accessing the data from elsewhere such as from a `HashMap` or another collection.
possible use cases is having types with dynamic layouts while having rules to their usage such as locking the layout once created.
 it also allows custom types to be dynamically extended by the scripter while keeping the benefits of being a static `Shared<AnyObj>` but not seeming like a collection which `[]` accesses give the impression of. 

## Benchmarks
**Note**
Due to the tiny footprints of the functions, the differences are very hard to see if any and can be improved with a faster hashmap regardless  but honestly values these small are easily within margin of error.

### Before
```
test fields::actual_field_get                    ... bench:         418 ns/iter (+/- 88)
test fields::actual_field_set                    ... bench:         434 ns/iter (+/- 161)

test fields::string_key_classic_index_get        ... bench:         523 ns/iter (+/- 52)
test fields::static_string_key_classic_index_get ... bench:         486 ns/iter (+/- 80)
```
### After
```
test fields::actual_field_get                     ... bench:         413 ns/iter (+/- 47)
test fields::actual_field_set                     ... bench:         432 ns/iter (+/- 25)

test fields::string_key_classic_index_get         ... bench:         500 ns/iter (+/- 14)
test fields::static_string_key_classic_index_get  ... bench:         469 ns/iter (+/- 32)

test fields::string_key_fallback_field_get        ... bench:         499 ns/iter (+/- 15)
test fields::static_string_key_fallback_field_get ... bench:         469 ns/iter (+/- 20)

test fields::string_fallback_field_set            ... bench:         596 ns/iter (+/- 24)
test fields::static_string_fallback_field_set     ... bench:         608 ns/iter (+/- 14)
```

## Closes
#381 #263 

## Notes
Regarding the changes done to this PR, I do wonder if FALLBACK_* is preferred choice compared to META_* or META_FIELD_* since in most script languages I have used, META usually implies it does it first/instead not after, which although being a option would be a fine choice.

I do like the advantage of the current design being that it prioritises actual fields first.

I do wonder if it was changed to use the 'meta' getter/setter first if it would be plausible to pass in the original field getter and setter functions so u could do this:
```rust
|this: &Custom, default_get: NativeFunction, name: String| if let Ok(v) = default_get(name) {
    Ok(v)
} else {
    //Do my field get
}
```
This approach however would have overhead and although could be faster for types which only want 'meta' fields I definitely feel it would cost for classic field get/sets which would be a waste and a shame and it isn't the most attractive solution regardless.

Another possible solution could be explicitly declaring a type as having 'meta' fields and which order to prioritise finding them such as `MetaFieldAccess::First` `MetaFieldAccess::Last`, `MetaFieldAccess::Always` and finally `MetaFieldAccess::Never`(default) which would be drastically cheaper and simpler than it being passed in as a argument to the meta function which in my opinion reduces the understandability for implementors.
The enum system could even be applied to the `Any` derive macro as an attribute to make it easy to implement and recognise by looking at types.