### PR TITLE
Support generic parameters when registering functions

### DIFF
--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -409,9 +409,11 @@ mod collections {
 #[doc(hidden)]
 pub mod __private {
     pub use crate::module::module::Module;
-    pub use crate::module::InstallWith;
-    pub use crate::module::{FunctionMetaData, FunctionMetaKind};
-    pub use crate::module::{MacroMetaData, MacroMetaKind};
+    pub use crate::module::{
+        FunctionMetaData, FunctionMetaKind, InstallWith, MacroMetaData, MacroMetaKind,
+    };
+    pub use crate::params::Params;
+    pub use crate::runtime::TypeOf;
 }
 
 #[cfg(test)]

--- a/crates/rune/src/modules/ops.rs
+++ b/crates/rune/src/modules/ops.rs
@@ -1,7 +1,7 @@
 //! The `std::ops` module.
 
-use crate::runtime::{Function, Protocol, Range, TypeOf, Value};
-use crate::{ContextError, Module, Params};
+use crate::runtime::{Function, Protocol, Range, Value};
+use crate::{ContextError, Module};
 
 /// Construct the `std::ops` module.
 pub fn module() -> Result<Module, ContextError> {
@@ -30,12 +30,7 @@ pub fn module() -> Result<Module, ContextError> {
     module.field_fn(Protocol::SET, "end", range_set_end)?;
     module.inst_fn(Protocol::INTO_ITER, Range::into_iterator)?;
 
-    module
-        .inst_fn(
-            Params::new("contains", [u64::type_of()]),
-            Range::contains_int,
-        )?
-        .docs(["Test if the range contains the given integer."]);
+    module.function_meta(Range::__contains_int__meta)?;
 
     module.inst_fn("iter", Range::into_iterator)?.docs([
         "Iterate over the range.",

--- a/crates/rune/src/modules/result.rs
+++ b/crates/rune/src/modules/result.rs
@@ -35,7 +35,7 @@ pub fn module() -> Result<Module, ContextError> {
 ///
 /// Converts self into an `Option<T>`, consuming `self`, and discarding the
 /// error, if any.
-#[rune::function(instance, path = Result::<Value, Value>::ok)]
+#[rune::function(instance)]
 fn ok(result: &Result<Value, Value>) -> Option<Value> {
     result.as_ref().ok().cloned()
 }

--- a/crates/rune/src/modules/vec.rs
+++ b/crates/rune/src/modules/vec.rs
@@ -3,8 +3,8 @@
 use core::cmp;
 
 use crate as rune;
-use crate::runtime::{Function, Protocol, TypeOf, Value, Vec, VmResult};
-use crate::{ContextError, Module, Params};
+use crate::runtime::{Function, Protocol, Value, Vec, VmResult};
+use crate::{ContextError, Module};
 
 /// Construct the `std::vec` module.
 pub fn module() -> Result<Module, ContextError> {
@@ -27,12 +27,12 @@ pub fn module() -> Result<Module, ContextError> {
     module.inst_fn(Protocol::INTO_ITER, Vec::into_iterator)?;
     module.inst_fn(Protocol::INDEX_SET, Vec::set)?;
 
-    // TODO: parameterize with generics.
-    module.inst_fn(Params::new("sort", [i64::type_of()]), sort_int)?;
+    module.function_meta(sort_int)?;
     Ok(module)
 }
 
 /// Sort a vector of integers.
+#[rune::function(instance, path = sort::<i64>)]
 fn sort_int(vec: &mut Vec) {
     vec.sort_by(|a, b| match (a, b) {
         (Value::Integer(a), Value::Integer(b)) => a.cmp(b),

--- a/crates/rune/src/runtime/range.rs
+++ b/crates/rune/src/runtime/range.rs
@@ -1,6 +1,7 @@
 use core::fmt;
 use core::ops;
 
+use crate as rune;
 use crate::compile::Named;
 use crate::module::InstallWith;
 use crate::runtime::{
@@ -77,7 +78,8 @@ impl Range {
         VmResult::Ok(true)
     }
 
-    /// Test if the current range contains the given integer.
+    /// Test if the range contains the given integer.
+    #[rune::function(keep, path = contains::<i64>)]
     pub(crate) fn contains_int(&self, n: i64) -> VmResult<bool> {
         let start: Option<i64> = match self.start.clone() {
             Some(value) => Some(vm_try!(FromValue::from_value(value))),


### PR DESCRIPTION
This adds support for specifying generic arguments to `#[rune::function]`, such as sort:

```rust
/// Sort a vector of integers.
#[rune::function(instance, path = sort::<i64>)]
fn sort_int(vec: &mut Vec) {
    vec.sort_by(|a, b| match (a, b) {
        (Value::Integer(a), Value::Integer(b)) => a.cmp(b),
        // NB: fall back to sorting by address.
        _ => (a as *const _ as usize).cmp(&(b as *const _ as usize)),
    });
}
```