### PR TITLE
Capture more metadata

### DIFF
--- a/crates/rune/src/compile/context_error.rs
+++ b/crates/rune/src/compile/context_error.rs
@@ -55,6 +55,8 @@ pub enum ContextError {
     },
     #[error("Type `{item}` at `{type_info}` already has a specification")]
     ConflictingTypeMeta { item: ItemBuf, type_info: TypeInfo },
+    #[error("Variant `{index}` for `{type_info}` already has a specification")]
+    ConflictingVariantMeta { index: usize, type_info: TypeInfo },
     #[error(
         "Conflicting meta hash `{hash}` for existing `{existing}` when inserting item `{item}`"
     )]
@@ -78,7 +80,7 @@ pub enum ContextError {
     #[error("Container `{container}` is not registered")]
     MissingContainer { container: TypeInfo },
     #[error("Missing variant {index} for `{type_info}`")]
-    MissingVariant { type_info: TypeInfo, index: usize },
+    MissingVariant { index: usize, type_info: TypeInfo },
     #[error("Expected associated function")]
     ExpectedAssociated,
     #[error("Type hash mismatch for `{type_info}`, from module is `{hash}` while from item `{item}` is `{item_hash}`. A possibility is that it has the wrong #[rune(item = ..)] setting.")]

--- a/crates/rune/src/compile/meta.rs
+++ b/crates/rune/src/compile/meta.rs
@@ -130,12 +130,12 @@ impl Meta {
 /// The kind of a variant.
 #[derive(Debug, Clone)]
 pub enum Fields {
-    /// A tuple variant.
-    Tuple(Tuple),
-    /// A struct variant.
-    Struct(Struct),
-    /// A unit variant.
-    Unit,
+    /// Named fields.
+    Named(FieldsNamed),
+    /// Unnamed fields.
+    Unnamed(usize),
+    /// Empty.
+    Empty,
 }
 
 /// Compile-time metadata kind about a unit.
@@ -247,22 +247,12 @@ pub struct Import {
     pub(crate) module: ModId,
 }
 
-/// The metadata about a struct.
+/// Metadata about named fields.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
-pub struct Struct {
+pub struct FieldsNamed {
     /// Fields associated with the type.
     pub(crate) fields: HashSet<Box<str>>,
-}
-
-/// The metadata about a tuple.
-#[derive(Debug, Clone)]
-#[non_exhaustive]
-pub struct Tuple {
-    /// The number of arguments the variant takes.
-    pub(crate) args: usize,
-    /// Hash of the constructor function.
-    pub(crate) hash: Hash,
 }
 
 /// Item and the module that the item belongs to.

--- a/crates/rune/src/languageserver/state.rs
+++ b/crates/rune/src/languageserver/state.rs
@@ -868,27 +868,27 @@ impl CompileVisitor for Visitor {
 
         let kind = match &meta.kind {
             meta::Kind::Struct {
-                fields: meta::Fields::Unit,
+                fields: meta::Fields::Empty,
                 ..
             } => DefinitionKind::UnitStruct,
             meta::Kind::Struct {
-                fields: meta::Fields::Tuple(..),
+                fields: meta::Fields::Unnamed(..),
                 ..
             } => DefinitionKind::TupleStruct,
             meta::Kind::Struct {
-                fields: meta::Fields::Struct(..),
+                fields: meta::Fields::Named(..),
                 ..
             } => DefinitionKind::Struct,
             meta::Kind::Variant {
-                fields: meta::Fields::Unit,
+                fields: meta::Fields::Empty,
                 ..
             } => DefinitionKind::UnitVariant,
             meta::Kind::Variant {
-                fields: meta::Fields::Tuple(..),
+                fields: meta::Fields::Unnamed(..),
                 ..
             } => DefinitionKind::TupleVariant,
             meta::Kind::Variant {
-                fields: meta::Fields::Struct(..),
+                fields: meta::Fields::Named(..),
                 ..
             } => DefinitionKind::StructVariant,
             meta::Kind::Enum { .. } => DefinitionKind::Enum,

--- a/crates/rune/src/modules/ops.rs
+++ b/crates/rune/src/modules/ops.rs
@@ -7,18 +7,22 @@ use crate::{ContextError, Module, Params};
 pub fn module() -> Result<Module, ContextError> {
     let mut module = Module::with_crate_item("std", ["ops"]);
 
-    module.ty::<Range>()?.docs([
-        "Type for a range expression.",
-        "",
-        "A range expression is one of:",
-        "* `..<value>`",
-        "* `<value>..<value>`",
-        "* `<value>..`",
-        "* `..=<value>`",
-        "* `<value>..=<value>`",
-    ]);
+    module.ty::<Range>()?;
 
-    module.struct_meta::<Range, 2>(["start", "end"])?;
+    module
+        .type_meta::<Range>()?
+        .make_named_struct(&["start", "end"])?
+        .docs([
+            "Type for a range expression.",
+            "",
+            "A range expression is one of:",
+            "* `..<value>`",
+            "* `<value>..<value>`",
+            "* `<value>..`",
+            "* `..=<value>`",
+            "* `<value>..=<value>`",
+        ]);
+
     module.field_fn(Protocol::GET, "start", |r: &Range| r.start.clone())?;
     module.field_fn(Protocol::SET, "start", range_set_start)?;
 

--- a/crates/rune/src/query.rs
+++ b/crates/rune/src/query.rs
@@ -1709,11 +1709,11 @@ fn unit_body_meta(item: &Item, enum_item: Option<(Hash, usize)>) -> (Hash, meta:
         Some((enum_hash, index)) => meta::Kind::Variant {
             enum_hash,
             index,
-            fields: meta::Fields::Unit,
+            fields: meta::Fields::Empty,
             constructor: None,
         },
         None => meta::Kind::Struct {
-            fields: meta::Fields::Unit,
+            fields: meta::Fields::Empty,
             constructor: None,
         },
     };
@@ -1729,20 +1729,15 @@ fn tuple_body_meta(
 ) -> (Hash, meta::Kind) {
     let type_hash = Hash::type_hash(item);
 
-    let tuple = meta::Tuple {
-        args: tuple.len(),
-        hash: Hash::type_hash(item),
-    };
-
     let kind = match enum_ {
         Some((enum_hash, index)) => meta::Kind::Variant {
             enum_hash,
             index,
-            fields: meta::Fields::Tuple(tuple),
+            fields: meta::Fields::Unnamed(tuple.len()),
             constructor: None,
         },
         None => meta::Kind::Struct {
-            fields: meta::Fields::Tuple(tuple),
+            fields: meta::Fields::Unnamed(tuple.len()),
             constructor: None,
         },
     };
@@ -1766,17 +1761,17 @@ fn struct_body_meta(
         fields.insert(name.into());
     }
 
-    let st = meta::Struct { fields };
+    let st = meta::FieldsNamed { fields };
 
     let kind = match enum_ {
         Some((enum_hash, index)) => meta::Kind::Variant {
             enum_hash,
             index,
-            fields: meta::Fields::Struct(st),
+            fields: meta::Fields::Named(st),
             constructor: None,
         },
         None => meta::Kind::Struct {
-            fields: meta::Fields::Struct(st),
+            fields: meta::Fields::Named(st),
             constructor: None,
         },
     };

--- a/crates/rune/src/tests.rs
+++ b/crates/rune/src/tests.rs
@@ -353,7 +353,6 @@ mod compiler_warnings;
 mod core_macros;
 mod custom_macros;
 mod destructuring;
-mod external_enum;
 mod external_ops;
 mod for_loop;
 mod generic_native;

--- a/crates/rune/tests/external_enum.rs
+++ b/crates/rune/tests/external_enum.rs
@@ -1,35 +1,36 @@
-prelude!();
+use rune::{from_value, prepare, sources};
+use rune::{Any, Context, ContextError, Module, Vm};
 
 use std::sync::Arc;
+
+#[derive(Debug, Any, PartialEq, Eq)]
+enum External {
+    #[rune(constructor)]
+    First(#[rune(get)] u32),
+    #[rune(constructor)]
+    Second(#[rune(get)] u32),
+    #[rune(constructor)]
+    Third,
+    Fourth {
+        #[rune(get)]
+        a: u32,
+        #[rune(get)]
+        b: u32,
+    },
+    #[rune(constructor)]
+    Output(#[rune(get)] u32),
+}
+
+pub fn module() -> Result<Module, ContextError> {
+    let mut module = Module::new();
+    module.ty::<External>()?;
+    Ok(module)
+}
 
 /// Tests pattern matching and constructing over an external variant from within
 /// Rune.
 #[test]
 fn test_external_enum() -> Result<(), Box<dyn std::error::Error>> {
-    #[derive(Debug, Any, PartialEq, Eq)]
-    enum External {
-        #[rune(constructor)]
-        First(#[rune(get)] u32),
-        #[rune(constructor)]
-        Second(#[rune(get)] u32),
-        #[rune(constructor)]
-        Third,
-        Fourth {
-            #[rune(get)]
-            a: u32,
-            #[rune(get)]
-            b: u32,
-        },
-        #[rune(constructor)]
-        Output(#[rune(get)] u32),
-    }
-
-    pub fn module() -> Result<Module, ContextError> {
-        let mut module = Module::new();
-        module.ty::<External>()?;
-        Ok(module)
-    }
-
     let m = module()?;
 
     let mut context = Context::new();

--- a/scripts/book/objects/json.rn
+++ b/scripts/book/objects/json.rn
@@ -2,7 +2,7 @@ async fn get_commits(repo, limit) {
     let limit = limit.unwrap_or(10);
 
     let client = http::Client::new();
-    let request = client.get(`https://api.github.com/repos/${repo}/commits`).await?;
+    let request = client.get(`https://api.github.com/repos/${repo}/commits`);
     let response = request.header("User-Agent", "Rune").send().await?;
     let text = response.text().await?;
     let json = json::from_string(text)?;

--- a/scripts/book/streams/basic_stream.rn
+++ b/scripts/book/streams/basic_stream.rn
@@ -2,8 +2,7 @@ async fn send_requests(list) {
     let client = http::Client::new();
 
     let do_request = async |url| {
-        let response = client.get(url).await?;
-        Ok(response.send().await?.status())
+        Ok(client.get(url).send().await?.status())
     };
 
     for url in list {

--- a/scripts/http.rn
+++ b/scripts/http.rn
@@ -11,7 +11,7 @@ pub async fn main() {
     let body = json::to_bytes(#{ "hello": "world" })?;
 
     let client = http::Client::new();
-    let response = client.post("https://postman-echo.com/post").await?.body_bytes(body).await?.send().await?;
+    let response = client.post("https://postman-echo.com/post").body_bytes(body).send().await?;
 
     let response = response.json().await?;
 


### PR DESCRIPTION
Change `Any` to capture more metadata that can be used for documentation.

In particular documentation for types and variants.