### PR TITLE
Avoid doc conflicts

### DIFF
--- a/crates/rune/src/cli.rs
+++ b/crates/rune/src/cli.rs
@@ -33,6 +33,13 @@ use crate::modules::capture_io::CaptureIo;
 use crate::termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 use crate::{Context, ContextError, Options, Hash};
 
+/// Commands which by default should look in the workspace for entrypoints.
+macro_rules! workspace_command {
+    () => {
+        Command::Check(..) | Command::Doc(..) | Command::Fmt(..)
+    }
+}
+
 /// Default about splash.
 const DEFAULT_ABOUT: &str = "The Rune Language Interpreter";
 
@@ -290,7 +297,7 @@ impl Command {
     fn find_bins(&self) -> Option<WorkspaceFilter<'_>> {
         if !matches!(
             self,
-            Command::Run(..) | Command::Check(..) | Command::Doc(..)
+            Command::Run(..) | workspace_command!()
         ) {
             return None;
         }
@@ -307,7 +314,7 @@ impl Command {
     fn find_tests(&self) -> Option<WorkspaceFilter<'_>> {
         if !matches!(
             self,
-            Command::Test(..) | Command::Check(..) | Command::Doc(..)
+            Command::Test(..) | workspace_command!()
         ) {
             return None;
         }
@@ -324,7 +331,7 @@ impl Command {
     fn find_examples(&self) -> Option<WorkspaceFilter<'_>> {
         if !matches!(
             self,
-            Command::Run(..) | Command::Check(..) | Command::Doc(..)
+            Command::Run(..) | workspace_command!()
         ) {
             return None;
         }
@@ -341,7 +348,7 @@ impl Command {
     fn find_benches(&self) -> Option<WorkspaceFilter<'_>> {
         if !matches!(
             self,
-            Command::Bench(..) | Command::Check(..) | Command::Doc(..)
+            Command::Bench(..) | workspace_command!()
         ) {
             return None;
         }

--- a/crates/rune/src/doc/context.rs
+++ b/crates/rune/src/doc/context.rs
@@ -18,11 +18,11 @@ pub(crate) enum MetaSource<'a> {
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Meta<'a> {
+    /// Item of the meta.
+    pub(crate) item: &'a Item,
     /// The meta source.
     #[allow(unused)]
     pub(crate) source: MetaSource<'a>,
-    /// Item of the meta.
-    pub(crate) item: &'a Item,
     /// Type hash for the meta item.
     pub(crate) hash: Hash,
     /// Kind of the meta item.

--- a/crates/rune/src/doc/context.rs
+++ b/crates/rune/src/doc/context.rs
@@ -112,7 +112,7 @@ impl<'a> Context<'a> {
     }
 
     /// Iterate over all types associated with the given hash.
-    pub(crate) fn associated(&self, hash: Hash) -> impl Iterator<Item = Assoc<'_>> {
+    pub(crate) fn associated(&self, hash: Hash) -> impl Iterator<Item = Assoc<'a>> {
         fn visitor_to_associated(
             hash: Hash,
             visitor: &Visitor,
@@ -223,7 +223,7 @@ impl<'a> Context<'a> {
     }
 
     /// Lookup all meta matching the given item.
-    pub(crate) fn meta(&self, item: &Item) -> Vec<Meta<'_>> {
+    pub(crate) fn meta(&self, item: &Item) -> Vec<Meta<'a>> {
         let mut out = Vec::new();
 
         for visitor in self.visitors {

--- a/crates/rune/src/doc/html/enum_.rs
+++ b/crates/rune/src/doc/html/enum_.rs
@@ -10,7 +10,7 @@ use super::Ctxt;
 
 /// Build an enumeration.
 #[tracing::instrument(skip_all)]
-pub(super) fn build(cx: &Ctxt<'_>, hash: Hash) -> Result<()> {
+pub(super) fn build(cx: &Ctxt<'_, '_>, hash: Hash) -> Result<()> {
     #[derive(Serialize)]
     struct Params<'a> {
         #[serde(flatten)]

--- a/crates/rune/src/doc/html/js.rs
+++ b/crates/rune/src/doc/html/js.rs
@@ -1,0 +1,17 @@
+use crate::no_std::prelude::*;
+
+/// Encode `string` as part of a quoted javascript string.
+pub(crate) fn encode_quoted(out: &mut String, string: &str) {
+    for c in string.chars() {
+        let s = match c {
+            '\\' => "\\\\",
+            '\"' => "\\\"",
+            c => {
+                out.push(c);
+                continue;
+            }
+        };
+
+        out.push_str(s);
+    }
+}

--- a/crates/rune/src/doc/visitor.rs
+++ b/crates/rune/src/doc/visitor.rs
@@ -43,13 +43,19 @@ impl Visitor {
         I: IntoIterator,
         I::Item: IntoComponent,
     {
-        Self {
-            base: base.into_iter().collect(),
+        let mut this = Self {
+            base: base.into_iter().collect::<ItemBuf>(),
             names: Names::default(),
             data: HashMap::default(),
             item_to_hash: HashMap::new(),
             associated: HashMap::new(),
-        }
+        };
+
+        let hash = Hash::type_hash(&this.base);
+        this.names.insert(&this.base);
+        this.data.insert(hash, VisitorData::new(this.base.clone(), hash, meta::Kind::Module));
+        this.item_to_hash.insert(this.base.clone(), hash);
+        this
     }
 
     /// Get meta by item.

--- a/crates/rune/src/workspace.rs
+++ b/crates/rune/src/workspace.rs
@@ -21,7 +21,7 @@ pub use self::error::{WorkspaceError};
 pub(crate) use self::error::WorkspaceErrorKind;
 
 mod manifest;
-pub use self::manifest::{Manifest, WorkspaceFilter};
+pub use self::manifest::{Manifest, WorkspaceFilter, Package, FoundKind, Found, FoundPackage};
 
 mod diagnostics;
 pub use self::diagnostics::{Diagnostics, Diagnostic, FatalDiagnostic};


### PR DESCRIPTION
This ensures that we generate documentation for each entrypoint, even if they belong to the same crate (as is the case with `examples`).