### PR TITLE
Rework how generic functions are accesed

### DIFF
--- a/crates/rune-core/src/hash.rs
+++ b/crates/rune-core/src/hash.rs
@@ -51,6 +51,12 @@ impl Hash {
         self.0
     }
 
+    /// Test if hash is empty.
+    #[doc(hidden)]
+    pub const fn is_empty(&self) -> bool {
+        self.0 == 0
+    }
+
     /// Construct a simple hash from something that is hashable.
     fn of<T: hash::Hash>(thing: T) -> Self {
         let mut hasher = Self::new_hasher();

--- a/crates/rune-core/src/type_of.rs
+++ b/crates/rune-core/src/type_of.rs
@@ -2,7 +2,16 @@ use crate::hash::Hash;
 
 /// Full type information.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct FullTypeOf {
     #[doc(hidden)]
     pub hash: Hash,
+}
+
+impl FullTypeOf {
+    #[inline]
+    #[doc(hidden)]
+    pub fn new(hash: Hash) -> Self {
+        Self { hash }
+    }
 }

--- a/crates/rune-macros/src/any.rs
+++ b/crates/rune-macros/src/any.rs
@@ -465,6 +465,12 @@ where
         quote!(#hash::new(#type_hash))
     };
 
+    let parameters_hash = if !generic_names.is_empty() {
+        quote!(#hash::parameters([#(<#generic_names as #type_of>::type_hash()),*]))
+    } else {
+        quote!(#hash::EMPTY)
+    };
+
     Ok(quote! {
         #[automatically_derived]
         impl #impl_generics #any for #ident #ty_generics #where_clause {
@@ -487,6 +493,11 @@ where
             #[inline]
             fn type_hash() -> #hash {
                 <Self as #any>::type_hash()
+            }
+
+            #[inline]
+            fn parameters_hash() -> #hash {
+                #parameters_hash
             }
 
             #[inline]

--- a/crates/rune/src/cli/benches.rs
+++ b/crates/rune/src/cli/benches.rs
@@ -38,7 +38,7 @@ impl Bencher {
 
 /// Registers `std::test` module.
 pub(super) fn test_module() -> Result<Module, ContextError> {
-    let mut module = Module::with_item(["std", "test"]);
+    let mut module = Module::with_crate_item("std" ["test"]);
     module.ty::<Bencher>()?;
     module.inst_fn("iter", Bencher::iter)?;
     Ok(module)

--- a/crates/rune/src/cli/benches.rs
+++ b/crates/rune/src/cli/benches.rs
@@ -11,7 +11,8 @@ use crate::cli::{ExitCode, Io};
 use crate::compile::{Item, ItemBuf};
 use crate::modules::capture_io::CaptureIo;
 use crate::runtime::{Function, Unit, Value};
-use crate::{Any, Context, ContextError, Hash, Module, Sources, Vm};
+use crate::{Context, Hash, Sources, Vm};
+use crate::modules::test::Bencher;
 
 #[derive(Parser, Debug)]
 pub(super) struct Flags {
@@ -22,26 +23,6 @@ pub(super) struct Flags {
     /// Iterations to run of the benchmark
     #[arg(long, default_value = "100")]
     iterations: u32,
-}
-
-#[derive(Default, Any)]
-#[rune(module = crate, item = ::std::test)]
-pub(super) struct Bencher {
-    fns: Vec<Function>,
-}
-
-impl Bencher {
-    fn iter(&mut self, f: Function) {
-        self.fns.push(f);
-    }
-}
-
-/// Registers `std::test` module.
-pub(super) fn test_module() -> Result<Module, ContextError> {
-    let mut module = Module::with_crate_item("std" ["test"]);
-    module.ty::<Bencher>()?;
-    module.inst_fn("iter", Bencher::iter)?;
-    Ok(module)
 }
 
 /// Run benchmarks.
@@ -82,9 +63,11 @@ pub(super) async fn run(
             continue;
         }
 
-        let multiple = bencher.fns.len() > 1;
+        let fns = bencher.into_functions();
 
-        for (i, f) in bencher.fns.iter().enumerate() {
+        let multiple = fns.len() > 1;
+
+        for (i, f) in fns.iter().enumerate() {
             if let Err(e) = bench_fn(io, i, item, args, f, multiple) {
                 writeln!(io.stdout, "{}: Error in bench iteration: {}", item, e)?;
 

--- a/crates/rune/src/compile/context_error.rs
+++ b/crates/rune/src/compile/context_error.rs
@@ -23,12 +23,12 @@ pub enum ContextError {
         signature: Box<meta::Signature>,
         hash: Hash,
     },
-    #[error("Function `{item}` already exists")]
-    ConflictingFunctionName { item: ItemBuf },
-    #[error("Macro `{item}` already exists")]
-    ConflictingMacroName { item: ItemBuf },
-    #[error("Constant `{item}` already exists")]
-    ConflictingConstantName { item: ItemBuf },
+    #[error("Function `{item}` already exists with hash `{hash}`")]
+    ConflictingFunctionName { item: ItemBuf, hash: Hash },
+    #[error("Macro `{item}` already exists with hash `{hash}`")]
+    ConflictingMacroName { item: ItemBuf, hash: Hash },
+    #[error("Constant `{item}` already exists with hash `{hash}`")]
+    ConflictingConstantName { item: ItemBuf, hash: Hash },
     #[error("Instance function `{name}` for type `{type_info}` already exists")]
     ConflictingInstanceFunction { type_info: TypeInfo, name: Box<str> },
     #[error("Protocol function `{name}` for type `{type_info}` already exists")]
@@ -47,8 +47,12 @@ pub enum ContextError {
     },
     #[error("Module `{item}` with hash `{hash}` already exists")]
     ConflictingModule { item: ItemBuf, hash: Hash },
-    #[error("Type `{item}` already exists `{type_info}`")]
-    ConflictingType { item: ItemBuf, type_info: TypeInfo },
+    #[error("Type `{item}` already exists `{type_info}` with hash `{hash}`")]
+    ConflictingType {
+        item: ItemBuf,
+        type_info: TypeInfo,
+        hash: Hash,
+    },
     #[error("Type `{item}` at `{type_info}` already has a specification")]
     ConflictingTypeMeta { item: ItemBuf, type_info: TypeInfo },
     #[error(
@@ -71,10 +75,17 @@ pub enum ContextError {
     MissingType { item: ItemBuf, type_info: TypeInfo },
     #[error("Type `{item}` with info `{type_info}` is registered but is not an enum")]
     MissingEnum { item: ItemBuf, type_info: TypeInfo },
-    #[error("Instance `{instance_type}` does not exist in module")]
-    MissingInstance { instance_type: TypeInfo },
+    #[error("Container `{container}` is not registered")]
+    MissingContainer { container: TypeInfo },
     #[error("Missing variant {index} for `{type_info}`")]
     MissingVariant { type_info: TypeInfo, index: usize },
     #[error("Expected associated function")]
     ExpectedAssociated,
+    #[error("Type hash mismatch for `{type_info}`, from module is `{hash}` while from item `{item}` is `{item_hash}`. A possibility is that it has the wrong #[rune(item = ..)] setting.")]
+    TypeHashMismatch {
+        type_info: TypeInfo,
+        item: ItemBuf,
+        hash: Hash,
+        item_hash: Hash,
+    },
 }

--- a/crates/rune/src/compile/v1.rs
+++ b/crates/rune/src/compile/v1.rs
@@ -63,7 +63,7 @@ impl<'a> Assembler<'a> {
     fn select_context_meta<'m>(
         &self,
         item: ItemId,
-        metas: impl ExactSizeIterator<Item = &'m ContextMeta> + Clone,
+        metas: impl Iterator<Item = &'m ContextMeta> + Clone,
         parameters: Option<Hash>,
     ) -> Result<Option<&'m ContextMeta>, Box<QueryErrorKind>> {
         let parameters = parameters.unwrap_or(Hash::EMPTY);
@@ -110,9 +110,9 @@ impl<'a> Assembler<'a> {
             }
         }
 
-        let meta = self.context.lookup_meta(self.q.pool.item(item));
+        let metas = self.context.lookup_meta(self.q.pool.item(item));
 
-        let Some(meta) = self.select_context_meta(item, meta, generics).with_span(span)? else {
+        let Some(meta) = self.select_context_meta(item, metas, generics).with_span(span)? else {
             return Ok(None);
         };
 

--- a/crates/rune/src/fmt/whitespace/tests.rs
+++ b/crates/rune/src/fmt/whitespace/tests.rs
@@ -41,7 +41,6 @@ fn test_empty_lines_with_multiple_empty_lines() {
 "#;
 
     let empty_lines = gather_empty_line_spans(source).unwrap();
-    dbg!(&empty_lines);
     assert_eq!(empty_lines.len(), 2);
     assert_eq!(empty_lines[0].span, Span::new(12, 13));
     assert_eq!(empty_lines[1].span, Span::new(25, 26));

--- a/crates/rune/src/module.rs
+++ b/crates/rune/src/module.rs
@@ -25,7 +25,7 @@ pub(crate) use self::function_meta::{
 
 #[doc(hidden)]
 pub use self::function_meta::{FunctionMetaData, FunctionMetaKind, MacroMetaData, MacroMetaKind};
-pub use self::function_traits::{AssocType, AsyncFunction, AsyncInstFn, Function, InstFn};
+pub use self::function_traits::{AsyncFunction, AsyncInstFn, Function, InstFn};
 #[doc(hidden)]
 pub use self::module::Module;
 
@@ -108,6 +108,8 @@ pub(crate) struct ModuleType {
     pub(crate) item: ItemBuf,
     /// Type hash.
     pub(crate) hash: Hash,
+    /// Parameters hash.
+    pub(crate) parameters_hash: Hash,
     /// Type information for the installed type.
     pub(crate) type_info: TypeInfo,
     /// The specification for the type.
@@ -228,9 +230,9 @@ pub(crate) struct ModuleFunction {
 
 #[derive(Clone)]
 pub(crate) struct ModuleAssociated {
-    pub(crate) key: AssociatedKey,
+    pub(crate) container: FullTypeOf,
+    pub(crate) container_type_info: TypeInfo,
     pub(crate) name: AssociatedFunctionName,
-    pub(crate) type_info: TypeInfo,
     pub(crate) handler: Arc<FunctionHandler>,
     pub(crate) is_async: bool,
     pub(crate) args: Option<usize>,

--- a/crates/rune/src/module/module.rs
+++ b/crates/rune/src/module/module.rs
@@ -332,9 +332,9 @@ impl Module {
     /// This shows how to register the unit type `()` as `nonstd::unit`.
     ///
     /// ```
-    /// use rune::Module;
+    /// use rune::{Any, Module};
     ///
-    /// let mut module = Module::with_item(["nonstd"]);
+    /// let mut module = Module::with_crate("nonstd");
     /// module.unit("unit")?;
     /// # Ok::<_, rune::Error>(())
     pub fn unit<N>(&mut self, name: N) -> Result<(), ContextError>

--- a/crates/rune/src/module/module.rs
+++ b/crates/rune/src/module/module.rs
@@ -24,9 +24,9 @@ enum Name {
     /// An associated key.
     Associated(AssociatedKey),
     /// A regular item.
-    Item(ItemBuf),
+    Item(Hash),
     /// A macro.
-    Macro(ItemBuf),
+    Macro(Hash),
 }
 
 /// A [Module] that is a collection of native functions and types.
@@ -167,12 +167,17 @@ impl Module {
     where
         T: Named + TypeOf + InstallWith,
     {
-        let item = ItemBuf::with_item(&[T::full_name()]);
+        let item = ItemBuf::with_item([T::BASE_NAME]);
         let hash = T::type_hash();
+        let parameters_hash = T::parameters_hash();
         let type_info = T::type_info();
 
-        if !self.names.insert(Name::Item(item.clone())) {
-            return Err(ContextError::ConflictingType { item, type_info });
+        if !self.names.insert(Name::Item(hash)) {
+            return Err(ContextError::ConflictingType {
+                item,
+                type_info,
+                hash,
+            });
         }
 
         let index = self.types.len();
@@ -181,6 +186,7 @@ impl Module {
         self.types.push(ModuleType {
             item,
             hash,
+            parameters_hash,
             type_info,
             spec: None,
             docs: Docs::default(),
@@ -469,6 +475,7 @@ impl Module {
         V: ToValue,
     {
         let item = ItemBuf::with_item(name);
+        let hash = Hash::type_hash(&item);
 
         let value = match value.to_value() {
             VmResult::Ok(v) => v,
@@ -480,8 +487,8 @@ impl Module {
             VmResult::Err(error) => return Err(ContextError::ValueError { error }),
         };
 
-        if !self.names.insert(Name::Item(item.clone())) {
-            return Err(ContextError::ConflictingConstantName { item });
+        if !self.names.insert(Name::Item(hash)) {
+            return Err(ContextError::ConflictingConstantName { item, hash });
         }
 
         self.constants.push(ModuleConstant {
@@ -538,8 +545,13 @@ impl Module {
 
         match meta.kind {
             MacroMetaKind::Function(data) => {
-                if !self.names.insert(Name::Macro(data.item.clone())) {
-                    return Err(ContextError::ConflictingMacroName { item: data.item });
+                let hash = Hash::type_hash(&data.item);
+
+                if !self.names.insert(Name::Macro(hash)) {
+                    return Err(ContextError::ConflictingMacroName {
+                        item: data.item,
+                        hash,
+                    });
                 }
 
                 let mut docs = Docs::default();
@@ -593,9 +605,10 @@ impl Module {
         N::Item: IntoComponent,
     {
         let item = ItemBuf::with_item(name);
+        let hash = Hash::type_hash(&item);
 
-        if !self.names.insert(Name::Macro(item.clone())) {
-            return Err(ContextError::ConflictingMacroName { item });
+        if !self.names.insert(Name::Macro(hash)) {
+            return Err(ContextError::ConflictingMacroName { item, hash });
         }
 
         let handler: Arc<MacroHandler> = Arc::new(f);
@@ -956,9 +969,10 @@ impl Module {
         N::Item: IntoComponent,
     {
         let item = ItemBuf::with_item(name);
+        let hash = Hash::type_hash(&item);
 
-        if !self.names.insert(Name::Item(item.clone())) {
-            return Err(ContextError::ConflictingFunctionName { item });
+        if !self.names.insert(Name::Item(hash)) {
+            return Err(ContextError::ConflictingFunctionName { item, hash });
         }
 
         self.functions.push(ModuleFunction {
@@ -983,8 +997,13 @@ impl Module {
         data: FunctionData,
         docs: Docs,
     ) -> Result<ItemMut<'_>, ContextError> {
-        if !self.names.insert(Name::Item(data.item.clone())) {
-            return Err(ContextError::ConflictingFunctionName { item: data.item });
+        let hash = Hash::type_hash(&data.item);
+
+        if !self.names.insert(Name::Item(hash)) {
+            return Err(ContextError::ConflictingFunctionName {
+                item: data.item,
+                hash,
+            });
         }
 
         self.functions.push(ModuleFunction {
@@ -1008,37 +1027,36 @@ impl Module {
         data: AssociatedFunctionData,
         docs: Docs,
     ) -> Result<ItemMut<'_>, ContextError> {
-        let key = data.assoc_key();
-
-        if !self.names.insert(Name::Associated(key.clone())) {
+        if !self.names.insert(Name::Associated(data.assoc_key())) {
             return Err(match data.name.kind {
                 AssociatedKind::Protocol(protocol) => ContextError::ConflictingProtocolFunction {
-                    type_info: data.ty.type_info,
+                    type_info: data.container_type_info,
                     name: protocol.name.into(),
                 },
                 AssociatedKind::FieldFn(protocol, field) => {
                     ContextError::ConflictingFieldFunction {
-                        type_info: data.ty.type_info,
+                        type_info: data.container_type_info,
                         name: protocol.name.into(),
                         field,
                     }
                 }
                 AssociatedKind::IndexFn(protocol, index) => {
                     ContextError::ConflictingIndexFunction {
-                        type_info: data.ty.type_info,
+                        type_info: data.container_type_info,
                         name: protocol.name.into(),
                         index,
                     }
                 }
                 AssociatedKind::Instance(name) => ContextError::ConflictingInstanceFunction {
-                    type_info: data.ty.type_info,
+                    type_info: data.container_type_info,
                     name,
                 },
             });
         }
 
         self.associated.push(ModuleAssociated {
-            key,
+            container: data.container,
+            container_type_info: data.container_type_info,
             name: data.name,
             handler: data.handler,
             is_async: data.is_async,
@@ -1046,7 +1064,6 @@ impl Module {
             return_type: data.return_type,
             argument_types: data.argument_types,
             docs,
-            type_info: data.ty.type_info,
         });
 
         let m = self.associated.last_mut().unwrap();

--- a/crates/rune/src/modules/collections/vec_deque.rs
+++ b/crates/rune/src/modules/collections/vec_deque.rs
@@ -32,7 +32,7 @@ pub(super) fn setup(module: &mut Module) -> Result<(), ContextError> {
 }
 
 #[derive(Any, Clone, Default)]
-#[rune(module = crate, item = ::std::collections::VecDeque)]
+#[rune(module = crate, item = ::std::collections)]
 struct VecDeque {
     inner: collections::VecDeque<Value>,
 }

--- a/crates/rune/src/runtime/static_type.rs
+++ b/crates/rune/src/runtime/static_type.rs
@@ -6,7 +6,7 @@ use crate::no_std::prelude::*;
 use crate::no_std::vec;
 
 use crate::runtime as rt;
-use crate::runtime::RawStr;
+use crate::runtime::{RawStr, TypeInfo};
 use crate::Hash;
 
 /// Static type information.
@@ -17,6 +17,13 @@ pub struct StaticType {
     pub name: RawStr,
     /// The hash of the static type.
     pub hash: Hash,
+}
+
+impl StaticType {
+    #[inline]
+    pub(crate) fn type_info(&'static self) -> TypeInfo {
+        TypeInfo::StaticType(self)
+    }
 }
 
 impl cmp::PartialEq for &'static StaticType {
@@ -145,7 +152,7 @@ impl_static_type!(rt::Tuple => TUPLE_TYPE);
 pub static OBJECT_TYPE: &StaticType = &StaticType {
     name: RawStr::from_str("Object"),
     // hash for ::std::object::Object
-    hash: Hash::new(0xd080f2e951218dde),
+    hash: Hash::new(0x2f5c2c7799148025),
 };
 
 impl_static_type!(rt::Object => OBJECT_TYPE);
@@ -237,7 +244,7 @@ impl_static_type!(rt::Format => FORMAT_TYPE);
 pub static ITERATOR_TYPE: &StaticType = &StaticType {
     name: RawStr::from_str("Iterator"),
     // hash for ::std::iter::Iterator
-    hash: Hash::new(0xe08fbd4d99f308e9),
+    hash: Hash::new(0xff918cc536a3fa32),
 };
 
 impl_static_type!(rt::Iterator => ITERATOR_TYPE);

--- a/crates/rune/src/runtime/type_of.rs
+++ b/crates/rune/src/runtime/type_of.rs
@@ -9,9 +9,13 @@ pub trait TypeOf {
     /// Type information for the given type.
     #[inline]
     fn type_of() -> FullTypeOf {
-        FullTypeOf {
-            hash: Self::type_hash(),
-        }
+        FullTypeOf::new(Self::type_hash())
+    }
+
+    /// Parameters hash.
+    #[inline]
+    fn parameters_hash() -> Hash {
+        Hash::EMPTY
     }
 
     /// Convert into a type hash.
@@ -83,6 +87,16 @@ where
     T: ?Sized + TypeOf,
 {
     #[inline]
+    fn type_of() -> FullTypeOf {
+        T::type_of()
+    }
+
+    #[inline]
+    fn parameters_hash() -> Hash {
+        T::parameters_hash()
+    }
+
+    #[inline]
     fn type_hash() -> Hash {
         T::type_hash()
     }
@@ -98,6 +112,16 @@ impl<T> TypeOf for &mut T
 where
     T: ?Sized + TypeOf,
 {
+    #[inline]
+    fn type_of() -> FullTypeOf {
+        T::type_of()
+    }
+
+    #[inline]
+    fn parameters_hash() -> Hash {
+        T::parameters_hash()
+    }
+
     #[inline]
     fn type_hash() -> Hash {
         T::type_hash()
@@ -115,6 +139,16 @@ where
     T: ?Sized + TypeOf,
 {
     #[inline]
+    fn type_of() -> FullTypeOf {
+        T::type_of()
+    }
+
+    #[inline]
+    fn parameters_hash() -> Hash {
+        T::parameters_hash()
+    }
+
+    #[inline]
     fn type_hash() -> Hash {
         T::type_hash()
     }
@@ -131,6 +165,16 @@ where
     T: ?Sized + TypeOf,
 {
     #[inline]
+    fn type_of() -> FullTypeOf {
+        T::type_of()
+    }
+
+    #[inline]
+    fn parameters_hash() -> Hash {
+        T::parameters_hash()
+    }
+
+    #[inline]
     fn type_hash() -> Hash {
         T::type_hash()
     }
@@ -146,6 +190,16 @@ impl<T> TypeOf for Shared<T>
 where
     T: ?Sized + TypeOf,
 {
+    #[inline]
+    fn type_of() -> FullTypeOf {
+        T::type_of()
+    }
+
+    #[inline]
+    fn parameters_hash() -> Hash {
+        T::parameters_hash()
+    }
+
     #[inline]
     fn type_hash() -> Hash {
         T::type_hash()

--- a/crates/rune/src/runtime/vm.rs
+++ b/crates/rune/src/runtime/vm.rs
@@ -2001,7 +2001,7 @@ impl Vm {
                 let handler = self
                     .context
                     .function(hash)
-                    .ok_or(VmErrorKind::MissingFunction { hash })?;
+                    .ok_or(VmErrorKind::MissingContextFunction { hash })?;
 
                 Function::from_handler(handler.clone(), hash)
             }

--- a/crates/rune/src/runtime/vm_error.rs
+++ b/crates/rune/src/runtime/vm_error.rs
@@ -420,6 +420,8 @@ pub(crate) enum VmErrorKind {
     MissingEntryHash { hash: Hash },
     #[error("Missing function with hash `{hash}`")]
     MissingFunction { hash: Hash },
+    #[error("Missing context function with hash `{hash}`")]
+    MissingContextFunction { hash: Hash },
     #[error("Missing instance function `{hash}` for `{instance}`")]
     MissingInstanceFunction { hash: Hash, instance: TypeInfo },
     #[error("Instruction pointer `{ip}` is out-of-bounds `0-{length}`")]

--- a/crates/rune/src/tests/bug_344.rs
+++ b/crates/rune/src/tests/bug_344.rs
@@ -171,7 +171,7 @@ impl GuardCheck {
 
 impl Any for GuardCheck {
     fn type_hash() -> Hash {
-        Hash::new(0x10)
+        Hash::new(0x6b8fb6d544712e99)
     }
 }
 

--- a/crates/rune/src/tests/generic_native.rs
+++ b/crates/rune/src/tests/generic_native.rs
@@ -3,6 +3,7 @@
 prelude!();
 
 #[derive(Any)]
+#[rune(item = ::native_crate)]
 struct Generic<T>
 where
     T: 'static + Clone + Named + UnsafeFromValue + ToValue + MaybeTypeOf + TypeOf,

--- a/crates/rune/src/tests/type_name_native.rs
+++ b/crates/rune/src/tests/type_name_native.rs
@@ -3,6 +3,7 @@
 prelude!();
 
 #[derive(Any)]
+#[rune(item = ::native_crate)]
 pub struct NativeStruct(pub u32);
 
 pub fn native_fn() {}


### PR DESCRIPTION
The returned meta immediately contains the meta of the function, rather than its (type erased) type path.