### PR TITLE
Move meta hash

### DIFF
--- a/crates/rune-cli/src/visitor.rs
+++ b/crates/rune-cli/src/visitor.rs
@@ -35,23 +35,11 @@ impl FunctionVisitor {
 impl CompileVisitor for FunctionVisitor {
     fn register_meta(&mut self, meta: MetaRef<'_>) {
         let type_hash = match (self.attribute, &meta.kind) {
-            (
-                Attribute::Test,
-                MetaKind::Function {
-                    is_test, type_hash, ..
-                },
-            ) if *is_test => type_hash,
-            (
-                Attribute::Bench,
-                MetaKind::Function {
-                    is_bench,
-                    type_hash,
-                    ..
-                },
-            ) if *is_bench => type_hash,
+            (Attribute::Test, MetaKind::Function { is_test, .. }) if *is_test => meta.hash,
+            (Attribute::Bench, MetaKind::Function { is_bench, .. }) if *is_bench => meta.hash,
             _ => return,
         };
 
-        self.functions.push((*type_hash, meta.item.to_owned()));
+        self.functions.push((type_hash, meta.item.to_owned()));
     }
 }

--- a/crates/rune/src/compile/context_error.rs
+++ b/crates/rune/src/compile/context_error.rs
@@ -1,0 +1,58 @@
+use thiserror::Error;
+
+use crate::compile::{ContextSignature, ItemBuf, Meta};
+use crate::runtime::{TypeInfo, VmError};
+use crate::Hash;
+
+/// An error raised when building the context.
+#[derive(Debug, Error)]
+#[allow(missing_docs)]
+#[non_exhaustive]
+pub enum ContextError {
+    #[error("`()` types are already present")]
+    UnitAlreadyPresent,
+    #[error("`{name}` types are already present")]
+    InternalAlreadyPresent { name: &'static str },
+    #[error("conflicting meta {existing} while trying to insert {current}")]
+    ConflictingMeta {
+        current: Box<Meta>,
+        existing: Box<Meta>,
+    },
+    #[error("function `{signature}` ({hash}) already exists")]
+    ConflictingFunction {
+        signature: Box<ContextSignature>,
+        hash: Hash,
+    },
+    #[error("function with name `{name}` already exists")]
+    ConflictingFunctionName { name: ItemBuf },
+    #[error("constant with name `{name}` already exists")]
+    ConflictingConstantName { name: ItemBuf },
+    #[error("instance function `{name}` for type `{type_info}` already exists")]
+    ConflictingInstanceFunction { type_info: TypeInfo, name: Box<str> },
+    #[error("protocol function `{name}` for type `{type_info}` already exists")]
+    ConflictingProtocolFunction { type_info: TypeInfo, name: Box<str> },
+    #[error("protocol function with hash `{hash}` for type `{type_info}` already exists")]
+    ConflictingInstanceFunctionHash { type_info: TypeInfo, hash: Hash },
+    #[error("module `{item}` with hash `{hash}` already exists")]
+    ConflictingModule { item: ItemBuf, hash: Hash },
+    #[error("type `{item}` already exists `{type_info}`")]
+    ConflictingType { item: ItemBuf, type_info: TypeInfo },
+    #[error("type `{item}` at `{type_info}` already has a specification")]
+    ConflictingTypeMeta { item: ItemBuf, type_info: TypeInfo },
+    #[error("type `{item}` with info `{type_info}` isn't registered")]
+    MissingType { item: ItemBuf, type_info: TypeInfo },
+    #[error("type `{item}` with info `{type_info}` is registered but is not an enum")]
+    MissingEnum { item: ItemBuf, type_info: TypeInfo },
+    #[error("tried to insert conflicting hash `{hash}` for `{existing}`")]
+    ConflictingTypeHash { hash: Hash, existing: Hash },
+    #[error("variant with `{item}` already exists")]
+    ConflictingVariant { item: ItemBuf },
+    #[error("instance `{instance_type}` does not exist in module")]
+    MissingInstance { instance_type: TypeInfo },
+    #[error("error when converting to constant value: {error}")]
+    ValueError { error: VmError },
+    #[error("missing variant {index} for `{type_info}`")]
+    MissingVariant { type_info: TypeInfo, index: usize },
+    #[error("constructor for variant {index} in `{type_info}` has already been registered")]
+    VariantConstructorConflict { type_info: TypeInfo, index: usize },
+}

--- a/crates/rune/src/compile/mod.rs
+++ b/crates/rune/src/compile/mod.rs
@@ -26,7 +26,10 @@ pub use self::compile_visitor::CompileVisitor;
 pub(crate) use self::compile_visitor::NoopCompileVisitor;
 
 pub(crate) mod context;
-pub use self::context::{Context, ContextError, ContextSignature, ContextTypeInfo};
+pub use self::context::Context;
+
+pub(crate) mod context_error;
+pub use self::context_error::ContextError;
 
 mod docs;
 pub use self::docs::Docs;
@@ -61,7 +64,7 @@ pub(crate) use self::meta::{
     CaptureMeta, ContextMeta, ContextMetaKind, Doc, ItemMeta, PrivMeta, PrivMetaKind,
     PrivStructMeta, PrivTupleMeta, PrivVariantMeta,
 };
-pub use self::meta::{Meta, MetaKind, MetaRef, SourceMeta};
+pub use self::meta::{ContextSignature, ContextTypeInfo, Meta, MetaKind, MetaRef, SourceMeta};
 
 mod function_meta;
 pub(crate) use self::function_meta::{AssocFnData, FunctionData};

--- a/crates/rune/src/compile/unit_builder.rs
+++ b/crates/rune/src/compile/unit_builder.rs
@@ -300,11 +300,10 @@ impl UnitBuilder {
                 }
             }
             PrivMetaKind::Struct {
-                type_hash,
                 variant: PrivVariantMeta::Unit,
                 ..
             } => {
-                let info = UnitFn::UnitStruct { hash: type_hash };
+                let info = UnitFn::UnitStruct { hash: meta.hash };
 
                 let signature = DebugSignature::new(
                     pool.item(meta.item_meta.item).to_owned(),
@@ -312,18 +311,18 @@ impl UnitBuilder {
                 );
 
                 let rtti = Arc::new(Rtti {
-                    hash: type_hash,
+                    hash: meta.hash,
                     item: pool.item(meta.item_meta.item).to_owned(),
                 });
 
-                if self.rtti.insert(type_hash, rtti).is_some() {
+                if self.rtti.insert(meta.hash, rtti).is_some() {
                     return Err(QueryError::new(
                         span,
-                        QueryErrorKind::TypeRttiConflict { hash: type_hash },
+                        QueryErrorKind::TypeRttiConflict { hash: meta.hash },
                     ));
                 }
 
-                if self.functions.insert(type_hash, info).is_some() {
+                if self.functions.insert(meta.hash, info).is_some() {
                     return Err(QueryError::new(
                         span,
                         QueryErrorKind::FunctionConflict {
@@ -333,11 +332,11 @@ impl UnitBuilder {
                 }
 
                 self.constants.insert(
-                    Hash::instance_function(type_hash, Protocol::INTO_TYPE_NAME),
+                    Hash::instance_function(meta.hash, Protocol::INTO_TYPE_NAME),
                     ConstValue::String(signature.path.to_string()),
                 );
 
-                self.debug_info_mut().functions.insert(type_hash, signature);
+                self.debug_info_mut().functions.insert(meta.hash, signature);
             }
             PrivMetaKind::Struct {
                 variant: PrivVariantMeta::Tuple(ref tuple),
@@ -404,7 +403,6 @@ impl UnitBuilder {
                 }
             }
             PrivMetaKind::Variant {
-                type_hash,
                 enum_item,
                 variant: PrivVariantMeta::Unit,
                 ..
@@ -413,25 +411,25 @@ impl UnitBuilder {
 
                 let rtti = Arc::new(VariantRtti {
                     enum_hash,
-                    hash: type_hash,
+                    hash: meta.hash,
                     item: pool.item(meta.item_meta.item).to_owned(),
                 });
 
-                if self.variant_rtti.insert(type_hash, rtti).is_some() {
+                if self.variant_rtti.insert(meta.hash, rtti).is_some() {
                     return Err(QueryError::new(
                         span,
-                        QueryErrorKind::VariantRttiConflict { hash: type_hash },
+                        QueryErrorKind::VariantRttiConflict { hash: meta.hash },
                     ));
                 }
 
-                let info = UnitFn::UnitVariant { hash: type_hash };
+                let info = UnitFn::UnitVariant { hash: meta.hash };
 
                 let signature = DebugSignature::new(
                     pool.item(meta.item_meta.item).to_owned(),
                     DebugArgs::EmptyArgs,
                 );
 
-                if self.functions.insert(type_hash, info).is_some() {
+                if self.functions.insert(meta.hash, info).is_some() {
                     return Err(QueryError::new(
                         span,
                         QueryErrorKind::FunctionConflict {
@@ -440,7 +438,7 @@ impl UnitBuilder {
                     ));
                 }
 
-                self.debug_info_mut().functions.insert(type_hash, signature);
+                self.debug_info_mut().functions.insert(meta.hash, signature);
             }
             PrivMetaKind::Variant {
                 enum_item,
@@ -506,9 +504,9 @@ impl UnitBuilder {
                     ));
                 }
             }
-            PrivMetaKind::Enum { type_hash } => {
+            PrivMetaKind::Enum { .. } => {
                 self.constants.insert(
-                    Hash::instance_function(type_hash, Protocol::INTO_TYPE_NAME),
+                    Hash::instance_function(meta.hash, Protocol::INTO_TYPE_NAME),
                     ConstValue::String(pool.item(meta.item_meta.item).to_string()),
                 );
             }


### PR DESCRIPTION
Makes things more consistent and opens the door to enumerating associated items.