### PR TITLE
Build macro documentation

### DIFF
--- a/crates/rune/src/compile/context_error.rs
+++ b/crates/rune/src/compile/context_error.rs
@@ -5,7 +5,7 @@ use crate::no_std::thiserror;
 use thiserror::Error;
 
 use crate::compile::meta;
-use crate::compile::{ItemBuf, MetaInfo};
+use crate::compile::ItemBuf;
 use crate::runtime::{TypeInfo, VmError};
 use crate::Hash;
 
@@ -14,60 +14,61 @@ use crate::Hash;
 #[allow(missing_docs)]
 #[non_exhaustive]
 pub enum ContextError {
-    #[error("`()` types are already present")]
+    #[error("Unit `()` type is already present")]
     UnitAlreadyPresent,
-    #[error("`{name}` types are already present")]
+    #[error("Type for name `{name}` is already present")]
     InternalAlreadyPresent { name: &'static str },
-    #[error("conflicting meta {existing} while trying to insert {current}")]
-    ConflictingMeta {
-        current: Box<MetaInfo>,
-        existing: Box<MetaInfo>,
-    },
-    #[error("function `{signature}` ({hash}) already exists")]
+    #[error("Function `{signature}` ({hash}) already exists")]
     ConflictingFunction {
         signature: Box<meta::Signature>,
         hash: Hash,
     },
-    #[error("function with name `{name}` already exists")]
+    #[error("Function with name `{name}` already exists")]
     ConflictingFunctionName { name: ItemBuf },
-    #[error("constant with name `{name}` already exists")]
+    #[error("Constant with name `{name}` already exists")]
     ConflictingConstantName { name: ItemBuf },
-    #[error("instance function `{name}` for type `{type_info}` already exists")]
+    #[error("Instance function `{name}` for type `{type_info}` already exists")]
     ConflictingInstanceFunction { type_info: TypeInfo, name: Box<str> },
-    #[error("protocol function `{name}` for type `{type_info}` already exists")]
+    #[error("Protocol function `{name}` for type `{type_info}` already exists")]
     ConflictingProtocolFunction { type_info: TypeInfo, name: Box<str> },
-    #[error("field function `{name}` for field `{field}` and type `{type_info}` already exists")]
+    #[error("Field function `{name}` for field `{field}` and type `{type_info}` already exists")]
     ConflictingFieldFunction {
         type_info: TypeInfo,
         name: Box<str>,
         field: Box<str>,
     },
-    #[error("index function `{name}` for index `{index}` and type `{type_info}` already exists")]
+    #[error("Index function `{name}` for index `{index}` and type `{type_info}` already exists")]
     ConflictingIndexFunction {
         type_info: TypeInfo,
         name: Box<str>,
         index: usize,
     },
-    #[error("module `{item}` with hash `{hash}` already exists")]
+    #[error("Module `{item}` with hash `{hash}` already exists")]
     ConflictingModule { item: ItemBuf, hash: Hash },
-    #[error("type `{item}` already exists `{type_info}`")]
+    #[error("Type `{item}` already exists `{type_info}`")]
     ConflictingType { item: ItemBuf, type_info: TypeInfo },
-    #[error("type `{item}` at `{type_info}` already has a specification")]
+    #[error("Type `{item}` at `{type_info}` already has a specification")]
     ConflictingTypeMeta { item: ItemBuf, type_info: TypeInfo },
-    #[error("type `{item}` with info `{type_info}` isn't registered")]
+    #[error("Type `{item}` with info `{type_info}` isn't registered")]
     MissingType { item: ItemBuf, type_info: TypeInfo },
-    #[error("type `{item}` with info `{type_info}` is registered but is not an enum")]
+    #[error("Type `{item}` with info `{type_info}` is registered but is not an enum")]
     MissingEnum { item: ItemBuf, type_info: TypeInfo },
-    #[error("tried to insert conflicting hash `{hash}` for `{existing}`")]
+    #[error("Conflicting meta hash `{hash}` for `{existing}` when inserting item `{item}`")]
+    ConflictingMetaHash {
+        item: ItemBuf,
+        hash: Hash,
+        existing: Hash,
+    },
+    #[error("Tried to insert conflicting hash `{hash}` for `{existing}`")]
     ConflictingTypeHash { hash: Hash, existing: Hash },
-    #[error("variant with `{item}` already exists")]
+    #[error("Variant with `{item}` already exists")]
     ConflictingVariant { item: ItemBuf },
-    #[error("instance `{instance_type}` does not exist in module")]
+    #[error("Instance `{instance_type}` does not exist in module")]
     MissingInstance { instance_type: TypeInfo },
-    #[error("error when converting to constant value: {error}")]
+    #[error("Error when converting to constant value: {error}")]
     ValueError { error: VmError },
-    #[error("missing variant {index} for `{type_info}`")]
+    #[error("Missing variant {index} for `{type_info}`")]
     MissingVariant { type_info: TypeInfo, index: usize },
-    #[error("constructor for variant {index} in `{type_info}` has already been registered")]
+    #[error("Constructor for variant {index} in `{type_info}` has already been registered")]
     VariantConstructorConflict { type_info: TypeInfo, index: usize },
 }

--- a/crates/rune/src/compile/item/component_ref.rs
+++ b/crates/rune/src/compile/item/component_ref.rs
@@ -20,6 +20,7 @@ pub enum ComponentRef<'a> {
 
 impl<'a> ComponentRef<'a> {
     /// Get the component as a string.
+    #[cfg(feature = "doc")]
     pub(crate) fn as_str(&self) -> Option<&'a str> {
         match self {
             ComponentRef::Str(string) => Some(string),

--- a/crates/rune/src/compile/meta.rs
+++ b/crates/rune/src/compile/meta.rs
@@ -118,6 +118,7 @@ impl Meta {
             Kind::Const { .. } => None,
             Kind::ConstFn { .. } => None,
             Kind::Import { .. } => None,
+            Kind::Macro => None,
             Kind::Module => None,
         }
     }
@@ -157,6 +158,8 @@ pub enum Kind {
     },
     /// An enum item.
     Enum,
+    /// A macro item.
+    Macro,
     /// A function declaration.
     Function {
         /// If the function is asynchronous.

--- a/crates/rune/src/compile/meta_info.rs
+++ b/crates/rune/src/compile/meta_info.rs
@@ -40,6 +40,9 @@ impl fmt::Display for MetaInfo {
             MetaInfoKind::Enum => {
                 write!(fmt, "enum {}", self.item)?;
             }
+            MetaInfoKind::Macro => {
+                write!(fmt, "macro {}", self.item)?;
+            }
             MetaInfoKind::Function => {
                 write!(fmt, "fn {}", self.item)?;
             }
@@ -73,6 +76,7 @@ pub(crate) enum MetaInfoKind {
     Struct,
     Variant,
     Enum,
+    Macro,
     Function,
     Closure,
     AsyncBlock,
@@ -89,6 +93,7 @@ impl MetaInfoKind {
             meta::Kind::Struct { .. } => MetaInfoKind::Struct,
             meta::Kind::Variant { .. } => MetaInfoKind::Variant,
             meta::Kind::Enum { .. } => MetaInfoKind::Enum,
+            meta::Kind::Macro { .. } => MetaInfoKind::Macro,
             meta::Kind::Function { .. } => MetaInfoKind::Function,
             meta::Kind::Closure { .. } => MetaInfoKind::Closure,
             meta::Kind::AsyncBlock { .. } => MetaInfoKind::AsyncBlock,

--- a/crates/rune/src/compile/unit_builder.rs
+++ b/crates/rune/src/compile/unit_builder.rs
@@ -510,6 +510,7 @@ impl UnitBuilder {
                     ConstValue::String(pool.item(meta.item_meta.item).to_string()),
                 );
             }
+            meta::Kind::Macro { .. } => (),
             meta::Kind::Function { .. } => (),
             meta::Kind::Closure { .. } => (),
             meta::Kind::AsyncBlock { .. } => (),

--- a/crates/rune/src/doc/static/macro.html.hbs
+++ b/crates/rune/src/doc/static/macro.html.hbs
@@ -1,0 +1,9 @@
+<html>
+<head></head>
+{{#each fonts}}<link rel="preload" as="font" type="font/woff2" crossorigin="" href="{{this}}">{{/each}}
+{{#each css}}<link rel="stylesheet" type="text/css" href="{{this}}">{{/each}}
+<body>
+<h3 class="title">Macro {{literal module}}::<span class="macro">{{name}}</span>(..)</h3>
+{{#if doc}}{{literal doc}}{{/if}}
+</body>
+</html>

--- a/crates/rune/src/doc/static/module.html.hbs
+++ b/crates/rune/src/doc/static/module.html.hbs
@@ -45,6 +45,16 @@
 {{/each}}
 {{/if}}
 
+{{#if macros}}
+<h4 class="section-title">Macros</h4>
+
+{{#each macros}}
+    <div id="macro.{{this.name}}" class="item-entry">
+    <a class="macro" href="{{this.path}}">{{this.name}}</a>{{#if this.doc}}<span class="inline-sep">&dash;</span><span class="inline-docs">{{literal this.doc}}</span>{{/if}}
+    </div>
+{{/each}}
+{{/if}}
+
 {{#if modules}}
 <h4 class="section-title">Modules</h4>
 

--- a/crates/rune/src/doc/static/runedoc.css
+++ b/crates/rune/src/doc/static/runedoc.css
@@ -6,6 +6,7 @@
     --headings-border-bottom-color: #d2d2d2;
     --type-link-color: #2dbfb8;
     --fn-link-color: #2bab63;
+    --macro-link-color: #09bd00;
     --mod-link-color: #d2991d;
 }
 
@@ -86,6 +87,10 @@ a {
 
 .fn {
     color: var(--fn-link-color);
+}
+
+.macro {
+    color: var(--macro-link-color);
 }
 
 .module {

--- a/crates/rune/src/languageserver/completion.rs
+++ b/crates/rune/src/languageserver/completion.rs
@@ -101,11 +101,12 @@ pub(super) fn complete_native_instance_data(
         };
 
         if n.starts_with(symbol) {
-            let meta = context.lookup_meta_by_hash(info.0);
+            let meta = context.lookup_meta_by_hash(info.0).first();
+
             let return_type = info
                 .1
                 .return_type
-                .and_then(|hash| context.lookup_meta_by_hash(hash))
+                .and_then(|hash| context.lookup_meta_by_hash(hash).first())
                 .map(|r| r.item.clone());
 
             let docs = meta.map(|meta| meta.docs.lines().join("\n"));
@@ -162,11 +163,12 @@ pub(super) fn complete_native_loose_data(
 
         let func_name = item.to_string().trim_start_matches("::").to_owned();
         if func_name.starts_with(symbol) {
-            let meta = context.lookup_meta_by_hash(info.0);
+            let meta = context.lookup_meta_by_hash(info.0).first();
+
             let return_type = info
                 .1
                 .return_type
-                .and_then(|hash| context.lookup_meta_by_hash(hash))
+                .and_then(|hash| context.lookup_meta_by_hash(hash).first())
                 .map(|r| r.item.clone());
 
             let docs = meta.map(|meta| meta.docs.lines().join("\n"));


### PR DESCRIPTION
This adds basic support for building macro documentation.

We still have no way to capture comments for macros, for this I'm planning to introduce another attribute `#[rune::macro]` which does the same thing as `#[rune::function]`. But macros also weren't registered as meta items since they are namespaced differently, so that was fixed.

![image](https://user-images.githubusercontent.com/111092/236516378-f5a3f112-1ac0-4380-a2cb-7f127fc0c2b5.png)
