### PR TITLE
Changing colors for formatting and print diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable
-    - run: cargo run --bin rune -- fmt --experimental --recursive --verbose tools scripts
-    - run: cargo run --bin rune -- fmt --verbose
+    - run: cargo run --bin rune -- fmt --experimental --recursive --verbose --workspace tools scripts
 
   clippy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable
-    - run: shopt -s globstar ; cargo run --bin rune -- fmt --check **/*.rn
+    - run: cargo run --bin rune -- fmt --experimental --recursive --verbose tools scripts
+    - run: cargo run --bin rune -- fmt --verbose
 
   clippy:
     runs-on: ubuntu-latest

--- a/crates/rune/Cargo.toml
+++ b/crates/rune/Cargo.toml
@@ -19,7 +19,7 @@ emit = ["codespan-reporting"]
 bench = []
 workspace = ["toml", "semver", "relative-path", "serde-hashkey", "linked-hash-map"]
 doc = ["rust-embed", "handlebars", "pulldown-cmark", "syntect"]
-cli = ["doc", "bincode", "atty", "tracing-subscriber", "clap", "webbrowser", "capture-io", "disable-io", "languageserver", "fmt"]
+cli = ["doc", "bincode", "atty", "tracing-subscriber", "clap", "webbrowser", "capture-io", "disable-io", "languageserver", "fmt", "similar"]
 languageserver = ["lsp", "ropey", "percent-encoding", "url", "serde_json", "tokio", "tokio/macros", "tokio/io-std", "workspace", "doc"]
 capture-io = ["parking_lot"]
 disable-io = []
@@ -69,6 +69,7 @@ percent-encoding = { version = "2.2.0", optional = true }
 url = { version = "2.3.1", optional = true }
 serde_json = { version = "1.0.96", optional = true }
 linked-hash-map = { version = "0.5.6", optional = true }
+similar = { version = "2.2.1", optional = true, features = ["inline"] }
 
 [dev-dependencies]
 tokio = { version = "1.28.0", features = ["full"] }

--- a/crates/rune/src/cli.rs
+++ b/crates/rune/src/cli.rs
@@ -510,6 +510,10 @@ struct SharedFlags {
     #[arg(long)]
     warnings: bool,
 
+    /// Display verbose output.
+    #[arg(long)]
+    verbose: bool,
+
     /// Set the given compiler option (see `--help` for available options).
     ///
     /// memoize-instance-fn[=<true/false>] - Inline the lookup of an instance function where appropriate.
@@ -726,8 +730,8 @@ where
             }
         }
         Command::Doc(f) => return doc::run(io, entry, c, &f.command, &f.shared, options, entrys),
-        Command::Fmt(flags) => {
-            return format::run(io, entrys, &flags.command);
+        Command::Fmt(f) => {
+            return format::run(io, entry, c, entrys, &f.command, &f.shared, options);
         }
         Command::Test(f) => {
             for e in entrys {

--- a/crates/rune/src/sources.rs
+++ b/crates/rune/src/sources.rs
@@ -106,6 +106,12 @@ impl Sources {
     pub(crate) fn source_ids(&self) -> impl Iterator<Item = SourceId> {
         (0..self.sources.len()).map(|index| SourceId::new(index as u32))
     }
+
+    /// Iterate over all registered sources.
+    #[cfg(feature = "cli")]
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &Source> {
+        self.sources.iter()
+    }
 }
 
 #[cfg(feature = "codespan-reporting")]


### PR DESCRIPTION
Also reworking command to be a bit less verbose by default and more like `cargo fmt`.

Green now indicates *correctly formatted files*. Yellow threw me off a few times, because it asks for your attention while green means that things are OK.

![image](https://user-images.githubusercontent.com/111092/236827521-681f44c6-7796-47ec-a803-1aeccf64b49a.png)
