### PR TITLE
Add completion support to the language server

### DIFF
--- a/crates/rune/Cargo.toml
+++ b/crates/rune/Cargo.toml
@@ -20,7 +20,7 @@ bench = []
 workspace = ["toml", "semver", "relative-path", "serde-hashkey"]
 doc = ["rust-embed", "handlebars", "pulldown-cmark", "syntect"]
 cli = ["doc", "bincode", "atty", "tracing-subscriber", "anyhow/std", "clap", "webbrowser", "capture-io", "disable-io", "languageserver"]
-languageserver = ["lsp", "ropey", "percent-encoding", "url", "serde_json", "tokio", "workspace"]
+languageserver = ["lsp", "ropey", "percent-encoding", "url", "serde_json", "tokio", "workspace", "doc"]
 capture-io = ["parking_lot"]
 disable-io = []
 

--- a/crates/rune/src/doc/visitor.rs
+++ b/crates/rune/src/doc/visitor.rs
@@ -4,6 +4,7 @@ use crate::compile::{
 };
 use crate::hash::Hash;
 
+#[derive(Clone)] // TODO(TSol): this is a bit hackish
 pub(crate) struct VisitorData {
     pub(crate) item: ItemBuf,
     pub(crate) hash: Hash,
@@ -24,6 +25,7 @@ impl VisitorData {
     }
 }
 
+#[derive(Clone)] // TODO(TSol): this is a bit hackish
 /// Visitor used to collect documentation from rune sources.
 pub struct Visitor {
     pub(crate) base: ItemBuf,

--- a/crates/rune/src/indexing/index.rs
+++ b/crates/rune/src/indexing/index.rs
@@ -570,7 +570,7 @@ impl<'a> Indexer<'a> {
 
         let source_id = self.q.sources.insert(source);
         self.q.visitor.visit_mod(source_id, span);
-
+        
         self.queue.push_back(Task::LoadFile {
             kind: LoadFileKind::Module {
                 root: self.root.clone(),

--- a/crates/rune/src/languageserver.rs
+++ b/crates/rune/src/languageserver.rs
@@ -98,7 +98,6 @@ pub async fn run(context: Context, options: Options) -> Result<()> {
                     req(lsp::request::Shutdown, shutdown),
                     req(lsp::request::GotoDefinition, goto_definition),
                     req(lsp::request::Completion, completion),
-                    req(lsp::request::ResolveCompletionItem, resolve),
                     notif(lsp::notification::DidOpenTextDocument, did_open_text_document),
                     notif(lsp::notification::DidChangeTextDocument, did_change_text_document),
                     notif(lsp::notification::DidCloseTextDocument, did_close_text_document),
@@ -130,13 +129,13 @@ async fn initialize(
         definition_provider: Some(lsp::OneOf::Left(true)),
         completion_provider: Some(lsp::CompletionOptions {
             all_commit_characters: None,
-            resolve_provider: Some(true),
+            resolve_provider: Some(false),
             trigger_characters: Some(vec![".".into(), "::".into()]),
             work_done_progress_options: lsp::WorkDoneProgressOptions {
                 work_done_progress: None,
             },
             completion_item: Some(lsp::CompletionOptionsCompletionItem {
-                label_details_support: None,
+                label_details_support: Some(true),
             }),
         }),
         ..Default::default()
@@ -215,13 +214,6 @@ async fn completion(
 
     let results = results.map(lsp::CompletionResponse::Array);
     Ok(results)
-}
-
-/// Handle initialized notification.
-async fn resolve(_state: &mut State<'_>, item: lsp::CompletionItem) -> Result<lsp::CompletionItem> {
-    // TODO(TSolberg): We send docs with the immediate completions which is a bit overkill right now. We should only send docs when the user requests it.
-    // However, I'm not sure what the best key structure is for looking up data based on a completion item.
-    Ok(item)
 }
 
 /// Handle open text document.

--- a/crates/rune/src/languageserver.rs
+++ b/crates/rune/src/languageserver.rs
@@ -206,6 +206,7 @@ async fn completion(
     state: &mut State<'_>,
     params: lsp::CompletionParams,
 ) -> Result<Option<lsp::CompletionResponse>> {
+    tracing::info!("completion:  {:?}", params);
     let results = state
         .complete(
             &params.text_document_position.text_document.uri,
@@ -214,7 +215,7 @@ async fn completion(
         .await;
 
     let results = results.map(lsp::CompletionResponse::Array);
-
+    tracing::info!("results: {:?}", results);
     Ok(results)
 }
 

--- a/crates/rune/src/languageserver.rs
+++ b/crates/rune/src/languageserver.rs
@@ -9,7 +9,7 @@ mod state;
 mod url;
 
 use crate::workspace::MANIFEST_FILE;
-use crate::{Context, Hash, Options};
+use crate::{Context, Options};
 use anyhow::Result;
 use lsp::notification::Notification;
 use lsp::request::Request;
@@ -218,27 +218,9 @@ async fn completion(
 }
 
 /// Handle initialized notification.
-async fn resolve(
-    state: &mut State<'_>,
-    mut item: lsp::CompletionItem,
-) -> Result<lsp::CompletionItem> {
-    return Ok(item);
-    match &mut item.data {
-        Some(serde_json::Value::String(key)) => {
-            item.documentation = Some(lsp::Documentation::String("rune-function".into()));
-        }
-        Some(v) => {
-            let hash: Hash = serde_json::from_value(v.take())?;
-            if let Some(func) = state.context().lookup_meta_by_hash(hash) {
-                let docs = func.docs.lines().join("\n");
-                item.documentation = Some(lsp::Documentation::String(docs.into()));
-            } else {
-                item.documentation = None;
-            }
-        }
-        None => return Ok(item),
-    };
-
+async fn resolve(_state: &mut State<'_>, item: lsp::CompletionItem) -> Result<lsp::CompletionItem> {
+    // TODO(TSolberg): We send docs with the immediate completions which is a bit overkill right now. We should only send docs when the user requests it.
+    // However, I'm not sure what the best key structure is for looking up data based on a completion item.
     Ok(item)
 }
 

--- a/crates/rune/src/languageserver.rs
+++ b/crates/rune/src/languageserver.rs
@@ -222,6 +222,7 @@ async fn resolve(
     state: &mut State<'_>,
     mut item: lsp::CompletionItem,
 ) -> Result<lsp::CompletionItem> {
+    return Ok(item);
     match &mut item.data {
         Some(serde_json::Value::String(key)) => {
             item.documentation = Some(lsp::Documentation::String("rune-function".into()));

--- a/crates/rune/src/macros/macro_context.rs
+++ b/crates/rune/src/macros/macro_context.rs
@@ -5,8 +5,8 @@ use std::fmt;
 use crate::ast;
 use crate::ast::Span;
 use crate::compile::{
-    IrCompiler, IrError, IrEval, IrEvalContext, IrValue, ItemMeta, NoopCompileVisitor, Pool,
-    Prelude, UnitBuilder,
+    IrCompiler, IrError, IrEval, IrEvalContext, IrValue, ItemMeta, Pool,
+    Prelude, UnitBuilder, NoopCompileVisitor,
 };
 use crate::macros::{IntoLit, Storage, ToTokens, TokenStream};
 use crate::parse::{Parse, ParseError, ParseErrorKind, Resolve, ResolveError};
@@ -48,7 +48,7 @@ impl<'a> MacroContext<'a> {
         let mut storage = Storage::default();
         let mut sources = Sources::default();
         let mut pool = Pool::default();
-        let mut visitor = NoopCompileVisitor::new();
+        let mut visitors = NoopCompileVisitor::new();
         let mut inner = Default::default();
 
         let mut query = Query::new(
@@ -58,7 +58,7 @@ impl<'a> MacroContext<'a> {
             &mut storage,
             &mut sources,
             &mut pool,
-            &mut visitor,
+            &mut visitors,
             &gen,
             &mut inner,
         );

--- a/crates/rune/src/worker.rs
+++ b/crates/rune/src/worker.rs
@@ -65,7 +65,7 @@ impl<'a> Worker<'a> {
             queue: VecDeque::new(),
         }
     }
-
+    
     /// Run the worker until the task queue is empty.
     pub(crate) fn run(&mut self) {
         // NB: defer wildcard expansion until all other imports have been


### PR DESCRIPTION
Very rudimentary start for this I've been hacking at. It's *very* basic; but adds the basic infrastructure that can be improved.

The lookup starts by doing a "symbol + terminal" lookup. Likely this could be split into two checks; but I've opted to do one right now. This happens by searching back from the current cursor until a "terminal". So for example, given:
```rune
pub fn main() {
    let a =[1, 2, 3];
    fo|
}
```
We'd capture `;\n    fo`. The first character is what we use to check if we should lookup instance functions; and then we trim and use the rest for matching.

Then, we go through the unit and find all matches for the symbol - it doesn't seem like the debug info knows whether a rune fn is an instance function or not right now, so it'll return all.

Then, we lookup either all instance fns or all loose fns. It does seem like a lot of member functions also show up as loose fns functions, maybe due to receiver syntax.

In each case, we'll lookup as much possible regarding the item (i.e, docs, args, etc) and pass it along. There's a Resolve API to defer this a bit, but I'm not sure how to use it effectively etc. So I've opted to just return everything immediately.

Things I've noticed but haven't fixed:

* If the compile fails at all *when opening* the server there'll be no Rune-based completion until it succeeds again.
  * This means any custom Rust code will cause the LSP server to fail completion (though that's already the case with diagnostics)
* There's less info available for rune functions
* If you try to complete something common like `iter` you'll have... lots of almost identical matches.
* Completion of local variables or instance fields
* Actually, anything *except* functions aren't handled.
* I've jumped around in almost all .rn files in the repo and haven't had any issues; but... testing this is a bit iffy.
* I don't think I can see imports right now, so all function uses are absolute. If we could see this, we could prefer those items and only look at "non-imported" as secondary sources (+ auto-import!).
