### PR TITLE
Completely rework result handling

### DIFF
--- a/crates/rune-cli/src/benches.rs
+++ b/crates/rune-cli/src/benches.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 
 use clap::Parser;
 use rune::compile::{Item, ItemBuf};
-use rune::runtime::{Function, Unit, Value, VmResult};
+use rune::runtime::{Function, Unit, Value};
 use rune::{Any, Context, ContextError, Hash, Module, Sources};
 use rune_modules::capture_io::CaptureIo;
 
@@ -68,7 +68,7 @@ pub(crate) async fn run(
     for (hash, item) in fns {
         let mut bencher = Bencher::default();
 
-        if let VmResult::Err(error) = vm.call(*hash, (&mut bencher,)) {
+        if let Err(error) = vm.call(*hash, (&mut bencher,)) {
             writeln!(io.stdout, "{}: Error in benchmark", item)?;
             error.emit(io.stdout, sources)?;
             any_error = true;

--- a/crates/rune-cli/src/benches.rs
+++ b/crates/rune-cli/src/benches.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 
 use clap::Parser;
 use rune::compile::{Item, ItemBuf};
-use rune::runtime::{Function, Unit, Value};
+use rune::runtime::{Function, Unit, Value, VmResult};
 use rune::{Any, Context, ContextError, Hash, Module, Sources};
 use rune_modules::capture_io::CaptureIo;
 
@@ -68,7 +68,7 @@ pub(crate) async fn run(
     for (hash, item) in fns {
         let mut bencher = Bencher::default();
 
-        if let Err(error) = vm.call(*hash, (&mut bencher,)).into_result() {
+        if let VmResult::Err(error) = vm.call(*hash, (&mut bencher,)) {
             writeln!(io.stdout, "{}: Error in benchmark", item)?;
             error.emit(io.stdout, sources)?;
             any_error = true;

--- a/crates/rune-cli/src/benches.rs
+++ b/crates/rune-cli/src/benches.rs
@@ -68,7 +68,7 @@ pub(crate) async fn run(
     for (hash, item) in fns {
         let mut bencher = Bencher::default();
 
-        if let Err(error) = vm.call(*hash, (&mut bencher,)) {
+        if let Err(error) = vm.call(*hash, (&mut bencher,)).into_result() {
             writeln!(io.stdout, "{}: Error in benchmark", item)?;
             error.emit(io.stdout, sources)?;
             any_error = true;
@@ -115,7 +115,7 @@ fn bench_fn(
     multiple: bool,
 ) -> anyhow::Result<()> {
     for _ in 0..args.warmup {
-        let value = f.call::<_, Value>(())?;
+        let value = f.call::<_, Value>(()).into_result()?;
         drop(value);
     }
 
@@ -124,7 +124,7 @@ fn bench_fn(
 
     for _ in 0..args.iterations {
         let start = Instant::now();
-        let value = f.call::<_, Value>(())?;
+        let value = f.call::<_, Value>(()).into_result()?;
         let duration = Instant::now().duration_since(start);
         collected.push(duration.as_nanos() as i128);
         drop(value);

--- a/crates/rune-cli/src/run.rs
+++ b/crates/rune-cli/src/run.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 
 use anyhow::Result;
 use clap::Parser;
-use rune::runtime::{VmErrorWithTrace, VmExecution, VmResult};
+use rune::runtime::{VmError, VmExecution, VmResult};
 use rune::{Context, Sources, Unit, Value, Vm};
 
 use crate::{Config, ExitCode, Io, SharedFlags};
@@ -80,7 +80,7 @@ impl Flags {
 
 enum TraceError {
     Io(std::io::Error),
-    VmError(Box<VmErrorWithTrace>),
+    VmError(VmError),
 }
 
 impl From<std::io::Error> for TraceError {
@@ -167,7 +167,7 @@ pub(crate) async fn run(
     let last = Instant::now();
 
     let mut vm = Vm::new(runtime, unit);
-    let mut execution: VmExecution<_> = vm.execute(["main"], ()).into_result()?;
+    let mut execution: VmExecution<_> = vm.execute(["main"], ())?;
 
     let result = if args.trace {
         match do_trace(

--- a/crates/rune-cli/src/run.rs
+++ b/crates/rune-cli/src/run.rs
@@ -167,7 +167,7 @@ pub(crate) async fn run(
     let last = Instant::now();
 
     let mut vm = Vm::new(runtime, unit);
-    let mut execution: VmExecution<_> = vm.execute(["main"], ())?;
+    let mut execution: VmExecution<_> = vm.execute(["main"], ()).into_result()?;
     let result = if args.trace {
         match do_trace(
             io,
@@ -183,7 +183,7 @@ pub(crate) async fn run(
             Err(TraceError::VmError(vm)) => Err(vm),
         }
     } else {
-        execution.async_complete().await
+        execution.async_complete().await.into_result()
     };
 
     let errored = match result {
@@ -324,7 +324,7 @@ where
             writeln!(o)?;
         }
 
-        let result = match execution.async_step().await {
+        let result = match execution.async_step().await.into_result() {
             Ok(result) => result,
             Err(e) => return Err(TraceError::VmError(e)),
         };

--- a/crates/rune-cli/src/run.rs
+++ b/crates/rune-cli/src/run.rs
@@ -220,22 +220,22 @@ pub(crate) async fn run(
 
         while let Some((count, frame)) = it.next() {
             let stack_top = match it.peek() {
-                Some((_, next)) => next.stack_bottom(),
+                Some((_, next)) => next.stack_bottom,
                 None => stack.stack_bottom(),
             };
 
             let values = stack
-                .get(frame.stack_bottom()..stack_top)
+                .get(frame.stack_bottom..stack_top)
                 .expect("bad stack slice");
 
-            writeln!(io.stdout, "  frame #{} (+{})", count, frame.stack_bottom())?;
+            writeln!(io.stdout, "  frame #{} (+{})", count, frame.stack_bottom)?;
 
             if values.is_empty() {
                 writeln!(io.stdout, "    *empty*")?;
             }
 
             for (n, value) in stack.iter().enumerate() {
-                writeln!(io.stdout, "{}+{} = {:?}", frame.stack_bottom(), n, value)?;
+                writeln!(io.stdout, "{}+{} = {:?}", frame.stack_bottom, n, value)?;
             }
         }
 

--- a/crates/rune-cli/src/tests.rs
+++ b/crates/rune-cli/src/tests.rs
@@ -61,9 +61,9 @@ impl<'a> TestCase<'a> {
             write!(io.stdout, "Test {:30} ", self.item)?;
         }
 
-        let result = match vm.execute(self.hash, ()) {
+        let result = match vm.execute(self.hash, ()).into_result() {
+            Ok(mut execution) => execution.async_complete().await.into_result(),
             Err(err) => Err(err),
-            Ok(mut execution) => execution.async_complete().await,
         };
 
         if let Some(capture_io) = capture_io {

--- a/crates/rune-cli/src/tests.rs
+++ b/crates/rune-cli/src/tests.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 use anyhow::Result;
 use clap::Parser;
 use rune::compile::ItemBuf;
-use rune::runtime::{Unit, Value, Vm, VmErrorWithTrace, VmResult};
+use rune::runtime::{Unit, Value, Vm, VmError, VmResult};
 use rune::{Context, Hash, Sources};
 use rune_modules::capture_io::CaptureIo;
 
@@ -27,7 +27,7 @@ pub(crate) struct Flags {
 
 #[derive(Debug)]
 enum FailureReason {
-    Crash(Box<VmErrorWithTrace>),
+    Crash(VmError),
     ReturnedNone,
     ReturnedErr { output: Box<[u8]>, error: Value },
 }
@@ -62,8 +62,8 @@ impl<'a> TestCase<'a> {
         }
 
         let result = match vm.execute(self.hash, ()) {
-            VmResult::Ok(mut execution) => execution.async_complete().await,
-            VmResult::Err(err) => VmResult::Err(err),
+            Ok(mut execution) => execution.async_complete().await,
+            Err(err) => VmResult::Err(err),
         };
 
         if let Some(capture_io) = capture_io {

--- a/crates/rune-macros/src/any.rs
+++ b/crates/rune-macros/src/any.rs
@@ -394,7 +394,7 @@ where
         unsafe_from_value,
         unsafe_to_value,
         value,
-        vm_error,
+        vm_result,
         install_with,
         ..
     } = &tokens;
@@ -461,9 +461,8 @@ where
             type Output = *const #ident #ty_generics;
             type Guard = #raw_into_ref;
 
-            fn from_value(
-                value: #value,
-            ) -> ::std::result::Result<(Self::Output, Self::Guard), #vm_error> {
+            #[inline]
+            fn from_value(value: #value) -> #vm_result<(Self::Output, Self::Guard)> {
                 value.into_any_ptr()
             }
 
@@ -476,9 +475,7 @@ where
             type Output = *mut #ident  #ty_generics;
             type Guard = #raw_into_mut;
 
-            fn from_value(
-                value: #value,
-            ) -> ::std::result::Result<(Self::Output, Self::Guard), #vm_error> {
+            fn from_value(value: #value) -> #vm_result<(Self::Output, Self::Guard)> {
                 value.into_any_mut()
             }
 
@@ -490,18 +487,18 @@ where
         impl #impl_generics #unsafe_to_value for &#ident #ty_generics #where_clause {
             type Guard = #pointer_guard;
 
-            unsafe fn unsafe_to_value(self) -> ::std::result::Result<(#value, Self::Guard), #vm_error> {
+            unsafe fn unsafe_to_value(self) -> #vm_result<(#value, Self::Guard)> {
                 let (shared, guard) = #shared::from_ref(self);
-                Ok((#value::from(shared), guard))
+                #vm_result::Ok((#value::from(shared), guard))
             }
         }
 
         impl #impl_generics #unsafe_to_value for &mut #ident #ty_generics #where_clause {
             type Guard = #pointer_guard;
 
-            unsafe fn unsafe_to_value(self) -> ::std::result::Result<(#value, Self::Guard), #vm_error> {
+            unsafe fn unsafe_to_value(self) -> #vm_result<(#value, Self::Guard)> {
                 let (shared, guard) = #shared::from_mut(self);
-                Ok((#value::from(shared), guard))
+                #vm_result::Ok((#value::from(shared), guard))
             }
         }
     })

--- a/crates/rune-macros/src/any.rs
+++ b/crates/rune-macros/src/any.rs
@@ -68,7 +68,7 @@ impl syn::parse::Parse for Derive {
 
 impl Derive {
     pub(super) fn expand(self) -> Result<TokenStream, Vec<syn::Error>> {
-        let mut ctx = Context::new();
+        let ctx = Context::new();
 
         let attrs = match ctx.type_attrs(&self.input.attrs) {
             Some(attrs) => attrs,
@@ -78,11 +78,10 @@ impl Derive {
         let tokens = ctx.tokens_with_module(attrs.module.as_ref());
 
         let generics = &self.input.generics;
-        let install_with =
-            match expand_install_with(&mut ctx, &self.input, &tokens, &attrs, generics) {
-                Some(install_with) => install_with,
-                None => return Err(ctx.errors.into_inner()),
-            };
+        let install_with = match expand_install_with(&ctx, &self.input, &tokens, &attrs, generics) {
+            Some(install_with) => install_with,
+            None => return Err(ctx.errors.into_inner()),
+        };
 
         let name = match attrs.name {
             Some(name) => name,

--- a/crates/rune-macros/src/context.rs
+++ b/crates/rune-macros/src/context.rs
@@ -656,6 +656,7 @@ impl Context {
             variant: quote!(#module::compile::Variant),
             vm_error_kind: quote!(#module::runtime::VmErrorKind),
             vm_error: quote!(#module::runtime::VmError),
+            vm_result: quote!(#module::runtime::VmResult),
         }
     }
 }
@@ -701,6 +702,7 @@ pub(crate) struct Tokens {
     pub(crate) variant: TokenStream,
     pub(crate) vm_error_kind: TokenStream,
     pub(crate) vm_error: TokenStream,
+    pub(crate) vm_result: TokenStream,
 }
 
 impl Tokens {

--- a/crates/rune-macros/src/lib.rs
+++ b/crates/rune-macros/src/lib.rs
@@ -248,7 +248,6 @@ pub fn opaque(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 ///     field: u64,
 /// }
 ///
-/// # fn main() -> rune::Result<()> {
 /// let mut sources = rune::sources! {
 ///     entry => {
 ///         pub fn main() {
@@ -261,10 +260,10 @@ pub fn opaque(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 ///
 /// let mut vm = Vm::without_runtime(Arc::new(unit));
 /// let foo = vm.call(["main"], ())?;
-/// let foo = Foo::from_value(foo)?;
+/// let foo: Foo = rune::from_value(foo)?;
 ///
 /// assert_eq!(foo.field, 42);
-/// # Ok(()) }
+/// # Ok::<_, rune::Error>(())
 /// ```
 #[proc_macro_derive(FromValue, attributes(rune))]
 pub fn from_value(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
@@ -280,7 +279,7 @@ pub fn from_value(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 /// # Examples
 ///
 /// ```
-/// use rune::{FromValue, ToValue, Vm};
+/// use rune::{ToValue, Vm};
 /// use std::sync::Arc;
 ///
 /// #[derive(ToValue)]
@@ -288,7 +287,6 @@ pub fn from_value(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 ///     field: u64,
 /// }
 ///
-/// # fn main() -> rune::Result<()> {
 /// let mut sources = rune::sources! {
 ///     entry => {
 ///         pub fn main(foo) {
@@ -300,11 +298,11 @@ pub fn from_value(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 /// let unit = rune::prepare(&mut sources).build()?;
 ///
 /// let mut vm = Vm::without_runtime(Arc::new(unit));
-/// let foo = vm.call(["main"], (Foo { field: 42 },))?;
-/// let foo = u64::from_value(foo)?;
+/// let value = vm.call(["main"], (Foo { field: 42 },))?;
+/// let value: u64 = rune::from_value(value)?;
 ///
-/// assert_eq!(foo, 43);
-/// # Ok(()) }
+/// assert_eq!(value, 43);
+/// # Ok::<_, rune::Error>(())
 /// ```
 #[proc_macro_derive(ToValue, attributes(rune))]
 pub fn to_value(input: proc_macro::TokenStream) -> proc_macro::TokenStream {

--- a/crates/rune-macros/src/opaque.rs
+++ b/crates/rune-macros/src/opaque.rs
@@ -29,20 +29,20 @@ impl Derive {
                 }
             }
             syn::Data::Enum(en) => {
-                expander.ctx.errors.push(syn::Error::new_spanned(
+                expander.ctx.error(syn::Error::new_spanned(
                     en.enum_token,
                     "not supported on enums",
                 ));
             }
             syn::Data::Union(un) => {
-                expander.ctx.errors.push(syn::Error::new_spanned(
+                expander.ctx.error(syn::Error::new_spanned(
                     un.union_token,
                     "not supported on unions",
                 ));
             }
         }
 
-        Err(expander.ctx.errors)
+        Err(expander.ctx.errors.into_inner())
     }
 }
 
@@ -84,7 +84,7 @@ impl Expander {
 
             if attrs.id.is_some() {
                 if field.is_some() {
-                    self.ctx.errors.push(syn::Error::new_spanned(
+                    self.ctx.error(syn::Error::new_spanned(
                         f,
                         "only one field can be marked `#[rune(id)]`",
                     ));
@@ -97,7 +97,7 @@ impl Expander {
         let (n, f) = match field {
             Some(field) => field,
             None => {
-                self.ctx.errors.push(syn::Error::new_spanned(
+                self.ctx.error(syn::Error::new_spanned(
                     fields,
                     "could not find a suitable identifier field",
                 ));

--- a/crates/rune-macros/src/option_spanned.rs
+++ b/crates/rune-macros/src/option_spanned.rs
@@ -35,14 +35,14 @@ impl Derive {
                 }
             }
             syn::Data::Union(un) => {
-                expander.ctx.errors.push(syn::Error::new_spanned(
+                expander.ctx.error(syn::Error::new_spanned(
                     un.union_token,
                     "not supported on unions",
                 ));
             }
         }
 
-        Err(expander.ctx.errors)
+        Err(expander.ctx.errors.into_inner())
     }
 }
 
@@ -104,14 +104,14 @@ impl Expander {
         match fields {
             syn::Fields::Named(named) => self.expand_struct_named(named),
             syn::Fields::Unnamed(..) => {
-                self.ctx.errors.push(syn::Error::new_spanned(
+                self.ctx.error(syn::Error::new_spanned(
                     fields,
                     "tuple structs are not supported",
                 ));
                 None
             }
             syn::Fields::Unit => {
-                self.ctx.errors.push(syn::Error::new_spanned(
+                self.ctx.error(syn::Error::new_spanned(
                     fields,
                     "unit structs are not supported",
                 ));
@@ -181,7 +181,7 @@ impl Expander {
     ) -> Option<TokenStream> {
         match fields {
             syn::Fields::Named(..) => {
-                self.ctx.errors.push(syn::Error::new_spanned(
+                self.ctx.error(syn::Error::new_spanned(
                     fields,
                     "named enum variants are not supported",
                 ));

--- a/crates/rune-macros/src/parse.rs
+++ b/crates/rune-macros/src/parse.rs
@@ -30,20 +30,20 @@ impl Derive {
                 }
             }
             syn::Data::Enum(en) => {
-                expander.ctx.errors.push(syn::Error::new_spanned(
+                expander.ctx.error(syn::Error::new_spanned(
                     en.enum_token,
                     "not supported on enums",
                 ));
             }
             syn::Data::Union(un) => {
-                expander.ctx.errors.push(syn::Error::new_spanned(
+                expander.ctx.error(syn::Error::new_spanned(
                     un.union_token,
                     "not supported on unions",
                 ));
             }
         }
 
-        Err(expander.ctx.errors)
+        Err(expander.ctx.errors.into_inner())
     }
 }
 
@@ -75,14 +75,14 @@ impl Expander {
         match fields {
             syn::Fields::Named(named) => self.expand_struct_named(input, named),
             syn::Fields::Unnamed(..) => {
-                self.ctx.errors.push(syn::Error::new_spanned(
+                self.ctx.error(syn::Error::new_spanned(
                     fields,
                     "tuple structs are not supported",
                 ));
                 None
             }
             syn::Fields::Unit => {
-                self.ctx.errors.push(syn::Error::new_spanned(
+                self.ctx.error(syn::Error::new_spanned(
                     fields,
                     "unit structs are not supported",
                 ));
@@ -129,7 +129,7 @@ impl Expander {
             }
 
             if i - skipped != meta_fields.len() {
-                self.ctx.errors.push(syn::Error::new_spanned(
+                self.ctx.error(syn::Error::new_spanned(
                     field,
                     format!(
                         "The first sequence of fields may have `#[rune({})]`, \

--- a/crates/rune-macros/src/spanned.rs
+++ b/crates/rune-macros/src/spanned.rs
@@ -35,14 +35,14 @@ impl Derive {
                 }
             }
             syn::Data::Union(un) => {
-                expander.ctx.errors.push(syn::Error::new_spanned(
+                expander.ctx.error(syn::Error::new_spanned(
                     un.union_token,
                     "not supported on unions",
                 ));
             }
         }
 
-        Err(expander.ctx.errors)
+        Err(expander.ctx.errors.into_inner())
     }
 }
 
@@ -107,14 +107,14 @@ impl Expander {
         match fields {
             syn::Fields::Named(named) => self.expand_struct_named(named),
             syn::Fields::Unnamed(..) => {
-                self.ctx.errors.push(syn::Error::new_spanned(
+                self.ctx.error(syn::Error::new_spanned(
                     fields,
                     "tuple structs are not supported",
                 ));
                 None
             }
             syn::Fields::Unit => {
-                self.ctx.errors.push(syn::Error::new_spanned(
+                self.ctx.error(syn::Error::new_spanned(
                     fields,
                     "unit structs are not supported",
                 ));
@@ -153,7 +153,7 @@ impl Expander {
         let begin = match (optional, begin) {
             (false, Some(begin)) => begin,
             _ => {
-                self.ctx.errors.push(syn::Error::new_spanned(
+                self.ctx.error(syn::Error::new_spanned(
                     tokens,
                     "ran out of fields to calculate exact span",
                 ));
@@ -191,7 +191,7 @@ impl Expander {
     ) -> Option<TokenStream> {
         match fields {
             syn::Fields::Named(..) => {
-                self.ctx.errors.push(syn::Error::new_spanned(
+                self.ctx.error(syn::Error::new_spanned(
                     fields,
                     "named enum variants are not supported",
                 ));
@@ -199,7 +199,7 @@ impl Expander {
             }
             syn::Fields::Unnamed(unnamed) => self.expand_variant_unnamed(variant, unnamed),
             syn::Fields::Unit => {
-                self.ctx.errors.push(syn::Error::new_spanned(
+                self.ctx.error(syn::Error::new_spanned(
                     fields,
                     "unit variants are not supported",
                 ));

--- a/crates/rune-macros/src/to_tokens.rs
+++ b/crates/rune-macros/src/to_tokens.rs
@@ -35,14 +35,14 @@ impl Derive {
                 }
             }
             syn::Data::Union(un) => {
-                expander.ctx.errors.push(syn::Error::new_spanned(
+                expander.ctx.error(syn::Error::new_spanned(
                     un.union_token,
                     "not supported on unions",
                 ));
             }
         }
 
-        Err(expander.ctx.errors)
+        Err(expander.ctx.errors.into_inner())
     }
 }
 
@@ -102,14 +102,14 @@ impl Expander {
         match fields {
             syn::Fields::Named(named) => self.expand_struct_named(input, named),
             syn::Fields::Unnamed(..) => {
-                self.ctx.errors.push(syn::Error::new_spanned(
+                self.ctx.error(syn::Error::new_spanned(
                     fields,
                     "tuple structs are not supported",
                 ));
                 None
             }
             syn::Fields::Unit => {
-                self.ctx.errors.push(syn::Error::new_spanned(
+                self.ctx.error(syn::Error::new_spanned(
                     fields,
                     "unit structs are not supported",
                 ));

--- a/crates/rune-macros/src/to_value.rs
+++ b/crates/rune-macros/src/to_value.rs
@@ -18,13 +18,17 @@ impl Expander {
         let inner = self.expand_fields(&st.fields)?;
 
         let ident = &input.ident;
-        let value = &self.tokens.value;
-        let vm_error = &self.tokens.vm_error;
-        let to_value = &self.tokens.to_value;
+
+        let Tokens {
+            value,
+            vm_result,
+            to_value,
+            ..
+        } = &self.tokens;
 
         Some(quote! {
             impl #to_value for #ident {
-                fn to_value(self) -> ::std::result::Result<#value, #vm_error> {
+                fn to_value(self) -> #vm_result<#value> {
                     #inner
                 }
             }
@@ -37,23 +41,9 @@ impl Expander {
             syn::Fields::Unnamed(named) => self.expand_unnamed(named),
             syn::Fields::Named(named) => self.expand_named(named),
             syn::Fields::Unit => {
-                self.ctx.errors.push(syn::Error::new_spanned(
+                self.ctx.error(syn::Error::new_spanned(
                     fields,
                     "unit structs are not supported",
-                ));
-                None
-            }
-        }
-    }
-
-    /// Get a field identifier.
-    fn field_ident<'a>(&mut self, field: &'a syn::Field) -> Option<&'a syn::Ident> {
-        match &field.ident {
-            Some(ident) => Some(ident),
-            None => {
-                self.ctx.errors.push(syn::Error::new_spanned(
-                    field,
-                    "unnamed fields are not supported",
                 ));
                 None
             }
@@ -64,68 +54,69 @@ impl Expander {
     fn expand_unnamed(&mut self, unnamed: &syn::FieldsUnnamed) -> Option<TokenStream> {
         let mut to_values = Vec::new();
 
-        for (index, field) in unnamed.unnamed.iter().enumerate() {
-            let _ = self.ctx.field_attrs(&field.attrs)?;
+        let Tokens {
+            to_value,
+            value,
+            tuple,
+            vm_result,
+            ..
+        } = &self.tokens;
 
+        for (index, f) in unnamed.unnamed.iter().enumerate() {
+            let _ = self.ctx.field_attrs(&f.attrs)?;
             let index = syn::Index::from(index);
-
-            let to_value = &self.tokens.to_value;
-
-            to_values.push(quote_spanned! {
-                field.span() =>
-                tuple.push(#to_value::to_value(self.#index)?);
-            });
+            let to_value = self.tokens.vm_try(quote!(#to_value::to_value(self.#index)));
+            to_values.push(quote_spanned!(f.span() => tuple.push(#to_value)));
         }
 
         let cap = unnamed.unnamed.len();
-        let value = &self.tokens.value;
-        let tuple = &self.tokens.tuple;
 
         Some(quote_spanned! {
             unnamed.span() =>
             let mut tuple = Vec::with_capacity(#cap);
-            #(#to_values)*
-            Ok(#value::from(#tuple::from(tuple)))
+            #(#to_values;)*
+            #vm_result::Ok(#value::from(#tuple::from(tuple)))
         })
     }
 
     /// Expand named fields.
     fn expand_named(&mut self, named: &syn::FieldsNamed) -> Option<TokenStream> {
+        let Tokens {
+            to_value,
+            value,
+            object,
+            vm_result,
+            ..
+        } = &self.tokens;
+
         let mut to_values = Vec::new();
 
-        for field in &named.named {
-            let ident = self.field_ident(field)?;
-            let _ = self.ctx.field_attrs(&field.attrs)?;
+        for f in &named.named {
+            let ident = self.ctx.field_ident(f)?;
+            let _ = self.ctx.field_attrs(&f.attrs)?;
 
             let name = &syn::LitStr::new(&ident.to_string(), ident.span());
-
-            let to_value = &self.tokens.to_value;
-
-            to_values.push(quote_spanned! {
-                field.span() =>
-                object.insert(String::from(#name), #to_value::to_value(self.#ident)?);
-            });
+            let to_value = self.tokens.vm_try(quote!(#to_value::to_value(self.#ident)));
+            to_values
+                .push(quote_spanned!(f.span() => object.insert(String::from(#name), #to_value)));
         }
-
-        let value = &self.tokens.value;
-        let object = &self.tokens.object;
 
         Some(quote_spanned! {
             named.span() =>
             let mut object = <#object>::new();
-            #(#to_values)*
-            Ok(#value::from(object))
+            #(#to_values;)*
+            #vm_result::Ok(#value::from(object))
         })
     }
 }
 
 pub(super) fn expand(input: &syn::DeriveInput) -> Result<TokenStream, Vec<syn::Error>> {
-    let mut ctx = Context::new();
+    let ctx = Context::new();
 
     let attrs = match ctx.type_attrs(&input.attrs) {
         Some(attrs) => attrs,
         None => {
-            return Err(ctx.errors);
+            return Err(ctx.errors.into_inner());
         }
     };
 
@@ -143,18 +134,18 @@ pub(super) fn expand(input: &syn::DeriveInput) -> Result<TokenStream, Vec<syn::E
             }
         }
         syn::Data::Enum(en) => {
-            expander.ctx.errors.push(syn::Error::new_spanned(
+            expander.ctx.error(syn::Error::new_spanned(
                 en.enum_token,
                 "not supported on enums",
             ));
         }
         syn::Data::Union(un) => {
-            expander.ctx.errors.push(syn::Error::new_spanned(
+            expander.ctx.error(syn::Error::new_spanned(
                 un.union_token,
                 "not supported on unions",
             ));
         }
     }
 
-    Err(expander.ctx.errors)
+    Err(expander.ctx.errors.into_inner())
 }

--- a/crates/rune-modules/src/capture_io.rs
+++ b/crates/rune-modules/src/capture_io.rs
@@ -62,13 +62,19 @@ pub fn module(io: &CaptureIo) -> Result<Module, ContextError> {
     let o = io.clone();
 
     module.function(["print"], move |m: &str| {
-        write!(o.inner.lock(), "{}", m).map_err(Panic::custom)
+        match write!(o.inner.lock(), "{}", m) {
+            Ok(()) => VmResult::Ok(()),
+            Err(error) => VmResult::err(Panic::custom(error)),
+        }
     })?;
 
     let o = io.clone();
 
     module.function(["println"], move |m: &str| {
-        writeln!(o.inner.lock(), "{}", m).map_err(Panic::custom)
+        match writeln!(o.inner.lock(), "{}", m) {
+            Ok(()) => VmResult::Ok(()),
+            Err(error) => VmResult::err(Panic::custom(error)),
+        }
     })?;
 
     let o = io.clone();

--- a/crates/rune-modules/src/capture_io.rs
+++ b/crates/rune-modules/src/capture_io.rs
@@ -13,7 +13,7 @@
 //! ```
 
 use parking_lot::Mutex;
-use rune::runtime::{Panic, Stack, VmError};
+use rune::runtime::{Panic, Stack, VmError, VmResult};
 use rune::{ContextError, Module, Value};
 use std::io::{self, Write};
 use std::string::FromUtf8Error;
@@ -81,14 +81,14 @@ pub fn module(io: &CaptureIo) -> Result<Module, ContextError> {
     Ok(module)
 }
 
-fn dbg_impl<O>(o: &mut O, stack: &mut Stack, args: usize) -> Result<(), VmError>
+fn dbg_impl<O>(o: &mut O, stack: &mut Stack, args: usize) -> VmResult<()>
 where
     O: Write,
 {
-    for value in stack.drain(args)? {
-        writeln!(o, "{:?}", value).map_err(VmError::panic)?;
+    for value in rune::vm_try!(stack.drain(args)) {
+        rune::vm_try!(writeln!(o, "{:?}", value).map_err(VmError::panic));
     }
 
     stack.push(Value::Unit);
-    Ok(())
+    VmResult::Ok(())
 }

--- a/crates/rune-modules/src/capture_io.rs
+++ b/crates/rune-modules/src/capture_io.rs
@@ -13,7 +13,7 @@
 //! ```
 
 use parking_lot::Mutex;
-use rune::runtime::{Panic, Stack, VmError, VmResult};
+use rune::runtime::{Panic, Stack, VmResult};
 use rune::{ContextError, Module, Value};
 use std::io::{self, Write};
 use std::string::FromUtf8Error;
@@ -92,7 +92,7 @@ where
     O: Write,
 {
     for value in rune::vm_try!(stack.drain(args)) {
-        rune::vm_try!(writeln!(o, "{:?}", value).map_err(VmError::panic));
+        rune::vm_try!(writeln!(o, "{:?}", value).map_err(Panic::custom));
     }
 
     stack.push(Value::Unit);

--- a/crates/rune-modules/src/disable_io.rs
+++ b/crates/rune-modules/src/disable_io.rs
@@ -10,7 +10,7 @@
 //! # Ok(()) }
 //! ```
 
-use rune::runtime::Stack;
+use rune::runtime::{Stack, VmResult};
 use rune::{ContextError, Module};
 
 /// Provide a bunch of `std::io` functions which will cause any output to be ignored.
@@ -23,9 +23,9 @@ pub fn module() -> Result<Module, ContextError> {
 
     module.raw_fn(["dbg"], move |stack: &mut Stack, args: usize| {
         // NB: still need to maintain the stack.
-        drop(stack.drain(args)?);
+        drop(rune::vm_try!(stack.drain(args)));
         stack.push(());
-        Ok(())
+        VmResult::Ok(())
     })?;
 
     Ok(module)

--- a/crates/rune-modules/src/experiments/mod.rs
+++ b/crates/rune-modules/src/experiments/mod.rs
@@ -13,11 +13,9 @@
 //! Install it into your context:
 //!
 //! ```rust
-//! # fn main() -> rune::Result<()> {
 //! let mut context = rune::Context::with_default_modules()?;
 //! context.install(rune_modules::experiments::module(true)?)?;
-//! # Ok(())
-//! # }
+//! # Ok::<_, rune::Error>(())
 //! ```
 
 use rune::ast;

--- a/crates/rune-modules/src/fs.rs
+++ b/crates/rune-modules/src/fs.rs
@@ -13,11 +13,9 @@
 //! Install it into your context:
 //!
 //! ```rust
-//! # fn main() -> rune::Result<()> {
 //! let mut context = rune::Context::with_default_modules()?;
 //! context.install(rune_modules::fs::module(true)?)?;
-//! # Ok(())
-//! # }
+//! # Ok::<_, rune::Error>(())
 //! ```
 //!
 //! Use it in Rune:

--- a/crates/rune-modules/src/http.rs
+++ b/crates/rune-modules/src/http.rs
@@ -13,12 +13,10 @@
 //! Install it into your context:
 //!
 //! ```rust
-//! # fn main() -> rune::Result<()> {
 //! let mut context = rune::Context::with_default_modules()?;
 //! context.install(rune_modules::http::module(true)?)?;
 //! context.install(rune_modules::json::module(true)?)?;
-//! # Ok(())
-//! # }
+//! # Ok::<_, rune::Error>(())
 //! ```
 //!
 //! Use it in Rune:

--- a/crates/rune-modules/src/json.rs
+++ b/crates/rune-modules/src/json.rs
@@ -13,11 +13,9 @@
 //! Install it into your context:
 //!
 //! ```rust
-//! # fn main() -> rune::Result<()> {
 //! let mut context = rune::Context::with_default_modules()?;
 //! context.install(rune_modules::json::module(true)?)?;
-//! # Ok(())
-//! # }
+//! # Ok::<_, rune::Error>(())
 //! ```
 //!
 //! Use it in Rune:

--- a/crates/rune-modules/src/process.rs
+++ b/crates/rune-modules/src/process.rs
@@ -13,11 +13,9 @@
 //! Install it into your context:
 //!
 //! ```rust
-//! # fn main() -> rune::Result<()> {
 //! let mut context = rune::Context::with_default_modules()?;
 //! context.install(rune_modules::process::module(true)?)?;
-//! # Ok(())
-//! # }
+//! # Ok::<_, rune::Error>(())
 //! ```
 //!
 //! Use it in Rune:

--- a/crates/rune-modules/src/process.rs
+++ b/crates/rune-modules/src/process.rs
@@ -79,7 +79,7 @@ impl Command {
                     self.inner.arg(&***s);
                 }
                 actual => {
-                    return VmResult::Err(VmError::expected::<String>(rune::vm_try!(actual.type_info().into_result())));
+                    return VmResult::err(VmError::expected::<String>(rune::vm_try!(actual.type_info().into_result())));
                 }
             }
         }
@@ -116,7 +116,7 @@ impl Child {
         let inner = match self.inner {
             Some(inner) => inner,
             None => {
-                return VmResult::Err(VmError::panic("already completed"));
+                return VmResult::err(VmError::panic("already completed"));
             }
         };
 

--- a/crates/rune-modules/src/process.rs
+++ b/crates/rune-modules/src/process.rs
@@ -32,7 +32,7 @@
 //! ```
 
 use rune::{Any, Module, ContextError};
-use rune::runtime::{Bytes, Shared, Value, VmError, Protocol, VmResult};
+use rune::runtime::{Bytes, Shared, Value, VmErrorKind, Protocol, VmResult, Panic};
 use std::fmt;
 use std::io;
 use tokio::process;
@@ -79,7 +79,7 @@ impl Command {
                     self.inner.arg(&***s);
                 }
                 actual => {
-                    return VmResult::err(VmError::expected::<String>(rune::vm_try!(actual.type_info().into_result())));
+                    return VmResult::err(VmErrorKind::expected::<String>(rune::vm_try!(actual.type_info().into_result())));
                 }
             }
         }
@@ -116,7 +116,7 @@ impl Child {
         let inner = match self.inner {
             Some(inner) => inner,
             None => {
-                return VmResult::err(VmError::panic("already completed"));
+                return VmResult::err(Panic::custom("already completed"));
             }
         };
 

--- a/crates/rune-modules/src/rand.rs
+++ b/crates/rune-modules/src/rand.rs
@@ -140,14 +140,14 @@ mod tests {
     #[test]
     fn test_range_is_exclusive() {
         for _ in 0..100 {
-            assert_eq!(int_range(0, 1).unwrap().into_integer().unwrap(), 0);
+            assert_eq!(rune::from_value::<i64>(int_range(0, 1).unwrap()).unwrap(), 0);
         }
     }
 
     #[test]
     fn test_range_can_be_negative() {
         for _ in 0..100 {
-            assert_eq!(int_range(-2, -1).unwrap().into_integer().unwrap(), -2);
+            assert_eq!(rune::from_value::<i64>(int_range(-2, -1).unwrap()).unwrap(), -2);
         }
     }
 
@@ -155,8 +155,9 @@ mod tests {
     fn test_int_is_properly_signed() {
         let mut any_negative = false;
         let mut any_positive = false;
+
         for _ in 0..100 {
-            let v = int().unwrap().into_integer().unwrap();
+            let v: i64 = rune::from_value(int().unwrap()).unwrap();
             any_negative = any_negative || v < 0;
             any_positive = any_positive || v > 0;
         }

--- a/crates/rune-modules/src/rand.rs
+++ b/crates/rune-modules/src/rand.rs
@@ -14,11 +14,9 @@
 //! Install it into your context:
 //!
 //! ```rust
-//! # fn main() -> rune::Result<()> {
 //! let mut context = rune::Context::with_default_modules()?;
 //! context.install(rune_modules::rand::module(true)?)?;
-//! # Ok(())
-//! # }
+//! # Ok::<_, rune::Error>(())
 //! ```
 //!
 //! Use it in Rune:

--- a/crates/rune-modules/src/signal.rs
+++ b/crates/rune-modules/src/signal.rs
@@ -13,11 +13,9 @@
 //! Install it into your context:
 //!
 //! ```rust
-//! # fn main() -> rune::Result<()> {
 //! let mut context = rune::Context::with_default_modules()?;
 //! context.install(rune_modules::signal::module(true)?)?;
-//! # Ok(())
-//! # }
+//! # Ok::<_, rune::Error>(())
 //! ```
 //!
 //! Use it in Rune:

--- a/crates/rune-modules/src/time.rs
+++ b/crates/rune-modules/src/time.rs
@@ -13,11 +13,9 @@
 //! Install it into your context:
 //!
 //! ```rust
-//! # fn main() -> rune::Result<()> {
 //! let mut context = rune::Context::with_default_modules()?;
 //! context.install(rune_modules::time::module(true)?)?;
-//! # Ok(())
-//! # }
+//! # Ok::<_, rune::Error>(())
 //! ```
 //!
 //! Use it in Rune:

--- a/crates/rune-modules/src/toml.rs
+++ b/crates/rune-modules/src/toml.rs
@@ -13,11 +13,9 @@
 //! Install it into your context:
 //!
 //! ```rust
-//! # fn main() -> rune::Result<()> {
 //! let mut context = rune::Context::with_default_modules()?;
 //! context.install(rune_modules::toml::module(true)?)?;
-//! # Ok(())
-//! # }
+//! # Ok::<_, rune::Error>(())
 //! ```
 //!
 //! Use it in Rune:

--- a/crates/rune-wasm/src/lib.rs
+++ b/crates/rune-wasm/src/lib.rs
@@ -326,8 +326,8 @@ async fn inner_compile(
     let mut vm = rune::Vm::new(Arc::new(context.runtime()), unit);
 
     let mut execution = match vm.execute(["main"], ()) {
-        VmResult::Ok(execution) => execution,
-        VmResult::Err(error) => {
+        Ok(execution) => execution,
+        Err(error) => {
             error
                 .emit(&mut writer, &sources)
                 .context("emitting to buffer should never fail")?;

--- a/crates/rune-wasm/src/time.rs
+++ b/crates/rune-wasm/src/time.rs
@@ -1,5 +1,5 @@
 use js_sys::Promise;
-use rune::runtime::VmError;
+use rune::runtime::{Panic, VmResult};
 use rune::{Any, ContextError, Module};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
@@ -27,9 +27,13 @@ impl Duration {
     }
 }
 
-async fn delay_for(duration: Duration) -> Result<(), VmError> {
+async fn delay_for(duration: Duration) -> VmResult<()> {
     let promise = sleep(duration.0);
     let js_fut = JsFuture::from(promise);
-    js_fut.await.map_err(|_| VmError::panic("future errored"))?;
-    Ok(())
+
+    if js_fut.await.is_err() {
+        return VmResult::err(Panic::custom("future errored"));
+    }
+
+    VmResult::Ok(())
 }

--- a/crates/rune/src/ast/file.rs
+++ b/crates/rune/src/ast/file.rs
@@ -59,7 +59,6 @@ use crate::ast::prelude::*;
 /// use rune::SourceId;
 /// use rune::{ast, parse};
 ///
-/// # fn main() -> rune::Result<()> {
 /// let file = parse::parse_all::<ast::File>(r#"#!rune run
 ///
 /// fn main() {
@@ -70,7 +69,7 @@ use crate::ast::prelude::*;
 /// "#, SourceId::EMPTY, true)?;
 ///
 /// assert!(file.shebang.is_some());
-/// # Ok(()) }
+/// # Ok::<_, rune::Error>(())
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, ToTokens)]
 #[non_exhaustive]

--- a/crates/rune/src/ast/mod.rs
+++ b/crates/rune/src/ast/mod.rs
@@ -46,7 +46,7 @@
 //!
 //! let mut vm = Vm::new(runtime, unit);
 //! let value = vm.call(["main"], ())?;
-//! let value = String::from_value(value)?;
+//! let value: String = rune::from_value(value)?;
 //!
 //! assert_eq!(value, "hello");
 //! # Ok(()) }

--- a/crates/rune/src/ast/mod.rs
+++ b/crates/rune/src/ast/mod.rs
@@ -21,7 +21,6 @@
 //!     Ok(quote!(#string).into_token_stream(ctx))
 //! }
 //!
-//! # fn main() -> rune::Result<()> {
 //! let mut m = Module::new();
 //! m.macro_(["ident_to_string"], ident_to_string)?;
 //!
@@ -49,7 +48,7 @@
 //! let value: String = rune::from_value(value)?;
 //!
 //! assert_eq!(value, "hello");
-//! # Ok(()) }
+//! # Ok::<_, rune::Error>(())
 //! ```
 
 use crate::macros::{MacroContext, ToTokens, TokenStream};

--- a/crates/rune/src/build.rs
+++ b/crates/rune/src/build.rs
@@ -27,10 +27,9 @@ pub struct BuildError;
 ///
 /// ```
 /// use rune::termcolor::{ColorChoice, StandardStream};
-/// use rune::{Context, Options, Source, Vm};
+/// use rune::{Context, Source, Vm};
 /// use std::sync::Arc;
 ///
-/// # fn main() -> rune::Result<()> {
 /// let context = Context::with_default_modules()?;
 /// let runtime = Arc::new(context.runtime());
 ///
@@ -56,7 +55,7 @@ pub struct BuildError;
 /// let unit = result?;
 /// let unit = Arc::new(unit);
 /// let vm = Vm::new(runtime, unit);
-/// # Ok(()) }
+/// # Ok::<_, rune::Error>(())
 /// ```
 pub fn prepare(sources: &mut Sources) -> Build<'_> {
     Build {

--- a/crates/rune/src/compile/context.rs
+++ b/crates/rune/src/compile/context.rs
@@ -187,14 +187,13 @@ impl Context {
     /// use rune::{Context, Vm, Unit};
     /// use std::sync::Arc;
     ///
-    /// # fn main() -> rune::Result<()> {
     /// let context = Context::with_default_modules()?;
     ///
     /// let runtime = Arc::new(context.runtime());
     /// let unit = Arc::new(Unit::default());
     ///
     /// let vm = Vm::new(runtime, unit);
-    /// # Ok(()) }
+    /// # Ok::<_, rune::Error>(())
     /// ```
     pub fn runtime(&self) -> RuntimeContext {
         RuntimeContext::new(self.functions.clone(), self.constants.clone())
@@ -291,6 +290,7 @@ impl Context {
     }
 
     /// Lookup meta by its hash.
+    #[cfg(feature = "doc")]
     pub(crate) fn lookup_meta_by_hash(&self, hash: Hash) -> Option<&PrivMeta> {
         self.meta.get(&hash)
     }

--- a/crates/rune/src/compile/meta.rs
+++ b/crates/rune/src/compile/meta.rs
@@ -255,6 +255,7 @@ pub struct Signature {
     /// Arguments.
     pub(crate) args: Option<usize>,
     /// Return type of the function.
+    #[cfg_attr(not(feature = "doc"), allow(unused))]
     pub(crate) return_type: Option<Hash>,
     /// The kind of a signature.
     pub(crate) kind: SignatureKind,

--- a/crates/rune/src/compile/module.rs
+++ b/crates/rune/src/compile/module.rs
@@ -681,20 +681,12 @@ impl Module {
 
         let value = match value.to_value() {
             VmResult::Ok(v) => v,
-            VmResult::Err(e) => {
-                return Err(ContextError::ValueError {
-                    error: e.into_error(),
-                })
-            }
+            VmResult::Err(error) => return Err(ContextError::ValueError { error }),
         };
 
         let constant_value = match <ConstValue as FromValue>::from_value(value) {
             VmResult::Ok(v) => v,
-            VmResult::Err(e) => {
-                return Err(ContextError::ValueError {
-                    error: e.into_error(),
-                })
-            }
+            VmResult::Err(error) => return Err(ContextError::ValueError { error }),
         };
 
         self.constants.insert(name, constant_value);

--- a/crates/rune/src/diagnostics/emit.rs
+++ b/crates/rune/src/diagnostics/emit.rs
@@ -97,7 +97,7 @@ impl VmError {
                 None => continue,
             };
 
-            for ip in [l.ip].into_iter().chain(l.frames.iter().rev().map(|v| v.ip())) {
+            for ip in [l.ip].into_iter().chain(l.frames.iter().rev().map(|v| v.ip)) {
                 let debug_inst = match debug_info.instruction_at(ip) {
                     Some(debug_inst) => debug_inst,
                     None => continue,

--- a/crates/rune/src/diagnostics/mod.rs
+++ b/crates/rune/src/diagnostics/mod.rs
@@ -11,7 +11,6 @@
 //! use rune::termcolor::{ColorChoice, StandardStream};
 //! use rune::{Sources, Diagnostics};
 //!
-//! # fn main() -> rune::Result<()> {
 //! let mut sources = Sources::new();
 //!
 //! let mut diagnostics = Diagnostics::new();
@@ -28,7 +27,7 @@
 //! }
 //!
 //! let unit = result?;
-//! # Ok(()) }
+//! # Ok::<_, rune::Error>(())
 //! ```
 
 use crate::ast::Span;
@@ -82,7 +81,6 @@ impl Mode {
 /// use rune::{Sources, Diagnostics};
 /// use rune::termcolor::{StandardStream, ColorChoice};
 ///
-/// # fn main() -> rune::Result<()> {
 /// let mut sources = Sources::new();
 /// let mut diagnostics = Diagnostics::new();
 ///
@@ -92,7 +90,7 @@ impl Mode {
 ///     let mut writer = StandardStream::stderr(ColorChoice::Always);
 ///     diagnostics.emit(&mut writer, &sources)?;
 /// }
-/// # Ok(()) }
+/// # Ok::<_, rune::Error>(())
 /// ```
 #[derive(Debug)]
 pub struct Diagnostics {

--- a/crates/rune/src/doc/static/function.html.hbs
+++ b/crates/rune/src/doc/static/function.html.hbs
@@ -3,7 +3,7 @@
 {{#each fonts}}<link rel="preload" as="font" type="font/woff2" crossorigin="" href="{{this}}">{{/each}}
 {{#each css}}<link rel="stylesheet" type="text/css" href="{{this}}">{{/each}}
 <body>
-<h3 class="title">Function {{literal module}}::<span class="fn">{{name}}({{args}})</span></h3>
+<h3 class="title">Function {{literal module}}::<span class="fn">{{name}}</span>({{args}})</h3>
 {{#if this.doc}}{{literal this.doc}}{{/if}}
 </body>
 </html>

--- a/crates/rune/src/exported_macros.rs
+++ b/crates/rune/src/exported_macros.rs
@@ -1,0 +1,11 @@
+/// Helper to perform the try operation over
+/// [`VmResult`][crate::runtime::VmResult].
+#[macro_export]
+macro_rules! vm_try {
+    ($expr:expr) => {
+        match $crate::runtime::try_result($expr) {
+            $crate::runtime::VmResult::Ok(value) => value,
+            $crate::runtime::VmResult::Err(err) => return $crate::runtime::VmResult::Err(err),
+        }
+    };
+}

--- a/crates/rune/src/internal_macros.rs
+++ b/crates/rune/src/internal_macros.rs
@@ -1,3 +1,14 @@
+/// Helper to perform the try operation over
+/// [`VmResult`][crate::runtime::VmResult].
+macro_rules! vm_try {
+    ($expr:expr) => {
+        match $crate::runtime::try_result($expr) {
+            $crate::runtime::VmResult::Ok(value) => value,
+            $crate::runtime::VmResult::Err(err) => return $crate::runtime::VmResult::Err(err),
+        }
+    }
+}
+
 /// Helper macro to construct an error type.
 macro_rules! error {
     (

--- a/crates/rune/src/internal_macros.rs
+++ b/crates/rune/src/internal_macros.rs
@@ -1,14 +1,3 @@
-/// Helper to perform the try operation over
-/// [`VmResult`][crate::runtime::VmResult].
-macro_rules! vm_try {
-    ($expr:expr) => {
-        match $crate::runtime::try_result($expr) {
-            $crate::runtime::VmResult::Ok(value) => value,
-            $crate::runtime::VmResult::Err(err) => return $crate::runtime::VmResult::Err(err),
-        }
-    }
-}
-
 /// Helper macro to construct an error type.
 macro_rules! error {
     (

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -75,7 +75,7 @@
 //! [`termcolor`]: https://docs.rs/termcolor
 //!
 //! ```rust
-//! use rune::{Context, Diagnostics, FromValue, Source, Sources, Vm};
+//! use rune::{Context, Diagnostics, Source, Sources, Vm};
 //! use rune::termcolor::{ColorChoice, StandardStream};
 //! use std::sync::Arc;
 //!
@@ -110,7 +110,7 @@
 //!     let mut vm = Vm::new(runtime, Arc::new(unit));
 //!
 //!     let output = vm.call(["add"], (10i64, 20i64))?;
-//!     let output = i64::from_value(output)?;
+//!     let output: i64 = rune::from_value(output)?;
 //!
 //!     println!("{}", output);
 //!     Ok(())

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -183,6 +183,9 @@ pub type Error = anyhow::Error;
 mod internal_macros;
 
 #[macro_use]
+mod exported_macros;
+
+#[macro_use]
 pub mod ast;
 
 cfg_emit! {

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -225,7 +225,7 @@ pub mod parse;
 pub mod query;
 
 pub mod runtime;
-pub use self::runtime::{FromValue, ToValue, Unit, Value, Vm};
+pub use self::runtime::{from_value, to_value, FromValue, ToValue, Unit, Value, Vm};
 
 mod shared;
 

--- a/crates/rune/src/macros/mod.rs
+++ b/crates/rune/src/macros/mod.rs
@@ -8,7 +8,7 @@
 //! where the macro was invoked.
 //!
 //! ```
-//! use rune::{T, Context, FromValue, Module, Vm};
+//! use rune::{T, Context, Module, Vm};
 //! use rune::ast;
 //! use rune::macros::{quote, MacroContext, TokenStream};
 //! use rune::parse::Parser;
@@ -37,7 +37,6 @@
 //!     Ok(quote!(#output).into_token_stream(ctx))
 //! }
 //!
-//! # fn main() -> rune::Result<()> {
 //! let mut m = Module::new();
 //! m.macro_(["concat_idents"], concat_idents)?;
 //!
@@ -63,10 +62,10 @@
 //!
 //! let mut vm = Vm::new(runtime, unit);
 //! let value = vm.call(["main"], ())?;
-//! let value = u32::from_value(value)?;
+//! let value: u32 = rune::from_value(value)?;
 //!
 //! assert_eq!(value, 42);
-//! # Ok(()) }
+//! # Ok::<_, rune::Error>(())
 //! ```
 
 mod format_args;

--- a/crates/rune/src/modules/any.rs
+++ b/crates/rune/src/modules/any.rs
@@ -1,6 +1,6 @@
 //! `std::any` module.
 
-use crate::runtime::{Protocol, Value};
+use crate::runtime::{Protocol, Value, VmResult};
 use crate::{Any, ContextError, Module};
 use std::any::TypeId as StdTypeId;
 use std::fmt;
@@ -11,8 +11,8 @@ use std::fmt::Write;
 #[repr(transparent)]
 struct TypeId(StdTypeId);
 
-fn type_id_of_val(item: Value) -> TypeId {
-    unsafe { std::mem::transmute(item.type_hash().expect("no type known for item!")) }
+fn type_id_of_val(item: Value) -> VmResult<TypeId> {
+    VmResult::Ok(unsafe { std::mem::transmute(vm_try!(item.type_hash())) })
 }
 
 fn format_type_id(item: &TypeId, buf: &mut String) -> fmt::Result {

--- a/crates/rune/src/modules/char.rs
+++ b/crates/rune/src/modules/char.rs
@@ -1,6 +1,6 @@
 //! The `std::char` module.
 
-use crate::runtime::{Value, VmError, VmErrorKind};
+use crate::runtime::{Value, VmError, VmErrorKind, VmResult};
 use crate::{ContextError, Module};
 use std::char::ParseCharError;
 
@@ -33,8 +33,8 @@ pub fn module() -> Result<Module, ContextError> {
 /// assert_eq!(c.to_int(), 80);
 /// ```
 #[rune::function(instance)]
-fn to_int(value: char) -> Result<Value, VmError> {
-    Ok((value as i64).into())
+fn to_int(value: char) -> Value {
+    (value as i64).into()
 }
 
 /// Try to convert a number into a character.
@@ -46,13 +46,13 @@ fn to_int(value: char) -> Result<Value, VmError> {
 /// assert!(c.is_some());
 /// ```
 #[rune::function]
-fn from_int(value: i64) -> Result<Option<Value>, VmError> {
+fn from_int(value: i64) -> VmResult<Option<Value>> {
     if value < 0 {
-        Err(VmError::from(VmErrorKind::Underflow))
+        VmResult::Err(VmError::from(VmErrorKind::Underflow))
     } else if value > u32::MAX as i64 {
-        Err(VmError::from(VmErrorKind::Overflow))
+        VmResult::Err(VmError::from(VmErrorKind::Overflow))
     } else {
-        Ok(std::char::from_u32(value as u32).map(|v| v.into()))
+        VmResult::Ok(std::char::from_u32(value as u32).map(|v| v.into()))
     }
 }
 

--- a/crates/rune/src/modules/char.rs
+++ b/crates/rune/src/modules/char.rs
@@ -1,6 +1,6 @@
 //! The `std::char` module.
 
-use crate::runtime::{Value, VmError, VmErrorKind, VmResult};
+use crate::runtime::{Value, VmErrorKind, VmResult};
 use crate::{ContextError, Module};
 use std::char::ParseCharError;
 
@@ -48,9 +48,9 @@ fn to_int(value: char) -> Value {
 #[rune::function]
 fn from_int(value: i64) -> VmResult<Option<Value>> {
     if value < 0 {
-        VmResult::Err(VmError::from(VmErrorKind::Underflow))
+        VmResult::err(VmErrorKind::Underflow)
     } else if value > u32::MAX as i64 {
-        VmResult::Err(VmError::from(VmErrorKind::Overflow))
+        VmResult::err(VmErrorKind::Overflow)
     } else {
         VmResult::Ok(std::char::from_u32(value as u32).map(|v| v.into()))
     }

--- a/crates/rune/src/modules/collections.rs
+++ b/crates/rune/src/modules/collections.rs
@@ -1,8 +1,6 @@
 //! `std::collections` module.
 
-use crate::runtime::{
-    Iterator, IteratorTrait, Key, Protocol, Ref, Value, VmError, VmErrorKind, VmResult,
-};
+use crate::runtime::{Iterator, IteratorTrait, Key, Protocol, Ref, Value, VmErrorKind, VmResult};
 use crate::{Any, ContextError, Module};
 use std::fmt;
 
@@ -377,10 +375,10 @@ impl VecDeque {
 
     fn get(&self, index: usize) -> VmResult<Value> {
         if index > self.inner.len() {
-            return VmResult::Err(VmError::from(VmErrorKind::OutOfRange {
+            return VmResult::err(VmErrorKind::OutOfRange {
                 index: index.into(),
                 len: self.inner.len().into(),
-            }));
+            });
         }
 
         VmResult::Ok(self.inner[index].clone())
@@ -388,10 +386,10 @@ impl VecDeque {
 
     fn set(&mut self, index: usize, value: Value) -> VmResult<()> {
         if index > self.inner.len() {
-            return VmResult::Err(VmError::from(VmErrorKind::OutOfRange {
+            return VmResult::err(VmErrorKind::OutOfRange {
                 index: index.into(),
                 len: self.inner.len().into(),
-            }));
+            });
         }
 
         self.inner[index] = value;

--- a/crates/rune/src/modules/core.rs
+++ b/crates/rune/src/modules/core.rs
@@ -2,7 +2,7 @@
 
 use crate::macros::{quote, FormatArgs, MacroContext, TokenStream};
 use crate::parse::Parser;
-use crate::runtime::{Panic, Tuple, Value};
+use crate::runtime::{Panic, Tuple, Value, VmResult};
 use crate::{ContextError, Module};
 
 /// Construct the `std` module.
@@ -26,8 +26,8 @@ pub fn module() -> Result<Module, ContextError> {
     Ok(module)
 }
 
-fn panic_impl(m: &str) -> Result<(), Panic> {
-    Err(Panic::custom(m.to_owned()))
+fn panic_impl(m: &str) -> VmResult<()> {
+    VmResult::err(Panic::custom(m.to_owned()))
 }
 
 fn is_readable(value: Value) -> bool {

--- a/crates/rune/src/modules/future.rs
+++ b/crates/rune/src/modules/future.rs
@@ -25,7 +25,7 @@ where
     for (index, value) in values.into_iter().enumerate() {
         let future = match value {
             Value::Future(future) => vm_try!(future.clone().into_mut()),
-            value => return VmResult::Err(vm_try!(VmError::bad_argument::<Future>(index, value))),
+            value => return VmResult::err(vm_try!(VmError::bad_argument::<Future>(index, value))),
         };
 
         futures.push(SelectFuture::new(index, future));
@@ -54,17 +54,17 @@ async fn join(value: Value) -> VmResult<Value> {
                 try_join_impl(vec.iter(), vec.len(), Value::vec).await
             ))
         }
-        value => VmResult::Err(vm_try!(VmError::bad_argument::<Vec<Value>>(0, &value))),
+        value => VmResult::err(vm_try!(VmError::bad_argument::<Vec<Value>>(0, &value))),
     }
 }
 
 /// The join implementation.
 fn raw_join(stack: &mut Stack, args: usize) -> VmResult<()> {
     if args != 1 {
-        return VmResult::Err(VmError::from(VmErrorKind::BadArgumentCount {
+        return VmResult::err(VmErrorKind::BadArgumentCount {
             actual: args,
             expected: 1,
-        }));
+        });
     }
 
     let value = vm_try!(stack.pop());

--- a/crates/rune/src/modules/future.rs
+++ b/crates/rune/src/modules/future.rs
@@ -1,7 +1,7 @@
 //! The `std::future` module.
 
 use crate::runtime::future::SelectFuture;
-use crate::runtime::{Future, Shared, Stack, Value, VmError, VmErrorKind, VmResult};
+use crate::runtime::{Future, Shared, Stack, Value, VmErrorKind, VmResult};
 use crate::{ContextError, Module};
 
 /// Construct the `std::future` module.
@@ -25,7 +25,9 @@ where
     for (index, value) in values.into_iter().enumerate() {
         let future = match value {
             Value::Future(future) => vm_try!(future.clone().into_mut()),
-            value => return VmResult::err(vm_try!(VmError::bad_argument::<Future>(index, value))),
+            value => {
+                return VmResult::err(vm_try!(VmErrorKind::bad_argument::<Future>(index, value)))
+            }
         };
 
         futures.push(SelectFuture::new(index, future));
@@ -54,7 +56,7 @@ async fn join(value: Value) -> VmResult<Value> {
                 try_join_impl(vec.iter(), vec.len(), Value::vec).await
             ))
         }
-        value => VmResult::err(vm_try!(VmError::bad_argument::<Vec<Value>>(0, &value))),
+        value => VmResult::err(vm_try!(VmErrorKind::bad_argument::<Vec<Value>>(0, &value))),
     }
 }
 

--- a/crates/rune/src/modules/io.rs
+++ b/crates/rune/src/modules/io.rs
@@ -8,7 +8,7 @@ use std::io::Write as _;
 use crate as rune;
 use crate::macros::{quote, FormatArgs, MacroContext, TokenStream};
 use crate::parse::Parser;
-use crate::runtime::{Panic, Protocol, Stack, Value, VmError, VmResult};
+use crate::runtime::{Panic, Protocol, Stack, Value, VmResult};
 use crate::{ContextError, Module};
 
 /// Construct the `std::io` module.
@@ -41,7 +41,7 @@ fn dbg_impl(stack: &mut Stack, args: usize) -> VmResult<()> {
     let mut stdout = stdout.lock();
 
     for value in vm_try!(stack.drain(args)) {
-        vm_try!(writeln!(stdout, "{:?}", value).map_err(VmError::panic));
+        vm_try!(writeln!(stdout, "{:?}", value).map_err(Panic::custom));
     }
 
     stack.push(Value::Unit);

--- a/crates/rune/src/modules/io.rs
+++ b/crates/rune/src/modules/io.rs
@@ -78,10 +78,15 @@ pub(crate) fn print_macro(
 /// print("Hi!");
 /// ```
 #[rune::function(path = print)]
-fn print_impl(m: &str) -> Result<(), Panic> {
+fn print_impl(m: &str) -> VmResult<()> {
     let stdout = io::stdout();
     let mut stdout = stdout.lock();
-    write!(stdout, "{}", m).map_err(Panic::custom)
+
+    if let Err(error) = write!(stdout, "{}", m) {
+        return VmResult::err(Panic::custom(error));
+    }
+
+    VmResult::Ok(())
 }
 
 /// Implementation for the `println!` macro.
@@ -106,8 +111,13 @@ pub(crate) fn println_macro(
 /// println("Hi!");
 /// ```
 #[rune::function(path = println)]
-fn println_impl(message: &str) -> Result<(), Panic> {
+fn println_impl(message: &str) -> VmResult<()> {
     let stdout = io::stdout();
     let mut stdout = stdout.lock();
-    writeln!(stdout, "{}", message).map_err(Panic::custom)
+
+    if let Err(error) = writeln!(stdout, "{}", message) {
+        return VmResult::err(Panic::custom(error));
+    }
+
+    VmResult::Ok(())
 }

--- a/crates/rune/src/modules/iter.rs
+++ b/crates/rune/src/modules/iter.rs
@@ -1,7 +1,7 @@
 //! The `std::iter` module.
 
 use crate as rune;
-use crate::runtime::{FromValue, Iterator, Object, Protocol, Tuple, TypeOf, Value, Vec, VmError};
+use crate::runtime::{FromValue, Iterator, Object, Protocol, Tuple, TypeOf, Value, Vec, VmResult};
 use crate::{ContextError, Module, Params};
 
 /// Construct the `std::iter` module.
@@ -87,22 +87,22 @@ fn range(start: i64, end: i64) -> Iterator {
     Iterator::from_double_ended("std::iter::Range", start..end)
 }
 
-fn collect_vec(it: Iterator) -> Result<Vec, VmError> {
-    Ok(Vec::from(it.collect::<Value>()?))
+fn collect_vec(it: Iterator) -> VmResult<Vec> {
+    VmResult::Ok(Vec::from(vm_try!(it.collect::<Value>())))
 }
 
-fn collect_tuple(it: Iterator) -> Result<Tuple, VmError> {
-    Ok(Tuple::from(it.collect::<Value>()?))
+fn collect_tuple(it: Iterator) -> VmResult<Tuple> {
+    VmResult::Ok(Tuple::from(vm_try!(it.collect::<Value>())))
 }
 
-fn collect_object(mut it: Iterator) -> Result<Object, VmError> {
+fn collect_object(mut it: Iterator) -> VmResult<Object> {
     let (cap, _) = it.size_hint();
     let mut object = Object::with_capacity(cap);
 
-    while let Some(value) = it.next()? {
-        let (key, value) = <(String, Value)>::from_value(value)?;
+    while let Some(value) = vm_try!(it.next()) {
+        let (key, value) = vm_try!(<(String, Value)>::from_value(value));
         object.insert(key, value);
     }
 
-    Ok(object)
+    VmResult::Ok(object)
 }

--- a/crates/rune/src/modules/mem.rs
+++ b/crates/rune/src/modules/mem.rs
@@ -1,7 +1,7 @@
 //! The `std::mem` module.
 
 use crate as rune;
-use crate::runtime::{Value, VmError};
+use crate::runtime::{Value, VmResult};
 use crate::{ContextError, Module};
 
 /// Construct the `std` module.
@@ -25,7 +25,7 @@ pub fn module() -> Result<Module, ContextError> {
 /// drop(v);
 /// ```
 #[rune::function]
-fn drop(value: Value) -> Result<(), VmError> {
-    value.take()?;
-    Ok(())
+fn drop(value: Value) -> VmResult<()> {
+    vm_try!(value.take());
+    VmResult::Ok(())
 }

--- a/crates/rune/src/modules/option.rs
+++ b/crates/rune/src/modules/option.rs
@@ -98,7 +98,7 @@ fn map_impl(option: &Option<Value>, then: Function) -> VmResult<Option<Value>> {
 fn and_then_impl(option: &Option<Value>, then: Function) -> VmResult<Option<Value>> {
     match option {
         // no need to clone v, passing the same reference forward
-        Some(v) => VmResult::Ok(Some(vm_try!(then.call::<_, _>((v,))))),
+        Some(v) => VmResult::Ok(vm_try!(then.call::<_, _>((v,)))),
         None => VmResult::Ok(None),
     }
 }

--- a/crates/rune/src/modules/option.rs
+++ b/crates/rune/src/modules/option.rs
@@ -1,7 +1,7 @@
 //! The `std::option` module.
 
 use crate as rune;
-use crate::runtime::{Function, Iterator, Protocol, Shared, Value, VmError, VmResult};
+use crate::runtime::{Function, Iterator, Panic, Protocol, Shared, Value, VmResult};
 use crate::{ContextError, Module};
 
 /// Construct the `std::option` module.
@@ -76,16 +76,14 @@ fn option_iter(option: &Option<Value>) -> Iterator {
 fn unwrap_impl(option: Option<Value>) -> VmResult<Value> {
     match option {
         Some(some) => VmResult::Ok(some),
-        None => VmResult::err(VmError::panic(
-            "called `Option::unwrap()` on a `None` value",
-        )),
+        None => VmResult::err(Panic::custom("called `Option::unwrap()` on a `None` value")),
     }
 }
 
 fn expect_impl(option: Option<Value>, message: &str) -> VmResult<Value> {
     match option {
         Some(some) => VmResult::Ok(some),
-        None => VmResult::err(VmError::panic(message.to_owned())),
+        None => VmResult::err(Panic::custom(message.to_owned())),
     }
 }
 

--- a/crates/rune/src/modules/option.rs
+++ b/crates/rune/src/modules/option.rs
@@ -76,7 +76,7 @@ fn option_iter(option: &Option<Value>) -> Iterator {
 fn unwrap_impl(option: Option<Value>) -> VmResult<Value> {
     match option {
         Some(some) => VmResult::Ok(some),
-        None => VmResult::Err(VmError::panic(
+        None => VmResult::err(VmError::panic(
             "called `Option::unwrap()` on a `None` value",
         )),
     }
@@ -85,7 +85,7 @@ fn unwrap_impl(option: Option<Value>) -> VmResult<Value> {
 fn expect_impl(option: Option<Value>, message: &str) -> VmResult<Value> {
     match option {
         Some(some) => VmResult::Ok(some),
-        None => VmResult::Err(VmError::panic(message.to_owned())),
+        None => VmResult::err(VmError::panic(message.to_owned())),
     }
 }
 

--- a/crates/rune/src/modules/result.rs
+++ b/crates/rune/src/modules/result.rs
@@ -34,7 +34,7 @@ fn is_err(result: &Result<Value, Value>) -> bool {
 fn unwrap_impl(result: Result<Value, Value>) -> VmResult<Value> {
     match result {
         Ok(value) => VmResult::Ok(value),
-        Err(err) => VmResult::Err(VmError::panic(format!(
+        Err(err) => VmResult::err(VmError::panic(format!(
             "called `Result::unwrap()` on an `Err` value: {:?}",
             err
         ))),
@@ -44,7 +44,7 @@ fn unwrap_impl(result: Result<Value, Value>) -> VmResult<Value> {
 fn expect_impl(result: Result<Value, Value>, message: &str) -> VmResult<Value> {
     match result {
         Ok(value) => VmResult::Ok(value),
-        Err(err) => VmResult::Err(VmError::panic(format!("{}: {:?}", message, err))),
+        Err(err) => VmResult::err(VmError::panic(format!("{}: {:?}", message, err))),
     }
 }
 

--- a/crates/rune/src/modules/result.rs
+++ b/crates/rune/src/modules/result.rs
@@ -1,6 +1,6 @@
 //! The `std::result` module.
 
-use crate::runtime::{Function, Value, VmError, VmResult};
+use crate::runtime::{Function, Panic, Value, VmResult};
 use crate::{ContextError, Module};
 
 /// Construct the `std::result` module.
@@ -34,7 +34,7 @@ fn is_err(result: &Result<Value, Value>) -> bool {
 fn unwrap_impl(result: Result<Value, Value>) -> VmResult<Value> {
     match result {
         Ok(value) => VmResult::Ok(value),
-        Err(err) => VmResult::err(VmError::panic(format!(
+        Err(err) => VmResult::err(Panic::custom(format!(
             "called `Result::unwrap()` on an `Err` value: {:?}",
             err
         ))),
@@ -44,7 +44,7 @@ fn unwrap_impl(result: Result<Value, Value>) -> VmResult<Value> {
 fn expect_impl(result: Result<Value, Value>, message: &str) -> VmResult<Value> {
     match result {
         Ok(value) => VmResult::Ok(value),
-        Err(err) => VmResult::err(VmError::panic(format!("{}: {:?}", message, err))),
+        Err(err) => VmResult::err(Panic::custom(format!("{}: {:?}", message, err))),
     }
 }
 

--- a/crates/rune/src/modules/string.rs
+++ b/crates/rune/src/modules/string.rs
@@ -1,6 +1,6 @@
 //! The `std::string` module.
 
-use crate::runtime::{Bytes, Iterator, Protocol, Value, VmError, VmErrorKind, VmResult};
+use crate::runtime::{Bytes, Iterator, Panic, Protocol, Value, VmErrorKind, VmResult};
 use crate::{Any, ContextError, Module};
 
 /// Construct the `std::string` module.
@@ -88,7 +88,7 @@ fn string_split(this: &str, value: Value) -> VmResult<Iterator> {
             .map(String::from)
             .collect::<Vec<String>>(),
         Value::Char(pat) => this.split(pat).map(String::from).collect::<Vec<String>>(),
-        value => return VmResult::err(vm_try!(VmError::bad_argument::<String>(0, &value))),
+        value => return VmResult::err(vm_try!(VmErrorKind::bad_argument::<String>(0, &value))),
     };
 
     VmResult::Ok(Iterator::from_double_ended(
@@ -171,6 +171,6 @@ fn string_get(s: &str, key: Value) -> VmResult<Option<String>> {
 fn string_index_get(s: &str, key: Value) -> VmResult<String> {
     match vm_try!(string_get(s, key)) {
         Some(slice) => VmResult::Ok(slice),
-        None => VmResult::err(VmError::panic("missing string slice")),
+        None => VmResult::err(Panic::custom("missing string slice")),
     }
 }

--- a/crates/rune/src/modules/string.rs
+++ b/crates/rune/src/modules/string.rs
@@ -88,7 +88,7 @@ fn string_split(this: &str, value: Value) -> VmResult<Iterator> {
             .map(String::from)
             .collect::<Vec<String>>(),
         Value::Char(pat) => this.split(pat).map(String::from).collect::<Vec<String>>(),
-        value => return VmResult::Err(vm_try!(VmError::bad_argument::<String>(0, &value))),
+        value => return VmResult::err(vm_try!(VmError::bad_argument::<String>(0, &value))),
     };
 
     VmResult::Ok(Iterator::from_double_ended(
@@ -154,16 +154,16 @@ fn string_get(s: &str, key: Value) -> VmResult<Option<String>> {
                 RangeLimits::Closed => match (start, end) {
                     (Some(start), Some(end)) => s.get(start..=end),
                     (None, Some(end)) => s.get(..=end),
-                    _ => return VmResult::Err(VmError::from(VmErrorKind::UnsupportedRange)),
+                    _ => return VmResult::err(VmErrorKind::UnsupportedRange),
                 },
             };
 
             VmResult::Ok(out.map(|out| out.to_owned()))
         }
-        index => VmResult::Err(VmError::from(VmErrorKind::UnsupportedIndexGet {
+        index => VmResult::err(VmErrorKind::UnsupportedIndexGet {
             target: String::type_info(),
             index: vm_try!(index.type_info()),
-        })),
+        }),
     }
 }
 
@@ -171,6 +171,6 @@ fn string_get(s: &str, key: Value) -> VmResult<Option<String>> {
 fn string_index_get(s: &str, key: Value) -> VmResult<String> {
     match vm_try!(string_get(s, key)) {
         Some(slice) => VmResult::Ok(slice),
-        None => VmResult::Err(VmError::panic("missing string slice")),
+        None => VmResult::err(VmError::panic("missing string slice")),
     }
 }

--- a/crates/rune/src/parse/parser.rs
+++ b/crates/rune/src/parse/parser.rs
@@ -15,10 +15,9 @@ use std::ops;
 /// use rune::SourceId;
 /// use rune::parse::Parser;
 ///
-/// # fn main() -> rune::Result<()> {
 /// let mut parser = Parser::new("fn foo() {}", SourceId::empty(), false);
 /// let ast = parser.parse::<ast::ItemFn>()?;
-/// # Ok(()) }
+/// # Ok::<_, rune::Error>(())
 /// ```
 #[derive(Debug)]
 pub struct Parser<'a> {

--- a/crates/rune/src/runtime/access.rs
+++ b/crates/rune/src/runtime/access.rs
@@ -321,13 +321,12 @@ impl<'a, T: ?Sized> BorrowRef<'a, T> {
     /// ```
     /// use rune::runtime::{BorrowRef, Shared};
     ///
-    /// # fn main() -> rune::Result<()> {
     /// let vec = Shared::<Vec<u32>>::new(vec![1, 2, 3, 4]);
     /// let vec = vec.borrow_ref()?;
     /// let value: BorrowRef<[u32]> = BorrowRef::map(vec, |vec| &vec[0..2]);
     ///
     /// assert_eq!(&*value, &[1u32, 2u32][..]);
-    /// # Ok(()) }
+    /// # Ok::<_, rune::Error>(())
     /// ```
     pub fn map<M, U: ?Sized>(this: Self, m: M) -> BorrowRef<'a, U>
     where
@@ -346,13 +345,12 @@ impl<'a, T: ?Sized> BorrowRef<'a, T> {
     /// ```
     /// use rune::runtime::{BorrowRef, Shared};
     ///
-    /// # fn main() -> rune::Result<()> {
     /// let vec = Shared::<Vec<u32>>::new(vec![1, 2, 3, 4]);
     /// let vec = vec.borrow_ref()?;
     /// let mut value: Option<BorrowRef<[u32]>> = BorrowRef::try_map(vec, |vec| vec.get(0..2));
     ///
     /// assert_eq!(value.as_deref(), Some(&[1u32, 2u32][..]));
-    /// # Ok(()) }
+    /// # Ok::<_, rune::Error>(())
     /// ```
     pub fn try_map<M, U: ?Sized>(this: Self, m: M) -> Option<BorrowRef<'a, U>>
     where
@@ -461,13 +459,12 @@ impl<'a, T: ?Sized> BorrowMut<'a, T> {
     /// ```
     /// use rune::runtime::{BorrowMut, Shared};
     ///
-    /// # fn main() -> rune::Result<()> {
     /// let vec = Shared::<Vec<u32>>::new(vec![1, 2, 3, 4]);
     /// let vec = vec.borrow_mut()?;
     /// let value: BorrowMut<[u32]> = BorrowMut::map(vec, |vec| &mut vec[0..2]);
     ///
     /// assert_eq!(&*value, &mut [1u32, 2u32][..]);
-    /// # Ok(()) }
+    /// # Ok::<_, rune::Error>(())
     /// ```
     pub fn map<M, U: ?Sized>(this: Self, m: M) -> BorrowMut<'a, U>
     where
@@ -486,13 +483,12 @@ impl<'a, T: ?Sized> BorrowMut<'a, T> {
     /// ```
     /// use rune::runtime::{BorrowMut, Shared};
     ///
-    /// # fn main() -> rune::Result<()> {
     /// let vec = Shared::<Vec<u32>>::new(vec![1, 2, 3, 4]);
     /// let vec = vec.borrow_mut()?;
     /// let mut value: Option<BorrowMut<[u32]>> = BorrowMut::try_map(vec, |vec| vec.get_mut(0..2));
     ///
     /// assert_eq!(value.as_deref_mut(), Some(&mut [1u32, 2u32][..]));
-    /// # Ok(()) }
+    /// # Ok::<_, rune::Error>(())
     /// ```
     pub fn try_map<M, U: ?Sized>(this: Self, m: M) -> Option<BorrowMut<'a, U>>
     where

--- a/crates/rune/src/runtime/bytes.rs
+++ b/crates/rune/src/runtime/bytes.rs
@@ -210,7 +210,7 @@ mod tests {
         let shared = Value::Bytes(Shared::new(Bytes::new()));
 
         let _ = {
-            let shared = shared.into_bytes()?;
+            let shared = shared.into_bytes().into_result()?;
             let out = shared.borrow_ref()?.clone();
             out
         };

--- a/crates/rune/src/runtime/call.rs
+++ b/crates/rune/src/runtime/call.rs
@@ -25,7 +25,10 @@ impl Call {
             Call::Stream => Value::from(Stream::new(vm)),
             Call::Generator => Value::from(Generator::new(vm)),
             Call::Immediate => vm_try!(vm.complete()),
-            Call::Async => Value::from(Future::new(vm.async_complete())),
+            Call::Async => {
+                let mut execution = vm.into_execution();
+                Value::from(Future::new(async move { execution.async_complete().await }))
+            }
         })
     }
 }

--- a/crates/rune/src/runtime/call.rs
+++ b/crates/rune/src/runtime/call.rs
@@ -1,4 +1,4 @@
-use crate::runtime::{Future, Generator, Stream, Value, Vm, VmError};
+use crate::runtime::{Future, Generator, Stream, Value, Vm, VmResult};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -20,11 +20,11 @@ pub enum Call {
 impl Call {
     /// Perform the call with the given virtual machine.
     #[inline]
-    pub(crate) fn call_with_vm(self, vm: Vm) -> Result<Value, VmError> {
-        Ok(match self {
+    pub(crate) fn call_with_vm(self, vm: Vm) -> VmResult<Value> {
+        VmResult::Ok(match self {
             Call::Stream => Value::from(Stream::new(vm)),
             Call::Generator => Value::from(Generator::new(vm)),
-            Call::Immediate => vm.complete()?,
+            Call::Immediate => vm_try!(vm.complete()),
             Call::Async => Value::from(Future::new(vm.async_complete())),
         })
     }

--- a/crates/rune/src/runtime/const_value.rs
+++ b/crates/rune/src/runtime/const_value.rs
@@ -1,6 +1,6 @@
 use crate::collections::HashMap;
 use crate::runtime::{
-    Bytes, FromValue, Object, Shared, StaticString, ToValue, Tuple, TypeInfo, Value, Vec, VmError,
+    Bytes, FromValue, Object, Shared, StaticString, ToValue, Tuple, TypeInfo, Value, Vec,
     VmErrorKind, VmResult,
 };
 use serde::{Deserialize, Serialize};
@@ -169,9 +169,9 @@ impl FromValue for ConstValue {
                 Self::Object(const_object)
             }
             value => {
-                return VmResult::Err(VmError::from(VmErrorKind::ConstNotSupported {
+                return VmResult::err(VmErrorKind::ConstNotSupported {
                     actual: vm_try!(value.type_info()),
-                }))
+                })
             }
         })
     }

--- a/crates/rune/src/runtime/env.rs
+++ b/crates/rune/src/runtime/env.rs
@@ -7,7 +7,7 @@
 //!
 //! See the corresponding function for documentation.
 
-use crate::runtime::{RuntimeContext, Unit, VmError, VmErrorKind, VmResult};
+use crate::runtime::{RuntimeContext, Unit, VmErrorKind, VmResult};
 use std::cell::Cell;
 use std::ptr;
 use std::sync::Arc;
@@ -23,7 +23,7 @@ where
     let Env { context, unit } = env;
 
     if context.is_null() || unit.is_null() {
-        return VmResult::Err(VmError::from(VmErrorKind::MissingInterfaceEnvironment));
+        return VmResult::err(VmErrorKind::MissingInterfaceEnvironment);
     }
 
     // Safety: context and unit can only be registered publicly through

--- a/crates/rune/src/runtime/env.rs
+++ b/crates/rune/src/runtime/env.rs
@@ -7,7 +7,7 @@
 //!
 //! See the corresponding function for documentation.
 
-use crate::runtime::{RuntimeContext, Unit, VmError, VmErrorKind};
+use crate::runtime::{RuntimeContext, Unit, VmError, VmErrorKind, VmResult};
 use std::cell::Cell;
 use std::ptr;
 use std::sync::Arc;
@@ -15,15 +15,15 @@ use std::sync::Arc;
 thread_local! { static ENV: Cell<Env> = Cell::new(Env::null()) }
 
 /// Call the given closure with access to the checked environment.
-pub(crate) fn with<F, T>(c: F) -> Result<T, VmError>
+pub(crate) fn with<F, T>(c: F) -> VmResult<T>
 where
-    F: FnOnce(&Arc<RuntimeContext>, &Arc<Unit>) -> Result<T, VmError>,
+    F: FnOnce(&Arc<RuntimeContext>, &Arc<Unit>) -> VmResult<T>,
 {
     let env = ENV.with(|env| env.get());
     let Env { context, unit } = env;
 
     if context.is_null() || unit.is_null() {
-        return Err(VmError::from(VmErrorKind::MissingInterfaceEnvironment));
+        return VmResult::Err(VmError::from(VmErrorKind::MissingInterfaceEnvironment));
     }
 
     // Safety: context and unit can only be registered publicly through

--- a/crates/rune/src/runtime/from_value.rs
+++ b/crates/rune/src/runtime/from_value.rs
@@ -1,12 +1,51 @@
+use std::sync::Arc;
+
 use crate::runtime::{
-    AnyObj, Mut, RawMut, RawRef, Ref, Shared, StaticString, Value, VmErrorKind, VmIntegerRepr,
-    VmResult,
+    AnyObj, Mut, RawMut, RawRef, Ref, Shared, StaticString, Value, VmError, VmErrorKind,
+    VmIntegerRepr, VmResult,
 };
 use crate::Any;
-use std::sync::Arc;
 
 #[doc(inline)]
 pub use rune_macros::FromValue;
+
+/// Convert something into the dynamic [`Value`].
+///
+/// # Examples
+///
+/// ```
+/// use rune::{FromValue, ToValue, Vm};
+/// use std::sync::Arc;
+///
+/// #[derive(ToValue)]
+/// struct Foo {
+///     field: u64,
+/// }
+///
+/// # fn main() -> rune::Result<()> {
+/// let mut sources = rune::sources! {
+///     entry => {
+///         pub fn main(foo) {
+///             foo.field + 1
+///         }
+///     }
+/// };
+///
+/// let unit = rune::prepare(&mut sources).build()?;
+///
+/// let mut vm = Vm::without_runtime(Arc::new(unit));
+/// let foo = vm.call(["main"], (Foo { field: 42 },))?;
+/// let foo: u64 = rune::from_value(foo)?;
+///
+/// assert_eq!(foo, 43);
+/// # Ok(()) }
+/// ```
+pub fn from_value<T>(value: Value) -> Result<T, VmError>
+where
+    T: FromValue,
+{
+    T::from_value(value).into_result()
+}
 
 /// Trait for converting types from the dynamic [Value] container.
 ///

--- a/crates/rune/src/runtime/from_value.rs
+++ b/crates/rune/src/runtime/from_value.rs
@@ -14,7 +14,7 @@ pub use rune_macros::FromValue;
 /// # Examples
 ///
 /// ```
-/// use rune::{FromValue, ToValue, Vm};
+/// use rune::{ToValue, Vm};
 /// use std::sync::Arc;
 ///
 /// #[derive(ToValue)]
@@ -22,7 +22,6 @@ pub use rune_macros::FromValue;
 ///     field: u64,
 /// }
 ///
-/// # fn main() -> rune::Result<()> {
 /// let mut sources = rune::sources! {
 ///     entry => {
 ///         pub fn main(foo) {
@@ -38,7 +37,7 @@ pub use rune_macros::FromValue;
 /// let foo: u64 = rune::from_value(foo)?;
 ///
 /// assert_eq!(foo, 43);
-/// # Ok(()) }
+/// # Ok::<_, rune::Error>(())
 /// ```
 pub fn from_value<T>(value: Value) -> Result<T, VmError>
 where
@@ -52,7 +51,7 @@ where
 /// # Examples
 ///
 /// ```
-/// use rune::{Context, FromValue, Sources, Source, Vm};
+/// use rune::{FromValue, Vm};
 /// use std::sync::Arc;
 ///
 /// #[derive(FromValue)]
@@ -60,7 +59,6 @@ where
 ///     field: u64,
 /// }
 ///
-/// # fn main() -> rune::Result<()> {
 /// let mut sources = rune::sources!(entry => {
 ///     pub fn main() { #{field: 42} }
 /// });
@@ -69,10 +67,10 @@ where
 ///
 /// let mut vm = Vm::without_runtime(Arc::new(unit));
 /// let foo = vm.call(["main"], ())?;
-/// let foo = Foo::from_value(foo)?;
+/// let foo: Foo = rune::from_value(foo)?;
 ///
 /// assert_eq!(foo.field, 42);
-/// # Ok(()) }
+/// # Ok::<_, rune::Error>(())
 /// ```
 pub trait FromValue: 'static + Sized {
     /// Try to convert to the given type, from the given value.

--- a/crates/rune/src/runtime/from_value.rs
+++ b/crates/rune/src/runtime/from_value.rs
@@ -203,7 +203,7 @@ impl FromValue for String {
         match value {
             Value::String(string) => VmResult::Ok(vm_try!(string.borrow_ref()).clone()),
             Value::StaticString(string) => VmResult::Ok((**string).to_owned()),
-            actual => VmResult::Err(VmError::expected::<String>(vm_try!(actual.type_info()))),
+            actual => VmResult::err(VmError::expected::<String>(vm_try!(actual.type_info()))),
         }
     }
 }
@@ -212,7 +212,7 @@ impl FromValue for Mut<String> {
     fn from_value(value: Value) -> VmResult<Self> {
         match value {
             Value::String(string) => VmResult::Ok(vm_try!(string.into_mut())),
-            actual => VmResult::Err(VmError::expected::<String>(vm_try!(actual.type_info()))),
+            actual => VmResult::err(VmError::expected::<String>(vm_try!(actual.type_info()))),
         }
     }
 }
@@ -221,7 +221,7 @@ impl FromValue for Ref<String> {
     fn from_value(value: Value) -> VmResult<Self> {
         match value {
             Value::String(string) => VmResult::Ok(vm_try!(string.into_ref())),
-            actual => VmResult::Err(VmError::expected::<String>(vm_try!(actual.type_info()))),
+            actual => VmResult::err(VmError::expected::<String>(vm_try!(actual.type_info()))),
         }
     }
 }
@@ -260,7 +260,7 @@ impl UnsafeFromValue for &str {
                 (string.as_ref().as_str(), StrGuard::StaticString(string))
             }
             actual => {
-                return VmResult::Err(VmError::expected::<String>(vm_try!(actual.type_info())))
+                return VmResult::err(VmError::expected::<String>(vm_try!(actual.type_info())))
             }
         })
     }
@@ -283,7 +283,7 @@ impl UnsafeFromValue for &mut str {
                 // it is live.
                 VmResult::Ok((unsafe { (*s).as_mut_str() }, Some(guard)))
             }
-            actual => VmResult::Err(VmError::expected::<String>(vm_try!(actual.type_info()))),
+            actual => VmResult::err(VmError::expected::<String>(vm_try!(actual.type_info()))),
         }
     }
 
@@ -305,7 +305,7 @@ impl UnsafeFromValue for &String {
             }
             Value::StaticString(string) => (&**string, StrGuard::StaticString(string)),
             actual => {
-                return VmResult::Err(VmError::expected::<String>(vm_try!(actual.type_info())));
+                return VmResult::err(VmError::expected::<String>(vm_try!(actual.type_info())));
             }
         })
     }
@@ -327,7 +327,7 @@ impl UnsafeFromValue for &mut String {
                 (s, guard)
             }
             actual => {
-                return VmResult::Err(VmError::expected::<String>(vm_try!(actual.type_info())));
+                return VmResult::err(VmError::expected::<String>(vm_try!(actual.type_info())));
             }
         })
     }
@@ -413,7 +413,7 @@ macro_rules! impl_number {
                 match integer.try_into() {
                     Ok(number) => VmResult::Ok(number),
                     Err(..) => {
-                        VmResult::Err(VmError::from(VmErrorKind::ValueToIntegerCoercionError {
+                        VmResult::err(VmError::from(VmErrorKind::ValueToIntegerCoercionError {
                             from: VmIntegerRepr::from(integer),
                             to: std::any::type_name::<Self>(),
                         }))

--- a/crates/rune/src/runtime/function.rs
+++ b/crates/rune/src/runtime/function.rs
@@ -1,7 +1,7 @@
 use crate::runtime::{
     Args, Call, ConstValue, FromValue, FunctionHandler, RawRef, Ref, Rtti, RuntimeContext, Shared,
-    Stack, Tuple, Unit, UnsafeFromValue, Value, VariantRtti, Vm, VmCall, VmError, VmErrorKind,
-    VmHalt, VmResult,
+    Stack, Tuple, Unit, UnsafeFromValue, Value, VariantRtti, Vm, VmCall, VmErrorKind, VmHalt,
+    VmResult,
 };
 use crate::shared::AssertSend;
 use crate::Hash;
@@ -935,10 +935,7 @@ impl UnsafeFromValue for &Function {
 
 fn check_args(actual: usize, expected: usize) -> VmResult<()> {
     if actual != expected {
-        return VmResult::Err(VmError::from(VmErrorKind::BadArgumentCount {
-            expected,
-            actual,
-        }));
+        return VmResult::err(VmErrorKind::BadArgumentCount { expected, actual });
     }
 
     VmResult::Ok(())

--- a/crates/rune/src/runtime/function.rs
+++ b/crates/rune/src/runtime/function.rs
@@ -19,11 +19,10 @@ impl Function {
     /// # Examples
     ///
     /// ```
-    /// use rune::{Hash, Vm, FromValue};
+    /// use rune::{Hash, Vm};
     /// use rune::runtime::Function;
     /// use std::sync::Arc;
     ///
-    /// # fn main() -> rune::Result<()> {
     /// let mut sources = rune::sources! {
     ///     entry => {
     ///         pub fn main(function) {
@@ -40,9 +39,9 @@ impl Function {
     /// assert_eq!(function.type_hash(), Hash::EMPTY);
     ///
     /// let value = vm.call(["main"], (function,))?;
-    /// let value = u32::from_value(value)?;
+    /// let value: u32 = rune::from_value(value)?;
     /// assert_eq!(value, 42);
-    /// # Ok(()) }
+    /// # Ok::<_, rune::Error>(())
     /// ```
     pub fn function<Func, Args>(f: Func) -> Self
     where
@@ -61,7 +60,7 @@ impl Function {
     /// # Examples
     ///
     /// ```
-    /// use rune::{Hash, Vm, FromValue};
+    /// use rune::{Hash, Vm};
     /// use rune::runtime::Function;
     /// use std::sync::Arc;
     ///
@@ -82,7 +81,7 @@ impl Function {
     /// assert_eq!(function.type_hash(), Hash::EMPTY);
     ///
     /// let value = vm.async_call(["main"], (function,)).await?;
-    /// let value = u32::from_value(value)?;
+    /// let value: u32 = rune::from_value(value)?;
     /// assert_eq!(value, 42);
     /// # Ok(()) }
     /// ```
@@ -113,11 +112,10 @@ impl Function {
     /// # Examples
     ///
     /// ```
-    /// use rune::{Hash, Vm, FromValue};
+    /// use rune::{Hash, Vm};
     /// use rune::runtime::Function;
     /// use std::sync::Arc;
     ///
-    /// # fn main() -> rune::Result<()> {
     /// let mut sources = rune::sources! {
     ///     entry => {
     ///         fn add(a, b) {
@@ -132,9 +130,9 @@ impl Function {
     /// let mut vm = Vm::without_runtime(Arc::new(unit));
     /// let value = vm.call(["main"], ())?;
     ///
-    /// let value = Function::from_value(value)?;
-    /// assert_eq!(value.call::<_, u32>((1, 2))?, 3);
-    /// # Ok(()) }
+    /// let value: Function = rune::from_value(value)?;
+    /// assert_eq!(value.call::<_, u32>((1, 2)).into_result()?, 3);
+    /// # Ok::<_, rune::Error>(())
     /// ```
     pub fn call<A, T>(&self, args: A) -> VmResult<T>
     where
@@ -222,11 +220,10 @@ impl Function {
     /// [Hash::type_hash].
     ///
     /// ```
-    /// use rune::{Hash, Vm, FromValue};
+    /// use rune::{Hash, Vm};
     /// use rune::runtime::Function;
     /// use std::sync::Arc;
     ///
-    /// # fn main() -> rune::Result<()> {
     /// let mut sources = rune::sources! {
     ///     entry => {
     ///         fn pony() { }
@@ -238,10 +235,10 @@ impl Function {
     /// let unit = rune::prepare(&mut sources).build()?;
     /// let mut vm = Vm::without_runtime(Arc::new(unit));
     /// let pony = vm.call(["main"], ())?;
-    /// let pony = Function::from_value(pony)?;
+    /// let pony: Function = rune::from_value(pony)?;
     ///
     /// assert_eq!(pony.type_hash(), Hash::type_hash(["pony"]));
-    /// # Ok(()) }
+    /// # Ok::<_, rune::Error>(())
     /// ```
     pub fn type_hash(&self) -> Hash {
         self.0.type_hash()
@@ -254,11 +251,10 @@ impl Function {
     /// # Examples
     ///
     /// ```
-    /// use rune::{Hash, Vm, FromValue};
+    /// use rune::{Hash, Vm};
     /// use rune::runtime::Function;
     /// use std::sync::Arc;
     ///
-    /// # fn main() -> rune::Result<()> {
     /// let mut sources = rune::sources! {
     ///     entry => {
     ///         fn pony() { }
@@ -270,13 +266,13 @@ impl Function {
     /// let unit = rune::prepare(&mut sources).build()?;
     /// let mut vm = Vm::without_runtime(Arc::new(unit));
     /// let pony = vm.call(["main"], ())?;
-    /// let pony = Function::from_value(pony)?;
+    /// let pony: Function = rune::from_value(pony)?;
     ///
     /// // This is fine, since `pony` is a free function.
-    /// let pony = pony.into_sync()?;
+    /// let pony = pony.into_sync().into_result()?;
     ///
     /// assert_eq!(pony.type_hash(), Hash::type_hash(["pony"]));
-    /// # Ok(()) }
+    /// # Ok::<_, rune::Error>(())
     /// ```
     ///
     /// The following *does not* work, because we return a closure which tries
@@ -284,11 +280,10 @@ impl Function {
     /// constant value.
     ///
     /// ```
-    /// use rune::{Hash, Vm, FromValue};
+    /// use rune::{Hash, Vm};
     /// use rune::runtime::Function;
     /// use std::sync::Arc;
     ///
-    /// # fn main() -> rune::Result<()> {
     /// let mut sources = rune::sources! {
     ///     entry => {
     ///         fn generator() {
@@ -308,12 +303,12 @@ impl Function {
     /// let unit = rune::prepare(&mut sources).build()?;
     /// let mut vm = Vm::without_runtime(Arc::new(unit));
     /// let closure = vm.call(["main"], ())?;
-    /// let closure = Function::from_value(closure)?;
+    /// let closure: Function = rune::from_value(closure)?;
     ///
     /// // This is *not* fine since the returned closure has captured a
     /// // generator which is not a constant value.
     /// assert!(closure.into_sync().is_err());
-    /// # Ok(()) }
+    /// # Ok::<_, rune::Error>(())
     /// ```
     pub fn into_sync(self) -> VmResult<SyncFunction> {
         VmResult::Ok(SyncFunction(vm_try!(self.0.into_sync())))
@@ -333,7 +328,7 @@ impl SyncFunction {
     /// # Examples
     ///
     /// ```
-    /// use rune::{Hash, Vm, FromValue};
+    /// use rune::{Hash, Vm};
     /// use rune::runtime::SyncFunction;
     /// use std::sync::Arc;
     ///
@@ -352,9 +347,9 @@ impl SyncFunction {
     /// let unit = rune::prepare(&mut sources).build()?;
     /// let mut vm = Vm::without_runtime(Arc::new(unit));
     /// let add = vm.call(["main"], ())?;
-    /// let add = SyncFunction::from_value(add)?;
+    /// let add: SyncFunction = rune::from_value(add)?;
     ///
-    /// let value = add.async_send_call::<_, u32>((1, 2)).await?;
+    /// let value = add.async_send_call::<_, u32>((1, 2)).await.into_result()?;
     /// assert_eq!(value, 3);
     /// # Ok(()) }
     /// ```
@@ -371,11 +366,10 @@ impl SyncFunction {
     /// # Examples
     ///
     /// ```
-    /// use rune::{Hash, Vm, FromValue};
+    /// use rune::{Hash, Vm};
     /// use rune::runtime::SyncFunction;
     /// use std::sync::Arc;
     ///
-    /// # fn main() -> rune::Result<()> {
     /// let mut sources = rune::sources! {
     ///     entry => {
     ///         fn add(a, b) {
@@ -389,10 +383,10 @@ impl SyncFunction {
     /// let unit = rune::prepare(&mut sources).build()?;
     /// let mut vm = Vm::without_runtime(Arc::new(unit));
     /// let add = vm.call(["main"], ())?;
-    /// let add = SyncFunction::from_value(add)?;
+    /// let add: SyncFunction = rune::from_value(add)?;
     ///
-    /// assert_eq!(add.call::<_, u32>((1, 2))?, 3);
-    /// # Ok(()) }
+    /// assert_eq!(add.call::<_, u32>((1, 2)).into_result()?, 3);
+    /// # Ok::<_, rune::Error>(())
     /// ```
     pub fn call<A, T>(&self, args: A) -> VmResult<T>
     where
@@ -410,11 +404,10 @@ impl SyncFunction {
     /// [Hash::type_hash].
     ///
     /// ```
-    /// use rune::{Hash, Vm, FromValue};
+    /// use rune::{Hash, Vm};
     /// use rune::runtime::SyncFunction;
     /// use std::sync::Arc;
     ///
-    /// # fn main() -> rune::Result<()> {
     /// let mut sources = rune::sources! {
     ///     entry => {
     ///         fn pony() { }
@@ -426,10 +419,10 @@ impl SyncFunction {
     /// let unit = rune::prepare(&mut sources).build()?;
     /// let mut vm = Vm::without_runtime(Arc::new(unit));
     /// let pony = vm.call(["main"], ())?;
-    /// let pony = SyncFunction::from_value(pony)?;
+    /// let pony: SyncFunction = rune::from_value(pony)?;
     ///
     /// assert_eq!(pony.type_hash(), Hash::type_hash(["pony"]));
-    /// # Ok(()) }
+    /// # Ok::<_, rune::Error>(())
     /// ```
     pub fn type_hash(&self) -> Hash {
         self.0.type_hash()

--- a/crates/rune/src/runtime/future.rs
+++ b/crates/rune/src/runtime/future.rs
@@ -1,6 +1,6 @@
 use crate::compile::{InstallWith, Named};
 use crate::runtime::{
-    FromValue, Mut, RawMut, RawRef, RawStr, Ref, Shared, ToValue, UnsafeFromValue, Value, VmError,
+    FromValue, Mut, RawMut, RawRef, RawStr, Ref, Shared, ToValue, UnsafeFromValue, Value,
     VmErrorKind, VmResult,
 };
 use pin_project::pin_project;
@@ -51,7 +51,7 @@ impl future::Future for Future {
         let future = match &mut this.future {
             Some(future) => future,
             None => {
-                return Poll::Ready(VmResult::Err(VmError::from(VmErrorKind::FutureCompleted)));
+                return Poll::Ready(VmResult::err(VmErrorKind::FutureCompleted));
             }
         };
 

--- a/crates/rune/src/runtime/generator_state.rs
+++ b/crates/rune/src/runtime/generator_state.rs
@@ -6,11 +6,10 @@ use crate::{compile::Named, InstallWith};
 /// The state of a generator.
 ///
 /// ```
-/// use rune::{Context, FromValue, Value, Vm};
+/// use rune::{Value, Vm};
 /// use rune::runtime::{Generator, GeneratorState};
 /// use std::sync::Arc;
 ///
-/// # fn main() -> rune::Result<()> {
 /// let mut sources = rune::sources! {
 ///     entry => {
 ///         pub fn main() {
@@ -27,28 +26,28 @@ use crate::{compile::Named, InstallWith};
 /// let mut execution = vm.execute(["main"], ())?;
 ///
 /// // Initial resume doesn't take a value.
-/// let first = match execution.resume()? {
-///     GeneratorState::Yielded(first) => i64::from_value(first)?,
+/// let first = match execution.resume().into_result()? {
+///     GeneratorState::Yielded(first) => rune::from_value::<i64>(first)?,
 ///     GeneratorState::Complete(..) => panic!("generator completed"),
 /// };
 ///
 /// assert_eq!(first, 1);
 ///
 /// // Additional resumes require a value.
-/// let second = match execution.resume_with(Value::from(2i64))? {
-///     GeneratorState::Yielded(second) => i64::from_value(second)?,
+/// let second = match execution.resume_with(Value::from(2i64)).into_result()? {
+///     GeneratorState::Yielded(second) => rune::from_value::<i64>(second)?,
 ///     GeneratorState::Complete(..) => panic!("generator completed"),
 /// };
 ///
 /// assert_eq!(second, 3);
 ///
-/// let ret = match execution.resume_with(Value::from(42i64))? {
-///     GeneratorState::Complete(ret) => i64::from_value(ret)?,
+/// let ret = match execution.resume_with(Value::from(42i64)).into_result()? {
+///     GeneratorState::Complete(ret) => rune::from_value::<i64>(ret)?,
 ///     GeneratorState::Yielded(..) => panic!("generator yielded"),
 /// };
 ///
 /// assert_eq!(ret, 42);
-/// # Ok(()) }
+/// # Ok::<_, rune::Error>(())
 /// ```
 #[derive(Debug)]
 pub enum GeneratorState {

--- a/crates/rune/src/runtime/generator_state.rs
+++ b/crates/rune/src/runtime/generator_state.rs
@@ -1,5 +1,5 @@
 use crate::runtime::{
-    FromValue, Mut, RawMut, RawRef, RawStr, Ref, Shared, UnsafeFromValue, Value, VmError,
+    FromValue, Mut, RawMut, RawRef, RawStr, Ref, Shared, UnsafeFromValue, Value, VmResult,
 };
 use crate::{compile::Named, InstallWith};
 
@@ -71,15 +71,17 @@ impl GeneratorState {
 }
 
 impl FromValue for Shared<GeneratorState> {
-    fn from_value(value: Value) -> Result<Self, VmError> {
+    #[inline]
+    fn from_value(value: Value) -> VmResult<Self> {
         value.into_generator_state()
     }
 }
 
 impl FromValue for GeneratorState {
-    fn from_value(value: Value) -> Result<Self, VmError> {
-        let state = value.into_generator_state()?;
-        Ok(state.take()?)
+    fn from_value(value: Value) -> VmResult<Self> {
+        let state = vm_try!(value.into_generator_state());
+        let state = vm_try!(state.take());
+        VmResult::Ok(state)
     }
 }
 
@@ -87,10 +89,10 @@ impl UnsafeFromValue for &GeneratorState {
     type Output = *const GeneratorState;
     type Guard = RawRef;
 
-    fn from_value(value: Value) -> Result<(Self::Output, Self::Guard), VmError> {
-        let state = value.into_generator_state()?;
-        let (state, guard) = Ref::into_raw(state.into_ref()?);
-        Ok((state, guard))
+    fn from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
+        let state = vm_try!(value.into_generator_state());
+        let (state, guard) = Ref::into_raw(vm_try!(state.into_ref()));
+        VmResult::Ok((state, guard))
     }
 
     unsafe fn unsafe_coerce(output: Self::Output) -> Self {
@@ -102,9 +104,10 @@ impl UnsafeFromValue for &mut GeneratorState {
     type Output = *mut GeneratorState;
     type Guard = RawMut;
 
-    fn from_value(value: Value) -> Result<(Self::Output, Self::Guard), VmError> {
-        let state = value.into_generator_state()?;
-        Ok(Mut::into_raw(state.into_mut()?))
+    fn from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
+        let state = vm_try!(value.into_generator_state());
+        let state = vm_try!(state.into_mut());
+        VmResult::Ok(Mut::into_raw(state))
     }
 
     unsafe fn unsafe_coerce(output: Self::Output) -> Self {

--- a/crates/rune/src/runtime/guarded_args.rs
+++ b/crates/rune/src/runtime/guarded_args.rs
@@ -1,4 +1,4 @@
-use crate::runtime::{Stack, UnsafeToValue, VmError};
+use crate::runtime::{Stack, UnsafeToValue, VmResult};
 
 /// Trait for converting arguments onto the stack.
 ///
@@ -16,7 +16,7 @@ pub trait GuardedArgs {
     /// This is implemented for and allows encoding references on the stack.
     /// The returned guard must be dropped before any used references are
     /// invalidated.
-    unsafe fn unsafe_into_stack(self, stack: &mut Stack) -> Result<Self::Guard, VmError>;
+    unsafe fn unsafe_into_stack(self, stack: &mut Stack) -> VmResult<Self::Guard>;
 
     /// The number of arguments.
     fn count(&self) -> usize;
@@ -40,11 +40,11 @@ macro_rules! impl_into_args {
             type Guard = ($($ty::Guard,)*);
 
             #[allow(unused)]
-            unsafe fn unsafe_into_stack(self, stack: &mut Stack) -> Result<Self::Guard, VmError> {
+            unsafe fn unsafe_into_stack(self, stack: &mut Stack) -> VmResult<Self::Guard> {
                 let ($($value,)*) = self;
-                $(let $value = $value.unsafe_to_value()?;)*
+                $(let $value = vm_try!($value.unsafe_to_value());)*
                 $(stack.push($value.0);)*
-                Ok(($($value.1,)*))
+                VmResult::Ok(($($value.1,)*))
             }
 
             fn count(&self) -> usize {

--- a/crates/rune/src/runtime/iterator.rs
+++ b/crates/rune/src/runtime/iterator.rs
@@ -1,7 +1,7 @@
 use crate::compile::Named;
 use crate::runtime::{
-    FromValue, Function, Mut, RawMut, RawRef, RawStr, Ref, ToValue, UnsafeFromValue, Value,
-    VmError, VmErrorKind, VmResult,
+    FromValue, Function, Mut, Panic, RawMut, RawRef, RawStr, Ref, ToValue, UnsafeFromValue, Value,
+    VmErrorKind, VmResult,
 };
 use crate::InstallWith;
 use std::fmt;
@@ -36,7 +36,7 @@ trait RuneIterator: fmt::Debug {
         let (lower, upper) = self.size_hint();
 
         if !matches!(upper, Some(upper) if lower == upper) {
-            return VmResult::err(VmError::panic(format!(
+            return VmResult::err(Panic::custom(format!(
                 "`{:?}` is not an exact-sized iterator",
                 self
             )));
@@ -237,7 +237,7 @@ impl Iterator {
     /// Map the iterator using the given function.
     pub fn rev(self) -> VmResult<Self> {
         if !self.iter.is_double_ended() {
-            return VmResult::err(VmError::panic(format!(
+            return VmResult::err(Panic::custom(format!(
                 "`{:?}` is not a double-ended iterator",
                 self
             )));
@@ -292,7 +292,7 @@ impl Iterator {
     pub fn peek(&mut self) -> VmResult<Option<Value>> {
         match &mut self.iter {
             IterRepr::Peekable(peekable) => peekable.peek(),
-            _ => VmResult::err(VmError::panic(format!(
+            _ => VmResult::err(Panic::custom(format!(
                 "`{:?}` is not a peekable iterator",
                 self.iter
             ))),
@@ -460,7 +460,7 @@ impl RuneIterator for IterRepr {
 
     fn next_back(&mut self) -> VmResult<Option<Value>> {
         match self {
-            Self::Iterator(iter) => VmResult::err(VmError::panic(format!(
+            Self::Iterator(iter) => VmResult::err(Panic::custom(format!(
                 "`{}` is not a double-ended iterator",
                 iter.name
             ))),
@@ -1160,7 +1160,7 @@ where
                     rhs: vm_try!(v.type_info()),
                 }),
             },
-            None => VmResult::err(VmError::panic(
+            None => VmResult::err(Panic::custom(
                 "cannot take the product of an empty iterator",
             )),
         }
@@ -1219,7 +1219,7 @@ where
                     rhs: vm_try!(v.type_info()),
                 }),
             },
-            None => VmResult::err(VmError::panic("cannot take the sum of an empty iterator")),
+            None => VmResult::err(Panic::custom("cannot take the sum of an empty iterator")),
         }
     }
 }

--- a/crates/rune/src/runtime/iterator.rs
+++ b/crates/rune/src/runtime/iterator.rs
@@ -36,7 +36,7 @@ trait RuneIterator: fmt::Debug {
         let (lower, upper) = self.size_hint();
 
         if !matches!(upper, Some(upper) if lower == upper) {
-            return VmResult::Err(VmError::panic(format!(
+            return VmResult::err(VmError::panic(format!(
                 "`{:?}` is not an exact-sized iterator",
                 self
             )));
@@ -237,7 +237,7 @@ impl Iterator {
     /// Map the iterator using the given function.
     pub fn rev(self) -> VmResult<Self> {
         if !self.iter.is_double_ended() {
-            return VmResult::Err(VmError::panic(format!(
+            return VmResult::err(VmError::panic(format!(
                 "`{:?}` is not a double-ended iterator",
                 self
             )));
@@ -292,7 +292,7 @@ impl Iterator {
     pub fn peek(&mut self) -> VmResult<Option<Value>> {
         match &mut self.iter {
             IterRepr::Peekable(peekable) => peekable.peek(),
-            _ => VmResult::Err(VmError::panic(format!(
+            _ => VmResult::err(VmError::panic(format!(
                 "`{:?}` is not a peekable iterator",
                 self.iter
             ))),
@@ -460,7 +460,7 @@ impl RuneIterator for IterRepr {
 
     fn next_back(&mut self) -> VmResult<Option<Value>> {
         match self {
-            Self::Iterator(iter) => VmResult::Err(VmError::panic(format!(
+            Self::Iterator(iter) => VmResult::err(VmError::panic(format!(
                 "`{}` is not a double-ended iterator",
                 iter.name
             ))),
@@ -1154,13 +1154,13 @@ where
                 Value::Float(v) => {
                     VmResult::Ok(Value::Float(vm_try!(self.resolve_internal_simple(v))))
                 }
-                _ => VmResult::Err(VmError::from(VmErrorKind::UnsupportedBinaryOperation {
+                _ => VmResult::err(VmErrorKind::UnsupportedBinaryOperation {
                     op: "*",
                     lhs: vm_try!(v.type_info()),
                     rhs: vm_try!(v.type_info()),
-                })),
+                }),
             },
-            None => VmResult::Err(VmError::panic(
+            None => VmResult::err(VmError::panic(
                 "cannot take the product of an empty iterator",
             )),
         }
@@ -1213,13 +1213,13 @@ where
                 Value::Float(v) => {
                     VmResult::Ok(Value::Float(vm_try!(self.resolve_internal_simple(v))))
                 }
-                _ => VmResult::Err(VmError::from(VmErrorKind::UnsupportedBinaryOperation {
+                _ => VmResult::err(VmErrorKind::UnsupportedBinaryOperation {
                     op: "+",
                     lhs: vm_try!(v.type_info()),
                     rhs: vm_try!(v.type_info()),
-                })),
+                }),
             },
-            None => VmResult::Err(VmError::panic("cannot take the sum of an empty iterator")),
+            None => VmResult::err(VmError::panic("cannot take the sum of an empty iterator")),
         }
     }
 }

--- a/crates/rune/src/runtime/key.rs
+++ b/crates/rune/src/runtime/key.rs
@@ -1,6 +1,6 @@
 use crate::runtime::{
     Bytes, FromValue, Object, Shared, StaticString, ToValue, Tuple, TypeInfo, Value, Variant,
-    VariantData, VariantRtti, Vec, VmError, VmErrorKind, VmResult,
+    VariantData, VariantRtti, Vec, VmErrorKind, VmResult,
 };
 use serde::{de, ser};
 use std::cmp;
@@ -91,9 +91,9 @@ impl Key {
                 })
             }
             value => {
-                return VmResult::Err(VmError::from(VmErrorKind::KeyNotSupported {
+                return VmResult::err(VmErrorKind::KeyNotSupported {
                     actual: vm_try!(value.type_info()),
-                }))
+                });
             }
         });
 

--- a/crates/rune/src/runtime/mod.rs
+++ b/crates/rune/src/runtime/mod.rs
@@ -104,7 +104,7 @@ pub use self::vec::Vec;
 pub use self::vec_tuple::VecTuple;
 pub use self::vm::{CallFrame, Vm};
 pub(crate) use self::vm_call::VmCall;
-pub use self::vm_error::{VmError, VmErrorKind, VmIntegerRepr};
+pub use self::vm_error::{VmError, VmErrorKind, VmIntegerRepr, VmResult, TryFromResult, try_result};
 pub use self::vm_execution::{ExecutionState, VmExecution, VmSendExecution};
 pub(crate) use self::vm_halt::VmHalt;
 pub use self::vm_halt::VmHaltInfo;

--- a/crates/rune/src/runtime/mod.rs
+++ b/crates/rune/src/runtime/mod.rs
@@ -105,7 +105,7 @@ pub use self::vec_tuple::VecTuple;
 pub use self::vm::{CallFrame, Vm};
 pub(crate) use self::vm_call::VmCall;
 pub use self::vm_error::{
-    try_result, TryFromResult, VmError, VmErrorKind, VmErrorWithTrace, VmIntegerRepr, VmResult,
+    try_result, TryFromResult, VmError, VmErrorKind, VmIntegerRepr, VmResult,
 };
 pub use self::vm_execution::{ExecutionState, VmExecution, VmSendExecution};
 pub(crate) use self::vm_halt::VmHalt;

--- a/crates/rune/src/runtime/mod.rs
+++ b/crates/rune/src/runtime/mod.rs
@@ -105,7 +105,7 @@ pub use self::vec_tuple::VecTuple;
 pub use self::vm::{CallFrame, Vm};
 pub(crate) use self::vm_call::VmCall;
 pub use self::vm_error::{
-    try_result, TryFromResult, VmError, VmErrorKind, VmIntegerRepr, VmResult,
+    try_result, TryFromResult, VmError, VmErrorKind, VmErrorWithTrace, VmIntegerRepr, VmResult,
 };
 pub use self::vm_execution::{ExecutionState, VmExecution, VmSendExecution};
 pub(crate) use self::vm_halt::VmHalt;

--- a/crates/rune/src/runtime/mod.rs
+++ b/crates/rune/src/runtime/mod.rs
@@ -61,7 +61,7 @@ pub use self::call::Call;
 pub use self::const_value::ConstValue;
 pub use self::debug::{DebugInfo, DebugInst};
 pub use self::format::{Format, FormatSpec};
-pub use self::from_value::{FromValue, UnsafeFromValue};
+pub use self::from_value::{from_value, FromValue, UnsafeFromValue};
 pub use self::function::{Function, SyncFunction};
 pub use self::future::Future;
 pub use self::generator::Generator;
@@ -93,7 +93,7 @@ pub use self::static_type::{
     UNIT_TYPE, VEC_TYPE,
 };
 pub use self::stream::Stream;
-pub use self::to_value::{ToValue, UnsafeToValue};
+pub use self::to_value::{to_value, ToValue, UnsafeToValue};
 pub use self::tuple::Tuple;
 pub use self::type_info::{AnyTypeInfo, TypeInfo};
 pub use self::type_of::{FullTypeOf, MaybeTypeOf, TypeOf};

--- a/crates/rune/src/runtime/mod.rs
+++ b/crates/rune/src/runtime/mod.rs
@@ -104,7 +104,9 @@ pub use self::vec::Vec;
 pub use self::vec_tuple::VecTuple;
 pub use self::vm::{CallFrame, Vm};
 pub(crate) use self::vm_call::VmCall;
-pub use self::vm_error::{VmError, VmErrorKind, VmIntegerRepr, VmResult, TryFromResult, try_result};
+pub use self::vm_error::{
+    try_result, TryFromResult, VmError, VmErrorKind, VmIntegerRepr, VmResult,
+};
 pub use self::vm_execution::{ExecutionState, VmExecution, VmSendExecution};
 pub(crate) use self::vm_halt::VmHalt;
 pub use self::vm_halt::VmHaltInfo;

--- a/crates/rune/src/runtime/object.rs
+++ b/crates/rune/src/runtime/object.rs
@@ -60,18 +60,17 @@ pub type Values<'a> = btree_map::Values<'a, String, Value>;
 /// # Examples
 ///
 /// ```
-/// # fn main() -> rune::Result<()> {
 /// let mut object = rune::runtime::Object::new();
 /// assert!(object.is_empty());
 ///
-/// object.insert_value(String::from("foo"), 42)?;
-/// object.insert_value(String::from("bar"), true)?;
+/// object.insert_value(String::from("foo"), 42).into_result()?;
+/// object.insert_value(String::from("bar"), true).into_result()?;
 /// assert_eq!(2, object.len());
 ///
-/// assert_eq!(Some(42), object.get_value("foo")?);
-/// assert_eq!(Some(true), object.get_value("bar")?);
-/// assert_eq!(None::<bool>, object.get_value("baz")?);
-/// # Ok(()) }
+/// assert_eq!(Some(42), object.get_value("foo").into_result()?);
+/// assert_eq!(Some(true), object.get_value("bar").into_result()?);
+/// assert_eq!(None::<bool>, object.get_value("baz").into_result()?);
+/// # Ok::<_, rune::Error>(())
 /// ```
 #[derive(Default, Clone)]
 #[repr(transparent)]

--- a/crates/rune/src/runtime/protocol_caller.rs
+++ b/crates/rune/src/runtime/protocol_caller.rs
@@ -47,7 +47,7 @@ impl ProtocolCaller for EnvProtocolCaller {
 
             let handler = match context.function(hash) {
                 Some(handler) => handler,
-                None => return VmResult::Err(VmError::from(VmErrorKind::MissingFunction { hash })),
+                None => return VmResult::err(VmErrorKind::MissingFunction { hash }),
             };
 
             let mut stack = Stack::with_capacity(count);
@@ -81,9 +81,9 @@ impl ProtocolCaller for &mut Vm {
     {
         if let CallResult::Unsupported(..) = vm_try!(self.call_instance_fn(target, protocol, args))
         {
-            return VmResult::Err(VmError::from(VmErrorKind::MissingFunction {
+            return VmResult::err(VmErrorKind::MissingFunction {
                 hash: protocol.hash,
-            }));
+            });
         }
 
         VmResult::Ok(vm_try!(self.stack_mut().pop()))

--- a/crates/rune/src/runtime/range.rs
+++ b/crates/rune/src/runtime/range.rs
@@ -11,13 +11,11 @@ use std::ops;
 /// # Examples
 ///
 /// ```
-/// use rune::ToValue;
 /// use rune::runtime::{Range, RangeLimits};
 ///
-/// # fn main() -> rune::Result<()> {
-/// let from = 42i64.to_value()?;
+/// let from = rune::to_value(42i64)?;
 /// let _ = Range::new(Some(from), None, RangeLimits::HalfOpen);
-/// # Ok(()) }
+/// # Ok::<_, rune::Error>(())
 /// ```
 #[derive(Clone)]
 pub struct Range {

--- a/crates/rune/src/runtime/range.rs
+++ b/crates/rune/src/runtime/range.rs
@@ -1,7 +1,7 @@
 use crate::compile::{InstallWith, Named};
 use crate::runtime::{
     FromValue, Iterator, Mut, Panic, RawMut, RawRef, RawStr, Ref, ToValue, UnsafeFromValue, Value,
-    Vm, VmError, VmErrorKind, VmResult,
+    Vm, VmErrorKind, VmResult,
 };
 use std::fmt;
 use std::ops;
@@ -36,24 +36,24 @@ impl Range {
     }
 
     /// Coerce range into an iterator.
-    pub fn into_iterator(self) -> Result<Iterator, Panic> {
+    pub fn into_iterator(self) -> VmResult<Iterator> {
         match (self.limits, self.start, self.end) {
             (RangeLimits::HalfOpen, Some(Value::Integer(start)), Some(Value::Integer(end))) => {
-                return Ok(Iterator::from_double_ended("std::ops::Range", start..end));
+                return VmResult::Ok(Iterator::from_double_ended("std::ops::Range", start..end));
             }
             (RangeLimits::Closed, Some(Value::Integer(start)), Some(Value::Integer(end))) => {
-                return Ok(Iterator::from_double_ended(
+                return VmResult::Ok(Iterator::from_double_ended(
                     "std::ops::RangeToInclusive",
                     start..=end,
                 ));
             }
             (_, Some(Value::Integer(start)), None) => {
-                return Ok(Iterator::from("std::ops::RangeFrom", start..));
+                return VmResult::Ok(Iterator::from("std::ops::RangeFrom", start..));
             }
             _ => (),
         }
 
-        Err(Panic::custom("not an iterator"))
+        VmResult::err(Panic::custom("not an iterator"))
     }
 
     /// Value pointer equals implementation for a range.
@@ -99,7 +99,7 @@ impl Range {
             RangeLimits::Closed => match (start, end) {
                 (Some(start), Some(end)) => (start..=end).contains(&n),
                 (None, Some(end)) => (..=end).contains(&n),
-                _ => return VmResult::Err(VmError::from(VmErrorKind::UnsupportedRange)),
+                _ => return VmResult::err(VmErrorKind::UnsupportedRange),
             },
         };
 

--- a/crates/rune/src/runtime/runtime_context.rs
+++ b/crates/rune/src/runtime/runtime_context.rs
@@ -1,12 +1,12 @@
 use crate::collections::HashMap;
 use crate::macros::{MacroContext, TokenStream};
-use crate::runtime::{ConstValue, Stack, VmError};
+use crate::runtime::{ConstValue, Stack, VmResult};
 use crate::Hash;
 use std::fmt;
 use std::sync::Arc;
 
 /// A type-reduced function handler.
-pub(crate) type FunctionHandler = dyn Fn(&mut Stack, usize) -> Result<(), VmError> + Send + Sync;
+pub(crate) type FunctionHandler = dyn Fn(&mut Stack, usize) -> VmResult<()> + Send + Sync;
 
 /// A (type erased) macro handler.
 pub(crate) type MacroHandler =

--- a/crates/rune/src/runtime/select.rs
+++ b/crates/rune/src/runtime/select.rs
@@ -1,10 +1,12 @@
-use crate::runtime::future::SelectFuture;
-use crate::runtime::{Future, Mut, Value, VmError};
-use futures_core::Stream;
-use futures_util::stream::FuturesUnordered;
 use std::future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+
+use futures_core::Stream;
+use futures_util::stream::FuturesUnordered;
+
+use crate::runtime::future::SelectFuture;
+use crate::runtime::{Future, Mut, Value, VmResult};
 
 /// A stored select.
 #[derive(Debug)]
@@ -20,7 +22,7 @@ impl Select {
 }
 
 impl future::Future for Select {
-    type Output = Result<(usize, Value), VmError>;
+    type Output = VmResult<(usize, Value)>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let poll = Pin::new(&mut self.futures).poll_next(cx);

--- a/crates/rune/src/runtime/shared.rs
+++ b/crates/rune/src/runtime/shared.rs
@@ -895,13 +895,12 @@ impl<T: ?Sized> Ref<T> {
     /// ```
     /// use rune::runtime::{Shared, Ref};
     ///
-    /// # fn main() -> rune::Result<()> {
     /// let vec = Shared::<Vec<u32>>::new(vec![1, 2, 3, 4]);
     /// let vec = vec.into_ref()?;
     /// let value: Ref<[u32]> = Ref::map(vec, |vec| &vec[0..2]);
     ///
     /// assert_eq!(&*value, &[1u32, 2u32][..]);
-    /// # Ok(()) }
+    /// # Ok::<_, rune::Error>(())
     /// ```
     pub fn map<U: ?Sized, F>(this: Self, f: F) -> Ref<U>
     where
@@ -930,13 +929,12 @@ impl<T: ?Sized> Ref<T> {
     /// ```
     /// use rune::runtime::{Shared, Ref};
     ///
-    /// # fn main() -> rune::Result<()> {
     /// let vec = Shared::<Vec<u32>>::new(vec![1, 2, 3, 4]);
     /// let vec = vec.into_ref()?;
     /// let value: Option<Ref<[u32]>> = Ref::try_map(vec, |vec| vec.get(0..2));
     ///
     /// assert_eq!(value.as_deref(), Some(&[1u32, 2u32][..]));
-    /// # Ok(()) }
+    /// # Ok::<_, rune::Error>(())
     /// ```
     pub fn try_map<U: ?Sized, F>(this: Self, f: F) -> Option<Ref<U>>
     where
@@ -1016,13 +1014,12 @@ impl<T: ?Sized> Mut<T> {
     /// ```
     /// use rune::runtime::{Mut, Shared};
     ///
-    /// # fn main() -> rune::Result<()> {
     /// let vec = Shared::<Vec<u32>>::new(vec![1, 2, 3, 4]);
     /// let vec = vec.into_mut()?;
     /// let value: Mut<[u32]> = Mut::map(vec, |vec| &mut vec[0..2]);
     ///
     /// assert_eq!(&*value, &mut [1u32, 2u32][..]);
-    /// # Ok(()) }
+    /// # Ok::<_, rune::Error>(())
     /// ```
     pub fn map<U: ?Sized, F>(this: Self, f: F) -> Mut<U>
     where
@@ -1054,13 +1051,12 @@ impl<T: ?Sized> Mut<T> {
     /// ```
     /// use rune::runtime::{Mut, Shared};
     ///
-    /// # fn main() -> rune::Result<()> {
     /// let vec = Shared::<Vec<u32>>::new(vec![1, 2, 3, 4]);
     /// let vec = vec.into_mut()?;
     /// let mut value: Option<Mut<[u32]>> = Mut::try_map(vec, |vec| vec.get_mut(0..2));
     ///
     /// assert_eq!(value.as_deref_mut(), Some(&mut [1u32, 2u32][..]));
-    /// # Ok(()) }
+    /// # Ok::<_, rune::Error>(())
     /// ```
     pub fn try_map<U: ?Sized, F>(this: Self, f: F) -> Option<Mut<U>>
     where

--- a/crates/rune/src/runtime/stack.rs
+++ b/crates/rune/src/runtime/stack.rs
@@ -28,12 +28,11 @@ impl Stack {
     /// use rune::runtime::Stack;
     /// use rune::Value;
     ///
-    /// # fn main() -> Result<(), rune::runtime::StackError> {
     /// let mut stack = Stack::new();
     /// assert!(stack.pop().is_err());
     /// stack.push(String::from("Hello World"));
     /// assert!(matches!(stack.pop()?, Value::String(..)));
-    /// # Ok(()) }
+    /// # Ok::<_, rune::Error>(())
     /// ```
     pub const fn new() -> Self {
         Self {
@@ -48,12 +47,11 @@ impl Stack {
     /// use rune::runtime::Stack;
     /// use rune::Value;
     ///
-    /// # fn main() -> Result<(), rune::runtime::StackError> {
     /// let mut stack = Stack::with_capacity(16);
     /// assert!(stack.pop().is_err());
     /// stack.push(String::from("Hello World"));
     /// assert!(matches!(stack.pop()?, Value::String(..)));
-    /// # Ok(()) }
+    /// # Ok::<_, rune::Error>(())
     /// ```
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
@@ -119,12 +117,11 @@ impl Stack {
     /// use rune::runtime::Stack;
     /// use rune::Value;
     ///
-    /// # fn main() -> Result<(), rune::runtime::StackError> {
     /// let mut stack = Stack::new();
     /// assert!(stack.pop().is_err());
     /// stack.push(String::from("Hello World"));
     /// assert!(matches!(stack.pop()?, Value::String(..)));
-    /// # Ok(()) }
+    /// # Ok::<_, rune::Error>(())
     /// ```
     pub fn push<T>(&mut self, value: T)
     where
@@ -139,12 +136,11 @@ impl Stack {
     /// use rune::runtime::Stack;
     /// use rune::Value;
     ///
-    /// # fn main() -> Result<(), rune::runtime::StackError> {
     /// let mut stack = Stack::new();
     /// assert!(stack.pop().is_err());
     /// stack.push(String::from("Hello World"));
     /// assert!(matches!(stack.pop()?, Value::String(..)));
-    /// # Ok(()) }
+    /// # Ok::<_, rune::Error>(())
     /// ```
     pub fn pop(&mut self) -> Result<Value, StackError> {
         if self.stack.len() == self.stack_bottom {
@@ -161,7 +157,6 @@ impl Stack {
     /// use rune::runtime::Stack;
     /// use rune::Value;
     ///
-    /// # fn main() -> Result<(), rune::runtime::StackError> {
     /// let mut stack = Stack::new();
     ///
     /// stack.push(42i64);
@@ -173,7 +168,7 @@ impl Stack {
     /// assert!(matches!(it.next(), Some(Value::String(..))));
     /// assert!(matches!(it.next(), Some(Value::Unit)));
     /// assert!(matches!(it.next(), None));
-    /// # Ok(()) }
+    /// # Ok::<_, rune::Error>(())
     /// ```
     pub fn drain(
         &mut self,
@@ -191,7 +186,6 @@ impl Stack {
     /// use rune::runtime::Stack;
     /// use rune::Value;
     ///
-    /// # fn main() -> Result<(), rune::runtime::StackError> {
     /// let mut stack = Stack::new();
     ///
     /// stack.extend([Value::from(42i64), Value::from(String::from("foo")), Value::Unit]);
@@ -201,7 +195,7 @@ impl Stack {
     /// assert!(matches!(it.next(), Some(Value::String(..))));
     /// assert!(matches!(it.next(), Some(Value::Unit)));
     /// assert!(matches!(it.next(), None));
-    /// # Ok(()) }
+    /// # Ok::<_, rune::Error>(())
     /// ```
     pub fn extend<I>(&mut self, iter: I)
     where

--- a/crates/rune/src/runtime/to_value.rs
+++ b/crates/rune/src/runtime/to_value.rs
@@ -1,6 +1,4 @@
-use crate::runtime::{
-    AnyObj, Object, Panic, Shared, Value, VmError, VmErrorKind, VmIntegerRepr, VmResult,
-};
+use crate::runtime::{AnyObj, Object, Shared, Value, VmErrorKind, VmIntegerRepr, VmResult};
 use crate::Any;
 
 #[doc(inline)]
@@ -114,20 +112,6 @@ impl ToValue for &str {
     }
 }
 
-// Result impls
-
-impl<T> ToValue for Result<T, Panic>
-where
-    T: ToValue,
-{
-    fn to_value(self) -> VmResult<Value> {
-        match self {
-            Ok(value) => VmResult::Ok(vm_try!(value.to_value())),
-            Err(reason) => VmResult::Err(VmError::from(VmErrorKind::Panic { reason })),
-        }
-    }
-}
-
 impl<T> ToValue for VmResult<T>
 where
     T: ToValue,
@@ -170,12 +154,10 @@ macro_rules! number_value_trait {
 
                 match self.try_into() {
                     Ok(number) => VmResult::Ok(Value::Integer(number)),
-                    Err(..) => {
-                        VmResult::Err(VmError::from(VmErrorKind::IntegerToValueCoercionError {
-                            from: VmIntegerRepr::from(self),
-                            to: std::any::type_name::<i64>(),
-                        }))
-                    }
+                    Err(..) => VmResult::err(VmErrorKind::IntegerToValueCoercionError {
+                        from: VmIntegerRepr::from(self),
+                        to: std::any::type_name::<i64>(),
+                    }),
                 }
             }
         }

--- a/crates/rune/src/runtime/to_value.rs
+++ b/crates/rune/src/runtime/to_value.rs
@@ -1,10 +1,50 @@
-use crate::runtime::{AnyObj, Object, Shared, Value, VmErrorKind, VmIntegerRepr, VmResult};
+use crate::runtime::{
+    AnyObj, Object, Shared, Value, VmError, VmErrorKind, VmIntegerRepr, VmResult,
+};
 use crate::Any;
 
 #[doc(inline)]
 pub use rune_macros::ToValue;
 
-/// Trait for converting types into the dynamic [Value] container.
+/// Convert something into the dynamic [`Value`].
+///
+/// # Examples
+///
+/// ```
+/// use rune::{FromValue, ToValue, Vm};
+/// use std::sync::Arc;
+///
+/// #[derive(ToValue)]
+/// struct Foo {
+///     field: u64,
+/// }
+///
+/// # fn main() -> rune::Result<()> {
+/// let mut sources = rune::sources! {
+///     entry => {
+///         pub fn main(foo) {
+///             foo.field + 1
+///         }
+///     }
+/// };
+///
+/// let unit = rune::prepare(&mut sources).build()?;
+///
+/// let mut vm = Vm::without_runtime(Arc::new(unit));
+/// let foo = vm.call(["main"], (Foo { field: 42 },))?;
+/// let foo: u64 = rune::from_value(foo)?;
+///
+/// assert_eq!(foo, 43);
+/// # Ok(()) }
+/// ```
+pub fn to_value<T>(value: T) -> Result<Value, VmError>
+where
+    T: ToValue,
+{
+    T::to_value(value).into_result()
+}
+
+/// Trait for converting types into the dynamic [`Value`] container.
 ///
 /// # Examples
 ///

--- a/crates/rune/src/runtime/to_value.rs
+++ b/crates/rune/src/runtime/to_value.rs
@@ -11,7 +11,7 @@ pub use rune_macros::ToValue;
 /// # Examples
 ///
 /// ```
-/// use rune::{FromValue, ToValue, Vm};
+/// use rune::{ToValue, Vm};
 /// use std::sync::Arc;
 ///
 /// #[derive(ToValue)]
@@ -19,7 +19,6 @@ pub use rune_macros::ToValue;
 ///     field: u64,
 /// }
 ///
-/// # fn main() -> rune::Result<()> {
 /// let mut sources = rune::sources! {
 ///     entry => {
 ///         pub fn main(foo) {
@@ -35,7 +34,7 @@ pub use rune_macros::ToValue;
 /// let foo: u64 = rune::from_value(foo)?;
 ///
 /// assert_eq!(foo, 43);
-/// # Ok(()) }
+/// # Ok::<_, rune::Error>(())
 /// ```
 pub fn to_value<T>(value: T) -> Result<Value, VmError>
 where
@@ -49,7 +48,7 @@ where
 /// # Examples
 ///
 /// ```
-/// use rune::{FromValue, ToValue, Vm};
+/// use rune::{ToValue, Vm};
 /// use std::sync::Arc;
 ///
 /// #[derive(ToValue)]
@@ -57,7 +56,6 @@ where
 ///     field: u64,
 /// }
 ///
-/// # fn main() -> rune::Result<()> {
 /// let mut sources = rune::sources! {
 ///     entry => {
 ///         pub fn main(foo) {
@@ -70,10 +68,10 @@ where
 ///
 /// let mut vm = Vm::without_runtime(Arc::new(unit));
 /// let foo = vm.call(["main"], (Foo { field: 42 },))?;
-/// let foo = u64::from_value(foo)?;
+/// let foo: u64 = rune::from_value(foo)?;
 ///
 /// assert_eq!(foo, 43);
-/// # Ok(()) }
+/// # Ok::<_, rune::Error>(())
 /// ```
 pub trait ToValue: Sized {
     /// Convert into a value.

--- a/crates/rune/src/runtime/tuple.rs
+++ b/crates/rune/src/runtime/tuple.rs
@@ -1,5 +1,5 @@
 use crate::runtime::{
-    ConstValue, FromValue, Mut, Ref, ToValue, Value, Vm, VmError, VmErrorKind, VmResult, TUPLE_TYPE,
+    ConstValue, FromValue, Mut, Ref, ToValue, Value, Vm, VmErrorKind, VmResult, TUPLE_TYPE,
 };
 use std::fmt;
 use std::ops;
@@ -173,7 +173,7 @@ impl FromValue for Tuple {
         match value {
             Value::Unit => VmResult::Ok(Self::empty()),
             Value::Tuple(tuple) => VmResult::Ok(vm_try!(tuple.take())),
-            actual => VmResult::err(VmError::expected::<Self>(vm_try!(actual.type_info()))),
+            actual => VmResult::err(VmErrorKind::expected::<Self>(vm_try!(actual.type_info()))),
         }
     }
 }

--- a/crates/rune/src/runtime/tuple.rs
+++ b/crates/rune/src/runtime/tuple.rs
@@ -173,7 +173,7 @@ impl FromValue for Tuple {
         match value {
             Value::Unit => VmResult::Ok(Self::empty()),
             Value::Tuple(tuple) => VmResult::Ok(vm_try!(tuple.take())),
-            actual => VmResult::Err(VmError::expected::<Self>(vm_try!(actual.type_info()))),
+            actual => VmResult::err(VmError::expected::<Self>(vm_try!(actual.type_info()))),
         }
     }
 }
@@ -197,10 +197,10 @@ macro_rules! impl_tuple {
                 let tuple = vm_try!(vm_try!(value.into_tuple()).take());
 
                 if tuple.len() != $count {
-                    return VmResult::Err(VmError::from(VmErrorKind::ExpectedTupleLength {
+                    return VmResult::err(VmErrorKind::ExpectedTupleLength {
                         actual: tuple.len(),
                         expected: $count,
-                    }));
+                    });
                 }
 
                 #[allow(unused_mut, unused_variables)]
@@ -210,7 +210,7 @@ macro_rules! impl_tuple {
                     let $var = match it.next() {
                         Some(value) => vm_try!(<$ty>::from_value(value)),
                         None => {
-                            return VmResult::Err(VmError::from(VmErrorKind::IterationError));
+                            return VmResult::err(VmErrorKind::IterationError);
                         },
                     };
                 )*

--- a/crates/rune/src/runtime/value.rs
+++ b/crates/rune/src/runtime/value.rs
@@ -1096,11 +1096,11 @@ impl Value {
             },
         }
 
-        err(VmErrorKind::from(VmErrorKind::UnsupportedBinaryOperation {
+        err(VmErrorKind::UnsupportedBinaryOperation {
             op: "==",
             lhs: vm_try!(a.type_info()),
             rhs: vm_try!(b.type_info()),
-        }))
+        })
     }
 }
 

--- a/crates/rune/src/runtime/value.rs
+++ b/crates/rune/src/runtime/value.rs
@@ -4,7 +4,7 @@ use crate::runtime::{
     AccessKind, AnyObj, Bytes, ConstValue, EnvProtocolCaller, Format, FromValue, FullTypeOf,
     Function, Future, Generator, GeneratorState, Iterator, MaybeTypeOf, Mut, Object, Protocol,
     ProtocolCaller, Range, RawMut, RawRef, Ref, Shared, StaticString, Stream, ToValue, Tuple,
-    TypeInfo, Variant, Vec, Vm, VmError, VmErrorKind, VmResult,
+    TypeInfo, Variant, Vec, Vm, VmErrorKind, VmResult,
 };
 use crate::{Any, Hash};
 use serde::{de, ser, Deserialize, Serialize};
@@ -21,7 +21,7 @@ use VmResult::Ok;
 // Small helper function to build errors.
 fn err<T, E>(error: E) -> VmResult<T>
 where
-    VmError: From<E>,
+    VmErrorKind: From<E>,
 {
     VmResult::err(error)
 }
@@ -570,7 +570,7 @@ impl Value {
                 match name {
                     ConstValue::String(s) => return Ok(s.clone()),
                     ConstValue::StaticString(s) => return Ok((*s).to_string()),
-                    _ => return err(VmError::expected::<String>(name.type_info())),
+                    _ => return err(VmErrorKind::expected::<String>(name.type_info())),
                 }
             }
 
@@ -578,7 +578,7 @@ impl Value {
                 match name {
                     ConstValue::String(s) => return Ok(s.clone()),
                     ConstValue::StaticString(s) => return Ok((*s).to_string()),
-                    _ => return err(VmError::expected::<String>(name.type_info())),
+                    _ => return err(VmErrorKind::expected::<String>(name.type_info())),
                 }
             }
 
@@ -658,7 +658,7 @@ impl Value {
     pub fn into_unit(self) -> VmResult<()> {
         match self {
             Value::Unit => Ok(()),
-            actual => err(VmError::expected::<()>(vm_try!(actual.type_info()))),
+            actual => err(VmErrorKind::expected::<()>(vm_try!(actual.type_info()))),
         }
     }
 
@@ -667,7 +667,7 @@ impl Value {
     pub fn into_bool(self) -> VmResult<bool> {
         match self {
             Self::Bool(b) => Ok(b),
-            actual => err(VmError::expected::<bool>(vm_try!(actual.type_info()))),
+            actual => err(VmErrorKind::expected::<bool>(vm_try!(actual.type_info()))),
         }
     }
 
@@ -676,7 +676,7 @@ impl Value {
     pub fn as_bool(&self) -> VmResult<bool> {
         match self {
             Self::Bool(b) => Ok(*b),
-            actual => err(VmError::expected::<bool>(vm_try!(actual.type_info()))),
+            actual => err(VmErrorKind::expected::<bool>(vm_try!(actual.type_info()))),
         }
     }
 
@@ -685,7 +685,7 @@ impl Value {
     pub fn into_byte(self) -> VmResult<u8> {
         match self {
             Self::Byte(b) => Ok(b),
-            actual => err(VmError::expected::<u8>(vm_try!(actual.type_info()))),
+            actual => err(VmErrorKind::expected::<u8>(vm_try!(actual.type_info()))),
         }
     }
 
@@ -694,7 +694,7 @@ impl Value {
     pub fn into_char(self) -> VmResult<char> {
         match self {
             Self::Char(c) => Ok(c),
-            actual => err(VmError::expected::<char>(vm_try!(actual.type_info()))),
+            actual => err(VmErrorKind::expected::<char>(vm_try!(actual.type_info()))),
         }
     }
 
@@ -703,7 +703,7 @@ impl Value {
     pub fn into_integer(self) -> VmResult<i64> {
         match self {
             Self::Integer(integer) => Ok(integer),
-            actual => err(VmError::expected::<i64>(vm_try!(actual.type_info()))),
+            actual => err(VmErrorKind::expected::<i64>(vm_try!(actual.type_info()))),
         }
     }
 
@@ -712,7 +712,7 @@ impl Value {
     pub fn into_float(self) -> VmResult<f64> {
         match self {
             Self::Float(float) => Ok(float),
-            actual => err(VmError::expected::<f64>(vm_try!(actual.type_info()))),
+            actual => err(VmErrorKind::expected::<f64>(vm_try!(actual.type_info()))),
         }
     }
 
@@ -721,7 +721,7 @@ impl Value {
     pub fn into_result(self) -> VmResult<Shared<Result<Value, Value>>> {
         match self {
             Self::Result(result) => Ok(result),
-            actual => err(VmError::expected::<Result<Value, Value>>(vm_try!(
+            actual => err(VmErrorKind::expected::<Result<Value, Value>>(vm_try!(
                 actual.type_info()
             ))),
         }
@@ -732,7 +732,7 @@ impl Value {
     pub fn as_result(&self) -> VmResult<&Shared<Result<Value, Value>>> {
         match self {
             Self::Result(result) => Ok(result),
-            actual => err(VmError::expected::<Result<Value, Value>>(vm_try!(
+            actual => err(VmErrorKind::expected::<Result<Value, Value>>(vm_try!(
                 actual.type_info()
             ))),
         }
@@ -743,7 +743,7 @@ impl Value {
     pub fn into_generator(self) -> VmResult<Shared<Generator<Vm>>> {
         match self {
             Value::Generator(generator) => Ok(generator),
-            actual => err(VmError::expected::<Generator<Vm>>(vm_try!(
+            actual => err(VmErrorKind::expected::<Generator<Vm>>(vm_try!(
                 actual.type_info()
             ))),
         }
@@ -754,7 +754,9 @@ impl Value {
     pub fn into_stream(self) -> VmResult<Shared<Stream<Vm>>> {
         match self {
             Value::Stream(stream) => Ok(stream),
-            actual => err(VmError::expected::<Stream<Vm>>(vm_try!(actual.type_info()))),
+            actual => err(VmErrorKind::expected::<Stream<Vm>>(vm_try!(
+                actual.type_info()
+            ))),
         }
     }
 
@@ -763,7 +765,7 @@ impl Value {
     pub fn into_generator_state(self) -> VmResult<Shared<GeneratorState>> {
         match self {
             Value::GeneratorState(state) => Ok(state),
-            actual => err(VmError::expected::<GeneratorState>(vm_try!(
+            actual => err(VmErrorKind::expected::<GeneratorState>(vm_try!(
                 actual.type_info()
             ))),
         }
@@ -774,7 +776,7 @@ impl Value {
     pub fn into_option(self) -> VmResult<Shared<Option<Value>>> {
         match self {
             Self::Option(option) => Ok(option),
-            actual => err(VmError::expected::<Option<Value>>(vm_try!(
+            actual => err(VmErrorKind::expected::<Option<Value>>(vm_try!(
                 actual.type_info()
             ))),
         }
@@ -785,7 +787,7 @@ impl Value {
     pub fn into_string(self) -> VmResult<Shared<String>> {
         match self {
             Self::String(string) => Ok(string),
-            actual => err(VmError::expected::<String>(vm_try!(actual.type_info()))),
+            actual => err(VmErrorKind::expected::<String>(vm_try!(actual.type_info()))),
         }
     }
 
@@ -794,7 +796,7 @@ impl Value {
     pub fn into_bytes(self) -> VmResult<Shared<Bytes>> {
         match self {
             Self::Bytes(bytes) => Ok(bytes),
-            actual => err(VmError::expected::<Bytes>(vm_try!(actual.type_info()))),
+            actual => err(VmErrorKind::expected::<Bytes>(vm_try!(actual.type_info()))),
         }
     }
 
@@ -803,7 +805,7 @@ impl Value {
     pub fn into_vec(self) -> VmResult<Shared<Vec>> {
         match self {
             Self::Vec(vec) => Ok(vec),
-            actual => err(VmError::expected::<Vec>(vm_try!(actual.type_info()))),
+            actual => err(VmErrorKind::expected::<Vec>(vm_try!(actual.type_info()))),
         }
     }
 
@@ -812,7 +814,7 @@ impl Value {
     pub fn into_tuple(self) -> VmResult<Shared<Tuple>> {
         match self {
             Self::Tuple(tuple) => Ok(tuple),
-            actual => err(VmError::expected::<Tuple>(vm_try!(actual.type_info()))),
+            actual => err(VmErrorKind::expected::<Tuple>(vm_try!(actual.type_info()))),
         }
     }
 
@@ -821,7 +823,7 @@ impl Value {
     pub fn into_object(self) -> VmResult<Shared<Object>> {
         match self {
             Self::Object(object) => Ok(object),
-            actual => err(VmError::expected::<Object>(vm_try!(actual.type_info()))),
+            actual => err(VmErrorKind::expected::<Object>(vm_try!(actual.type_info()))),
         }
     }
 
@@ -830,7 +832,7 @@ impl Value {
     pub fn into_range(self) -> VmResult<Shared<Range>> {
         match self {
             Self::Range(object) => Ok(object),
-            actual => err(VmError::expected::<Range>(vm_try!(actual.type_info()))),
+            actual => err(VmErrorKind::expected::<Range>(vm_try!(actual.type_info()))),
         }
     }
 
@@ -839,7 +841,9 @@ impl Value {
     pub fn into_function(self) -> VmResult<Shared<Function>> {
         match self {
             Self::Function(function) => Ok(function),
-            actual => err(VmError::expected::<Function>(vm_try!(actual.type_info()))),
+            actual => err(VmErrorKind::expected::<Function>(vm_try!(
+                actual.type_info()
+            ))),
         }
     }
 
@@ -848,7 +852,7 @@ impl Value {
     pub fn into_format(self) -> VmResult<Box<Format>> {
         match self {
             Value::Format(format) => Ok(format),
-            actual => err(VmError::expected::<Format>(vm_try!(actual.type_info()))),
+            actual => err(VmErrorKind::expected::<Format>(vm_try!(actual.type_info()))),
         }
     }
 
@@ -857,7 +861,9 @@ impl Value {
     pub fn into_iterator(self) -> VmResult<Shared<Iterator>> {
         match self {
             Value::Iterator(format) => Ok(format),
-            actual => err(VmError::expected::<Iterator>(vm_try!(actual.type_info()))),
+            actual => err(VmErrorKind::expected::<Iterator>(vm_try!(
+                actual.type_info()
+            ))),
         }
     }
 
@@ -866,7 +872,7 @@ impl Value {
     pub fn into_any(self) -> VmResult<Shared<AnyObj>> {
         match self {
             Self::Any(any) => Ok(any),
-            actual => err(VmError::expected_any(vm_try!(actual.type_info()))),
+            actual => err(VmErrorKind::expected_any(vm_try!(actual.type_info()))),
         }
     }
 
@@ -890,7 +896,7 @@ impl Value {
                 let (data, guard) = Ref::into_raw(any);
                 Ok((data, guard))
             }
-            actual => err(VmError::expected_any(vm_try!(actual.type_info()))),
+            actual => err(VmErrorKind::expected_any(vm_try!(actual.type_info()))),
         }
     }
 
@@ -914,7 +920,7 @@ impl Value {
                 let (data, guard) = Mut::into_raw(any);
                 Ok((data, guard))
             }
-            actual => err(VmError::expected_any(vm_try!(actual.type_info()))),
+            actual => err(VmErrorKind::expected_any(vm_try!(actual.type_info()))),
         }
     }
 
@@ -1090,7 +1096,7 @@ impl Value {
             },
         }
 
-        err(VmError::from(VmErrorKind::UnsupportedBinaryOperation {
+        err(VmErrorKind::from(VmErrorKind::UnsupportedBinaryOperation {
             op: "==",
             lhs: vm_try!(a.type_info()),
             rhs: vm_try!(b.type_info()),
@@ -1187,7 +1193,7 @@ impl fmt::Debug for Value {
 
                 match value.string_debug(&mut s) {
                     Ok(result) => result?,
-                    Err(error) => return write!(f, "{:?}", error.error),
+                    Err(error) => return write!(f, "{:?}", error),
                 }
 
                 f.write_str(&s)?;

--- a/crates/rune/src/runtime/value.rs
+++ b/crates/rune/src/runtime/value.rs
@@ -18,6 +18,14 @@ use std::vec;
 use VmResult::Err;
 use VmResult::Ok;
 
+// Small helper function to build errors.
+fn err<T, E>(error: E) -> VmResult<T>
+where
+    VmError: From<E>,
+{
+    VmResult::err(error)
+}
+
 /// A empty with a well-defined type.
 pub struct UnitStruct {
     /// The type hash of the empty.
@@ -562,7 +570,7 @@ impl Value {
                 match name {
                     ConstValue::String(s) => return Ok(s.clone()),
                     ConstValue::StaticString(s) => return Ok((*s).to_string()),
-                    _ => return Err(VmError::expected::<String>(name.type_info())),
+                    _ => return err(VmError::expected::<String>(name.type_info())),
                 }
             }
 
@@ -570,7 +578,7 @@ impl Value {
                 match name {
                     ConstValue::String(s) => return Ok(s.clone()),
                     ConstValue::StaticString(s) => return Ok((*s).to_string()),
-                    _ => return Err(VmError::expected::<String>(name.type_info())),
+                    _ => return err(VmError::expected::<String>(name.type_info())),
                 }
             }
 
@@ -650,7 +658,7 @@ impl Value {
     pub fn into_unit(self) -> VmResult<()> {
         match self {
             Value::Unit => Ok(()),
-            actual => Err(VmError::expected::<()>(vm_try!(actual.type_info()))),
+            actual => err(VmError::expected::<()>(vm_try!(actual.type_info()))),
         }
     }
 
@@ -659,7 +667,7 @@ impl Value {
     pub fn into_bool(self) -> VmResult<bool> {
         match self {
             Self::Bool(b) => Ok(b),
-            actual => Err(VmError::expected::<bool>(vm_try!(actual.type_info()))),
+            actual => err(VmError::expected::<bool>(vm_try!(actual.type_info()))),
         }
     }
 
@@ -668,7 +676,7 @@ impl Value {
     pub fn as_bool(&self) -> VmResult<bool> {
         match self {
             Self::Bool(b) => Ok(*b),
-            actual => Err(VmError::expected::<bool>(vm_try!(actual.type_info()))),
+            actual => err(VmError::expected::<bool>(vm_try!(actual.type_info()))),
         }
     }
 
@@ -677,7 +685,7 @@ impl Value {
     pub fn into_byte(self) -> VmResult<u8> {
         match self {
             Self::Byte(b) => Ok(b),
-            actual => Err(VmError::expected::<u8>(vm_try!(actual.type_info()))),
+            actual => err(VmError::expected::<u8>(vm_try!(actual.type_info()))),
         }
     }
 
@@ -686,7 +694,7 @@ impl Value {
     pub fn into_char(self) -> VmResult<char> {
         match self {
             Self::Char(c) => Ok(c),
-            actual => Err(VmError::expected::<char>(vm_try!(actual.type_info()))),
+            actual => err(VmError::expected::<char>(vm_try!(actual.type_info()))),
         }
     }
 
@@ -695,7 +703,7 @@ impl Value {
     pub fn into_integer(self) -> VmResult<i64> {
         match self {
             Self::Integer(integer) => Ok(integer),
-            actual => Err(VmError::expected::<i64>(vm_try!(actual.type_info()))),
+            actual => err(VmError::expected::<i64>(vm_try!(actual.type_info()))),
         }
     }
 
@@ -704,7 +712,7 @@ impl Value {
     pub fn into_float(self) -> VmResult<f64> {
         match self {
             Self::Float(float) => Ok(float),
-            actual => Err(VmError::expected::<f64>(vm_try!(actual.type_info()))),
+            actual => err(VmError::expected::<f64>(vm_try!(actual.type_info()))),
         }
     }
 
@@ -713,7 +721,7 @@ impl Value {
     pub fn into_result(self) -> VmResult<Shared<Result<Value, Value>>> {
         match self {
             Self::Result(result) => Ok(result),
-            actual => Err(VmError::expected::<Result<Value, Value>>(vm_try!(
+            actual => err(VmError::expected::<Result<Value, Value>>(vm_try!(
                 actual.type_info()
             ))),
         }
@@ -724,7 +732,7 @@ impl Value {
     pub fn as_result(&self) -> VmResult<&Shared<Result<Value, Value>>> {
         match self {
             Self::Result(result) => Ok(result),
-            actual => Err(VmError::expected::<Result<Value, Value>>(vm_try!(
+            actual => err(VmError::expected::<Result<Value, Value>>(vm_try!(
                 actual.type_info()
             ))),
         }
@@ -735,7 +743,7 @@ impl Value {
     pub fn into_generator(self) -> VmResult<Shared<Generator<Vm>>> {
         match self {
             Value::Generator(generator) => Ok(generator),
-            actual => Err(VmError::expected::<Generator<Vm>>(vm_try!(
+            actual => err(VmError::expected::<Generator<Vm>>(vm_try!(
                 actual.type_info()
             ))),
         }
@@ -746,7 +754,7 @@ impl Value {
     pub fn into_stream(self) -> VmResult<Shared<Stream<Vm>>> {
         match self {
             Value::Stream(stream) => Ok(stream),
-            actual => Err(VmError::expected::<Stream<Vm>>(vm_try!(actual.type_info()))),
+            actual => err(VmError::expected::<Stream<Vm>>(vm_try!(actual.type_info()))),
         }
     }
 
@@ -755,7 +763,7 @@ impl Value {
     pub fn into_generator_state(self) -> VmResult<Shared<GeneratorState>> {
         match self {
             Value::GeneratorState(state) => Ok(state),
-            actual => Err(VmError::expected::<GeneratorState>(vm_try!(
+            actual => err(VmError::expected::<GeneratorState>(vm_try!(
                 actual.type_info()
             ))),
         }
@@ -766,7 +774,7 @@ impl Value {
     pub fn into_option(self) -> VmResult<Shared<Option<Value>>> {
         match self {
             Self::Option(option) => Ok(option),
-            actual => Err(VmError::expected::<Option<Value>>(vm_try!(
+            actual => err(VmError::expected::<Option<Value>>(vm_try!(
                 actual.type_info()
             ))),
         }
@@ -777,7 +785,7 @@ impl Value {
     pub fn into_string(self) -> VmResult<Shared<String>> {
         match self {
             Self::String(string) => Ok(string),
-            actual => Err(VmError::expected::<String>(vm_try!(actual.type_info()))),
+            actual => err(VmError::expected::<String>(vm_try!(actual.type_info()))),
         }
     }
 
@@ -786,7 +794,7 @@ impl Value {
     pub fn into_bytes(self) -> VmResult<Shared<Bytes>> {
         match self {
             Self::Bytes(bytes) => Ok(bytes),
-            actual => Err(VmError::expected::<Bytes>(vm_try!(actual.type_info()))),
+            actual => err(VmError::expected::<Bytes>(vm_try!(actual.type_info()))),
         }
     }
 
@@ -795,7 +803,7 @@ impl Value {
     pub fn into_vec(self) -> VmResult<Shared<Vec>> {
         match self {
             Self::Vec(vec) => Ok(vec),
-            actual => Err(VmError::expected::<Vec>(vm_try!(actual.type_info()))),
+            actual => err(VmError::expected::<Vec>(vm_try!(actual.type_info()))),
         }
     }
 
@@ -804,7 +812,7 @@ impl Value {
     pub fn into_tuple(self) -> VmResult<Shared<Tuple>> {
         match self {
             Self::Tuple(tuple) => Ok(tuple),
-            actual => Err(VmError::expected::<Tuple>(vm_try!(actual.type_info()))),
+            actual => err(VmError::expected::<Tuple>(vm_try!(actual.type_info()))),
         }
     }
 
@@ -813,7 +821,7 @@ impl Value {
     pub fn into_object(self) -> VmResult<Shared<Object>> {
         match self {
             Self::Object(object) => Ok(object),
-            actual => Err(VmError::expected::<Object>(vm_try!(actual.type_info()))),
+            actual => err(VmError::expected::<Object>(vm_try!(actual.type_info()))),
         }
     }
 
@@ -822,7 +830,7 @@ impl Value {
     pub fn into_range(self) -> VmResult<Shared<Range>> {
         match self {
             Self::Range(object) => Ok(object),
-            actual => Err(VmError::expected::<Range>(vm_try!(actual.type_info()))),
+            actual => err(VmError::expected::<Range>(vm_try!(actual.type_info()))),
         }
     }
 
@@ -831,7 +839,7 @@ impl Value {
     pub fn into_function(self) -> VmResult<Shared<Function>> {
         match self {
             Self::Function(function) => Ok(function),
-            actual => Err(VmError::expected::<Function>(vm_try!(actual.type_info()))),
+            actual => err(VmError::expected::<Function>(vm_try!(actual.type_info()))),
         }
     }
 
@@ -840,7 +848,7 @@ impl Value {
     pub fn into_format(self) -> VmResult<Box<Format>> {
         match self {
             Value::Format(format) => Ok(format),
-            actual => Err(VmError::expected::<Format>(vm_try!(actual.type_info()))),
+            actual => err(VmError::expected::<Format>(vm_try!(actual.type_info()))),
         }
     }
 
@@ -849,7 +857,7 @@ impl Value {
     pub fn into_iterator(self) -> VmResult<Shared<Iterator>> {
         match self {
             Value::Iterator(format) => Ok(format),
-            actual => Err(VmError::expected::<Iterator>(vm_try!(actual.type_info()))),
+            actual => err(VmError::expected::<Iterator>(vm_try!(actual.type_info()))),
         }
     }
 
@@ -858,7 +866,7 @@ impl Value {
     pub fn into_any(self) -> VmResult<Shared<AnyObj>> {
         match self {
             Self::Any(any) => Ok(any),
-            actual => Err(VmError::expected_any(vm_try!(actual.type_info()))),
+            actual => err(VmError::expected_any(vm_try!(actual.type_info()))),
         }
     }
 
@@ -882,7 +890,7 @@ impl Value {
                 let (data, guard) = Ref::into_raw(any);
                 Ok((data, guard))
             }
-            actual => Err(VmError::expected_any(vm_try!(actual.type_info()))),
+            actual => err(VmError::expected_any(vm_try!(actual.type_info()))),
         }
     }
 
@@ -906,7 +914,7 @@ impl Value {
                 let (data, guard) = Mut::into_raw(any);
                 Ok((data, guard))
             }
-            actual => Err(VmError::expected_any(vm_try!(actual.type_info()))),
+            actual => err(VmError::expected_any(vm_try!(actual.type_info()))),
         }
     }
 
@@ -1082,7 +1090,7 @@ impl Value {
             },
         }
 
-        Err(VmError::from(VmErrorKind::UnsupportedBinaryOperation {
+        err(VmError::from(VmErrorKind::UnsupportedBinaryOperation {
             op: "==",
             lhs: vm_try!(a.type_info()),
             rhs: vm_try!(b.type_info()),
@@ -1179,7 +1187,7 @@ impl fmt::Debug for Value {
 
                 match value.string_debug(&mut s) {
                     Ok(result) => result?,
-                    Err(error) => return write!(f, "{error:?}"),
+                    Err(error) => return write!(f, "{:?}", error.error),
                 }
 
                 f.write_str(&s)?;

--- a/crates/rune/src/runtime/variant.rs
+++ b/crates/rune/src/runtime/variant.rs
@@ -1,4 +1,4 @@
-use crate::runtime::{Object, Tuple, TypeInfo, VariantRtti, Vm, VmError};
+use crate::runtime::{Object, Tuple, TypeInfo, VariantRtti, Vm, VmResult};
 use std::fmt;
 use std::sync::Arc;
 
@@ -54,24 +54,24 @@ impl Variant {
     }
 
     /// Perform a deep value comparison of two variants.
-    pub(crate) fn value_ptr_eq(vm: &mut Vm, a: &Self, b: &Self) -> Result<bool, VmError> {
+    pub(crate) fn value_ptr_eq(vm: &mut Vm, a: &Self, b: &Self) -> VmResult<bool> {
         debug_assert_eq!(
             a.rtti.enum_hash, b.rtti.enum_hash,
             "comparison only makes sense if enum hashes match"
         );
 
         if a.rtti.hash != b.rtti.hash {
-            return Ok(false);
+            return VmResult::Ok(false);
         }
 
-        Ok(match (&a.data, &b.data) {
-            (VariantData::Unit, VariantData::Unit) => true,
+        match (&a.data, &b.data) {
+            (VariantData::Unit, VariantData::Unit) => VmResult::Ok(true),
             (VariantData::Tuple(a), VariantData::Tuple(b)) => return Tuple::value_ptr_eq(vm, a, b),
             (VariantData::Struct(a), VariantData::Struct(b)) => {
                 return Object::value_ptr_eq(vm, a, b)
             }
-            _ => false,
-        })
+            _ => VmResult::Ok(false),
+        }
     }
 }
 

--- a/crates/rune/src/runtime/variant.rs
+++ b/crates/rune/src/runtime/variant.rs
@@ -66,10 +66,8 @@ impl Variant {
 
         match (&a.data, &b.data) {
             (VariantData::Unit, VariantData::Unit) => VmResult::Ok(true),
-            (VariantData::Tuple(a), VariantData::Tuple(b)) => return Tuple::value_ptr_eq(vm, a, b),
-            (VariantData::Struct(a), VariantData::Struct(b)) => {
-                return Object::value_ptr_eq(vm, a, b)
-            }
+            (VariantData::Tuple(a), VariantData::Tuple(b)) => Tuple::value_ptr_eq(vm, a, b),
+            (VariantData::Struct(a), VariantData::Struct(b)) => Object::value_ptr_eq(vm, a, b),
             _ => VmResult::Ok(false),
         }
     }

--- a/crates/rune/src/runtime/vec.rs
+++ b/crates/rune/src/runtime/vec.rs
@@ -1,7 +1,7 @@
 use crate::compile::{InstallWith, Named};
 use crate::runtime::{
     FromValue, Iterator, Mut, RawMut, RawRef, RawStr, Ref, Shared, ToValue, UnsafeFromValue, Value,
-    Vm, VmError, VmErrorKind, VmResult,
+    Vm, VmErrorKind, VmResult,
 };
 use std::cmp;
 use std::fmt;
@@ -14,18 +14,17 @@ use std::vec;
 /// # Examples
 ///
 /// ```
-/// # fn main() -> rune::Result<()> {
 /// let mut vec = rune::runtime::Vec::new();
 /// assert!(vec.is_empty());
 ///
-/// vec.push_value(42)?;
-/// vec.push_value(true)?;
+/// vec.push_value(42).into_result()?;
+/// vec.push_value(true).into_result()?;
 /// assert_eq!(2, vec.len());
 ///
-/// assert_eq!(Some(42), vec.get_value(0)?);
-/// assert_eq!(Some(true), vec.get_value(1)?);
-/// assert_eq!(None::<bool>, vec.get_value(2)?);
-/// # Ok(()) }
+/// assert_eq!(Some(42), vec.get_value(0).into_result()?);
+/// assert_eq!(Some(true), vec.get_value(1).into_result()?);
+/// assert_eq!(None::<bool>, vec.get_value(2).into_result()?);
+/// # Ok::<_, rune::Error>(())
 /// ```
 #[derive(Clone)]
 #[repr(transparent)]
@@ -93,12 +92,12 @@ impl Vec {
 
     /// Appends an element to the back of a dynamic vector, converting it as
     /// necessary through the [`ToValue`] trait.
-    pub fn push_value<T>(&mut self, value: T) -> Result<(), VmError>
+    pub fn push_value<T>(&mut self, value: T) -> VmResult<()>
     where
         T: ToValue,
     {
-        self.inner.push(value.to_value().into_result()?);
-        Ok(())
+        self.inner.push(vm_try!(value.to_value()));
+        VmResult::Ok(())
     }
 
     /// Get the value at the given index.

--- a/crates/rune/src/runtime/vec.rs
+++ b/crates/rune/src/runtime/vec.rs
@@ -76,10 +76,10 @@ impl Vec {
     /// Set by index
     pub fn set(&mut self, index: usize, value: Value) -> VmResult<()> {
         if index >= self.len() {
-            VmResult::Err(VmError::from(VmErrorKind::OutOfRange {
+            VmResult::err(VmErrorKind::OutOfRange {
                 index: index.into(),
                 len: self.len().into(),
-            }))
+            })
         } else {
             self.inner[index] = value;
             VmResult::Ok(())

--- a/crates/rune/src/runtime/vec_tuple.rs
+++ b/crates/rune/src/runtime/vec_tuple.rs
@@ -1,4 +1,4 @@
-use crate::runtime::{FromValue, ToValue, Value, VmError, VmErrorKind, VmResult};
+use crate::runtime::{FromValue, ToValue, Value, VmErrorKind, VmResult};
 
 /// A helper type to deserialize arrays with different interior types.
 ///
@@ -38,10 +38,10 @@ macro_rules! impl_from_value_tuple_vec {
                 let vec = vm_try!(vec.take());
 
                 if vec.len() != $count {
-                    return VmResult::Err(VmError::from(VmErrorKind::ExpectedTupleLength {
+                    return VmResult::err(VmErrorKind::ExpectedTupleLength {
                         actual: vec.len(),
                         expected: $count,
-                    }));
+                    });
                 }
 
                 #[allow(unused_mut, unused_variables)]
@@ -51,7 +51,7 @@ macro_rules! impl_from_value_tuple_vec {
                     let $value: $ty = match it.next() {
                         Some(value) => vm_try!(<$ty>::from_value(value)),
                         None => {
-                            return VmResult::Err(VmError::from(VmErrorKind::IterationError));
+                            return VmResult::err(VmErrorKind::IterationError);
                         },
                     };
                 )*

--- a/crates/rune/src/runtime/vm.rs
+++ b/crates/rune/src/runtime/vm.rs
@@ -189,12 +189,11 @@ impl Vm {
     /// # Examples
     ///
     /// ```
-    /// use rune::{Context, Vm, Unit, FromValue};
+    /// use rune::{Context, Vm, Unit};
     /// use rune::compile::ItemBuf;
     ///
     /// use std::sync::Arc;
     ///
-    /// # fn main() -> rune::Result<()> {
     /// let context = Context::with_default_modules()?;
     /// let context = Arc::new(context.runtime());
     ///
@@ -218,7 +217,7 @@ impl Vm {
     /// // Looking up an item from the source.
     /// let dynamic_max = vm.lookup_function(["max"])?;
     ///
-    /// let value = i64::from_value(dynamic_max.call((10, 20))?)?;
+    /// let value: i64 = rune::from_value(dynamic_max.call((10, 20)).into_result()?)?;
     /// assert_eq!(value, 20);
     ///
     /// // Building an item buffer to lookup an `::std` item.
@@ -228,9 +227,9 @@ impl Vm {
     ///
     /// let max = vm.lookup_function(&item)?;
     ///
-    /// let value = i64::from_value(max.call((10, 20)).into_result()?)?;
+    /// let value: i64 = rune::from_value(max.call((10, 20)).into_result()?)?;
     /// assert_eq!(value, 20);
-    /// # Ok(()) }
+    /// # Ok::<_, rune::Error>(())
     /// ```
     pub fn lookup_function<N>(&self, name: N) -> Result<Function, VmError>
     where
@@ -271,10 +270,9 @@ impl Vm {
     /// # Examples
     ///
     /// ```,no_run
-    /// use rune::{Context, Unit, FromValue, Source};
+    /// use rune::{Context, Unit};
     /// use std::sync::Arc;
     ///
-    /// # fn main() -> rune::Result<()> {
     /// let context = Context::with_default_modules()?;
     /// let context = Arc::new(context.runtime());
     ///
@@ -284,21 +282,20 @@ impl Vm {
     ///
     /// let mut vm = rune::Vm::new(context, unit);
     ///
-    /// let output = vm.execute(["main"], (33i64,))?.complete()?;
-    /// let output = i64::from_value(output)?;
+    /// let output = vm.execute(["main"], (33i64,))?.complete().into_result()?;
+    /// let output: i64 = rune::from_value(output)?;
     ///
     /// println!("output: {}", output);
-    /// # Ok(()) }
+    /// # Ok::<_, rune::Error>(())
     /// ```
     ///
     /// You can use a `Vec<Value>` to provide a variadic collection of
     /// arguments.
     ///
     /// ```,no_run
-    /// use rune::{Context, Unit, FromValue, Source, ToValue};
+    /// use rune::{Context, Unit};
     /// use std::sync::Arc;
     ///
-    /// # fn main() -> rune::Result<()> {
     /// let context = Context::with_default_modules()?;
     /// let context = Arc::new(context.runtime());
     ///
@@ -309,14 +306,14 @@ impl Vm {
     /// let mut vm = rune::Vm::new(context, unit);
     ///
     /// let mut args = Vec::new();
-    /// args.push(1u32.to_value()?);
-    /// args.push(String::from("Hello World").to_value()?);
+    /// args.push(rune::to_value(1u32)?);
+    /// args.push(rune::to_value(String::from("Hello World"))?);
     ///
-    /// let output = vm.execute(["main"], args)?.complete()?;
-    /// let output = i64::from_value(output)?;
+    /// let output = vm.execute(["main"], args)?.complete().into_result()?;
+    /// let output: i64 = rune::from_value(output)?;
     ///
     /// println!("output: {}", output);
-    /// # Ok(()) }
+    /// # Ok::<_, rune::Error>(())
     /// ```
     pub fn execute<A, N>(&mut self, name: N, args: A) -> Result<VmExecution<&mut Self>, VmError>
     where
@@ -2859,10 +2856,9 @@ impl Vm {
     /// [Value::string_display] which requires access to a virtual machine.
     ///
     /// ```,no_run
-    /// use rune::{Context, Unit, FromValue, Source};
+    /// use rune::{Context, Unit};
     /// use std::sync::Arc;
     ///
-    /// # fn main() -> rune::Result<()> {
     /// let context = Context::with_default_modules()?;
     /// let context = Arc::new(context.runtime());
     ///
@@ -2872,7 +2868,7 @@ impl Vm {
     ///
     /// let mut vm = rune::Vm::new(context, unit);
     ///
-    /// let output = vm.execute(["main"], ())?.complete()?;
+    /// let output = vm.call(["main"], ())?;
     ///
     /// // Call the string_display protocol on `output`. This requires
     /// // access to a virtual machine since it might use functions
@@ -2882,8 +2878,8 @@ impl Vm {
     ///
     /// // Note: We do an extra unwrap because the return value is
     /// // `fmt::Result`.
-    /// vm.with(|| output.string_display(&mut s, &mut buf))?.expect("formatting should succeed");
-    /// # Ok(()) }
+    /// vm.with(|| output.string_display(&mut s, &mut buf)).into_result()?.expect("formatting should succeed");
+    /// # Ok::<_, rune::Error>(())
     /// ```
     pub fn with<F, T>(&mut self, f: F) -> T
     where

--- a/crates/rune/src/runtime/vm.rs
+++ b/crates/rune/src/runtime/vm.rs
@@ -664,7 +664,7 @@ impl Vm {
 
                 match &*result {
                     Result::Ok(value) if index == 0 => Some(value.clone()),
-                    Result::Err(value) if index == 1 => Some(value.clone()),
+                    Result::Err(value) if index == 0 => Some(value.clone()),
                     _ => None,
                 }
             }
@@ -682,7 +682,7 @@ impl Vm {
 
                 match &*state {
                     Yielded(value) if index == 0 => Some(value.clone()),
-                    Complete(value) if index == 1 => Some(value.clone()),
+                    Complete(value) if index == 0 => Some(value.clone()),
                     _ => None,
                 }
             }
@@ -736,7 +736,7 @@ impl Vm {
 
                 BorrowMut::try_map(result, |result| match result {
                     Result::Ok(value) if index == 0 => Some(value),
-                    Result::Err(value) if index == 1 => Some(value),
+                    Result::Err(value) if index == 0 => Some(value),
                     _ => None,
                 })
             }
@@ -754,7 +754,7 @@ impl Vm {
 
                 BorrowMut::try_map(state, |state| match state {
                     Yielded(value) if index == 0 => Some(value),
-                    Complete(value) if index == 1 => Some(value),
+                    Complete(value) if index == 0 => Some(value),
                     _ => None,
                 })
             }

--- a/crates/rune/src/runtime/vm_call.rs
+++ b/crates/rune/src/runtime/vm_call.rs
@@ -1,4 +1,4 @@
-use crate::runtime::{Call, Future, Generator, Stream, Value, Vm, VmError, VmExecution};
+use crate::runtime::{Call, Future, Generator, Stream, Value, Vm, VmExecution};
 
 /// An instruction to push a virtual machine to the execution.
 #[derive(Debug)]
@@ -14,7 +14,7 @@ impl VmCall {
     }
 
     /// Encode the push itno an execution.
-    pub(crate) fn into_execution<T>(self, execution: &mut VmExecution<T>) -> Result<(), VmError>
+    pub(crate) fn into_execution<T>(self, execution: &mut VmExecution<T>)
     where
         T: AsMut<Vm>,
     {
@@ -22,7 +22,7 @@ impl VmCall {
             Call::Async => Value::from(Future::new(self.vm.async_complete())),
             Call::Immediate => {
                 execution.push_vm(self.vm);
-                return Ok(());
+                return;
             }
             Call::Stream => Value::from(Stream::new(self.vm)),
             Call::Generator => Value::from(Generator::new(self.vm)),
@@ -31,6 +31,5 @@ impl VmCall {
         let vm = execution.vm_mut();
         vm.stack_mut().push(value);
         vm.advance();
-        Ok(())
     }
 }

--- a/crates/rune/src/runtime/vm_call.rs
+++ b/crates/rune/src/runtime/vm_call.rs
@@ -19,7 +19,10 @@ impl VmCall {
         T: AsMut<Vm>,
     {
         let value = match self.call {
-            Call::Async => Value::from(Future::new(self.vm.async_complete())),
+            Call::Async => {
+                let mut execution = self.vm.into_execution();
+                Value::from(Future::new(async move { execution.async_complete().await }))
+            }
             Call::Immediate => {
                 execution.push_vm(self.vm);
                 return;

--- a/crates/rune/src/runtime/vm_error.rs
+++ b/crates/rune/src/runtime/vm_error.rs
@@ -19,6 +19,10 @@ pub trait TryFromResult {
 }
 
 /// Helper to coerce one result type into [`VmResult`].
+///
+/// Despite being public, this is actually private API (`#[doc(hidden)]`). Use
+/// at your own risk.
+#[doc(hidden)]
 pub fn try_result<T>(result: T) -> VmResult<T::Ok>
 where
     T: TryFromResult,
@@ -196,11 +200,21 @@ impl<T> VmResult<T> {
     }
 
     /// Expect a value or panic.
+    #[doc(hidden)]
     pub fn expect(self, msg: &str) -> T {
-        match self {
-            VmResult::Ok(t) => t,
-            VmResult::Err(error) => panic!("{msg}: {error:?}"),
-        }
+        self.into_result().expect(msg)
+    }
+
+    /// Unwrap the interior value.
+    #[doc(hidden)]
+    pub fn unwrap(self) -> T {
+        self.into_result().unwrap()
+    }
+
+    /// Test if it is an error.
+    #[doc(hidden)]
+    pub fn is_err(&self) -> bool {
+        matches!(self, Self::Err(..))
     }
 }
 

--- a/crates/rune/src/runtime/vm_execution.rs
+++ b/crates/rune/src/runtime/vm_execution.rs
@@ -1,6 +1,7 @@
 use crate::runtime::budget;
 use crate::runtime::{
     Generator, GeneratorState, Stream, Value, Vm, VmError, VmErrorKind, VmHalt, VmHaltInfo,
+    VmResult,
 };
 use crate::shared::AssertSend;
 use std::fmt;
@@ -102,7 +103,7 @@ where
     /// let unit = rune::prepare(&mut sources).build()?;
     ///
     /// let mut vm = Vm::without_runtime(Arc::new(unit));
-    /// let mut generator = vm.execute(["main"], ())?.into_generator()?;
+    /// let mut generator = vm.execute(["main"], ())?.into_generator();
     ///
     /// let mut n = 1i64;
     ///
@@ -113,8 +114,8 @@ where
     /// }
     /// # Ok(()) }
     /// ```
-    pub fn into_generator(self) -> Result<Generator<T>, VmError> {
-        Ok(Generator::from_execution(self))
+    pub fn into_generator(self) -> Generator<T> {
+        Generator::from_execution(self)
     }
 
     /// Coerce the current execution into a stream if appropriate.
@@ -136,7 +137,7 @@ where
     /// let unit = rune::prepare(&mut sources).build()?;
     ///
     /// let mut vm = Vm::without_runtime(Arc::new(unit));
-    /// let mut stream = vm.execute(["main"], ())?.into_stream()?;
+    /// let mut stream = vm.execute(["main"], ())?.into_stream();
     ///
     /// let mut n = 1i64;
     ///
@@ -147,8 +148,8 @@ where
     /// }
     /// # Ok(()) }
     /// ```
-    pub fn into_stream(self) -> Result<Stream<T>, VmError> {
-        Ok(Stream::from_execution(self))
+    pub fn into_stream(self) -> Stream<T> {
+        Stream::from_execution(self)
     }
 
     /// Get a reference to the current virtual machine.
@@ -167,10 +168,10 @@ where
     /// Complete the current execution without support for async instructions.
     ///
     /// This will error if the execution is suspended through yielding.
-    pub async fn async_complete(&mut self) -> Result<Value, VmError> {
-        match self.async_resume().await? {
-            GeneratorState::Complete(value) => Ok(value),
-            GeneratorState::Yielded(..) => Err(VmError::from(VmErrorKind::Halted {
+    pub async fn async_complete(&mut self) -> VmResult<Value> {
+        match vm_try!(self.async_resume().await) {
+            GeneratorState::Complete(value) => VmResult::Ok(value),
+            GeneratorState::Yielded(..) => VmResult::Err(VmError::from(VmErrorKind::Halted {
                 halt: VmHaltInfo::Yielded,
             })),
         }
@@ -180,10 +181,10 @@ where
     ///
     /// If any async instructions are encountered, this will error. This will
     /// also error if the execution is suspended through yielding.
-    pub fn complete(&mut self) -> Result<Value, VmError> {
-        match self.resume()? {
-            GeneratorState::Complete(value) => Ok(value),
-            GeneratorState::Yielded(..) => Err(VmError::from(VmErrorKind::Halted {
+    pub fn complete(&mut self) -> VmResult<Value> {
+        match vm_try!(self.resume()) {
+            GeneratorState::Complete(value) => VmResult::Ok(value),
+            GeneratorState::Yielded(..) => VmResult::Err(VmError::from(VmErrorKind::Halted {
                 halt: VmHaltInfo::Yielded,
             })),
         }
@@ -191,13 +192,12 @@ where
 
     /// Resume the current execution with the given value and resume
     /// asynchronous execution.
-    pub async fn async_resume_with(&mut self, value: Value) -> Result<GeneratorState, VmError> {
+    pub async fn async_resume_with(&mut self, value: Value) -> VmResult<GeneratorState> {
         if !matches!(self.state, ExecutionState::Resumed) {
-            return Err(VmErrorKind::ExpectedExecutionState {
+            return VmResult::Err(VmError::from(VmErrorKind::ExpectedExecutionState {
                 expected: ExecutionState::Resumed,
                 actual: self.state,
-            }
-            .into());
+            }));
         }
 
         vm_mut!(self).stack_mut().push(value);
@@ -208,7 +208,7 @@ where
     ///
     /// If the function being executed is a generator or stream this will resume
     /// it while returning a unit from the current `yield`.
-    pub async fn async_resume(&mut self) -> Result<GeneratorState, VmError> {
+    pub async fn async_resume(&mut self) -> VmResult<GeneratorState> {
         if matches!(self.state, ExecutionState::Resumed) {
             vm_mut!(self).stack_mut().push(Value::Unit);
         } else {
@@ -218,50 +218,49 @@ where
         self.inner_async_resume().await
     }
 
-    async fn inner_async_resume(&mut self) -> Result<GeneratorState, VmError> {
+    async fn inner_async_resume(&mut self) -> VmResult<GeneratorState> {
         loop {
             let len = self.vms.len();
             let vm = vm_mut!(self);
 
-            match Self::run(vm)? {
+            match vm_try!(Self::run(vm)) {
                 VmHalt::Exited => (),
                 VmHalt::Awaited(awaited) => {
-                    awaited.into_vm(vm).await?;
+                    vm_try!(awaited.into_vm(vm).await);
                     continue;
                 }
                 VmHalt::VmCall(vm_call) => {
-                    vm_call.into_execution(self)?;
+                    vm_call.into_execution(self);
                     continue;
                 }
                 VmHalt::Yielded => {
-                    let value = vm.stack_mut().pop()?;
-                    return Ok(GeneratorState::Yielded(value));
+                    let value = vm_try!(vm.stack_mut().pop());
+                    return VmResult::Ok(GeneratorState::Yielded(value));
                 }
                 halt => {
-                    return Err(VmError::from(VmErrorKind::Halted {
+                    return VmResult::Err(VmError::from(VmErrorKind::Halted {
                         halt: halt.into_info(),
                     }))
                 }
             }
 
             if len == 0 {
-                let value = self.end()?;
-                return Ok(GeneratorState::Complete(value));
+                let value = vm_try!(self.end());
+                return VmResult::Ok(GeneratorState::Complete(value));
             }
 
-            self.pop_vm()?;
+            vm_try!(self.pop_vm());
         }
     }
 
     /// Resume the current execution with the given value and resume synchronous
     /// execution.
-    pub fn resume_with(&mut self, value: Value) -> Result<GeneratorState, VmError> {
+    pub fn resume_with(&mut self, value: Value) -> VmResult<GeneratorState> {
         if !matches!(self.state, ExecutionState::Resumed) {
-            return Err(VmErrorKind::ExpectedExecutionState {
+            return VmResult::Err(VmError::from(VmErrorKind::ExpectedExecutionState {
                 expected: ExecutionState::Resumed,
                 actual: self.state,
-            }
-            .into());
+            }));
         }
 
         vm_mut!(self).stack_mut().push(value);
@@ -275,7 +274,7 @@ where
     ///
     /// If any async instructions are encountered, this will error with
     /// [VmErrorKind::Halted].
-    pub fn resume(&mut self) -> Result<GeneratorState, VmError> {
+    pub fn resume(&mut self) -> VmResult<GeneratorState> {
         if matches!(self.state, ExecutionState::Resumed) {
             vm_mut!(self).stack_mut().push(Value::Unit);
         } else {
@@ -285,34 +284,34 @@ where
         self.inner_resume()
     }
 
-    fn inner_resume(&mut self) -> Result<GeneratorState, VmError> {
+    fn inner_resume(&mut self) -> VmResult<GeneratorState> {
         loop {
             let len = self.vms.len();
             let vm = vm_mut!(self);
 
-            match Self::run(vm)? {
+            match vm_try!(Self::run(vm)) {
                 VmHalt::Exited => (),
                 VmHalt::VmCall(vm_call) => {
-                    vm_call.into_execution(self)?;
+                    vm_call.into_execution(self);
                     continue;
                 }
                 VmHalt::Yielded => {
-                    let value = vm.stack_mut().pop()?;
-                    return Ok(GeneratorState::Yielded(value));
+                    let value = vm_try!(vm.stack_mut().pop());
+                    return VmResult::Ok(GeneratorState::Yielded(value));
                 }
                 halt => {
-                    return Err(VmError::from(VmErrorKind::Halted {
+                    return VmResult::Err(VmError::from(VmErrorKind::Halted {
                         halt: halt.into_info(),
-                    }))
+                    }));
                 }
             }
 
             if len == 0 {
-                let value = self.end()?;
-                return Ok(GeneratorState::Complete(value));
+                let value = vm_try!(self.end());
+                return VmResult::Ok(GeneratorState::Complete(value));
             }
 
-            self.pop_vm()?;
+            vm_try!(self.pop_vm());
         }
     }
 
@@ -320,72 +319,72 @@ where
     /// instructions.
     ///
     /// If any async instructions are encountered, this will error.
-    pub fn step(&mut self) -> Result<Option<Value>, VmError> {
+    pub fn step(&mut self) -> VmResult<Option<Value>> {
         let len = self.vms.len();
         let vm = vm_mut!(self);
 
-        match budget::with(1, || Self::run(vm)).call()? {
+        match vm_try!(budget::with(1, || Self::run(vm)).call()) {
             VmHalt::Exited => (),
             VmHalt::VmCall(vm_call) => {
-                vm_call.into_execution(self)?;
-                return Ok(None);
+                vm_call.into_execution(self);
+                return VmResult::Ok(None);
             }
-            VmHalt::Limited => return Ok(None),
+            VmHalt::Limited => return VmResult::Ok(None),
             halt => {
-                return Err(VmError::from(VmErrorKind::Halted {
+                return VmResult::Err(VmError::from(VmErrorKind::Halted {
                     halt: halt.into_info(),
                 }))
             }
         }
 
         if len == 0 {
-            let value = self.end()?;
-            return Ok(Some(value));
+            let value = vm_try!(self.end());
+            return VmResult::Ok(Some(value));
         }
 
-        self.pop_vm()?;
-        Ok(None)
+        vm_try!(self.pop_vm());
+        VmResult::Ok(None)
     }
 
     /// Step the single execution for one step with support for async
     /// instructions.
-    pub async fn async_step(&mut self) -> Result<Option<Value>, VmError> {
+    pub async fn async_step(&mut self) -> VmResult<Option<Value>> {
         let len = self.vms.len();
         let vm = vm_mut!(self);
 
-        match budget::with(1, || Self::run(vm)).call()? {
+        match vm_try!(budget::with(1, || Self::run(vm)).call()) {
             VmHalt::Exited => (),
             VmHalt::Awaited(awaited) => {
-                awaited.into_vm(vm).await?;
-                return Ok(None);
+                vm_try!(awaited.into_vm(vm).await);
+                return VmResult::Ok(None);
             }
             VmHalt::VmCall(vm_call) => {
-                vm_call.into_execution(self)?;
-                return Ok(None);
+                vm_call.into_execution(self);
+                return VmResult::Ok(None);
             }
-            VmHalt::Limited => return Ok(None),
+            VmHalt::Limited => return VmResult::Ok(None),
             halt => {
-                return Err(VmError::from(VmErrorKind::Halted {
+                return VmResult::Err(VmError::from(VmErrorKind::Halted {
                     halt: halt.into_info(),
                 }))
             }
         }
 
         if len == 0 {
-            let value = self.end()?;
-            return Ok(Some(value));
+            let value = vm_try!(self.end());
+            return VmResult::Ok(Some(value));
         }
 
-        self.pop_vm()?;
-        Ok(None)
+        vm_try!(self.pop_vm());
+        VmResult::Ok(None)
     }
 
     /// End execution and perform debug checks.
-    pub(crate) fn end(&mut self) -> Result<Value, VmError> {
+    pub(crate) fn end(&mut self) -> VmResult<Value> {
         let vm = self.head.as_mut();
-        let value = vm.stack_mut().pop()?;
+        let value = vm_try!(vm.stack_mut().pop());
         debug_assert!(self.vms.is_empty(), "execution vms should be empty");
-        Ok(value)
+        VmResult::Ok(value)
     }
 
     /// Push a virtual machine state onto the execution.
@@ -396,25 +395,27 @@ where
 
     /// Pop a virtual machine state from the execution and transfer the top of
     /// the stack from the popped machine.
-    fn pop_vm(&mut self) -> Result<(), VmError> {
-        let (mut from, state) = self.vms.pop().ok_or(VmErrorKind::NoRunningVm)?;
+    fn pop_vm(&mut self) -> VmResult<()> {
+        let (mut from, state) = vm_try!(self.vms.pop().ok_or(VmErrorKind::NoRunningVm));
 
         let stack = from.stack_mut();
-        let value = stack.pop()?;
+        let value = vm_try!(stack.pop());
         debug_assert!(stack.is_empty(), "vm stack not clean");
 
         let onto = vm_mut!(self);
         onto.stack_mut().push(value);
         onto.advance();
         self.state = state;
-        Ok(())
+        VmResult::Ok(())
     }
 
     #[inline]
-    fn run(vm: &mut Vm) -> Result<VmHalt, VmError> {
+    fn run(vm: &mut Vm) -> VmResult<VmHalt> {
         match vm.run() {
-            Ok(reason) => Ok(reason),
-            Err(error) => Err(error.into_unwinded(vm.unit(), vm.ip(), vm.call_frames().to_vec())),
+            VmResult::Ok(reason) => VmResult::Ok(reason),
+            VmResult::Err(error) => {
+                VmResult::Err(error.into_unwinded(vm.unit(), vm.ip(), vm.call_frames().to_vec()))
+            }
         }
     }
 }
@@ -453,15 +454,13 @@ impl VmSendExecution {
     /// This requires that the result of the Vm is converted into a
     /// [crate::FromValue] that also implements [Send],  which prevents non-Send
     /// values from escaping from the virtual machine.
-    pub fn async_complete(
-        mut self,
-    ) -> impl Future<Output = Result<Value, VmError>> + Send + 'static {
+    pub fn async_complete(mut self) -> impl Future<Output = VmResult<Value>> + Send + 'static {
         let future = async move {
-            let result = self.0.async_resume().await?;
+            let result = vm_try!(self.0.async_resume().await);
 
             match result {
-                GeneratorState::Complete(value) => Ok(value),
-                GeneratorState::Yielded(..) => Err(VmError::from(VmErrorKind::Halted {
+                GeneratorState::Complete(value) => VmResult::Ok(value),
+                GeneratorState::Yielded(..) => VmResult::Err(VmError::from(VmErrorKind::Halted {
                     halt: VmHaltInfo::Yielded,
                 })),
             }

--- a/crates/rune/src/runtime/vm_execution.rs
+++ b/crates/rune/src/runtime/vm_execution.rs
@@ -86,10 +86,9 @@ where
     /// Coerce the current execution into a generator if appropriate.
     ///
     /// ```
-    /// use rune::{Context, FromValue, Vm};
+    /// use rune::Vm;
     /// use std::sync::Arc;
     ///
-    /// # fn main() -> rune::Result<()> {
     /// let mut sources = rune::sources! {
     ///     entry => {
     ///         pub fn main() {
@@ -106,12 +105,12 @@ where
     ///
     /// let mut n = 1i64;
     ///
-    /// while let Some(value) = generator.next()? {
-    ///     let value = i64::from_value(value)?;
+    /// while let Some(value) = generator.next().into_result()? {
+    ///     let value: i64 = rune::from_value(value)?;
     ///     assert_eq!(value, n);
     ///     n += 1;
     /// }
-    /// # Ok(()) }
+    /// # Ok::<_, rune::Error>(())
     /// ```
     pub fn into_generator(self) -> Generator<T> {
         Generator::from_execution(self)
@@ -120,7 +119,7 @@ where
     /// Coerce the current execution into a stream if appropriate.
     ///
     /// ```
-    /// use rune::{Context, FromValue, Vm};
+    /// use rune::Vm;
     /// use std::sync::Arc;
     ///
     /// # #[tokio::main] async fn main() -> rune::Result<()> {
@@ -140,8 +139,8 @@ where
     ///
     /// let mut n = 1i64;
     ///
-    /// while let Some(value) = stream.next().await? {
-    ///     let value = i64::from_value(value)?;
+    /// while let Some(value) = stream.next().await.into_result()? {
+    ///     let value: i64 = rune::from_value(value)?;
     ///     assert_eq!(value, n);
     ///     n += 1;
     /// }

--- a/examples/examples/checked_add_assign.rs
+++ b/examples/examples/checked_add_assign.rs
@@ -1,4 +1,4 @@
-use rune::runtime::{VmError, VmErrorKind};
+use rune::runtime::{VmErrorKind, VmResult};
 use rune::termcolor::{ColorChoice, StandardStream};
 use rune::{Any, ContextError, Diagnostics, Module, Vm};
 use std::sync::Arc;
@@ -11,13 +11,13 @@ struct External {
 
 #[allow(clippy::unnecessary_lazy_evaluations)]
 impl External {
-    fn value_add_assign(&mut self, other: i64) -> Result<(), VmError> {
-        self.value = self
+    fn value_add_assign(&mut self, other: i64) -> VmResult<()> {
+        self.value = rune::vm_try!(self
             .value
             .checked_add(other)
-            .ok_or_else(|| VmErrorKind::Overflow)?;
+            .ok_or_else(|| VmErrorKind::Overflow));
 
-        Ok(())
+        VmResult::Ok(())
     }
 }
 
@@ -56,8 +56,7 @@ fn main() -> rune::Result<()> {
         value: i64::max_value(),
     };
     let err = vm.call(["main"], (input,)).unwrap_err();
-    let (kind, _) = err.as_unwound();
-    println!("{:?}", kind);
+    println!("{:?}", err.kind());
     Ok(())
 }
 

--- a/examples/examples/concat_idents.rs
+++ b/examples/examples/concat_idents.rs
@@ -2,7 +2,7 @@ use rune::ast;
 use rune::macros::{quote, MacroContext, TokenStream};
 use rune::parse::Parser;
 use rune::termcolor::{ColorChoice, StandardStream};
-use rune::{Context, Diagnostics, FromValue, Module, Vm, T};
+use rune::{Context, Diagnostics, Module, Vm, T};
 use std::sync::Arc;
 
 fn concat_idents(ctx: &mut MacroContext<'_>, stream: &TokenStream) -> rune::Result<TokenStream> {
@@ -63,7 +63,7 @@ fn main() -> rune::Result<()> {
 
     let mut vm = Vm::new(runtime, unit);
     let value = vm.call(["main"], ())?;
-    let value = u32::from_value(value)?;
+    let value: u32 = rune::from_value(value)?;
 
     assert_eq!(value, 42);
     Ok(())

--- a/examples/examples/custom_instance_fn.rs
+++ b/examples/examples/custom_instance_fn.rs
@@ -1,5 +1,5 @@
 use rune::termcolor::{ColorChoice, StandardStream};
-use rune::{ContextError, Diagnostics, FromValue, Module, Vm};
+use rune::{ContextError, Diagnostics, Module, Vm};
 use std::sync::Arc;
 
 fn divide_by_three(value: i64) -> i64 {
@@ -35,8 +35,8 @@ async fn main() -> rune::Result<()> {
     let unit = result?;
 
     let mut vm = Vm::new(runtime, Arc::new(unit));
-    let output = vm.execute(["main"], (33i64,))?.complete()?;
-    let output = i64::from_value(output)?;
+    let output = vm.execute(["main"], (33i64,))?.complete().into_result()?;
+    let output: i64 = rune::from_value(output)?;
 
     println!("output: {}", output);
     Ok(())

--- a/examples/examples/custom_mul.rs
+++ b/examples/examples/custom_mul.rs
@@ -2,7 +2,7 @@
 //! specific type `Foo`.
 
 use rune::runtime::Protocol;
-use rune::{Any, ContextError, Diagnostics, FromValue, Module, Vm};
+use rune::{Any, ContextError, Diagnostics, Module, Vm};
 use std::sync::Arc;
 
 #[derive(Debug, Default, Any)]
@@ -43,7 +43,7 @@ fn main() -> rune::Result<()> {
 
     let mut vm = Vm::new(runtime, Arc::new(unit));
     let output = vm.call(["main"], (Foo { field: 5 },))?;
-    let output = Foo::from_value(output)?;
+    let output: Foo = rune::from_value(output)?;
 
     println!("output: {:?}", output);
     Ok(())

--- a/examples/examples/external_enum.rs
+++ b/examples/examples/external_enum.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use rune::runtime::Vm;
 use rune::termcolor::{ColorChoice, StandardStream};
-use rune::{Any, ContextError, Diagnostics, FromValue, Module};
+use rune::{Any, ContextError, Diagnostics, Module};
 
 #[derive(Debug, Any, PartialEq, Eq)]
 enum External {
@@ -59,19 +59,19 @@ fn main() -> rune::Result<()> {
     let mut vm = Vm::new(runtime, Arc::new(unit));
 
     let output = vm.call(["main"], (External::First(42),))?;
-    let output = External::from_value(output)?;
+    let output: External = rune::from_value(output)?;
     println!("{:?}", output);
 
     let output = vm.call(["main"], (External::Second(42, 12345),))?;
-    let output = External::from_value(output)?;
+    let output: External = rune::from_value(output)?;
     println!("{:?}", output);
 
     let output = vm.call(["main"], (External::Third,))?;
-    let output = External::from_value(output)?;
+    let output: External = rune::from_value(output)?;
     println!("{:?}", output);
 
     let output = vm.call(["main"], (External::Fourth { a: 42, b: 2 },))?;
-    let output = External::from_value(output)?;
+    let output: External = rune::from_value(output)?;
     println!("{:?}", output);
     Ok(())
 }

--- a/examples/examples/minimal.rs
+++ b/examples/examples/minimal.rs
@@ -1,5 +1,5 @@
 use rune::termcolor::{ColorChoice, StandardStream};
-use rune::{Diagnostics, FromValue, Vm};
+use rune::{Diagnostics, Vm};
 use std::sync::Arc;
 
 fn main() -> rune::Result<()> {
@@ -28,8 +28,8 @@ fn main() -> rune::Result<()> {
     let unit = result?;
 
     let mut vm = Vm::new(Arc::new(context.runtime()), Arc::new(unit));
-    let output = vm.execute(["main"], (33i64,))?.complete()?;
-    let output = i64::from_value(output)?;
+    let output = vm.execute(["main"], (33i64,))?.complete().into_result()?;
+    let output: i64 = rune::from_value(output)?;
 
     println!("output: {}", output);
     Ok(())

--- a/examples/examples/native_function.rs
+++ b/examples/examples/native_function.rs
@@ -1,5 +1,5 @@
 use rune::termcolor::{ColorChoice, StandardStream};
-use rune::{ContextError, Diagnostics, FromValue, Module, Vm};
+use rune::{ContextError, Diagnostics, Module, Vm};
 use std::sync::Arc;
 
 fn main() -> rune::Result<()> {
@@ -34,7 +34,7 @@ fn main() -> rune::Result<()> {
 
     let mut vm = Vm::new(runtime, Arc::new(unit));
     let output = vm.call(["main"], (1u32,))?;
-    let output = i64::from_value(output)?;
+    let output: i64 = rune::from_value(output)?;
 
     println!("{}", output);
     Ok(())

--- a/examples/examples/object.rs
+++ b/examples/examples/object.rs
@@ -1,6 +1,6 @@
 use rune::runtime::Object;
 use rune::termcolor::{ColorChoice, StandardStream};
-use rune::{Diagnostics, FromValue, Value, Vm};
+use rune::{Diagnostics, Value, Vm};
 use std::sync::Arc;
 
 fn main() -> rune::Result<()> {
@@ -37,7 +37,7 @@ fn main() -> rune::Result<()> {
     object.insert(String::from("key"), Value::from(42i64));
 
     let output = vm.call(["calc"], (object,))?;
-    let output = Object::from_value(output)?;
+    let output: Object = rune::from_value(output)?;
 
     println!("{:?}", output.get("key"));
     Ok(())

--- a/examples/examples/parsing_in_macro.rs
+++ b/examples/examples/parsing_in_macro.rs
@@ -2,7 +2,7 @@ use rune::macros::quote;
 use rune::parse::Parser;
 use rune::termcolor::{ColorChoice, StandardStream};
 use rune::{ast, ContextError};
-use rune::{Diagnostics, FromValue, Module, Vm};
+use rune::{Diagnostics, Module, Vm};
 use std::sync::Arc;
 
 pub fn main() -> rune::Result<()> {
@@ -37,8 +37,8 @@ pub fn main() -> rune::Result<()> {
     let unit = result?;
 
     let mut vm = Vm::new(runtime, Arc::new(unit));
-    let output = vm.execute(["main"], ())?.complete()?;
-    let output = <(u32, u32)>::from_value(output)?;
+    let output = vm.execute(["main"], ())?.complete().into_result()?;
+    let output: (u32, u32) = rune::from_value(output)?;
 
     println!("{:?}", output);
     Ok(())

--- a/examples/examples/proxy.rs
+++ b/examples/examples/proxy.rs
@@ -45,8 +45,11 @@ fn main() -> rune::Result<()> {
     let input = MyBytes {
         bytes: vec![77, 77, 77, 77],
     };
-    let output = vm.execute(["passthrough"], (input,))?.complete().into_result()?;
-    let mut output = Proxy::from_value(output).into_result()?;
+    let output = vm
+        .execute(["passthrough"], (input,))?
+        .complete()
+        .into_result()?;
+    let mut output: Proxy = rune::from_value(output)?;
 
     println!("field: {:?}", output.field);
     println!("my_bytes: {:?}", output.my_bytes);

--- a/examples/examples/proxy.rs
+++ b/examples/examples/proxy.rs
@@ -45,8 +45,8 @@ fn main() -> rune::Result<()> {
     let input = MyBytes {
         bytes: vec![77, 77, 77, 77],
     };
-    let output = vm.execute(["passthrough"], (input,))?.complete()?;
-    let mut output = Proxy::from_value(output)?;
+    let output = vm.execute(["passthrough"], (input,))?.complete().into_result()?;
+    let mut output = Proxy::from_value(output).into_result()?;
 
     println!("field: {:?}", output.field);
     println!("my_bytes: {:?}", output.my_bytes);

--- a/examples/examples/rune_function.rs
+++ b/examples/examples/rune_function.rs
@@ -1,6 +1,6 @@
 use rune::runtime::Function;
 use rune::termcolor::{ColorChoice, StandardStream};
-use rune::{Diagnostics, FromValue, Vm};
+use rune::{Diagnostics, Vm};
 use std::sync::Arc;
 
 fn main() -> rune::Result<()> {
@@ -35,9 +35,9 @@ fn main() -> rune::Result<()> {
 
     let mut vm = Vm::new(runtime, Arc::new(unit));
     let output = vm.call(["main"], ())?;
-    let output = Function::from_value(output)?;
+    let output: Function = rune::from_value(output)?;
 
-    println!("{}", output.call::<(i64, i64), i64>((1, 3))?);
-    println!("{}", output.call::<(i64, i64), i64>((2, 6))?);
+    println!("{}", output.call::<(i64, i64), i64>((1, 3)).into_result()?);
+    println!("{}", output.call::<(i64, i64), i64>((2, 6)).into_result()?);
     Ok(())
 }

--- a/examples/examples/rune_function_macro.rs
+++ b/examples/examples/rune_function_macro.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use rune::termcolor::{ColorChoice, StandardStream};
 use rune::Any;
-use rune::{ContextError, Diagnostics, FromValue, Module, Vm};
+use rune::{ContextError, Diagnostics, Module, Vm};
 
 fn main() -> rune::Result<()> {
     let m = module()?;
@@ -36,7 +36,7 @@ fn main() -> rune::Result<()> {
 
     let mut vm = Vm::new(runtime, Arc::new(unit));
     let output = vm.call(["main"], (1u32,))?;
-    let output = i64::from_value(output)?;
+    let output: i64 = rune::from_value(output)?;
 
     println!("{}", output);
     Ok(())

--- a/examples/examples/simple_external.rs
+++ b/examples/examples/simple_external.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use rune::runtime::Vm;
 use rune::termcolor::{ColorChoice, StandardStream};
-use rune::{Any, ContextError, Diagnostics, FromValue, Module};
+use rune::{Any, ContextError, Diagnostics, Module};
 
 #[derive(Debug, Any)]
 struct External {
@@ -47,7 +47,7 @@ fn main() -> rune::Result<()> {
     let mut vm = Vm::new(runtime, Arc::new(unit));
 
     let output = vm.call(["main"], (External { value: 42 },))?;
-    let output = External::from_value(output)?;
+    let output: External = rune::from_value(output)?;
     println!("{:?}", output);
     assert_eq!(output.value, 42);
     Ok(())

--- a/examples/examples/tuple.rs
+++ b/examples/examples/tuple.rs
@@ -1,5 +1,5 @@
 use rune::termcolor::{ColorChoice, StandardStream};
-use rune::{Diagnostics, FromValue, Vm};
+use rune::{Diagnostics, Vm};
 use std::sync::Arc;
 
 fn main() -> rune::Result<()> {
@@ -30,7 +30,7 @@ fn main() -> rune::Result<()> {
 
     let mut vm = Vm::new(runtime, Arc::new(unit));
     let output = vm.call(["calc"], ((1u32, 2u32),))?;
-    let output = <(i32, i32)>::from_value(output)?;
+    let output: (i32, i32) = rune::from_value(output)?;
 
     println!("{:?}", output);
     Ok(())

--- a/examples/examples/vec_args.rs
+++ b/examples/examples/vec_args.rs
@@ -1,6 +1,6 @@
-use rune::runtime::{Function, VmError};
+use rune::runtime::{Function, VmResult};
 use rune::termcolor::{ColorChoice, StandardStream};
-use rune::{ContextError, Diagnostics, FromValue, Module, Value, Vm};
+use rune::{ContextError, Diagnostics, Module, Value, Vm};
 use std::sync::Arc;
 
 fn main() -> rune::Result<()> {
@@ -38,7 +38,7 @@ fn main() -> rune::Result<()> {
 
     let mut vm = Vm::new(runtime, Arc::new(unit));
     let output = vm.call(["main"], ())?;
-    let output = u32::from_value(output)?;
+    let output: u32 = rune::from_value(output)?;
 
     println!("{}", output);
     Ok(())
@@ -49,7 +49,7 @@ fn module() -> Result<Module, ContextError> {
 
     m.function(
         ["pass_along"],
-        |func: Function, args: Vec<Value>| -> Result<Value, VmError> { func.call(args) },
+        |func: Function, args: Vec<Value>| -> VmResult<Value> { func.call(args) },
     )?;
 
     Ok(m)

--- a/examples/examples/vec_tuple.rs
+++ b/examples/examples/vec_tuple.rs
@@ -1,6 +1,6 @@
 use rune::runtime::VecTuple;
 use rune::termcolor::{ColorChoice, StandardStream};
-use rune::{Diagnostics, FromValue, Vm};
+use rune::{Diagnostics, Vm};
 use std::sync::Arc;
 
 fn main() -> rune::Result<()> {
@@ -34,7 +34,7 @@ fn main() -> rune::Result<()> {
 
     let input: VecTuple<(i64, String)> = VecTuple::new((1, String::from("Hello")));
     let output = vm.call(["calc"], (input,))?;
-    let VecTuple((a, b)) = VecTuple::<(u32, String)>::from_value(output)?;
+    let VecTuple((a, b)): VecTuple<(u32, String)> = rune::from_value(output)?;
 
     println!("({:?}, {:?})", a, b);
     Ok(())

--- a/examples/examples/vector.rs
+++ b/examples/examples/vector.rs
@@ -1,5 +1,5 @@
 use rune::termcolor::{ColorChoice, StandardStream};
-use rune::{Diagnostics, FromValue, Vm};
+use rune::{Diagnostics, Vm};
 use std::sync::Arc;
 
 fn main() -> rune::Result<()> {
@@ -37,7 +37,7 @@ fn main() -> rune::Result<()> {
 
     let input = vec![1, 2, 3, 4];
     let output = vm.call(["calc"], (input,))?;
-    let output = Vec::<i64>::from_value(output)?;
+    let output: Vec<i64> = rune::from_value(output)?;
 
     println!("{:?}", output);
     Ok(())

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -168,11 +168,10 @@ pub fn build(context: &Context, source: &str) -> rune::Result<Arc<Unit>> {
 /// use rune_tests::*;
 /// use rune::Value;
 ///
-/// # fn main() {
 /// let mut vm = rune_tests::rune_vm!(pub fn main() { true || false });
 /// let result = vm.execute(["main"], ()).unwrap().complete().unwrap();
 /// assert_eq!(result.into_bool().unwrap(), true);
-/// # }
+/// ```
 #[macro_export]
 macro_rules! rune_vm {
     ($($tt:tt)*) => {{
@@ -193,11 +192,10 @@ macro_rules! rune_vm {
 /// use rune_tests::*;
 /// use rune::Value;
 ///
-/// # fn main() {
 /// let mut vm = rune_tests::rune_vm!(pub fn main() { true || false });
 /// let result = vm.execute(["main"], ()).unwrap().complete().unwrap();
 /// assert_eq!(result.into_bool().unwrap(), true);
-/// # }
+/// ```
 #[macro_export]
 macro_rules! rune_vm_capture {
     ($($tt:tt)*) => {{
@@ -220,10 +218,9 @@ macro_rules! rune_vm_capture {
 /// ```
 /// use rune_tests::*;
 ///
-/// # fn main() {
 /// let out: bool = rune_tests::rune!(pub fn main() { true || false });
 /// assert_eq!(out, true);
-/// # }
+/// ```
 #[macro_export]
 macro_rules! rune {
     ($($tt:tt)*) => {{
@@ -239,10 +236,8 @@ macro_rules! rune {
 /// ```
 /// use rune_tests::*;
 ///
-/// # fn main() {
 /// let out: bool = rune_tests::rune_s!("pub fn main() { true || false }");
 /// assert_eq!(out, true);
-/// # }
 /// ```
 #[macro_export]
 macro_rules! rune_s {
@@ -261,6 +256,7 @@ macro_rules! rune_s {
 /// ```
 /// use rune_tests::*;
 /// use rune::Module;
+///
 /// fn get_native_module() -> Module {
 ///     Module::new()
 /// }
@@ -271,6 +267,7 @@ macro_rules! rune_s {
 ///     true,
 /// };
 /// # }
+/// ```
 #[macro_export]
 macro_rules! rune_n {
     ($module:expr, $args:expr, $ty:ty => $($tt:tt)*) => {{

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -301,8 +301,8 @@ macro_rules! assert_vm_error {
             }
         };
 
-        let (e, _) = match e {
-            $crate::RunError::VmError(e) => e.into_unwound(),
+        let e = match e {
+            $crate::RunError::VmError(e) => e,
             actual => {
                 panic!("expected vm error `{}` but was `{:?}`", stringify!($pat), actual);
             }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -3,7 +3,7 @@
 
 pub use ::rune_modules as modules;
 use rune::compile::{IntoComponent, ItemBuf};
-use rune::runtime::{Args, VmError};
+use rune::runtime::{Args, VmError, VmErrorWithTrace, VmResult};
 use rune::{termcolor, BuildError, Context, Diagnostics, FromValue, Source, Sources, Unit, Vm};
 use std::sync::Arc;
 use thiserror::Error;
@@ -15,15 +15,15 @@ pub enum RunError {
     #[error("build error")]
     BuildError(BuildError),
     /// A virtual machine error was raised during testing.
-    #[error("vm error")]
-    VmError(#[source] VmError),
+    #[error("vm error: {0}")]
+    VmError(Box<VmErrorWithTrace>),
 }
 
 impl RunError {
     /// Unpack into a vm error or panic with the given message.
     pub fn expect_vm_error(self, msg: &str) -> VmError {
         match self {
-            Self::VmError(error) => error,
+            Self::VmError(error) => error.into_error(),
             _ => panic!("{}", msg),
         }
     }
@@ -80,14 +80,20 @@ where
     ::futures_executor::block_on(async move {
         let mut vm = vm(context, sources, diagnostics)?;
 
-        let output = vm
-            .execute(&ItemBuf::with_item(function), args)
-            .map_err(RunError::VmError)?
-            .async_complete()
-            .await
-            .map_err(RunError::VmError)?;
+        let mut execute = match vm.execute(&ItemBuf::with_item(function), args) {
+            VmResult::Ok(execute) => execute,
+            VmResult::Err(err) => return Err(RunError::VmError(err)),
+        };
 
-        T::from_value(output).map_err(RunError::VmError)
+        let output = match execute.async_complete().await {
+            VmResult::Ok(output) => output,
+            VmResult::Err(err) => return Err(RunError::VmError(err)),
+        };
+
+        match T::from_value(output) {
+            VmResult::Ok(output) => Ok(output),
+            VmResult::Err(err) => Err(RunError::VmError(err)),
+        }
     })
 }
 

--- a/tests/tests/custom_macros.rs
+++ b/tests/tests/custom_macros.rs
@@ -1,7 +1,7 @@
 use rune::ast;
 use rune::macros::quote;
 use rune::parse::Parser;
-use rune::{Context, FromValue, Module, Vm};
+use rune::{Context, Module, Vm};
 use std::sync::Arc;
 
 #[test]
@@ -43,8 +43,8 @@ fn test_parse_in_macro() -> rune::Result<()> {
     let unit = rune::prepare(&mut sources).with_context(&context).build()?;
 
     let mut vm = Vm::new(Arc::new(context.runtime()), Arc::new(unit));
-    let output = vm.execute(["main"], ())?.complete()?;
-    let output = <(u32, u32)>::from_value(output)?;
+    let output = vm.execute(["main"], ())?.complete().into_result()?;
+    let output: (u32, u32) = rune::from_value(output)?;
 
     assert_eq!(output, (42, 42));
     Ok(())

--- a/tests/tests/external_enum.rs
+++ b/tests/tests/external_enum.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use rune::runtime::Vm;
-use rune::{Any, Context, ContextError, FromValue, Module};
+use rune::{Any, Context, ContextError, Module};
 
 /// Tests pattern matching and constructing over an external variant from within
 /// Rune.
@@ -56,19 +56,19 @@ fn test_external_enum() -> Result<(), Box<dyn std::error::Error>> {
     let mut vm = Vm::new(runtime, Arc::new(unit));
 
     let output = vm.call(["main"], (External::First(42),))?;
-    let output = External::from_value(output)?;
+    let output: External = rune::from_value(output)?;
     assert_eq!(output, External::Output(42));
 
     let output = vm.call(["main"], (External::Second(43),))?;
-    let output = External::from_value(output)?;
+    let output: External = rune::from_value(output)?;
     assert_eq!(output, External::Output(43 * 2));
 
     let output = vm.call(["main"], (External::Third,))?;
-    let output = External::from_value(output)?;
+    let output: External = rune::from_value(output)?;
     assert_eq!(output, External::Output(3));
 
     let output = vm.call(["main"], (External::Fourth { a: 2, b: 3 },))?;
-    let output = External::from_value(output)?;
+    let output: External = rune::from_value(output)?;
     assert_eq!(output, External::Output(2 * 3 * 4));
     Ok(())
 }

--- a/tests/tests/reference_error.rs
+++ b/tests/tests/reference_error.rs
@@ -1,4 +1,4 @@
-use rune::runtime::{AnyObj, Shared, VmError};
+use rune::runtime::{AnyObj, Shared, VmResult};
 use rune::Any;
 use rune::{Context, Module, Vm};
 use std::sync::Arc;
@@ -10,10 +10,10 @@ fn test_reference_error() -> rune::Result<()> {
         value: i64,
     }
 
-    fn take_it(this: Shared<AnyObj>) -> Result<(), VmError> {
+    fn take_it(this: Shared<AnyObj>) -> VmResult<()> {
         // NB: this will error, since this is a reference.
-        let _ = this.into_ref()?;
-        Ok(())
+        let _ = rune::vm_try!(this.into_ref());
+        VmResult::Ok(())
     }
 
     let mut module = Module::new();

--- a/tests/tests/vm_closures.rs
+++ b/tests/tests/vm_closures.rs
@@ -189,8 +189,8 @@ fn test_closure_in_lit_vec() -> rune::Result<()> {
 
     let (start, first, second, end) = ret.0;
     assert_eq!(0, start);
-    assert_eq!(2, first.call::<_, i64>(())?);
-    assert_eq!(4, second.call::<_, i64>(())?);
+    assert_eq!(2, first.call::<_, i64>(()).into_result()?);
+    assert_eq!(4, second.call::<_, i64>(()).into_result()?);
     assert_eq!(3, end);
     Ok(())
 }
@@ -203,8 +203,8 @@ fn test_closure_in_lit_tuple() -> rune::Result<()> {
 
     let (start, first, second, end) = ret;
     assert_eq!(0, start);
-    assert_eq!(2, first.call::<_, i64>(())?);
-    assert_eq!(4, second.call::<_, i64>(())?);
+    assert_eq!(2, first.call::<_, i64>(()).into_result()?);
+    assert_eq!(4, second.call::<_, i64>(()).into_result()?);
     assert_eq!(3, end);
     Ok(())
 }
@@ -224,8 +224,8 @@ fn test_closure_in_lit_object() -> rune::Result<()> {
     };
 
     assert_eq!(0, proxy.a);
-    assert_eq!(2, proxy.b.call::<_, i64>(())?);
-    assert_eq!(4, proxy.c.call::<_, i64>(())?);
+    assert_eq!(2, proxy.b.call::<_, i64>(()).into_result()?);
+    assert_eq!(4, proxy.c.call::<_, i64>(()).into_result()?);
     assert_eq!(3, proxy.d);
     Ok(())
 }

--- a/tests/tests/vm_function.rs
+++ b/tests/tests/vm_function.rs
@@ -33,7 +33,7 @@ fn test_function() {
         pub fn main() { Custom::A }
     };
 
-    assert!(function.call::<_, Value>(()).is_err());
+    assert!(function.call::<_, Value>(()).into_result().is_err());
     let value: Value = function.call((1i64,)).unwrap();
     assert!(matches!(value, Value::Variant(..)));
 
@@ -43,7 +43,7 @@ fn test_function() {
         pub fn main() { Custom }
     };
 
-    assert!(function.call::<_, Value>(()).is_err());
+    assert!(function.call::<_, Value>(()).into_result().is_err());
     let value: Value = function.call((1i64,)).unwrap();
     assert!(matches!(value, Value::TupleStruct(..)));
 
@@ -52,7 +52,7 @@ fn test_function() {
         pub fn main() { |a, b| a + b }
     };
 
-    assert!(function.call::<_, Value>((1i64,)).is_err());
+    assert!(function.call::<_, Value>((1i64,)).into_result().is_err());
     let value: Value = function.call((1i64, 2i64)).unwrap();
     assert!(matches!(value, Value::Integer(3)));
 
@@ -65,7 +65,7 @@ fn test_function() {
     )
     .unwrap();
 
-    assert!(function.call::<_, Value>((1i64,)).is_err());
+    assert!(function.call::<_, Value>((1i64,)).into_result().is_err());
     let value: Value = function.call(()).unwrap();
     assert!(matches!(value, Value::Integer(3)));
 }


### PR DESCRIPTION
This PR completely changes how result handling is done.

A fundamental problem with the current approach is that the following values are legal to return from a handler:
* Result<T, VmError> - which converts the error into an *internal* vm error if it's the `Err(..)` variant.
* Result<T, Panic> - which converts the `Result` into an internal panic, if it's the `Err(..)` variant.
* Result<T, E> - which converts the `Result` into a `Value`.

So let's say we want to know what the type of the expression is through a trait. For the first two variants, the type should be determined by `T`:

```rust
impl<T> TypeOf Result<T, VmError> where T: TypeOf {
    fn type_of() -> FullTypeOf {
        T::type_of()
    }
}
```

But what about the second variant? Well, the type is *supposed* to be [`RESULT_TYPE`](https://docs.rs/rune/latest/rune/runtime/static.RESULT_TYPE.html) **because** a `Result` is an internal type, which leads to an implementation like this:

```rust
impl<T, E> TypeOf Result<T, E> {
    fn type_of() -> FullTypeOf {
        RESULT_TYPE.into()
    }
}
```

But the keen-eyed might note that this implementation conflicts with the first one.

This PR introduces a separate type for propagating internal errors called `VmResult`. This type is completely unrelated to `std::result::Result` and is used internally wherever `Result<T, VmError>` was previously used.

By having a separate type, the first implementation becomes obvious, and it no longer conflicts with the `Result<T, E>` type:

```rust
impl<T> TypeOf VmResult<T> where T: TypeOf {
    fn type_of() -> FullTypeOf {
        T::type_of()
    }
}
```

A downside is that since [`try_trait_v2`](https://github.com/rust-lang/rust/issues/84277) is not stable (yet), we can't use the try operator `?` on it. So we also introduce `rune::vm_try!` to fill this gap, like the `try!` macro used to in Rust. Another downside is that `Result` combinators such as `Result::map_err` are not present.

Wherever appropriate we try to convert this into `Result<T, VmError>` so that it works as intended, however this is not always doable. If you ever encounter a `VmResult` in the wild but you need a `Result<T, VmError>` you can call `VmResult::into_result`.

The use of `FromValue` and `ToValue` is also somewhat complicated as a result. Two more utility methods have been added (which are also long overdue):
* `rune::from_value<T>(value: Value) -> Result<T, VmError>`.
* `rune::to_value<T>(value: T) -> Result<Value, VmError>`.

As a result of this PR, documentation types now display the correct return values, from this:

![image](https://user-images.githubusercontent.com/111092/229950715-377f4f15-3ae6-44b4-b55e-430ceeb7d22e.png)

To this:

![image](https://user-images.githubusercontent.com/111092/229950792-1a65a67e-59dd-4a7d-9c05-04b2d5b9bfee.png)
