### PR TITLE
Support for showing context documentation

### DIFF
--- a/crates/rune/src/compile/docs.rs
+++ b/crates/rune/src/compile/docs.rs
@@ -1,0 +1,58 @@
+/// The documentation for a function.
+#[derive(Clone, Default)]
+pub struct Docs {
+    /// Lines of documentation.
+    docs: Box<[String]>,
+    /// Names of arguments.
+    arguments: Option<Box<[String]>>,
+}
+
+impl Docs {
+    /// Get arguments associated with documentation.
+    pub fn args(&self) -> &[String] {
+        self.arguments
+            .as_ref()
+            .map(AsRef::as_ref)
+            .unwrap_or_default()
+    }
+
+    /// Iterate over lines in the documentation.
+    pub fn lines(&self) -> impl Iterator<Item = &str> {
+        self.docs.iter().map(|s| s.as_str())
+    }
+
+    /// Test if documentation is empty.
+    pub fn is_empty(&self) -> bool {
+        self.docs.is_empty()
+    }
+
+    /// Update documentation.
+    pub(crate) fn set_docs<S>(&mut self, docs: S)
+    where
+        S: IntoIterator,
+        S::Item: AsRef<str>,
+    {
+        let mut out = Vec::new();
+
+        for line in docs {
+            out.push(line.as_ref().to_owned());
+        }
+
+        self.docs = out.into();
+    }
+
+    /// Update arguments.
+    pub(crate) fn set_arguments<S>(&mut self, arguments: S)
+    where
+        S: IntoIterator,
+        S::Item: AsRef<str>,
+    {
+        let mut out = Vec::new();
+
+        for argument in arguments {
+            out.push(argument.as_ref().to_owned());
+        }
+
+        self.arguments = Some(out.into());
+    }
+}

--- a/crates/rune/src/compile/meta.rs
+++ b/crates/rune/src/compile/meta.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use crate::ast::{LitStr, Span};
 use crate::collections::HashSet;
 use crate::compile::attrs::Attributes;
-use crate::compile::{Item, ItemBuf, ItemId, Location, ModId, Pool, Visibility};
+use crate::compile::{Docs, Item, ItemBuf, ItemId, Location, ModId, Pool, Visibility};
 use crate::parse::{Id, ParseError, ResolveContext};
 use crate::query::ImportEntry;
 use crate::runtime::ConstValue;
@@ -178,11 +178,13 @@ impl Doc {
 
 /// Context metadata.
 #[non_exhaustive]
-pub(crate) struct ContextMeta {
+pub struct ContextMeta {
     /// The item of the returned compile meta.
-    pub(crate) item: ItemBuf,
+    pub item: ItemBuf,
     /// The kind of the compile meta.
-    pub(crate) kind: ContextMetaKind,
+    pub kind: ContextMetaKind,
+    /// Documentation associated with a context meta.
+    pub docs: Docs,
 }
 
 impl ContextMeta {
@@ -197,7 +199,7 @@ impl ContextMeta {
 
 /// Compile-time metadata kind about an item in a context.
 #[derive(Debug, Clone)]
-pub(crate) enum ContextMetaKind {
+pub enum ContextMetaKind {
     /// The type is completely opaque. We have no idea about what it is with the
     /// exception of it having a type hash.
     Unknown { type_hash: Hash },
@@ -334,7 +336,7 @@ impl PrivMeta {
 
 /// Private variant metadata.
 #[derive(Debug, Clone)]
-pub(crate) enum PrivVariantMeta {
+pub enum PrivVariantMeta {
     Tuple(PrivTupleMeta),
     Struct(PrivStructMeta),
     Unit,
@@ -472,7 +474,7 @@ impl PrivMetaKind {
 /// The metadata about a struct.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
-pub(crate) struct PrivStructMeta {
+pub struct PrivStructMeta {
     /// Fields associated with the type.
     pub(crate) fields: HashSet<Box<str>>,
 }
@@ -480,7 +482,7 @@ pub(crate) struct PrivStructMeta {
 /// The metadata about a tuple.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
-pub(crate) struct PrivTupleMeta {
+pub struct PrivTupleMeta {
     /// The number of arguments the variant takes.
     pub(crate) args: usize,
     /// Hash of the constructor function.

--- a/crates/rune/src/compile/mod.rs
+++ b/crates/rune/src/compile/mod.rs
@@ -28,6 +28,9 @@ pub(crate) use self::compile_visitor::NoopCompileVisitor;
 pub(crate) mod context;
 pub use self::context::{Context, ContextError, ContextSignature, ContextTypeInfo};
 
+mod docs;
+pub use self::docs::Docs;
+
 mod prelude;
 pub(crate) use self::prelude::Prelude;
 

--- a/crates/rune/src/modules/char.rs
+++ b/crates/rune/src/modules/char.rs
@@ -4,31 +4,49 @@ use crate::runtime::{Value, VmError, VmErrorKind};
 use crate::{ContextError, Module};
 use std::char::ParseCharError;
 
+use crate as rune;
+
 /// Construct the `std::char` module.
 pub fn module() -> Result<Module, ContextError> {
     let mut module = Module::with_crate_item("std", ["char"]);
     module.ty::<ParseCharError>()?;
 
-    module.function(["from_int"], char_from_int_impl)?;
-    module.function(["to_int"], char_to_int_impl)?;
-    module.function(["is_alphabetic"], char::is_alphabetic)?;
+    module.function_meta(from_int)?;
+    module.function_meta(to_int)?;
+    module.function_meta(is_alphabetic)?;
     module.function(["is_alphanumeric"], char::is_alphanumeric)?;
     module.function(["is_control"], char::is_control)?;
     module.function(["is_lowercase"], char::is_lowercase)?;
     module.function(["is_numeric"], char::is_numeric)?;
     module.function(["is_uppercase"], char::is_uppercase)?;
     module.function(["is_whitespace"], char::is_whitespace)?;
-
     module.function(["to_digit"], char::to_digit)?;
-
     Ok(module)
 }
 
-fn char_to_int_impl(value: char) -> Result<Value, VmError> {
+/// Convert a character into an integer.
+///
+/// # Examples
+///
+/// ```rune
+/// let c = char::from_int(80)?;
+/// assert_eq!(c.to_int(), 80);
+/// ```
+#[rune::function(instance)]
+fn to_int(value: char) -> Result<Value, VmError> {
     Ok((value as i64).into())
 }
 
-fn char_from_int_impl(value: i64) -> Result<Option<Value>, VmError> {
+/// Try to convert a number into a character.
+///
+/// # Examples
+///
+/// ```rune
+/// let c = char::from_int(80);
+/// assert!(c.is_some());
+/// ```
+#[rune::function]
+fn from_int(value: i64) -> Result<Option<Value>, VmError> {
     if value < 0 {
         Err(VmError::from(VmErrorKind::Underflow))
     } else if value > u32::MAX as i64 {
@@ -36,6 +54,24 @@ fn char_from_int_impl(value: i64) -> Result<Option<Value>, VmError> {
     } else {
         Ok(std::char::from_u32(value as u32).map(|v| v.into()))
     }
+}
+
+/// Convert a character into an integer.
+///
+/// # Examples
+///
+/// ```rune
+/// assert!('a'.is_alphabetic());
+/// assert!('京'.is_alphabetic());
+///
+/// let c = '💝';
+/// // love is many things, but it is not alphabetic
+/// assert!(!c.is_alphabetic());
+/// ```
+#[rune::function(instance)]
+#[inline]
+fn is_alphabetic(c: char) -> bool {
+    char::is_alphabetic(c)
 }
 
 crate::__internal_impl_any!(ParseCharError);

--- a/examples/examples/rune_function_macro.rs
+++ b/examples/examples/rune_function_macro.rs
@@ -73,10 +73,10 @@ impl Test {
 
 fn module() -> Result<Module, ContextError> {
     let mut m = Module::new();
-    m.function2(add)?;
-    m.function2(add_async)?;
+    m.function_meta(add)?;
+    m.function_meta(add_async)?;
     m.ty::<Test>()?;
-    m.function2(Test::add)?;
-    m.function2(Test::add_async)?;
+    m.function_meta(Test::add)?;
+    m.function_meta(Test::add_async)?;
     Ok(m)
 }


### PR DESCRIPTION
This is the first part where I try and actually document some of the internal functions. It comes with changes to the `#[rune::function]` macro. These are needed because free functions sometimes wants to be instance functions, and associated functions which *do not* take a receiver should be associated to the type in which they are declared.

Therefore I've added the following two options:
* `#[rune(instance)]` - which will register the function as an instance function, so the first argument will determine which instance it's in.
* `#[rune(path = Self)]` - For functions which are declared in associated types, this will add the registered name of `Self` for the full path.
* `#[rune(path = nested)]` - For free functions, this will put the function inside of a custom path (but not rename it).

# Future work

Eventually this documentation will be used for more things:
* The ability to run documentation tests which improves coverage of native functions.
* Generating html rustdoc-like sites.
* Integration into the language server so that when you're hovering over a type it should give you the documentation string.
* The ability to search for type documentation using `rune doc <name>` (see example below, but it should be filtered).

![image](https://user-images.githubusercontent.com/111092/227707922-89475a04-60cf-4b31-88f1-b6634d4d3a53.png)

Example declaration for `char::is_alphabetic`:

![image](https://user-images.githubusercontent.com/111092/227708217-9ce30425-6ad9-4c5c-9727-b22b925086b2.png)

Registration is done using `Module::register_meta`:

```rust
module.function_meta(is_alphabetic)?;
```