### PR TITLE
Generate documentation for associated types defined in Rune

### DIFF
--- a/crates/rune/src/compile/context.rs
+++ b/crates/rune/src/compile/context.rs
@@ -333,7 +333,7 @@ impl Context {
 
     /// Get all associated types for the given hash.
     #[cfg(feature = "doc")]
-    pub(crate) fn associated(&self, hash: Hash) -> impl Iterator<Item = &AssociatedFunction> {
+    pub(crate) fn associated(&self, hash: Hash) -> impl Iterator<Item = &AssociatedFunction> + '_ {
         self.associated
             .get(&hash)
             .into_iter()

--- a/crates/rune/src/compile/item/component_ref.rs
+++ b/crates/rune/src/compile/item/component_ref.rs
@@ -18,7 +18,15 @@ pub enum ComponentRef<'a> {
     Id(usize),
 }
 
-impl ComponentRef<'_> {
+impl<'a> ComponentRef<'a> {
+    /// Get the component as a string.
+    pub(crate) fn as_str(&self) -> Option<&'a str> {
+        match self {
+            ComponentRef::Str(string) => Some(string),
+            _ => None,
+        }
+    }
+
     /// Get the identifier of the component if it is an identifier component.
     pub fn id(self) -> Option<usize> {
         match self {

--- a/crates/rune/src/doc/html/enum_.rs
+++ b/crates/rune/src/doc/html/enum_.rs
@@ -27,7 +27,7 @@ pub(super) fn build(cx: &Ctxt<'_>, hash: Hash) -> Result<()> {
     let module = cx.module_path_html(false);
     let name = cx.item.last().context("missing module name")?;
 
-    let (protocols, methods) = super::type_::build_assoc(cx, hash)?;
+    let (protocols, methods) = super::type_::build_assoc_fns(cx, hash)?;
 
     cx.write_file(|cx| {
         cx.enum_template.render(&Params {

--- a/crates/rune/src/doc/html/type_.rs
+++ b/crates/rune/src/doc/html/type_.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use serde::Serialize;
 
 use crate::compile::{ComponentRef, Item};
-use crate::doc::context::{AssociatedKind, Kind, Signature};
+use crate::doc::context::{Assoc, AssocFnKind, Signature};
 use crate::hash::Hash;
 
 use super::Ctxt;
@@ -27,62 +27,31 @@ pub(super) struct Method<'a> {
     doc: Option<String>,
 }
 
-pub(super) fn build_assoc<'a>(
+pub(super) fn build_assoc_fns<'a>(
     cx: &'a Ctxt<'a>,
     hash: Hash,
 ) -> Result<(Vec<Protocol<'a>>, Vec<Method<'a>>)> {
     let mut protocols = Vec::new();
     let mut methods = Vec::new();
 
-    for name in cx.context.iter_components(&cx.item) {
-        let item = cx.item.join([name]);
-
-        let meta = match cx.context.meta(&item) {
-            Some(meta) => meta,
-            _ => continue,
-        };
-
-        let name = match name {
-            ComponentRef::Str(name) => name,
-            _ => continue,
-        };
-
-        match meta.kind {
-            Kind::Function(f) => {
-                if !matches!(f.signature, Signature::Instance { .. }) {
-                    methods.push(Method {
-                        is_async: f.is_async,
-                        name,
-                        args: super::args_to_string(f.args, f.signature)?,
-                        parameters: None,
-                        return_type: match f.return_type {
-                            Some(hash) => Some(cx.hash_to_link(hash)?),
-                            None => None,
-                        },
-                        doc: cx.render_docs(meta.docs)?,
-                    });
-                }
-            }
-            _ => {
-                continue;
-            }
-        }
-    }
-
     for assoc in cx.context.associated(hash) {
+        let Assoc::Fn(assoc) = assoc else {
+            continue;
+        };
+
         let value;
 
         let (protocol, value) = match assoc.kind {
-            AssociatedKind::Protocol(protocol) => (protocol, "value"),
-            AssociatedKind::FieldFn(protocol, field) => {
+            AssocFnKind::Protocol(protocol) => (protocol, "value"),
+            AssocFnKind::FieldFn(protocol, field) => {
                 value = format!("value.{field}");
                 (protocol, value.as_str())
             }
-            AssociatedKind::IndexFn(protocol, index) => {
+            AssocFnKind::IndexFn(protocol, index) => {
                 value = format!("value.{index}");
                 (protocol, value.as_str())
             }
-            AssociatedKind::Instance(name) => {
+            AssocFnKind::Instance(name) => {
                 let doc = cx.render_docs(assoc.docs)?;
 
                 let mut list = Vec::new();
@@ -157,7 +126,7 @@ pub(super) fn build(cx: &Ctxt<'_>, what: &str, what_class: &str, hash: Hash) -> 
     let module = cx.module_path_html(false);
     let name = cx.item.last().context("missing module name")?;
 
-    let (protocols, methods) = build_assoc(cx, hash)?;
+    let (protocols, methods) = build_assoc_fns(cx, hash)?;
 
     cx.write_file(|cx| {
         cx.type_template.render(&Params {

--- a/crates/rune/src/doc/static/function.html.hbs
+++ b/crates/rune/src/doc/static/function.html.hbs
@@ -3,7 +3,7 @@
 {{#each fonts}}<link rel="preload" as="font" type="font/woff2" crossorigin="" href="{{this}}">{{/each}}
 {{#each css}}<link rel="stylesheet" type="text/css" href="{{this}}">{{/each}}
 <body>
-<h3 class="title">Function {{literal module}}::<span class="fn">{{name}}</span>({{args}})</h3>
+<h3 class="title">Function {{literal module}}::<span class="fn">{{name}}</span>({{args}}){{#if this.return_type}} -&gt; {{literal this.return_type}}{{/if}}</h3>
 {{#if this.doc}}{{literal this.doc}}{{/if}}
 </body>
 </html>

--- a/crates/rune/src/doc/visitor.rs
+++ b/crates/rune/src/doc/visitor.rs
@@ -32,6 +32,8 @@ pub struct Visitor {
     pub(crate) names: Names,
     pub(crate) data: HashMap<Hash, VisitorData>,
     pub(crate) item_to_hash: HashMap<ItemBuf, Hash>,
+    /// Associated items.
+    pub(crate) associated: HashMap<Hash, Vec<Hash>>,
 }
 
 impl Visitor {
@@ -46,6 +48,7 @@ impl Visitor {
             names: Names::default(),
             data: HashMap::default(),
             item_to_hash: HashMap::new(),
+            associated: HashMap::new(),
         }
     }
 
@@ -76,6 +79,13 @@ impl CompileVisitor for Visitor {
             hash_map::Entry::Vacant(e) => {
                 e.insert(VisitorData::new(item, meta.hash, meta.kind.clone()));
             }
+        }
+
+        if let Some(container) = meta.associated_container {
+            self.associated
+                .entry(container)
+                .or_default()
+                .push(meta.hash);
         }
     }
 

--- a/crates/rune/src/modules/any.rs
+++ b/crates/rune/src/modules/any.rs
@@ -6,6 +6,7 @@ use core::mem::transmute;
 
 use crate::no_std::prelude::*;
 
+use crate as rune;
 use crate::runtime::{Protocol, Value, VmResult};
 use crate::{Any, ContextError, Module};
 
@@ -26,10 +27,29 @@ fn format_type_id(item: &TypeId, buf: &mut String) -> fmt::Result {
 pub fn module() -> Result<Module, ContextError> {
     let mut module = Module::with_crate_item("std", ["any"]);
 
-    module.function(["type_name_of_val"], Value::into_type_name)?;
+    module.function_meta(type_name_of_val)?;
 
     module.ty::<TypeId>()?;
     module.function(["TypeId", "of_val"], type_id_of_val)?;
     module.inst_fn(Protocol::STRING_DISPLAY, format_type_id)?;
     Ok(module)
+}
+
+/// Get the type name of a value.
+///
+/// # Examples
+///
+/// ```rune
+/// use std::any;
+///
+/// let value = 42;
+/// assert_eq!(any::type_name_of_val(value), "::std::int");
+///
+/// let value = [];
+/// assert_eq!(any::type_name_of_val(value), "::std::vec::Vec");
+/// ```
+#[rune::function]
+#[inline]
+pub fn type_name_of_val(value: Value) -> VmResult<String> {
+    value.into_type_name()
 }


### PR DESCRIPTION
That this also extends `doc::Visitor` to support iterating over associated functions which might be useful for completions.

```rust
struct Hello {
    field,
}

impl Hello {
    /// This function does something.
    /// 
    /// ```
    /// let hello = Hello {
    ///     field: 42,
    /// };
    ///
    /// hello.doit();
    /// ```
    fn doit(self) {

    }
}
```

Gives:

![image](https://user-images.githubusercontent.com/111092/236414030-aee4e6bf-96c5-4880-aff3-32bbb88f8ea4.png)
