### PR TITLE
Byte code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        feature: [capture-io, doc, cli, workspace]
+        feature: [capture-io, doc, cli, workspace, byte-code]
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable

--- a/crates/rune-core/Cargo.toml
+++ b/crates/rune-core/Cargo.toml
@@ -22,7 +22,7 @@ twox-hash = { version = "1.6.3", default-features = false }
 serde = { version = "1.0.163", default-features = false, features = ["derive", "alloc"] }
 smallvec = { version = "1.10.0", default-features = false, features = ["const_new", "serde"] }
 byteorder = { version = "1.4.3", default-features = false }
-musli = { version = "0.0.41", default-features = false, optional = true }
+musli = { version = "0.0.42", default-features = false, optional = true }
 
 [dev-dependencies]
 rune = { path = "../rune" }

--- a/crates/rune-core/Cargo.toml
+++ b/crates/rune-core/Cargo.toml
@@ -22,6 +22,7 @@ twox-hash = { version = "1.6.3", default-features = false }
 serde = { version = "1.0.163", default-features = false, features = ["derive", "alloc"] }
 smallvec = { version = "1.10.0", default-features = false, features = ["const_new", "serde"] }
 byteorder = { version = "1.4.3", default-features = false }
+musli = { version = "0.0.41", default-features = false, optional = true }
 
 [dev-dependencies]
 rune = { path = "../rune" }

--- a/crates/rune-core/src/hash.rs
+++ b/crates/rune-core/src/hash.rs
@@ -8,6 +8,8 @@ use core::mem;
 
 use serde::{Deserialize, Serialize};
 use twox_hash::XxHash64;
+#[cfg(feature = "musli")]
+use musli::{Decode, Encode};
 
 use crate::protocol::Protocol;
 
@@ -31,7 +33,9 @@ const FUNCTION_PARAMETERS: u64 = 0x6052c152243a6eb3;
 /// The primitive hash that among other things is used to reference items,
 /// types, and native functions.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "musli", derive(Decode, Encode))]
 #[repr(transparent)]
+#[cfg_attr(feature = "musli", musli(transparent))]
 pub struct Hash(u64);
 
 impl Hash {

--- a/crates/rune-core/src/hash.rs
+++ b/crates/rune-core/src/hash.rs
@@ -6,10 +6,10 @@ use core::fmt;
 use core::hash::{self, BuildHasher, BuildHasherDefault, Hash as _, Hasher};
 use core::mem;
 
-use serde::{Deserialize, Serialize};
-use twox_hash::XxHash64;
 #[cfg(feature = "musli")]
 use musli::{Decode, Encode};
+use serde::{Deserialize, Serialize};
+use twox_hash::XxHash64;
 
 use crate::protocol::Protocol;
 

--- a/crates/rune-macros/Cargo.toml
+++ b/crates/rune-macros/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["parser-implementations"]
 
 [dependencies]
 rune-core = { version = "=0.12.3", path = "../rune-core" }
-syn = { version = "2.0.15", features = ["full"] }
+syn = { version = "2.0.16", features = ["full"] }
 quote = "1.0.27"
 proc-macro2 = { version = "1.0.56", features = ["span-locations"] }
 

--- a/crates/rune/Cargo.toml
+++ b/crates/rune/Cargo.toml
@@ -24,12 +24,12 @@ languageserver = ["lsp", "ropey", "percent-encoding", "url", "serde_json", "toki
 capture-io = ["parking_lot"]
 disable-io = []
 fmt = []
-std = ["alloc", "anyhow", "thiserror", "num/std", "serde/std", "rune-core/std"]
+std = ["alloc", "anyhow", "thiserror", "num/std", "serde/std", "rune-core/std", "musli/std", "musli-storage/std"]
 alloc = []
 
 [dependencies]
 rune-macros = { version = "=0.12.3", path = "../rune-macros" }
-rune-core = { version = "=0.12.3", path = "../rune-core" }
+rune-core = { version = "=0.12.3", path = "../rune-core", features = ["musli"] }
 
 futures-core = { version = "0.3.28", default-features = false }
 futures-util = { version = "0.3.28", default-features = false, features = ["alloc"] }
@@ -43,6 +43,8 @@ smallvec = { version = "1.10.0", default-features = false, features = ["serde", 
 thiserror-impl = { version = "1.0.40", default-features = false }
 tracing =  { version = "0.1.37", default-features = false, features = ["attributes"] }
 hashbrown = { version = "0.13.2", features = ["serde"] }
+musli = { version = "0.0.41", default-features = false }
+musli-storage = { version = "0.0.41", default-features = false }
 
 anyhow = { version = "1.0.71", features = ["std"], optional = true }
 atty = { version = "0.2.14", optional = true }

--- a/crates/rune/Cargo.toml
+++ b/crates/rune/Cargo.toml
@@ -21,11 +21,11 @@ workspace = ["std", "toml", "semver", "relative-path", "serde-hashkey", "linked-
 doc = ["std", "rust-embed", "handlebars", "pulldown-cmark", "syntect", "sha2", "base64", "rune-core/doc", "relative-path"]
 cli = ["std", "emit", "doc", "bincode", "atty", "tracing-subscriber", "clap", "webbrowser", "capture-io", "disable-io", "languageserver", "fmt", "similar", "rand"]
 languageserver = ["lsp", "ropey", "percent-encoding", "url", "serde_json", "tokio", "tokio/macros", "tokio/io-std", "workspace", "doc"]
+byte-code = ["musli-storage"]
 capture-io = ["parking_lot"]
 disable-io = []
 fmt = []
-std = ["alloc", "anyhow", "thiserror", "num/std", "serde/std", "rune-core/std", "musli/std", "musli-storage/std"]
-alloc = []
+std = ["anyhow", "thiserror", "num/std", "serde/std", "rune-core/std", "musli/std", "musli-storage/std"]
 
 [dependencies]
 rune-macros = { version = "=0.12.3", path = "../rune-macros" }
@@ -35,7 +35,7 @@ futures-core = { version = "0.3.28", default-features = false }
 futures-util = { version = "0.3.28", default-features = false, features = ["alloc"] }
 itoa = "1.0.6"
 num = { version = "0.4.0", default-features = false, features = ["alloc"] }
-pin-project = "1.0.12"
+pin-project = "1.1.0"
 ryu = "1.0.13"
 serde = { version = "1.0.163", default-features = false, features = ["derive", "alloc", "rc"] }
 serde_bytes = { version = "0.11.9", default-features = false, features = ["alloc"] }
@@ -43,9 +43,9 @@ smallvec = { version = "1.10.0", default-features = false, features = ["serde", 
 thiserror-impl = { version = "1.0.40", default-features = false }
 tracing =  { version = "0.1.37", default-features = false, features = ["attributes"] }
 hashbrown = { version = "0.13.2", features = ["serde"] }
-musli = { version = "0.0.41", default-features = false }
-musli-storage = { version = "0.0.41", default-features = false }
+musli = { version = "0.0.42", default-features = false, features = ["alloc"] }
 
+musli-storage = { version = "0.0.42", default-features = false, optional = true, features = ["alloc"] }
 anyhow = { version = "1.0.71", features = ["std"], optional = true }
 atty = { version = "0.2.14", optional = true }
 bincode = { version = "1.3.3", optional = true }

--- a/crates/rune/src/build.rs
+++ b/crates/rune/src/build.rs
@@ -4,7 +4,7 @@ use core::mem::take;
 use crate::no_std as std;
 use crate::no_std::prelude::*;
 use crate::no_std::thiserror;
-use crate::runtime::unit::{DefaultStorage, UnitStorage};
+use crate::runtime::unit::{DefaultStorage, UnitEncoder};
 
 use thiserror::Error;
 
@@ -71,7 +71,7 @@ pub fn prepare(sources: &mut Sources) -> Build<'_, DefaultStorage> {
 /// Prepare with a custom unit storage.
 pub fn prepare_with<S>(sources: &mut Sources) -> Build<'_, S>
 where
-    S: UnitStorage,
+    S: UnitEncoder,
 {
     Build {
         sources,
@@ -199,10 +199,10 @@ impl<'a, S> Build<'a, S> {
         self
     }
 
-    /// Build a [Unit] with the current configuration.
+    /// Build a [`Unit`] with the current configuration.
     pub fn build(mut self) -> Result<Unit<S>, BuildError>
     where
-        S: UnitStorage,
+        S: Default + UnitEncoder,
     {
         let default_context;
 

--- a/crates/rune/src/cli/run.rs
+++ b/crates/rune/src/cli/run.rs
@@ -6,7 +6,7 @@ use anyhow::{anyhow, Result};
 use clap::Parser;
 
 use crate::cli::{Config, ExitCode, Io, CommandBase, AssetKind, SharedFlags};
-use crate::runtime::{VmError, VmExecution, VmResult};
+use crate::runtime::{VmError, VmExecution, VmResult, UnitStorage};
 use crate::{Context, Sources, Unit, Value, Vm};
 
 #[derive(Parser, Debug)]
@@ -145,6 +145,8 @@ pub(super) async fn run(
     }
 
     if args.dump_unit() {
+        writeln!(io.stdout, "Unit size: {} bytes", unit.instructions().bytes())?;
+
         if args.emit_instructions() {
             let mut o = io.stdout.lock();
             writeln!(o, "# instructions")?;

--- a/crates/rune/src/compile.rs
+++ b/crates/rune/src/compile.rs
@@ -84,7 +84,7 @@ use crate::hir;
 use crate::macros::Storage;
 use crate::parse::Resolve;
 use crate::query::{Build, BuildEntry, Query};
-use crate::runtime::unit::UnitStorageBuilder;
+use crate::runtime::unit::UnitEncoder;
 use crate::shared::{Consts, Gen};
 use crate::worker::{LoadFileKind, Task, Worker};
 use crate::{Diagnostics, Sources};
@@ -100,7 +100,7 @@ pub(crate) fn compile(
     options: &Options,
     visitor: &mut dyn CompileVisitor,
     source_loader: &mut dyn SourceLoader,
-    unit_storage: &mut dyn UnitStorageBuilder,
+    unit_storage: &mut dyn UnitEncoder,
 ) -> Result<(), ()> {
     // Shared id generator.
     let gen = Gen::new();
@@ -207,11 +207,7 @@ impl CompileBuildEntry<'_> {
     }
 
     #[tracing::instrument(skip_all)]
-    fn compile(
-        mut self,
-        entry: BuildEntry,
-        unit_storage: &mut dyn UnitStorageBuilder,
-    ) -> Result<()> {
+    fn compile(mut self, entry: BuildEntry, unit_storage: &mut dyn UnitEncoder) -> Result<()> {
         let BuildEntry {
             item_meta,
             build,

--- a/crates/rune/src/compile.rs
+++ b/crates/rune/src/compile.rs
@@ -84,6 +84,7 @@ use crate::hir;
 use crate::macros::Storage;
 use crate::parse::Resolve;
 use crate::query::{Build, BuildEntry, Query};
+use crate::runtime::unit::UnitStorageBuilder;
 use crate::shared::{Consts, Gen};
 use crate::worker::{LoadFileKind, Task, Worker};
 use crate::{Diagnostics, Sources};
@@ -99,6 +100,7 @@ pub(crate) fn compile(
     options: &Options,
     visitor: &mut dyn CompileVisitor,
     source_loader: &mut dyn SourceLoader,
+    unit_storage: &mut dyn UnitStorageBuilder,
 ) -> Result<(), ()> {
     // Shared id generator.
     let gen = Gen::new();
@@ -156,7 +158,7 @@ pub(crate) fn compile(
                 q: worker.q.borrow(),
             };
 
-            if let Err(error) = task.compile(entry) {
+            if let Err(error) = task.compile(entry, unit_storage) {
                 worker.diagnostics.error(source_id, error);
             }
         }
@@ -204,8 +206,12 @@ impl CompileBuildEntry<'_> {
         }
     }
 
-    #[tracing::instrument(skip(self, entry))]
-    fn compile(mut self, entry: BuildEntry) -> Result<()> {
+    #[tracing::instrument(skip_all)]
+    fn compile(
+        mut self,
+        entry: BuildEntry,
+        unit_storage: &mut dyn UnitStorageBuilder,
+    ) -> Result<()> {
         let BuildEntry {
             item_meta,
             build,
@@ -260,6 +266,7 @@ impl CompileBuildEntry<'_> {
                         asm,
                         f.call,
                         args,
+                        unit_storage,
                     )?;
                 }
             }
@@ -304,6 +311,7 @@ impl CompileBuildEntry<'_> {
                         asm,
                         f.call,
                         args,
+                        unit_storage,
                     )?;
                 }
             }
@@ -336,6 +344,7 @@ impl CompileBuildEntry<'_> {
                         asm,
                         closure.call,
                         args,
+                        unit_storage,
                     )?;
                 }
             }
@@ -365,6 +374,7 @@ impl CompileBuildEntry<'_> {
                         asm,
                         b.call,
                         Default::default(),
+                        unit_storage,
                     )?;
                 }
             }

--- a/crates/rune/src/compile/error.rs
+++ b/crates/rune/src/compile/error.rs
@@ -15,6 +15,7 @@ use crate::compile::{HasSpan, IrValue, ItemBuf, Location, MetaInfo, Visibility};
 use crate::macros::{SyntheticId, SyntheticKind};
 use crate::parse::{Expectation, Id, IntoExpectation, LexerMode};
 use crate::runtime::debug::DebugSignature;
+use crate::runtime::unit::EncodeError;
 use crate::runtime::{AccessError, TypeInfo, TypeOf};
 use crate::shared::scopes::MissingLocal;
 use crate::shared::MissingLastId;
@@ -216,6 +217,8 @@ pub(crate) enum CompileErrorKind {
     AccessError(#[from] AccessError),
     #[error("{0}")]
     HirError(#[from] HirErrorKind),
+    #[error("{0}")]
+    EncodeError(#[from] EncodeError),
     #[error("{0}")]
     MissingLastId(#[from] MissingLastId),
     #[error("Failed to load `{path}`: {error}")]

--- a/crates/rune/src/compile/error.rs
+++ b/crates/rune/src/compile/error.rs
@@ -6,7 +6,6 @@ use crate::no_std::path::PathBuf;
 use crate::no_std::prelude::*;
 use crate::no_std::thiserror;
 
-use musli_storage::error::BufferError;
 use thiserror::Error;
 
 use crate::ast;
@@ -226,11 +225,6 @@ pub(crate) enum CompileErrorKind {
         path: PathBuf,
         #[source]
         error: io::Error,
-    },
-    #[error("{error}")]
-    BufferError {
-        #[from]
-        error: BufferError,
     },
     #[error("File not found, expected a module file like `{path}.rn`")]
     ModNotFound { path: PathBuf },

--- a/crates/rune/src/compile/unit_builder.rs
+++ b/crates/rune/src/compile/unit_builder.rs
@@ -705,7 +705,7 @@ impl UnitBuilder {
                 AssemblyInst::Jump { label } => {
                     let jump = label
                         .jump()
-                        .ok_or_else(|| CompileErrorKind::MissingLabelLocation {
+                        .ok_or(CompileErrorKind::MissingLabelLocation {
                             name: label.name,
                             index: label.index,
                         })
@@ -718,7 +718,7 @@ impl UnitBuilder {
                 AssemblyInst::JumpIf { label } => {
                     let jump = label
                         .jump()
-                        .ok_or_else(|| CompileErrorKind::MissingLabelLocation {
+                        .ok_or(CompileErrorKind::MissingLabelLocation {
                             name: label.name,
                             index: label.index,
                         })
@@ -731,7 +731,7 @@ impl UnitBuilder {
                 AssemblyInst::JumpIfOrPop { label } => {
                     let jump = label
                         .jump()
-                        .ok_or_else(|| CompileErrorKind::MissingLabelLocation {
+                        .ok_or(CompileErrorKind::MissingLabelLocation {
                             name: label.name,
                             index: label.index,
                         })
@@ -744,7 +744,7 @@ impl UnitBuilder {
                 AssemblyInst::JumpIfNotOrPop { label } => {
                     let jump = label
                         .jump()
-                        .ok_or_else(|| CompileErrorKind::MissingLabelLocation {
+                        .ok_or(CompileErrorKind::MissingLabelLocation {
                             name: label.name,
                             index: label.index,
                         })
@@ -757,7 +757,7 @@ impl UnitBuilder {
                 AssemblyInst::JumpIfBranch { branch, label } => {
                     let jump = label
                         .jump()
-                        .ok_or_else(|| CompileErrorKind::MissingLabelLocation {
+                        .ok_or(CompileErrorKind::MissingLabelLocation {
                             name: label.name,
                             index: label.index,
                         })
@@ -770,7 +770,7 @@ impl UnitBuilder {
                 AssemblyInst::PopAndJumpIfNot { count, label } => {
                     let jump = label
                         .jump()
-                        .ok_or_else(|| CompileErrorKind::MissingLabelLocation {
+                        .ok_or(CompileErrorKind::MissingLabelLocation {
                             name: label.name,
                             index: label.index,
                         })
@@ -783,7 +783,7 @@ impl UnitBuilder {
                 AssemblyInst::IterNext { offset, label } => {
                     let jump = label
                         .jump()
-                        .ok_or_else(|| CompileErrorKind::MissingLabelLocation {
+                        .ok_or(CompileErrorKind::MissingLabelLocation {
                             name: label.name,
                             index: label.index,
                         })

--- a/crates/rune/src/compile/v1/assemble.rs
+++ b/crates/rune/src/compile/v1/assemble.rs
@@ -3211,7 +3211,7 @@ fn expr_loop(
     needs: Needs,
 ) -> compile::Result<Asm> {
     let continue_label = c.asm.new_label("while_continue");
-    let then_label = c.asm.new_label("whiel_then");
+    let then_label = c.asm.new_label("while_then");
     let end_label = c.asm.new_label("while_end");
     let break_label = c.asm.new_label("while_break");
 

--- a/crates/rune/src/compile/v1/assemble.rs
+++ b/crates/rune/src/compile/v1/assemble.rs
@@ -434,7 +434,7 @@ fn condition(
                 c.asm.jump(then_label, span);
                 c.asm.label(&false_label)?;
             } else {
-                c.asm.jump(&then_label, span);
+                c.asm.jump(then_label, span);
             };
 
             let scope = c.scopes.pop(expected, span)?;
@@ -2579,7 +2579,7 @@ fn expr_match(
     while let Some((branch, (label, scope))) = it.next() {
         let span = branch.span();
 
-        c.asm.label(&*label)?;
+        c.asm.label(label)?;
 
         let expected = c.scopes.push(scope.clone());
         expr(branch.body, c, needs)?.apply(c)?;

--- a/crates/rune/src/compile/v1/assemble.rs
+++ b/crates/rune/src/compile/v1/assemble.rs
@@ -231,13 +231,13 @@ fn pat_with_offset(
 
     let false_label = c.asm.new_label("let_panic");
 
-    if pat(hir, c, false_label, &load)? {
+    if pat(hir, c, &false_label, &load)? {
         c.diagnostics
             .let_pattern_might_panic(c.source_id, span, c.context());
 
         let ok_label = c.asm.new_label("let_ok");
-        c.asm.jump(ok_label, span);
-        c.asm.label(false_label)?;
+        c.asm.jump(&ok_label, span);
+        c.asm.label(&false_label)?;
         c.asm.push(
             Inst::Panic {
                 reason: PanicReason::UnmatchedPattern,
@@ -245,7 +245,7 @@ fn pat_with_offset(
             span,
         );
 
-        c.asm.label(ok_label)?;
+        c.asm.label(&ok_label)?;
     }
 
     Ok(())
@@ -261,7 +261,7 @@ fn pat_with_offset(
 fn pat(
     hir: &hir::Pat<'_>,
     c: &mut Assembler<'_>,
-    false_label: Label,
+    false_label: &Label,
     load: &dyn Fn(&mut Assembler<'_>, Needs) -> compile::Result<()>,
 ) -> compile::Result<bool> {
     let span = hir.span();
@@ -319,7 +319,7 @@ fn pat(
 fn pat_lit(
     hir: &hir::Expr<'_>,
     c: &mut Assembler<'_>,
-    false_label: Label,
+    false_label: &Label,
     load: &dyn Fn(&mut Assembler<'_>, Needs) -> compile::Result<()>,
 ) -> compile::Result<bool> {
     let span = hir.span();
@@ -406,7 +406,7 @@ fn pat_lit_inst(
 fn condition(
     condition: &hir::Condition<'_>,
     c: &mut Assembler<'_>,
-    then_label: Label,
+    then_label: &Label,
 ) -> compile::Result<Scope> {
     match condition {
         hir::Condition::Expr(e) => {
@@ -430,11 +430,11 @@ fn condition(
                 Ok(())
             };
 
-            if pat(expr_let.pat, c, false_label, &load)? {
+            if pat(expr_let.pat, c, &false_label, &load)? {
                 c.asm.jump(then_label, span);
-                c.asm.label(false_label)?;
+                c.asm.label(&false_label)?;
             } else {
-                c.asm.jump(then_label, span);
+                c.asm.jump(&then_label, span);
             };
 
             let scope = c.scopes.pop(expected, span)?;
@@ -449,7 +449,7 @@ fn pat_vec(
     span: Span,
     c: &mut Assembler<'_>,
     hir: &hir::PatItems<'_>,
-    false_label: Label,
+    false_label: &Label,
     load: &dyn Fn(&mut Assembler<'_>, Needs) -> compile::Result<()>,
 ) -> compile::Result<()> {
     // Assign the yet-to-be-verified tuple to an anonymous slot, so we can
@@ -571,7 +571,7 @@ fn pat_tuple(
     span: Span,
     c: &mut Assembler<'_>,
     hir: &hir::PatItems<'_>,
-    false_label: Label,
+    false_label: &Label,
     load: &dyn Fn(&mut Assembler<'_>, Needs) -> compile::Result<()>,
 ) -> compile::Result<()> {
     load(c, Needs::Value)?;
@@ -658,7 +658,7 @@ fn pat_object(
     span: Span,
     c: &mut Assembler<'_>,
     hir: &hir::PatItems<'_>,
-    false_label: Label,
+    false_label: &Label,
     load: &dyn Fn(&mut Assembler<'_>, Needs) -> compile::Result<()>,
 ) -> compile::Result<()> {
     // NB: bind the loaded variable (once) to an anonymous var.
@@ -849,7 +849,7 @@ fn pat_meta_binding(
     span: Span,
     c: &mut Assembler<'_>,
     meta: &meta::Meta,
-    false_label: Label,
+    false_label: &Label,
     load: &dyn Fn(&mut Assembler<'_>, Needs) -> compile::Result<()>,
 ) -> compile::Result<bool> {
     let inst = match tuple_match_for(span, c, meta) {
@@ -1414,10 +1414,10 @@ fn expr_binary(
 
         match bin_op {
             ast::BinOp::And(..) => {
-                c.asm.jump_if_not_or_pop(end_label, lhs.span());
+                c.asm.jump_if_not_or_pop(&end_label, lhs.span());
             }
             ast::BinOp::Or(..) => {
-                c.asm.jump_if_or_pop(end_label, lhs.span());
+                c.asm.jump_if_or_pop(&end_label, lhs.span());
             }
             op => {
                 return Err(compile::Error::new(
@@ -1429,7 +1429,7 @@ fn expr_binary(
 
         expr(rhs, c, Needs::Value)?.apply(c)?;
 
-        c.asm.label(end_label)?;
+        c.asm.label(&end_label)?;
 
         if !needs.value() {
             c.asm.push(Inst::Pop, span);
@@ -1624,7 +1624,8 @@ fn expr_break(
         match e {
             hir::ExprBreakValue::Expr(e) => {
                 expr(e, c, current_loop.needs)?.apply(c)?;
-                (current_loop, current_loop.drop.into_iter().collect(), true)
+                let to_drop = current_loop.drop.into_iter().collect();
+                (current_loop, to_drop, true)
             }
             hir::ExprBreakValue::Label(label) => {
                 let (last_loop, to_drop) =
@@ -1633,10 +1634,11 @@ fn expr_break(
             }
         }
     } else {
-        (current_loop, current_loop.drop.into_iter().collect(), false)
+        let to_drop = current_loop.drop.into_iter().collect();
+        (current_loop, to_drop, false)
     };
 
-    // Drop loop temporary. Typically an iterator.
+    // Drop loop temporaries. Typically an iterator.
     for offset in to_drop {
         c.asm.push(Inst::Drop { offset }, span);
     }
@@ -1659,7 +1661,7 @@ fn expr_break(
         c.locals_pop(vars, span);
     }
 
-    c.asm.jump(last_loop.break_label, span);
+    c.asm.jump(&last_loop.break_label, span);
     Ok(Asm::top(span))
 }
 
@@ -2102,7 +2104,7 @@ fn expr_continue(
 
     c.locals_pop(vars, span);
 
-    c.asm.jump(last_loop.continue_label, span);
+    c.asm.jump(&last_loop.continue_label, span);
     Ok(Asm::top(span))
 }
 
@@ -2280,13 +2282,13 @@ fn expr_for(
     };
 
     let continue_var_count = c.scopes.total_var_count(span)?;
-    c.asm.label(continue_label)?;
+    c.asm.label(&continue_label)?;
 
     let _guard = c.loops.push(Loop {
         label: hir.label.copied(),
-        continue_label,
+        continue_label: continue_label.clone(),
         continue_var_count,
-        break_label,
+        break_label: break_label.clone(),
         break_var_count,
         needs,
         drop: Some(iter_offset),
@@ -2345,7 +2347,7 @@ fn expr_for(
     }
 
     // Test loop condition and unwrap the option, or jump to `end_label` if the current value is `None`.
-    c.asm.iter_next(binding_offset, end_label, binding_span);
+    c.asm.iter_next(binding_offset, &end_label, binding_span);
 
     let body_span = hir.body.span();
     let guard = c.scopes.push_child(body_span)?;
@@ -2355,8 +2357,8 @@ fn expr_for(
     block(hir.body, c, Needs::None)?.apply(c)?;
     c.clean_last_scope(span, guard, Needs::None)?;
 
-    c.asm.jump(continue_label, span);
-    c.asm.label(end_label)?;
+    c.asm.jump(&continue_label, span);
+    c.asm.label(&end_label)?;
 
     // Drop the iterator.
     c.asm.push(
@@ -2374,7 +2376,7 @@ fn expr_for(
     }
 
     // NB: breaks produce their own value.
-    c.asm.label(break_label)?;
+    c.asm.label(&break_label)?;
     Ok(Asm::top(span))
 }
 
@@ -2390,11 +2392,11 @@ fn expr_if(
     let end_label = c.asm.new_label("if_end");
 
     let mut branches = Vec::new();
-    let then_scope = condition(hir.condition, c, then_label)?;
+    let then_scope = condition(hir.condition, c, &then_label)?;
 
     for branch in hir.expr_else_ifs {
         let label = c.asm.new_label("if_branch");
-        let scope = condition(branch.condition, c, label)?;
+        let scope = condition(branch.condition, c, &label)?;
         branches.push((branch, label, scope));
     }
 
@@ -2409,16 +2411,16 @@ fn expr_if(
         }
     }
 
-    c.asm.jump(end_label, span);
+    c.asm.jump(&end_label, span);
 
-    c.asm.label(then_label)?;
+    c.asm.label(&then_label)?;
 
     let expected = c.scopes.push(then_scope);
     block(hir.block, c, needs)?.apply(c)?;
     c.clean_last_scope(span, expected, needs)?;
 
     if !hir.expr_else_ifs.is_empty() {
-        c.asm.jump(end_label, span);
+        c.asm.jump(&end_label, span);
     }
 
     let mut it = branches.into_iter().peekable();
@@ -2426,18 +2428,18 @@ fn expr_if(
     while let Some((branch, label, scope)) = it.next() {
         let span = branch.span();
 
-        c.asm.label(label)?;
+        c.asm.label(&label)?;
 
         let scopes = c.scopes.push(scope);
         block(branch.block, c, needs)?.apply(c)?;
         c.clean_last_scope(span, scopes, needs)?;
 
         if it.peek().is_some() {
-            c.asm.jump(end_label, span);
+            c.asm.jump(&end_label, span);
         }
     }
 
-    c.asm.label(end_label)?;
+    c.asm.label(&end_label)?;
     Ok(Asm::top(span))
 }
 
@@ -2479,13 +2481,13 @@ fn expr_let(hir: &hir::ExprLet<'_>, c: &mut Assembler<'_>, needs: Needs) -> comp
 
     let false_label = c.asm.new_label("let_panic");
 
-    if pat(hir.pat, c, false_label, &load)? {
+    if pat(hir.pat, c, &false_label, &load)? {
         c.diagnostics
             .let_pattern_might_panic(c.source_id, span, c.context());
 
         let ok_label = c.asm.new_label("let_ok");
-        c.asm.jump(ok_label, span);
-        c.asm.label(false_label)?;
+        c.asm.jump(&ok_label, span);
+        c.asm.label(&false_label)?;
         c.asm.push(
             Inst::Panic {
                 reason: PanicReason::UnmatchedPattern,
@@ -2493,7 +2495,7 @@ fn expr_let(hir: &hir::ExprLet<'_>, c: &mut Assembler<'_>, needs: Needs) -> comp
             span,
         );
 
-        c.asm.label(ok_label)?;
+        c.asm.label(&ok_label)?;
     }
 
     // If a value is needed for a let expression, it is evaluated as a unit.
@@ -2537,7 +2539,7 @@ fn expr_match(
             Ok(())
         };
 
-        pat(branch.pat, c, match_false, &load)?;
+        pat(branch.pat, c, &match_false, &load)?;
 
         let scope = if let Some(condition) = branch.condition {
             let span = condition.span();
@@ -2550,16 +2552,16 @@ fn expr_match(
             let scope = c.scopes.pop(parent_guard, span)?;
 
             c.asm
-                .pop_and_jump_if_not(scope.local_var_count, match_false, span);
+                .pop_and_jump_if_not(scope.local_var_count, &match_false, span);
 
-            c.asm.jump(branch_label, span);
+            c.asm.jump(&branch_label, span);
             scope
         } else {
             c.scopes.pop(parent_guard, span)?
         };
 
-        c.asm.jump(branch_label, span);
-        c.asm.label(match_false)?;
+        c.asm.jump(&branch_label, span);
+        c.asm.label(&match_false)?;
 
         branches.push((branch_label, scope));
     }
@@ -2570,25 +2572,25 @@ fn expr_match(
         c.asm.push(Inst::unit(), span);
     }
 
-    c.asm.jump(end_label, span);
+    c.asm.jump(&end_label, span);
 
     let mut it = hir.branches.iter().zip(&branches).peekable();
 
     while let Some((branch, (label, scope))) = it.next() {
         let span = branch.span();
 
-        c.asm.label(*label)?;
+        c.asm.label(&*label)?;
 
         let expected = c.scopes.push(scope.clone());
         expr(branch.body, c, needs)?.apply(c)?;
         c.clean_last_scope(span, expected, needs)?;
 
         if it.peek().is_some() {
-            c.asm.jump(end_label, span);
+            c.asm.jump(&end_label, span);
         }
     }
 
-    c.asm.label(end_label)?;
+    c.asm.label(&end_label)?;
 
     // pop the implicit scope where we store the anonymous match variable.
     c.clean_last_scope(span, expected_scopes, needs)?;
@@ -2945,23 +2947,23 @@ fn expr_select(
     c.asm.push(Inst::Select { len }, span);
 
     for (branch, (label, _)) in branches.iter().enumerate() {
-        c.asm.jump_if_branch(branch as i64, *label, span);
+        c.asm.jump_if_branch(branch as i64, label, span);
     }
 
     if let Some((_, label)) = &default_branch {
         c.asm.push(Inst::Pop, span);
-        c.asm.jump(*label, span);
+        c.asm.jump(label, span);
     }
 
     if !needs.value() {
         c.asm.push(Inst::Pop, span);
     }
 
-    c.asm.jump(end_label, span);
+    c.asm.jump(&end_label, span);
 
     for (label, branch) in branches {
         let span = branch.span();
-        c.asm.label(label)?;
+        c.asm.label(&label)?;
 
         let expected = c.scopes.push_child(span)?;
 
@@ -2994,15 +2996,15 @@ fn expr_select(
         // Set up a new scope with the binding.
         expr(branch.body, c, needs)?.apply(c)?;
         c.clean_last_scope(span, expected, needs)?;
-        c.asm.jump(end_label, span);
+        c.asm.jump(&end_label, span);
     }
 
     if let Some((branch, label)) = default_branch {
-        c.asm.label(label)?;
+        c.asm.label(&label)?;
         expr(branch, c, needs)?.apply(c)?;
     }
 
-    c.asm.label(end_label)?;
+    c.asm.label(&end_label)?;
 
     c.contexts
         .pop()
@@ -3217,22 +3219,22 @@ fn expr_loop(
 
     let _guard = c.loops.push(Loop {
         label: hir.label.copied(),
-        continue_label,
+        continue_label: continue_label.clone(),
         continue_var_count: var_count,
-        break_label,
+        break_label: break_label.clone(),
         break_var_count: var_count,
         needs,
         drop: None,
     });
 
-    c.asm.label(continue_label)?;
+    c.asm.label(&continue_label)?;
 
     let expected = if let Some(hir) = hir.condition {
-        let then_scope = condition(hir, c, then_label)?;
+        let then_scope = condition(hir, c, &then_label)?;
         let expected = c.scopes.push(then_scope);
 
-        c.asm.jump(end_label, span);
-        c.asm.label(then_label)?;
+        c.asm.jump(&end_label, span);
+        c.asm.label(&then_label)?;
         Some(expected)
     } else {
         None
@@ -3244,15 +3246,15 @@ fn expr_loop(
         c.clean_last_scope(span, expected, Needs::None)?;
     }
 
-    c.asm.jump(continue_label, span);
-    c.asm.label(end_label)?;
+    c.asm.jump(&continue_label, span);
+    c.asm.label(&end_label)?;
 
     if needs.value() {
         c.asm.push(Inst::unit(), span);
     }
 
     // NB: breaks produce their own value / perform their own cleanup.
-    c.asm.label(break_label)?;
+    c.asm.label(&break_label)?;
     Ok(Asm::top(span))
 }
 
@@ -3440,13 +3442,13 @@ fn local(hir: &hir::Local<'_>, c: &mut Assembler<'_>, needs: Needs) -> compile::
 
     let false_label = c.asm.new_label("let_panic");
 
-    if pat(hir.pat, c, false_label, &load)? {
+    if pat(hir.pat, c, &false_label, &load)? {
         c.diagnostics
             .let_pattern_might_panic(c.source_id, span, c.context());
 
         let ok_label = c.asm.new_label("let_ok");
-        c.asm.jump(ok_label, span);
-        c.asm.label(false_label)?;
+        c.asm.jump(&ok_label, span);
+        c.asm.label(&false_label)?;
         c.asm.push(
             Inst::Panic {
                 reason: PanicReason::UnmatchedPattern,
@@ -3454,7 +3456,7 @@ fn local(hir: &hir::Local<'_>, c: &mut Assembler<'_>, needs: Needs) -> compile::
             span,
         );
 
-        c.asm.label(ok_label)?;
+        c.asm.label(&ok_label)?;
     }
 
     // If a value is needed for a let expression, it is evaluated as a unit.

--- a/crates/rune/src/compile/v1/loops.rs
+++ b/crates/rune/src/compile/v1/loops.rs
@@ -22,7 +22,7 @@ impl Drop for LoopGuard {
 }
 
 /// Loops we are inside.
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub(crate) struct Loop {
     /// The optional label of the start of the loop.
     pub(crate) label: Option<ast::Label>,
@@ -54,7 +54,7 @@ impl Loops {
 
     /// Get the last loop context.
     pub(crate) fn last(&self) -> Option<Loop> {
-        self.loops.borrow().last().copied()
+        self.loops.borrow().last().cloned()
     }
 
     /// Push loop information.
@@ -91,7 +91,7 @@ impl Loops {
             let label = label.resolve(ctx)?;
 
             if expected == label {
-                return Ok((*l, to_drop));
+                return Ok((l.clone(), to_drop));
             }
         }
 

--- a/crates/rune/src/diagnostics/dump_instructions.rs
+++ b/crates/rune/src/diagnostics/dump_instructions.rs
@@ -31,7 +31,7 @@ impl DumpInstructions for Unit {
     {
         let mut first_function = true;
 
-        for (n, inst) in self.iter_instructions().enumerate() {
+        for (n, inst) in self.iter_instructions() {
             let debug = self.debug_info().and_then(|d| d.instruction_at(n));
 
             if let Some((hash, signature)) = self.debug_info().and_then(|d| d.function_at(n)) {

--- a/crates/rune/src/diagnostics/emit.rs
+++ b/crates/rune/src/diagnostics/emit.rs
@@ -241,7 +241,7 @@ impl Unit {
     {
         let mut first_function = true;
 
-        for (n, inst) in self.iter_instructions().enumerate() {
+        for (n, inst) in self.iter_instructions() {
             let debug = self.debug_info().and_then(|d| d.instruction_at(n));
 
             if let Some((hash, signature)) = self.debug_info().and_then(|d| d.function_at(n)) {
@@ -260,7 +260,7 @@ impl Unit {
                 }
             }
 
-            if let Some(label) = debug.and_then(|d| d.label.as_ref()) {
+            for label in debug.map(|d| d.labels.as_slice()).unwrap_or_default() {
                 writeln!(out, "{}:", label)?;
             }
 

--- a/crates/rune/src/exported_macros.rs
+++ b/crates/rune/src/exported_macros.rs
@@ -5,7 +5,9 @@ macro_rules! vm_try {
     ($expr:expr) => {
         match $crate::runtime::try_result($expr) {
             $crate::runtime::VmResult::Ok(value) => value,
-            $crate::runtime::VmResult::Err(err) => return $crate::runtime::VmResult::Err(err),
+            $crate::runtime::VmResult::Err(err) => {
+                return $crate::runtime::VmResult::Err($crate::runtime::VmError::from(err))
+            }
         }
     };
 }

--- a/crates/rune/src/runtime.rs
+++ b/crates/rune/src/runtime.rs
@@ -129,9 +129,9 @@ pub use self::type_info::{AnyTypeInfo, TypeInfo};
 mod type_of;
 pub use self::type_of::{FullTypeOf, MaybeTypeOf, TypeOf};
 
-mod unit;
-pub use self::unit::Unit;
+pub mod unit;
 pub(crate) use self::unit::UnitFn;
+pub use self::unit::{Unit, UnitStorage};
 
 mod value;
 pub use self::value::{Rtti, Struct, TupleStruct, UnitStruct, Value, VariantRtti};

--- a/crates/rune/src/runtime.rs
+++ b/crates/rune/src/runtime.rs
@@ -69,7 +69,8 @@ mod key;
 pub use self::key::Key;
 
 mod label;
-pub use self::label::{DebugLabel, Label};
+pub use self::label::DebugLabel;
+pub(crate) use self::label::Label;
 
 mod object;
 pub use self::object::Object;

--- a/crates/rune/src/runtime/awaited.rs
+++ b/crates/rune/src/runtime/awaited.rs
@@ -16,13 +16,11 @@ impl Awaited {
             Self::Future(future) => {
                 let value = vm_try!(vm_try!(future.borrow_mut()).await);
                 vm.stack_mut().push(value);
-                vm.advance();
             }
             Self::Select(select) => {
                 let (branch, value) = vm_try!(select.await);
                 vm.stack_mut().push(value);
                 vm.stack_mut().push(vm_try!(ToValue::to_value(branch)));
-                vm.advance();
             }
         }
 

--- a/crates/rune/src/runtime/budget.rs
+++ b/crates/rune/src/runtime/budget.rs
@@ -31,6 +31,7 @@ pub struct Budget<T> {
 
 /// Wrap the given value with a budget.
 pub fn with<T>(budget: usize, value: T) -> Budget<T> {
+    tracing::trace!(?budget);
     Budget { budget, value }
 }
 

--- a/crates/rune/src/runtime/debug.rs
+++ b/crates/rune/src/runtime/debug.rs
@@ -17,7 +17,7 @@ use crate::{Hash, SourceId};
 #[non_exhaustive]
 pub struct DebugInfo {
     /// Debug information on each instruction.
-    pub instructions: Vec<DebugInst>,
+    pub instructions: HashMap<usize, DebugInst>,
     /// Function signatures.
     pub functions: HashMap<Hash, DebugSignature>,
     /// Reverse lookup of a function.
@@ -27,7 +27,7 @@ pub struct DebugInfo {
 impl DebugInfo {
     /// Get debug instruction at the given instruction pointer.
     pub fn instruction_at(&self, ip: usize) -> Option<&DebugInst> {
-        self.instructions.get(ip)
+        self.instructions.get(&ip)
     }
 
     /// Get the function corresponding to the given instruction pointer.
@@ -49,7 +49,7 @@ pub struct DebugInst {
     /// The comment for the line.
     pub comment: Option<Box<str>>,
     /// Label associated with the location.
-    pub label: Option<DebugLabel>,
+    pub labels: Vec<DebugLabel>,
 }
 
 impl DebugInst {
@@ -58,13 +58,13 @@ impl DebugInst {
         source_id: SourceId,
         span: Span,
         comment: Option<Box<str>>,
-        label: Option<DebugLabel>,
+        labels: Vec<DebugLabel>,
     ) -> Self {
         Self {
             source_id,
             span,
             comment,
-            label,
+            labels,
         }
     }
 }

--- a/crates/rune/src/runtime/format.rs
+++ b/crates/rune/src/runtime/format.rs
@@ -9,6 +9,7 @@ use core::str;
 
 use crate::no_std::prelude::*;
 
+use musli::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
 use crate::compile::Named;
@@ -61,7 +62,7 @@ impl FromValue for Format {
 }
 
 /// A format specification.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Decode, Encode)]
 #[non_exhaustive]
 pub struct FormatSpec {
     /// Formatting flags.
@@ -370,7 +371,7 @@ impl FormatSpec {
 }
 
 /// The type of formatting requested.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Decode, Encode)]
 #[non_exhaustive]
 pub enum Type {
     /// Display type (default).
@@ -437,7 +438,7 @@ impl fmt::Display for Type {
 }
 
 /// The alignment requested.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Decode, Encode)]
 #[non_exhaustive]
 pub enum Alignment {
     /// Left alignment.
@@ -501,8 +502,9 @@ pub enum Flag {
 }
 
 /// Format specification flags.
-#[derive(Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, Decode, Encode)]
 #[repr(transparent)]
+#[musli(transparent)]
 pub struct Flags(u32);
 
 impl Flags {

--- a/crates/rune/src/runtime/inst.rs
+++ b/crates/rune/src/runtime/inst.rs
@@ -1,5 +1,6 @@
 use core::fmt;
 
+use musli::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
 use crate::runtime::{FormatSpec, Type, Value};
@@ -9,7 +10,7 @@ use crate::Hash;
 ///
 /// To formulate a custom reason, use
 /// [`VmError::panic`][crate::runtime::VmError::panic].
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Decode, Encode)]
 #[non_exhaustive]
 pub enum PanicReason {
     /// Not implemented.
@@ -46,7 +47,7 @@ impl fmt::Display for PanicReason {
 }
 
 /// Type checks for built-in types.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Decode, Encode)]
 #[non_exhaustive]
 pub enum TypeCheck {
     /// Matches a unit type.
@@ -58,10 +59,13 @@ pub enum TypeCheck {
     /// Matches a vector.
     Vec,
     /// An option type, and the specified variant index.
+    #[musli(packed)]
     Option(usize),
     /// A result type, and the specified variant index.
+    #[musli(packed)]
     Result(usize),
     /// A generator state type, and the specified variant index.
+    #[musli(packed)]
     GeneratorState(usize),
 }
 
@@ -83,7 +87,7 @@ impl fmt::Display for TypeCheck {
 }
 
 /// An operation in the stack-based virtual machine.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Decode, Encode)]
 pub enum Inst {
     /// Not operator. Takes a boolean from the top of the stack  and inverts its
     /// logical value.
@@ -113,6 +117,7 @@ pub enum Inst {
     /// <value..>
     /// => <fn>
     /// ```
+    #[musli(packed)]
     Closure {
         /// The hash of the internally stored closure function.
         hash: Hash,
@@ -123,6 +128,7 @@ pub enum Inst {
     ///
     /// It will construct a new stack frame which includes the last `args`
     /// number of entries.
+    #[musli(packed)]
     Call {
         /// The hash of the function to call.
         hash: Hash,
@@ -133,6 +139,7 @@ pub enum Inst {
     ///
     /// The instance being called on should be on top of the stack, followed by
     /// `args` number of arguments.
+    #[musli(packed)]
     CallInstance {
         /// The hash of the name of the function to call.
         hash: Hash,
@@ -153,6 +160,7 @@ pub enum Inst {
     /// <value>
     /// => <fn>
     /// ```
+    #[musli(packed)]
     LoadInstanceFn {
         /// The name hash of the instance function.
         hash: Hash,
@@ -166,6 +174,7 @@ pub enum Inst {
     /// <args...>
     /// => <ret>
     /// ```
+    #[musli(packed)]
     CallFn {
         /// The number of arguments expected on the stack for this call.
         args: usize,
@@ -179,6 +188,7 @@ pub enum Inst {
     /// <index>
     /// => <value>
     /// ```
+    #[musli(packed)]
     IndexGet {
         /// How the target is addressed.
         target: InstAddress,
@@ -194,6 +204,7 @@ pub enum Inst {
     /// <tuple>
     /// => <value>
     /// ```
+    #[musli(packed)]
     TupleIndexGet {
         /// The index to fetch.
         index: usize,
@@ -207,6 +218,7 @@ pub enum Inst {
     /// <tuple>
     /// => *nothing*
     /// ```
+    #[musli(packed)]
     TupleIndexSet {
         /// The index to set.
         index: usize,
@@ -219,6 +231,7 @@ pub enum Inst {
     /// ```text
     /// => <value>
     /// ```
+    #[musli(packed)]
     TupleIndexGetAt {
         /// The slot offset to load the tuple from.
         offset: usize,
@@ -237,6 +250,7 @@ pub enum Inst {
     /// <object>
     /// => <value>
     /// ```
+    #[musli(packed)]
     ObjectIndexGet {
         /// The static string slot corresponding to the index to fetch.
         slot: usize,
@@ -254,6 +268,7 @@ pub enum Inst {
     /// <value>
     /// =>
     /// ```
+    #[musli(packed)]
     ObjectIndexSet {
         /// The static string slot corresponding to the index to set.
         slot: usize,
@@ -269,6 +284,7 @@ pub enum Inst {
     /// ```text
     /// => <value>
     /// ```
+    #[musli(packed)]
     ObjectIndexGetAt {
         /// The slot offset to get the value to load from.
         offset: usize,
@@ -309,6 +325,7 @@ pub enum Inst {
     /// <future...>
     /// => <value>
     /// ```
+    #[musli(packed)]
     Select {
         /// The number of futures to poll.
         len: usize,
@@ -320,6 +337,7 @@ pub enum Inst {
     /// ```text
     /// => <value>
     /// ```
+    #[musli(packed)]
     LoadFn {
         /// The hash of the function to push.
         hash: Hash,
@@ -331,6 +349,7 @@ pub enum Inst {
     /// ```text
     /// => <value>
     /// ```
+    #[musli(packed)]
     Push {
         /// The value to push.
         value: InstValue,
@@ -352,6 +371,7 @@ pub enum Inst {
     /// <value..>
     /// => *noop*
     /// ```
+    #[musli(packed)]
     PopN {
         /// The number of elements to pop from the stack.
         count: usize,
@@ -365,6 +385,7 @@ pub enum Inst {
     /// <bool>
     /// => *noop*
     /// ```
+    #[musli(packed)]
     PopAndJumpIfNot {
         /// The number of entries to pop of the condition is true.
         count: usize,
@@ -381,6 +402,7 @@ pub enum Inst {
     /// <value..>
     /// => <top>
     /// ```
+    #[musli(packed)]
     Clean {
         /// The number of entries in the stack to pop.
         count: usize,
@@ -389,12 +411,14 @@ pub enum Inst {
     /// frame.
     ///
     /// A copy is very cheap. It simply means pushing a reference to the stack.
+    #[musli(packed)]
     Copy {
         /// Offset to copy value from.
         offset: usize,
     },
     /// Move a variable from a location `offset` relative to the current call
     /// frame.
+    #[musli(packed)]
     Move {
         /// Offset to move value from.
         offset: usize,
@@ -407,6 +431,7 @@ pub enum Inst {
     /// ```text
     /// => *noop*
     /// ```
+    #[musli(packed)]
     Drop {
         /// Frame offset to drop.
         offset: usize,
@@ -421,6 +446,7 @@ pub enum Inst {
     Dup,
     /// Replace a value at the offset relative from the top of the stack, with
     /// the top of the stack.
+    #[musli(packed)]
     Replace {
         /// Offset to swap value from.
         offset: usize,
@@ -429,6 +455,7 @@ pub enum Inst {
     ///
     /// The stack frame will be cleared, and the value on the top of the stack
     /// will be left on top of it.
+    #[musli(packed)]
     Return {
         /// The address of the value to return.
         address: InstAddress,
@@ -451,6 +478,7 @@ pub enum Inst {
     /// *nothing*
     /// => *nothing*
     /// ```
+    #[musli(packed)]
     Jump {
         /// Offset to jump to.
         offset: isize,
@@ -464,6 +492,7 @@ pub enum Inst {
     /// <boolean>
     /// => *nothing*
     /// ```
+    #[musli(packed)]
     JumpIf {
         /// Offset to jump to.
         offset: isize,
@@ -477,6 +506,7 @@ pub enum Inst {
     /// <boolean>
     /// => *nothing*
     /// ```
+    #[musli(packed)]
     JumpIfOrPop {
         /// Offset to jump to.
         offset: isize,
@@ -490,6 +520,7 @@ pub enum Inst {
     /// <boolean>
     /// => *nothing*
     /// ```
+    #[musli(packed)]
     JumpIfNotOrPop {
         /// Offset to jump to.
         offset: isize,
@@ -503,6 +534,7 @@ pub enum Inst {
     /// <integer>
     /// => *nothing*
     /// ```
+    #[musli(packed)]
     JumpIfBranch {
         /// The branch value to compare against.
         branch: i64,
@@ -518,6 +550,7 @@ pub enum Inst {
     /// <value..>
     /// => <vec>
     /// ```
+    #[musli(packed)]
     Vec {
         /// The size of the vector.
         count: usize,
@@ -529,8 +562,10 @@ pub enum Inst {
     /// ```text
     /// => <tuple>
     /// ```
+    #[musli(packed)]
     Tuple1 {
         /// First element of the tuple.
+        #[musli(with = self::array::<_, 1>)]
         args: [InstAddress; 1],
     },
     /// Construct a push a two-tuple value onto the stack.
@@ -540,8 +575,10 @@ pub enum Inst {
     /// ```text
     /// => <tuple>
     /// ```
+    #[musli(packed)]
     Tuple2 {
         /// Tuple arguments.
+        #[musli(with = self::array::<_, 2>)]
         args: [InstAddress; 2],
     },
     /// Construct a push a three-tuple value onto the stack.
@@ -551,8 +588,10 @@ pub enum Inst {
     /// ```text
     /// => <tuple>
     /// ```
+    #[musli(packed)]
     Tuple3 {
         /// Tuple arguments.
+        #[musli(with = self::array::<_, 3>)]
         args: [InstAddress; 3],
     },
     /// Construct a push a four-tuple value onto the stack.
@@ -562,8 +601,10 @@ pub enum Inst {
     /// ```text
     /// => <tuple>
     /// ```
+    #[musli(packed)]
     Tuple4 {
         /// Tuple arguments.
+        #[musli(with = self::array::<_, 4>)]
         args: [InstAddress; 4],
     },
     /// Construct a push a tuple value onto the stack. The number of elements
@@ -575,6 +616,7 @@ pub enum Inst {
     /// <value..>
     /// => <tuple>
     /// ```
+    #[musli(packed)]
     Tuple {
         /// The size of the tuple.
         count: usize,
@@ -604,6 +646,7 @@ pub enum Inst {
     /// <value..>
     /// => <object>
     /// ```
+    #[musli(packed)]
     Object {
         /// The static slot of the object keys.
         slot: usize,
@@ -618,6 +661,7 @@ pub enum Inst {
     /// <to>
     /// => <range>
     /// ```
+    #[musli(packed)]
     Range {
         /// The limits of the range.
         limits: InstRangeLimits,
@@ -630,6 +674,7 @@ pub enum Inst {
     /// ```text
     /// => <object>
     /// ```
+    #[musli(packed)]
     UnitStruct {
         /// The type of the object to construct.
         hash: Hash,
@@ -646,6 +691,7 @@ pub enum Inst {
     /// <value..>
     /// => <object>
     /// ```
+    #[musli(packed)]
     Struct {
         /// The type of the object to construct.
         hash: Hash,
@@ -660,6 +706,7 @@ pub enum Inst {
     /// ```text
     /// => <object>
     /// ```
+    #[musli(packed)]
     UnitVariant {
         /// The type hash of the object variant to construct.
         hash: Hash,
@@ -676,6 +723,7 @@ pub enum Inst {
     /// <value..>
     /// => <object>
     /// ```
+    #[musli(packed)]
     StructVariant {
         /// The type hash of the object variant to construct.
         hash: Hash,
@@ -689,6 +737,7 @@ pub enum Inst {
     /// ```text
     /// => <string>
     /// ```
+    #[musli(packed)]
     String {
         /// The static string slot to load the string from.
         slot: usize,
@@ -700,6 +749,7 @@ pub enum Inst {
     /// ```text
     /// => <bytes>
     /// ```
+    #[musli(packed)]
     Bytes {
         /// The static byte string slot to load the string from.
         slot: usize,
@@ -715,6 +765,7 @@ pub enum Inst {
     /// <value...>
     /// => <string>
     /// ```
+    #[musli(packed)]
     StringConcat {
         /// The number of items to pop from the stack.
         len: usize,
@@ -723,6 +774,7 @@ pub enum Inst {
     },
     /// Push a combined format specification and value onto the stack. The value
     /// used is the last value on the stack.
+    #[musli(packed)]
     Format {
         /// The format specification to use.
         spec: FormatSpec,
@@ -745,6 +797,7 @@ pub enum Inst {
     /// <value>
     /// => <boolean>
     /// ```
+    #[musli(packed)]
     Try {
         /// Address to test if value.
         address: InstAddress,
@@ -762,6 +815,7 @@ pub enum Inst {
     /// <value>
     /// => <boolean>
     /// ```
+    #[musli(packed)]
     EqByte {
         /// The byte to test against.
         byte: u8,
@@ -774,6 +828,7 @@ pub enum Inst {
     /// <value>
     /// => <boolean>
     /// ```
+    #[musli(packed)]
     EqChar {
         /// The character to test against.
         char: char,
@@ -786,6 +841,7 @@ pub enum Inst {
     /// <value>
     /// => <boolean>
     /// ```
+    #[musli(packed)]
     EqInteger {
         /// The integer to test against.
         integer: i64,
@@ -799,6 +855,7 @@ pub enum Inst {
     /// <value>
     /// => <boolean>
     /// ```
+    #[musli(packed)]
     EqBool {
         /// The bool to test against.
         boolean: bool,
@@ -811,6 +868,7 @@ pub enum Inst {
     /// <value>
     /// => <boolean>
     /// ```
+    #[musli(packed)]
     EqString {
         /// The slot to test against.
         slot: usize,
@@ -823,6 +881,7 @@ pub enum Inst {
     /// <value>
     /// => <boolean>
     /// ```
+    #[musli(packed)]
     EqBytes {
         /// The slot to test against.
         slot: usize,
@@ -835,6 +894,7 @@ pub enum Inst {
     /// <value>
     /// => <boolean>
     /// ```
+    #[musli(packed)]
     MatchType {
         /// The type hash to match against.
         hash: Hash,
@@ -850,6 +910,7 @@ pub enum Inst {
     /// <value>
     /// => <boolean>
     /// ```
+    #[musli(packed)]
     MatchVariant {
         /// The exact type hash of the variant.
         variant_hash: Hash,
@@ -866,6 +927,7 @@ pub enum Inst {
     /// <value>
     /// => <boolean>
     /// ```
+    #[musli(packed)]
     MatchBuiltIn {
         /// The type to check for.
         type_check: TypeCheck,
@@ -879,6 +941,7 @@ pub enum Inst {
     /// <value>
     /// => <boolean>
     /// ```
+    #[musli(packed)]
     MatchSequence {
         /// Type constraints that the sequence must match.
         type_check: TypeCheck,
@@ -897,6 +960,7 @@ pub enum Inst {
     /// <object>
     /// => <boolean>
     /// ```
+    #[musli(packed)]
     MatchObject {
         /// The slot of object keys to use.
         slot: usize,
@@ -937,6 +1001,7 @@ pub enum Inst {
     /// <value..>
     /// => <variant>
     /// ```
+    #[musli(packed)]
     Variant {
         /// The kind of built-in variant to construct.
         variant: InstVariant,
@@ -949,6 +1014,7 @@ pub enum Inst {
     /// ```text
     /// => <value>
     /// ```
+    #[musli(packed)]
     Op {
         /// The actual operation.
         op: InstOp,
@@ -968,6 +1034,7 @@ pub enum Inst {
     /// <value>
     /// =>
     /// ```
+    #[musli(packed)]
     Assign {
         /// The target of the operation.
         target: InstTarget,
@@ -975,6 +1042,7 @@ pub enum Inst {
         op: InstAssignOp,
     },
     /// Advance an iterator at the given position.
+    #[musli(packed)]
     IterNext {
         /// The offset of the value being advanced.
         offset: usize,
@@ -985,6 +1053,7 @@ pub enum Inst {
     ///
     /// This should only be used during testing or extreme scenarios that are
     /// completely unrecoverable.
+    #[musli(packed)]
     Panic {
         /// The reason for the panic.
         reason: PanicReason,
@@ -1316,11 +1385,13 @@ impl fmt::Display for Inst {
 }
 
 /// How an instruction addresses a value.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, Copy, Serialize, Deserialize, Decode, Encode)]
 pub enum InstAddress {
     /// Addressed from the top of the stack.
+    #[default]
     Top,
     /// Value addressed at the given offset.
+    #[musli(packed)]
     Offset(usize),
 }
 
@@ -1334,7 +1405,7 @@ impl fmt::Display for InstAddress {
 }
 
 /// Range limits of a range expression.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Decode, Encode)]
 pub enum InstRangeLimits {
     /// A half-open range `a .. b`.
     HalfOpen,
@@ -1352,13 +1423,16 @@ impl fmt::Display for InstRangeLimits {
 }
 
 /// The target of an operation.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Encode, Decode)]
 pub enum InstTarget {
     /// Target is an offset to the current call frame.
+    #[musli(packed)]
     Offset(usize),
     /// Target the field of an object.
+    #[musli(packed)]
     Field(usize),
     /// Target a tuple field.
+    #[musli(packed)]
     TupleField(usize),
 }
 
@@ -1373,7 +1447,7 @@ impl fmt::Display for InstTarget {
 }
 
 /// An operation between two values on the machine.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Decode, Encode)]
 pub enum InstAssignOp {
     /// The add operation. `a + b`.
     Add,
@@ -1437,7 +1511,7 @@ impl fmt::Display for InstAssignOp {
 }
 
 /// An operation between two values on the machine.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Decode, Encode)]
 pub enum InstOp {
     /// The add operation. `a + b`.
     Add,
@@ -1608,22 +1682,28 @@ impl fmt::Display for InstOp {
 }
 
 /// A literal value that can be pushed.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Decode, Encode)]
 #[non_exhaustive]
 pub enum InstValue {
     /// A unit.
     Unit,
     /// A boolean.
+    #[musli(packed)]
     Bool(bool),
     /// A byte.
+    #[musli(packed)]
     Byte(u8),
     /// A character.
+    #[musli(packed)]
     Char(char),
     /// An integer.
+    #[musli(packed)]
     Integer(i64),
     /// A float.
+    #[musli(packed)]
     Float(f64),
     /// A type hash.
+    #[musli(packed)]
     Type(Type),
 }
 
@@ -1665,7 +1745,7 @@ impl fmt::Display for InstValue {
 }
 
 /// A variant that can be constructed.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Decode, Encode)]
 pub enum InstVariant {
     /// `Option::Some`, which uses one value.
     Some,
@@ -1695,5 +1775,49 @@ impl fmt::Display for InstVariant {
         }
 
         Ok(())
+    }
+}
+
+mod array {
+    use musli::de::SequenceDecoder;
+    use musli::en::SequenceEncoder;
+    use musli::{Decode, Decoder, Encode, Encoder, Mode};
+
+    #[inline]
+    pub(super) fn encode<M, E, T, const N: usize>(
+        this: &[T; N],
+        encoder: E,
+    ) -> Result<E::Ok, E::Error>
+    where
+        T: Encode<M>,
+        M: Mode,
+        E: Encoder,
+    {
+        let mut seq = encoder.encode_sequence(N)?;
+
+        for value in this {
+            value.encode(seq.next()?)?;
+        }
+
+        seq.end()
+    }
+
+    #[inline]
+    pub(super) fn decode<'de, M, D, T, const N: usize>(decoder: D) -> Result<[T; N], D::Error>
+    where
+        T: Copy + Default + Decode<'de, M>,
+        M: Mode,
+        D: Decoder<'de>,
+    {
+        let mut seq = decoder.decode_sequence()?;
+        let mut array = [T::default(); N];
+
+        for o in array.iter_mut() {
+            if let Some(value) = seq.next()? {
+                *o = T::decode(value)?;
+            }
+        }
+
+        Ok(array)
     }
 }

--- a/crates/rune/src/runtime/label.rs
+++ b/crates/rune/src/runtime/label.rs
@@ -39,7 +39,7 @@ impl Label {
         };
 
         self.jump.replace(Some(jump));
-        return true;
+        true
     }
 
     /// Convert into owned label.

--- a/crates/rune/src/runtime/label.rs
+++ b/crates/rune/src/runtime/label.rs
@@ -1,36 +1,64 @@
 //! A simple label used to jump to a code location.
 
+use core::cell::Cell;
 use core::fmt;
+use core::num::NonZeroUsize;
 
 use crate::no_std::borrow::Cow;
+use crate::no_std::rc::Rc;
 
 use serde::{Deserialize, Serialize};
 
 /// A label that can be jumped to.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct Label {
-    name: &'static str,
-    id: usize,
+#[derive(Debug, Clone)]
+pub(crate) struct Label {
+    pub(crate) name: &'static str,
+    pub(crate) index: usize,
+    jump: Rc<Cell<Option<NonZeroUsize>>>,
 }
 
 impl Label {
     /// Construct a new label.
-    pub fn new(name: &'static str, id: usize) -> Self {
-        Self { name, id }
+    pub(crate) fn new(name: &'static str, index: usize) -> Self {
+        Self {
+            name,
+            index,
+            jump: Rc::new(Cell::new(None)),
+        }
+    }
+
+    /// Get jump.
+    pub(crate) fn jump(&self) -> Option<usize> {
+        Some(self.jump.get()?.get().wrapping_sub(1))
+    }
+
+    /// Set jump.
+    pub(crate) fn set_jump(&self, jump: usize) -> bool {
+        let Some(jump) = NonZeroUsize::new(jump.wrapping_add(1)) else {
+            return false;
+        };
+
+        self.jump.replace(Some(jump));
+        return true;
     }
 
     /// Convert into owned label.
-    pub fn into_owned(self) -> DebugLabel {
+    pub(crate) fn to_debug_label(&self) -> DebugLabel {
         DebugLabel {
             name: self.name.into(),
-            id: self.id,
+            index: self.index,
+            jump: self.jump.get(),
         }
     }
 }
 
 impl fmt::Display for Label {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}_{}", self.name, self.id)
+        if let Some(jump) = self.jump() {
+            write!(f, "{}_{} ({jump})", self.name, self.index)
+        } else {
+            write!(f, "{}_{}", self.name, self.index)
+        }
     }
 }
 
@@ -39,12 +67,27 @@ impl fmt::Display for Label {
 pub struct DebugLabel {
     /// The name of the label.
     name: Cow<'static, str>,
-    /// The id of the label.
-    id: usize,
+    /// The index of the label.
+    index: usize,
+    /// The jump index of the label.
+    jump: Option<NonZeroUsize>,
+}
+
+impl DebugLabel {
+    /// Get jump.
+    pub(crate) fn jump(&self) -> Option<usize> {
+        Some(self.jump?.get().wrapping_sub(1))
+    }
 }
 
 impl fmt::Display for DebugLabel {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}_{}", self.name, self.id)
+        write!(f, "{}_{}", self.name, self.index)?;
+
+        if let Some(jump) = self.jump() {
+            write!(f, " ({jump})")?;
+        }
+
+        Ok(())
     }
 }

--- a/crates/rune/src/runtime/stack.rs
+++ b/crates/rune/src/runtime/stack.rs
@@ -338,11 +338,11 @@ impl Stack {
 
     // Assert that the stack frame has been restored to the previous top
     // at the point of return.
+    #[tracing::instrument(skip_all)]
     pub(crate) fn check_stack_top(&self) -> Result<(), StackError> {
         tracing::trace!(
-            "check_stack_top: self.stack.len() ({}) == self.stack_bottom ({})",
-            self.stack.len(),
-            self.stack_bottom
+            stack_len = self.stack.len(),
+            stack_bottom = self.stack_bottom,
         );
 
         if self.stack.len() == self.stack_bottom {
@@ -356,6 +356,7 @@ impl Stack {
     ///
     /// This asserts that the size of the current stack frame is exactly zero
     /// before restoring it.
+    #[tracing::instrument(skip_all)]
     pub(crate) fn pop_stack_top(&mut self, stack_bottom: usize) -> Result<(), StackError> {
         self.check_stack_top()?;
         self.stack_bottom = stack_bottom;

--- a/crates/rune/src/runtime/type_.rs
+++ b/crates/rune/src/runtime/type_.rs
@@ -1,3 +1,4 @@
+use musli::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
 use crate::compile::Named;
@@ -6,9 +7,10 @@ use crate::runtime::{RawStr, VmResult};
 use crate::{FromValue, Hash, Value};
 
 /// A value representing a type in the virtual machine.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Decode, Encode)]
 #[repr(transparent)]
 #[serde(transparent)]
+#[musli(transparent)]
 pub struct Type(Hash);
 
 impl Type {

--- a/crates/rune/src/runtime/unit.rs
+++ b/crates/rune/src/runtime/unit.rs
@@ -31,6 +31,7 @@ pub use self::byte_code::ByteCodeUnit;
 /// Default storage implementation to use.
 #[cfg(not(rune_byte_code))]
 pub type DefaultStorage = ArrayUnit;
+/// Default storage implementation to use.
 #[cfg(rune_byte_code)]
 pub type DefaultStorage = ByteCodeUnit;
 

--- a/crates/rune/src/runtime/unit.rs
+++ b/crates/rune/src/runtime/unit.rs
@@ -20,7 +20,9 @@ use crate::Hash;
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Unit {
     /// The instructions contained in the source file.
-    instructions: Vec<Inst>,
+    instructions: Vec<u8>,
+    /// Known jump offsets.
+    offsets: Vec<usize>,
     /// Where functions are located in the collection of instructions.
     functions: HashMap<Hash, UnitFn>,
     /// A static string.
@@ -48,7 +50,8 @@ impl Unit {
     /// Construct a new unit with the given content.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
-        instructions: Vec<Inst>,
+        instructions: Vec<u8>,
+        offsets: Vec<usize>,
         functions: HashMap<Hash, UnitFn>,
         static_strings: Vec<Arc<StaticString>>,
         static_bytes: Vec<Vec<u8>>,
@@ -60,6 +63,7 @@ impl Unit {
     ) -> Self {
         Self {
             instructions,
+            offsets,
             functions,
             static_strings,
             static_bytes,
@@ -71,6 +75,15 @@ impl Unit {
         }
     }
 
+    #[inline]
+    pub(crate) fn offset(&self, jump: usize) -> Option<usize> {
+        if let Some(&offset) = self.offsets.get(jump) {
+            Some(offset)
+        } else {
+            None
+        }
+    }
+
     /// Access debug information for the given location if it is available.
     pub fn debug_info(&self) -> Option<&DebugInfo> {
         let debug = self.debug.as_ref()?;
@@ -78,13 +91,21 @@ impl Unit {
     }
 
     /// Get raw underying instructions.
-    pub(crate) fn instructions(&self) -> &[Inst] {
+    pub(crate) fn instructions(&self) -> &[u8] {
         &self.instructions
     }
 
     /// Get the instruction at the given instruction pointer.
-    pub(crate) fn instruction_at(&self, ip: usize) -> Option<&Inst> {
-        self.instructions.get(ip)
+    pub(crate) fn instruction_at(&self, ip: usize) -> Result<Option<(Inst, usize)>, VmErrorKind> {
+        let Some(mut bytes) = self.instructions.get(ip..) else {
+            return Ok(None);
+        };
+
+        let start = bytes.as_ptr();
+        let inst: Inst =
+            musli_storage::decode(&mut bytes).map_err(|_| VmErrorKind::BadInstruction)?;
+        let len = (bytes.as_ptr() as usize).wrapping_sub(start as usize);
+        Ok(Some((inst, len)))
     }
 
     /// Iterate over all static strings in the unit.
@@ -114,8 +135,19 @@ impl Unit {
 
     /// Iterate over all instructions in order.
     #[cfg(feature = "emit")]
-    pub(crate) fn iter_instructions(&self) -> impl Iterator<Item = Inst> + '_ {
-        self.instructions.iter().copied()
+    pub(crate) fn iter_instructions(&self) -> impl Iterator<Item = (usize, Inst)> + '_ {
+        let mut address = &self.instructions[..];
+        let len = address.len();
+
+        std::iter::from_fn(move || {
+            if address.is_empty() {
+                return None;
+            }
+
+            let o = len - address.len();
+            let inst = musli_storage::decode(&mut address).ok()?;
+            Some((o, inst))
+        })
     }
 
     /// Iterate over dynamic functions.

--- a/crates/rune/src/runtime/unit/byte_code.rs
+++ b/crates/rune/src/runtime/unit/byte_code.rs
@@ -74,7 +74,7 @@ impl UnitStorage for ByteCodeUnit {
     type Iter<'this> = ByteCodeUnitIter<'this>;
 
     #[inline]
-    fn len(&self) -> usize {
+    fn end(&self) -> usize {
         self.bytes.len()
     }
 

--- a/crates/rune/src/runtime/unit/byte_code.rs
+++ b/crates/rune/src/runtime/unit/byte_code.rs
@@ -1,0 +1,106 @@
+use crate::no_std::vec::Vec;
+
+use serde::{Deserialize, Serialize};
+
+use crate::runtime::unit::{BadInstruction, BadJump, EncodeError, UnitEncoder, UnitStorage};
+use crate::runtime::Inst;
+
+/// Unit stored as byte code, which is a more compact representation than
+/// [`ArrayUnit`], but takes more time to execute since it needs to be decoded.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ByteCodeUnit {
+    /// The instructions contained in the source file.
+    bytes: Vec<u8>,
+    /// Known jump offsets.
+    offsets: Vec<usize>,
+}
+
+/// Iterator for [`ByteCodeUnit`].
+pub struct ByteCodeUnitIter<'a> {
+    address: &'a [u8],
+    len: usize,
+}
+
+impl<'a> Iterator for ByteCodeUnitIter<'a> {
+    type Item = (usize, Inst);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.address.is_empty() {
+            return None;
+        }
+
+        let ip = self.len.checked_sub(self.address.len())?;
+        let inst = musli_storage::decode(&mut self.address).ok()?;
+        Some((ip, inst))
+    }
+}
+
+impl UnitEncoder for ByteCodeUnit {
+    #[inline]
+    fn offset(&self) -> usize {
+        self.bytes.len()
+    }
+
+    #[inline]
+    fn encode(&mut self, inst: Inst) -> Result<(), EncodeError> {
+        musli_storage::encode(&mut self.bytes, &inst)?;
+        Ok(())
+    }
+
+    #[inline]
+    fn extend_offsets(&mut self, extra: usize) -> usize {
+        let base = self.offsets.len();
+        self.offsets.extend((0..extra).map(|_| 0));
+        base
+    }
+
+    #[inline]
+    fn mark_offset(&mut self, index: usize) {
+        if let Some(o) = self.offsets.get_mut(index) {
+            *o = self.bytes.len();
+        }
+    }
+
+    #[inline]
+    fn label_jump(&self, base: usize, _: usize, jump: usize) -> usize {
+        base.wrapping_add(jump)
+    }
+}
+
+impl UnitStorage for ByteCodeUnit {
+    type Iter<'this> = ByteCodeUnitIter<'this>;
+
+    #[inline]
+    fn len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    #[inline]
+    fn iter(&self) -> Self::Iter<'_> {
+        ByteCodeUnitIter {
+            address: &self.bytes[..],
+            len: self.bytes.len(),
+        }
+    }
+
+    fn get(&self, ip: usize) -> Result<Option<(Inst, usize)>, BadInstruction> {
+        let Some(mut bytes) = self.bytes.get(ip..) else {
+            return Ok(None);
+        };
+
+        let start = bytes.as_ptr();
+        let inst: Inst = musli_storage::decode(&mut bytes).map_err(|_| BadInstruction { ip })?;
+        let len = (bytes.as_ptr() as usize).wrapping_sub(start as usize);
+        Ok(Some((inst, len)))
+    }
+
+    #[inline]
+    fn translate(&self, jump: usize) -> Result<usize, BadJump> {
+        let Some(&offset) = self.offsets.get(jump) else {
+            return Err(BadJump { jump });
+        };
+
+        Ok(offset)
+    }
+}

--- a/crates/rune/src/runtime/unit/byte_code.rs
+++ b/crates/rune/src/runtime/unit/byte_code.rs
@@ -1,3 +1,5 @@
+use core::mem::size_of;
+
 use crate::no_std::vec::Vec;
 
 use serde::{Deserialize, Serialize};
@@ -74,6 +76,13 @@ impl UnitStorage for ByteCodeUnit {
     #[inline]
     fn len(&self) -> usize {
         self.bytes.len()
+    }
+
+    #[inline]
+    fn bytes(&self) -> usize {
+        self.bytes
+            .len()
+            .wrapping_add(self.offsets.len().wrapping_mul(size_of::<usize>()))
     }
 
     #[inline]

--- a/crates/rune/src/runtime/unit/storage.rs
+++ b/crates/rune/src/runtime/unit/storage.rs
@@ -5,6 +5,7 @@ use core::slice;
 use crate::no_std::error;
 use crate::no_std::vec::Vec;
 
+#[cfg(feature = "byte-code")]
 use musli_storage::error::BufferError;
 use serde::{Deserialize, Serialize};
 
@@ -13,38 +14,45 @@ use crate::runtime::Inst;
 mod sealed {
     pub trait Sealed {}
 
-    impl Sealed for super::BytesStorage {}
-
-    impl Sealed for super::ArrayStorage {}
+    #[cfg(feature = "byte-code")]
+    impl Sealed for crate::runtime::unit::ByteCodeUnit {}
+    impl Sealed for crate::runtime::unit::ArrayUnit {}
 }
 
 /// Builder trait for unit storage.
-pub trait UnitStorageBuilder: self::sealed::Sealed {
+pub trait UnitEncoder: self::sealed::Sealed {
     /// Current offset in storage, which also corresponds to the instruction
     /// pointer being built.
+    #[doc(hidden)]
     fn offset(&self) -> usize;
 
     /// Encode an instruction into the current storage.
+    #[doc(hidden)]
     fn encode(&mut self, inst: Inst) -> Result<(), EncodeError>;
 
     /// Indicate that the given number of offsets have been added.
+    #[doc(hidden)]
     fn extend_offsets(&mut self, extra: usize) -> usize;
 
     /// Mark that the given offset index is at the current offset.
+    #[doc(hidden)]
     fn mark_offset(&mut self, index: usize);
 
     /// Calculate label jump.
+    #[doc(hidden)]
     fn label_jump(&self, base: usize, offset: usize, jump: usize) -> usize;
 }
 
 /// Instruction storage used by a [`Unit`][super::Unit].
-pub trait UnitStorage:
-    self::sealed::Sealed + UnitStorageBuilder + fmt::Debug + Clone + Default
-{
+pub trait UnitStorage: self::sealed::Sealed + fmt::Debug + Default + Clone {
     /// Iterator over instructions and their corresponding instruction offsets.
     type Iter<'this>: Iterator<Item = (usize, Inst)>
     where
         Self: 'this;
+
+    /// Size of unit storage. This can be seen as the instruction pointer which
+    /// is just beyond the last instruction.
+    fn len(&self) -> usize;
 
     /// Iterate over all instructions.
     fn iter(&self) -> Self::Iter<'_>;
@@ -56,107 +64,13 @@ pub trait UnitStorage:
     fn translate(&self, jump: usize) -> Result<usize, BadJump>;
 }
 
-/// Unit stored as bytes.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct BytesStorage {
-    /// The instructions contained in the source file.
-    bytes: Vec<u8>,
-    /// Known jump offsets.
-    offsets: Vec<usize>,
-}
-
-/// Iterator for [`BytesStorage`].
-pub struct BytesStorageIter<'a> {
-    address: &'a [u8],
-    len: usize,
-}
-
-impl<'a> Iterator for BytesStorageIter<'a> {
-    type Item = (usize, Inst);
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.address.is_empty() {
-            return None;
-        }
-
-        let ip = self.len.checked_sub(self.address.len())?;
-        let inst = musli_storage::decode(&mut self.address).ok()?;
-        Some((ip, inst))
-    }
-}
-
-impl UnitStorageBuilder for BytesStorage {
-    #[inline]
-    fn offset(&self) -> usize {
-        self.bytes.len()
-    }
-
-    #[inline]
-    fn encode(&mut self, inst: Inst) -> Result<(), EncodeError> {
-        musli_storage::encode(&mut self.bytes, &inst)?;
-        Ok(())
-    }
-
-    #[inline]
-    fn extend_offsets(&mut self, extra: usize) -> usize {
-        let base = self.offsets.len();
-        self.offsets.extend((0..extra).map(|_| 0));
-        base
-    }
-
-    #[inline]
-    fn mark_offset(&mut self, index: usize) {
-        if let Some(o) = self.offsets.get_mut(index) {
-            *o = self.bytes.len();
-        }
-    }
-
-    #[inline]
-    fn label_jump(&self, base: usize, _: usize, jump: usize) -> usize {
-        base.wrapping_add(jump)
-    }
-}
-
-impl UnitStorage for BytesStorage {
-    type Iter<'this> = BytesStorageIter<'this>;
-
-    #[inline]
-    fn iter(&self) -> Self::Iter<'_> {
-        BytesStorageIter {
-            address: &self.bytes[..],
-            len: self.bytes.len(),
-        }
-    }
-
-    fn get(&self, ip: usize) -> Result<Option<(Inst, usize)>, BadInstruction> {
-        let Some(mut bytes) = self.bytes.get(ip..) else {
-            return Ok(None);
-        };
-
-        let start = bytes.as_ptr();
-        let inst: Inst = musli_storage::decode(&mut bytes).map_err(|_| BadInstruction { ip })?;
-        let len = (bytes.as_ptr() as usize).wrapping_sub(start as usize);
-        Ok(Some((inst, len)))
-    }
-
-    #[inline]
-    fn translate(&self, jump: usize) -> Result<usize, BadJump> {
-        let Some(&offset) = self.offsets.get(jump) else {
-            return Err(BadJump { jump });
-        };
-
-        Ok(offset)
-    }
-}
-
 /// Unit stored as array of instructions.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct ArrayStorage {
+pub struct ArrayUnit {
     instructions: Vec<Inst>,
 }
 
-impl UnitStorageBuilder for ArrayStorage {
+impl UnitEncoder for ArrayUnit {
     #[inline]
     fn offset(&self) -> usize {
         self.instructions.len()
@@ -182,8 +96,13 @@ impl UnitStorageBuilder for ArrayStorage {
     }
 }
 
-impl UnitStorage for ArrayStorage {
+impl UnitStorage for ArrayUnit {
     type Iter<'this> = iter::Enumerate<iter::Copied<slice::Iter<'this, Inst>>>;
+
+    #[inline]
+    fn len(&self) -> usize {
+        self.instructions.len()
+    }
 
     #[inline]
     fn iter(&self) -> Self::Iter<'_> {
@@ -207,10 +126,12 @@ impl UnitStorage for ArrayStorage {
 
 /// Error indicating that encoding failed.
 #[derive(Debug)]
+#[doc(hidden)]
 pub struct EncodeError {
     kind: EncodeErrorKind,
 }
 
+#[cfg(feature = "byte-code")]
 impl From<BufferError> for EncodeError {
     #[inline]
     fn from(error: BufferError) -> Self {
@@ -224,6 +145,7 @@ impl fmt::Display for EncodeError {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.kind {
+            #[cfg(feature = "byte-code")]
             EncodeErrorKind::BufferError { error } => error.fmt(f),
         }
     }
@@ -233,6 +155,7 @@ impl error::Error for EncodeError {}
 
 #[derive(Debug)]
 enum EncodeErrorKind {
+    #[cfg(feature = "byte-code")]
     BufferError { error: BufferError },
 }
 
@@ -240,7 +163,7 @@ enum EncodeErrorKind {
 /// pointer.
 #[derive(Debug)]
 pub struct BadInstruction {
-    ip: usize,
+    pub(crate) ip: usize,
 }
 
 impl fmt::Display for BadInstruction {
@@ -256,7 +179,7 @@ impl error::Error for BadInstruction {}
 /// pointer.
 #[derive(Debug)]
 pub struct BadJump {
-    jump: usize,
+    pub(crate) jump: usize,
 }
 
 impl fmt::Display for BadJump {

--- a/crates/rune/src/runtime/unit/storage.rs
+++ b/crates/rune/src/runtime/unit/storage.rs
@@ -53,7 +53,7 @@ pub trait UnitStorage: self::sealed::Sealed + fmt::Debug + Default + Clone {
 
     /// Size of unit storage. This can be seen as the instruction pointer which
     /// is just beyond the last instruction.
-    fn len(&self) -> usize;
+    fn end(&self) -> usize;
 
     /// Get the number of bytes which is used to store unit bytecode.
     fn bytes(&self) -> usize;
@@ -104,7 +104,7 @@ impl UnitStorage for ArrayUnit {
     type Iter<'this> = iter::Enumerate<iter::Copied<slice::Iter<'this, Inst>>>;
 
     #[inline]
-    fn len(&self) -> usize {
+    fn end(&self) -> usize {
         self.instructions.len()
     }
 

--- a/crates/rune/src/runtime/unit/storage.rs
+++ b/crates/rune/src/runtime/unit/storage.rs
@@ -1,0 +1,269 @@
+use core::fmt;
+use core::iter;
+use core::slice;
+
+use crate::no_std::error;
+use crate::no_std::vec::Vec;
+
+use musli_storage::error::BufferError;
+use serde::{Deserialize, Serialize};
+
+use crate::runtime::Inst;
+
+mod sealed {
+    pub trait Sealed {}
+
+    impl Sealed for super::BytesStorage {}
+
+    impl Sealed for super::ArrayStorage {}
+}
+
+/// Builder trait for unit storage.
+pub trait UnitStorageBuilder: self::sealed::Sealed {
+    /// Current offset in storage, which also corresponds to the instruction
+    /// pointer being built.
+    fn offset(&self) -> usize;
+
+    /// Encode an instruction into the current storage.
+    fn encode(&mut self, inst: Inst) -> Result<(), EncodeError>;
+
+    /// Indicate that the given number of offsets have been added.
+    fn extend_offsets(&mut self, extra: usize) -> usize;
+
+    /// Mark that the given offset index is at the current offset.
+    fn mark_offset(&mut self, index: usize);
+
+    /// Calculate label jump.
+    fn label_jump(&self, base: usize, offset: usize, jump: usize) -> usize;
+}
+
+/// Instruction storage used by a [`Unit`][super::Unit].
+pub trait UnitStorage:
+    self::sealed::Sealed + UnitStorageBuilder + fmt::Debug + Clone + Default
+{
+    /// Iterator over instructions and their corresponding instruction offsets.
+    type Iter<'this>: Iterator<Item = (usize, Inst)>
+    where
+        Self: 'this;
+
+    /// Iterate over all instructions.
+    fn iter(&self) -> Self::Iter<'_>;
+
+    /// Get the instruction at the given instruction pointer.
+    fn get(&self, ip: usize) -> Result<Option<(Inst, usize)>, BadInstruction>;
+
+    /// Translate the given jump offset.
+    fn translate(&self, jump: usize) -> Result<usize, BadJump>;
+}
+
+/// Unit stored as bytes.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct BytesStorage {
+    /// The instructions contained in the source file.
+    bytes: Vec<u8>,
+    /// Known jump offsets.
+    offsets: Vec<usize>,
+}
+
+/// Iterator for [`BytesStorage`].
+pub struct BytesStorageIter<'a> {
+    address: &'a [u8],
+    len: usize,
+}
+
+impl<'a> Iterator for BytesStorageIter<'a> {
+    type Item = (usize, Inst);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.address.is_empty() {
+            return None;
+        }
+
+        let ip = self.len.checked_sub(self.address.len())?;
+        let inst = musli_storage::decode(&mut self.address).ok()?;
+        Some((ip, inst))
+    }
+}
+
+impl UnitStorageBuilder for BytesStorage {
+    #[inline]
+    fn offset(&self) -> usize {
+        self.bytes.len()
+    }
+
+    #[inline]
+    fn encode(&mut self, inst: Inst) -> Result<(), EncodeError> {
+        musli_storage::encode(&mut self.bytes, &inst)?;
+        Ok(())
+    }
+
+    #[inline]
+    fn extend_offsets(&mut self, extra: usize) -> usize {
+        let base = self.offsets.len();
+        self.offsets.extend((0..extra).map(|_| 0));
+        base
+    }
+
+    #[inline]
+    fn mark_offset(&mut self, index: usize) {
+        if let Some(o) = self.offsets.get_mut(index) {
+            *o = self.bytes.len();
+        }
+    }
+
+    #[inline]
+    fn label_jump(&self, base: usize, _: usize, jump: usize) -> usize {
+        base.wrapping_add(jump)
+    }
+}
+
+impl UnitStorage for BytesStorage {
+    type Iter<'this> = BytesStorageIter<'this>;
+
+    #[inline]
+    fn iter(&self) -> Self::Iter<'_> {
+        BytesStorageIter {
+            address: &self.bytes[..],
+            len: self.bytes.len(),
+        }
+    }
+
+    fn get(&self, ip: usize) -> Result<Option<(Inst, usize)>, BadInstruction> {
+        let Some(mut bytes) = self.bytes.get(ip..) else {
+            return Ok(None);
+        };
+
+        let start = bytes.as_ptr();
+        let inst: Inst = musli_storage::decode(&mut bytes).map_err(|_| BadInstruction { ip })?;
+        let len = (bytes.as_ptr() as usize).wrapping_sub(start as usize);
+        Ok(Some((inst, len)))
+    }
+
+    #[inline]
+    fn translate(&self, jump: usize) -> Result<usize, BadJump> {
+        let Some(&offset) = self.offsets.get(jump) else {
+            return Err(BadJump { jump });
+        };
+
+        Ok(offset)
+    }
+}
+
+/// Unit stored as array of instructions.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ArrayStorage {
+    instructions: Vec<Inst>,
+}
+
+impl UnitStorageBuilder for ArrayStorage {
+    #[inline]
+    fn offset(&self) -> usize {
+        self.instructions.len()
+    }
+
+    #[inline]
+    fn encode(&mut self, inst: Inst) -> Result<(), EncodeError> {
+        self.instructions.push(inst);
+        Ok(())
+    }
+
+    #[inline]
+    fn extend_offsets(&mut self, _: usize) -> usize {
+        self.instructions.len()
+    }
+
+    #[inline]
+    fn mark_offset(&mut self, _: usize) {}
+
+    #[inline]
+    fn label_jump(&self, base: usize, offset: usize, _: usize) -> usize {
+        base.wrapping_add(offset)
+    }
+}
+
+impl UnitStorage for ArrayStorage {
+    type Iter<'this> = iter::Enumerate<iter::Copied<slice::Iter<'this, Inst>>>;
+
+    #[inline]
+    fn iter(&self) -> Self::Iter<'_> {
+        self.instructions.iter().copied().enumerate()
+    }
+
+    #[inline]
+    fn get(&self, ip: usize) -> Result<Option<(Inst, usize)>, BadInstruction> {
+        let Some(inst) = self.instructions.get(ip) else {
+            return Ok(None);
+        };
+
+        Ok(Some((*inst, 1)))
+    }
+
+    #[inline]
+    fn translate(&self, jump: usize) -> Result<usize, BadJump> {
+        Ok(jump)
+    }
+}
+
+/// Error indicating that encoding failed.
+#[derive(Debug)]
+pub struct EncodeError {
+    kind: EncodeErrorKind,
+}
+
+impl From<BufferError> for EncodeError {
+    #[inline]
+    fn from(error: BufferError) -> Self {
+        Self {
+            kind: EncodeErrorKind::BufferError { error },
+        }
+    }
+}
+
+impl fmt::Display for EncodeError {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.kind {
+            EncodeErrorKind::BufferError { error } => error.fmt(f),
+        }
+    }
+}
+
+impl error::Error for EncodeError {}
+
+#[derive(Debug)]
+enum EncodeErrorKind {
+    BufferError { error: BufferError },
+}
+
+/// Error indicating that a bad instruction was located at the given instruction
+/// pointer.
+#[derive(Debug)]
+pub struct BadInstruction {
+    ip: usize,
+}
+
+impl fmt::Display for BadInstruction {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Bad instruction at instruction {}", self.ip)
+    }
+}
+
+impl error::Error for BadInstruction {}
+
+/// Error indicating that a bad instruction was located at the given instruction
+/// pointer.
+#[derive(Debug)]
+pub struct BadJump {
+    jump: usize,
+}
+
+impl fmt::Display for BadJump {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Bad jump index {}", self.jump)
+    }
+}
+
+impl error::Error for BadJump {}

--- a/crates/rune/src/runtime/vm.rs
+++ b/crates/rune/src/runtime/vm.rs
@@ -2879,7 +2879,7 @@ impl Vm {
             let Some((inst, inst_len)) = vm_try!(self.unit.instruction_at(self.ip)) else {
                 return VmResult::err(VmErrorKind::IpOutOfBounds {
                     ip: self.ip,
-                    length: self.unit.instructions().len(),
+                    length: self.unit.instructions().end(),
                 });
             };
 

--- a/crates/rune/src/runtime/vm.rs
+++ b/crates/rune/src/runtime/vm.rs
@@ -9,7 +9,7 @@ use crate::no_std::sync::Arc;
 use crate::no_std::vec;
 use crate::runtime::budget;
 use crate::runtime::future::SelectFuture;
-use crate::runtime::unit::{UnitFn, UnitStorageBuilder};
+use crate::runtime::unit::{UnitFn, UnitStorage};
 use crate::runtime::{
     Args, Awaited, BorrowMut, Bytes, Call, Format, FormatSpec, FromValue, Function, Future,
     Generator, GuardedArgs, Inst, InstAddress, InstAssignOp, InstOp, InstRangeLimits, InstTarget,
@@ -2879,7 +2879,7 @@ impl Vm {
             let Some((inst, inst_len)) = vm_try!(self.unit.instruction_at(self.ip)) else {
                 return VmResult::err(VmErrorKind::IpOutOfBounds {
                     ip: self.ip,
-                    length: self.unit.instructions().offset(),
+                    length: self.unit.instructions().len(),
                 });
             };
 

--- a/crates/rune/src/runtime/vm.rs
+++ b/crates/rune/src/runtime/vm.rs
@@ -177,15 +177,6 @@ impl Vm {
         self.call_frames.clear();
     }
 
-    /// Modify the current instruction pointer.
-    pub fn modify_ip(&mut self, offset: isize) {
-        self.ip = if offset < 0 {
-            self.ip.wrapping_sub(-offset as usize)
-        } else {
-            self.ip.wrapping_add(offset as usize)
-        };
-    }
-
     /// Look up a function in the virtual machine by its name.
     ///
     /// # Examples
@@ -612,11 +603,12 @@ impl Vm {
             stack_bottom: stack_top,
         });
 
-        self.ip = ip.wrapping_sub(1);
+        self.ip = ip;
         Ok(())
     }
 
     /// Pop a call frame and return it.
+    #[tracing::instrument(skip_all)]
     fn pop_call_frame(&mut self) -> Result<bool, VmErrorKind> {
         let frame = match self.call_frames.pop() {
             Some(frame) => frame,
@@ -1120,23 +1112,27 @@ impl Vm {
         offset: usize,
         call: Call,
         args: usize,
-    ) -> Result<(), VmErrorKind> {
-        match call {
+    ) -> Result<bool, VmErrorKind> {
+        let moved = match call {
             Call::Async => {
                 self.call_async_fn(offset, args)?;
+                false
             }
             Call::Immediate => {
                 self.push_call_frame(offset, args)?;
+                true
             }
             Call::Stream => {
                 self.call_stream_fn(offset, args)?;
+                false
             }
             Call::Generator => {
                 self.call_generator_fn(offset, args)?;
+                false
             }
-        }
+        };
 
-        Ok(())
+        Ok(moved)
     }
 
     fn internal_num_assign(
@@ -1443,13 +1439,16 @@ impl Vm {
 
     /// pop-and-jump-if-not instruction.
     #[cfg_attr(feature = "bench", inline(never))]
-    fn op_pop_and_jump_if_not(&mut self, count: usize, offset: isize) -> VmResult<()> {
+    fn op_pop_and_jump_if_not(&mut self, count: usize, jump: usize) -> VmResult<()> {
         if vm_try!(vm_try!(self.stack.pop()).into_bool()) {
             return VmResult::Ok(());
         }
 
         vm_try!(self.stack.popn(count));
-        self.modify_ip(offset);
+        self.ip = vm_try!(self
+            .unit
+            .offset(jump)
+            .ok_or_else(|| VmErrorKind::BadJump { jump }));
         VmResult::Ok(())
     }
 
@@ -1507,16 +1506,22 @@ impl Vm {
 
     /// Perform a jump operation.
     #[cfg_attr(feature = "bench", inline(never))]
-    fn op_jump(&mut self, offset: isize) -> VmResult<()> {
-        self.modify_ip(offset);
+    fn op_jump(&mut self, jump: usize) -> VmResult<()> {
+        self.ip = vm_try!(self
+            .unit
+            .offset(jump)
+            .ok_or_else(|| VmErrorKind::BadJump { jump }));
         VmResult::Ok(())
     }
 
     /// Perform a conditional jump operation.
     #[cfg_attr(feature = "bench", inline(never))]
-    fn op_jump_if(&mut self, offset: isize) -> VmResult<()> {
+    fn op_jump_if(&mut self, jump: usize) -> VmResult<()> {
         if vm_try!(vm_try!(self.stack.pop()).into_bool()) {
-            self.modify_ip(offset);
+            self.ip = vm_try!(self
+                .unit
+                .offset(jump)
+                .ok_or_else(|| VmErrorKind::BadJump { jump }));
         }
 
         VmResult::Ok(())
@@ -1525,9 +1530,12 @@ impl Vm {
     /// Perform a conditional jump operation. Pops the stack if the jump is
     /// not performed.
     #[cfg_attr(feature = "bench", inline(never))]
-    fn op_jump_if_or_pop(&mut self, offset: isize) -> VmResult<()> {
+    fn op_jump_if_or_pop(&mut self, jump: usize) -> VmResult<()> {
         if vm_try!(vm_try!(self.stack.last()).as_bool()) {
-            self.modify_ip(offset);
+            self.ip = vm_try!(self
+                .unit
+                .offset(jump)
+                .ok_or_else(|| VmErrorKind::BadJump { jump }));
         } else {
             vm_try!(self.stack.pop());
         }
@@ -1538,9 +1546,12 @@ impl Vm {
     /// Perform a conditional jump operation. Pops the stack if the jump is
     /// not performed.
     #[cfg_attr(feature = "bench", inline(never))]
-    fn op_jump_if_not_or_pop(&mut self, offset: isize) -> VmResult<()> {
+    fn op_jump_if_not_or_pop(&mut self, jump: usize) -> VmResult<()> {
         if !vm_try!(vm_try!(self.stack.last()).as_bool()) {
-            self.modify_ip(offset);
+            self.ip = vm_try!(self
+                .unit
+                .offset(jump)
+                .ok_or_else(|| VmErrorKind::BadJump { jump }));
         } else {
             vm_try!(self.stack.pop());
         }
@@ -1550,10 +1561,13 @@ impl Vm {
 
     /// Perform a branch-conditional jump operation.
     #[cfg_attr(feature = "bench", inline(never))]
-    fn op_jump_if_branch(&mut self, branch: i64, offset: isize) -> VmResult<()> {
+    fn op_jump_if_branch(&mut self, branch: i64, jump: usize) -> VmResult<()> {
         if let Some(Value::Integer(current)) = self.stack.peek() {
             if *current == branch {
-                self.modify_ip(offset);
+                self.ip = vm_try!(self
+                    .unit
+                    .offset(jump)
+                    .ok_or_else(|| VmErrorKind::BadJump { jump }));
                 vm_try!(self.stack.pop());
             }
         }
@@ -2804,7 +2818,7 @@ impl Vm {
     }
 
     #[cfg_attr(feature = "bench", inline(never))]
-    fn op_iter_next(&mut self, offset: usize, jump: isize) -> VmResult<()> {
+    fn op_iter_next(&mut self, offset: usize, jump: usize) -> VmResult<()> {
         let value = vm_try!(self.stack.at_offset_mut(offset));
 
         let some = match value {
@@ -2814,7 +2828,10 @@ impl Vm {
                 match option {
                     Some(some) => some,
                     None => {
-                        self.modify_ip(jump);
+                        self.ip = vm_try!(self
+                            .unit
+                            .offset(jump)
+                            .ok_or_else(|| VmErrorKind::BadJump { jump }));
                         return VmResult::Ok(());
                     }
                 }
@@ -2880,14 +2897,16 @@ impl Vm {
                 return VmResult::Ok(VmHalt::Limited);
             }
 
-            let inst = *vm_try!(self.unit.instruction_at(self.ip).ok_or_else(|| {
-                VmErrorKind::IpOutOfBounds {
+            let Some((inst, inst_len)) = vm_try!(self.unit.instruction_at(self.ip)) else {
+                return VmResult::err(VmErrorKind::IpOutOfBounds {
                     ip: self.ip,
                     length: self.unit.instructions().len(),
-                }
-            }));
+                });
+            };
 
-            tracing::trace!("{}: {}", self.ip, inst);
+            tracing::trace!(ip = ?self.ip, ?inst);
+
+            self.ip = self.ip.wrapping_add(inst_len);
 
             match inst {
                 Inst::Not => {
@@ -2939,13 +2958,11 @@ impl Vm {
                 }
                 Inst::Return { address, clean } => {
                     if vm_try!(self.op_return(address, clean)) {
-                        self.advance();
                         return VmResult::Ok(VmHalt::Exited);
                     }
                 }
                 Inst::ReturnUnit => {
                     if vm_try!(self.op_return_unit()) {
-                        self.advance();
                         return VmResult::Ok(VmHalt::Exited);
                     }
                 }
@@ -2972,8 +2989,8 @@ impl Vm {
                 Inst::PopN { count } => {
                     vm_try!(self.op_popn(count));
                 }
-                Inst::PopAndJumpIfNot { count, offset } => {
-                    vm_try!(self.op_pop_and_jump_if_not(count, offset));
+                Inst::PopAndJumpIfNot { count, jump } => {
+                    vm_try!(self.op_pop_and_jump_if_not(count, jump));
                 }
                 Inst::Clean { count } => {
                     vm_try!(self.op_clean(count));
@@ -2993,20 +3010,20 @@ impl Vm {
                 Inst::Replace { offset } => {
                     vm_try!(self.op_replace(offset));
                 }
-                Inst::Jump { offset } => {
-                    vm_try!(self.op_jump(offset));
+                Inst::Jump { jump } => {
+                    vm_try!(self.op_jump(jump));
                 }
-                Inst::JumpIf { offset } => {
-                    vm_try!(self.op_jump_if(offset));
+                Inst::JumpIf { jump } => {
+                    vm_try!(self.op_jump_if(jump));
                 }
-                Inst::JumpIfOrPop { offset } => {
-                    vm_try!(self.op_jump_if_or_pop(offset));
+                Inst::JumpIfOrPop { jump } => {
+                    vm_try!(self.op_jump_if_or_pop(jump));
                 }
-                Inst::JumpIfNotOrPop { offset } => {
-                    vm_try!(self.op_jump_if_not_or_pop(offset));
+                Inst::JumpIfNotOrPop { jump } => {
+                    vm_try!(self.op_jump_if_not_or_pop(jump));
                 }
-                Inst::JumpIfBranch { branch, offset } => {
-                    vm_try!(self.op_jump_if_branch(branch, offset));
+                Inst::JumpIfBranch { branch, jump } => {
+                    vm_try!(self.op_jump_if_branch(branch, jump));
                 }
                 Inst::Vec { count } => {
                     vm_try!(self.op_vec(count));
@@ -3068,7 +3085,6 @@ impl Vm {
                     preserve,
                 } => {
                     if vm_try!(self.op_try(address, clean, preserve)) {
-                        self.advance();
                         return VmResult::Ok(VmHalt::Exited);
                     }
                 }
@@ -3114,11 +3130,9 @@ impl Vm {
                     vm_try!(self.op_match_object(slot, exact));
                 }
                 Inst::Yield => {
-                    self.advance();
                     return VmResult::Ok(VmHalt::Yielded);
                 }
                 Inst::YieldUnit => {
-                    self.advance();
                     self.stack.push(Value::Unit);
                     return VmResult::Ok(VmHalt::Yielded);
                 }
@@ -3140,15 +3154,7 @@ impl Vm {
                     });
                 }
             }
-
-            self.advance();
         }
-    }
-
-    /// Advance the instruction pointer.
-    #[inline]
-    pub(crate) fn advance(&mut self) {
-        self.ip = self.ip.wrapping_add(1);
     }
 }
 

--- a/crates/rune/src/runtime/vm_call.rs
+++ b/crates/rune/src/runtime/vm_call.rs
@@ -1,4 +1,4 @@
-use crate::runtime::{Call, Future, Generator, Stream, Value, Vm, VmExecution};
+use crate::runtime::{Call, Future, Generator, Stream, Value, Vm, VmExecution, VmResult};
 
 /// An instruction to push a virtual machine to the execution.
 #[derive(Debug)]
@@ -14,7 +14,7 @@ impl VmCall {
     }
 
     /// Encode the push itno an execution.
-    pub(crate) fn into_execution<T>(self, execution: &mut VmExecution<T>)
+    pub(crate) fn into_execution<T>(self, execution: &mut VmExecution<T>) -> VmResult<()>
     where
         T: AsMut<Vm>,
     {
@@ -25,7 +25,7 @@ impl VmCall {
             }
             Call::Immediate => {
                 execution.push_vm(self.vm);
-                return;
+                return VmResult::Ok(());
             }
             Call::Stream => Value::from(Stream::new(self.vm)),
             Call::Generator => Value::from(Generator::new(self.vm)),
@@ -33,6 +33,6 @@ impl VmCall {
 
         let vm = execution.vm_mut();
         vm.stack_mut().push(value);
-        vm.advance();
+        VmResult::Ok(())
     }
 }

--- a/crates/rune/src/runtime/vm_error.rs
+++ b/crates/rune/src/runtime/vm_error.rs
@@ -402,6 +402,8 @@ pub(crate) enum VmErrorKind {
     },
     #[error("Panicked: {reason}")]
     Panic { reason: Panic },
+    #[error("Invalid instruction")]
+    BadInstruction,
     #[error("No running virtual machines")]
     NoRunningVm,
     #[error("Halted for unexpected reason `{halt}`")]
@@ -549,6 +551,8 @@ pub(crate) enum VmErrorKind {
     ExpectedVariant { actual: TypeInfo },
     #[error("The object field get operation is not supported on `{target}`")]
     UnsupportedObjectFieldGet { target: TypeInfo },
+    #[error("Bad jump index {jump}")]
+    BadJump { jump: usize },
 }
 
 impl VmErrorKind {

--- a/crates/rune/src/runtime/vm_error.rs
+++ b/crates/rune/src/runtime/vm_error.rs
@@ -9,6 +9,7 @@ use thiserror::Error;
 
 use crate::compile::ItemBuf;
 use crate::hash::Hash;
+use crate::runtime::unit::{BadInstruction, BadJump};
 use crate::runtime::{
     AccessError, BoxedPanic, CallFrame, ExecutionState, FullTypeOf, Key, MaybeTypeOf, Panic,
     StackError, TypeInfo, TypeOf, Unit, Value, Vm, VmHaltInfo,
@@ -400,10 +401,18 @@ pub(crate) enum VmErrorKind {
         #[from]
         error: StackError,
     },
+    #[error("{error}")]
+    BadInstruction {
+        #[from]
+        error: BadInstruction,
+    },
+    #[error("{error}")]
+    BadJump {
+        #[from]
+        error: BadJump,
+    },
     #[error("Panicked: {reason}")]
     Panic { reason: Panic },
-    #[error("Invalid instruction")]
-    BadInstruction,
     #[error("No running virtual machines")]
     NoRunningVm,
     #[error("Halted for unexpected reason `{halt}`")]
@@ -551,8 +560,6 @@ pub(crate) enum VmErrorKind {
     ExpectedVariant { actual: TypeInfo },
     #[error("The object field get operation is not supported on `{target}`")]
     UnsupportedObjectFieldGet { target: TypeInfo },
-    #[error("Bad jump index {jump}")]
-    BadJump { jump: usize },
 }
 
 impl VmErrorKind {

--- a/crates/rune/src/worker/import.rs
+++ b/crates/rune/src/worker/import.rs
@@ -24,7 +24,7 @@ pub(crate) struct Import {
 
 impl Import {
     /// Lookup a local identifier in the current context and query.
-    fn lookup_local(&self, context: &Context, query: &Query, local: &str) -> ItemBuf {
+    fn lookup_local(&self, context: &Context, query: &Query<'_>, local: &str) -> ItemBuf {
         let item = query.pool.module_item(self.module).extended(local);
 
         if let ImportKind::Local = self.kind {
@@ -44,7 +44,7 @@ impl Import {
     pub(crate) fn process(
         mut self,
         context: &Context,
-        q: &mut Query,
+        q: &mut Query<'_>,
         add_task: &mut impl FnMut(Task),
     ) -> compile::Result<()> {
         let (name, first, initial) = match self.kind {

--- a/crates/rune/src/worker/wildcard_import.rs
+++ b/crates/rune/src/worker/wildcard_import.rs
@@ -19,7 +19,7 @@ pub(crate) struct WildcardImport {
 impl WildcardImport {
     pub(crate) fn process_global(
         &mut self,
-        query: &mut Query,
+        query: &mut Query<'_>,
         context: &Context,
     ) -> compile::Result<()> {
         if context.contains_prefix(&self.name) {


### PR DESCRIPTION
Add preliminary support for building and loading byte-code into the Vm from raw bytes, instead of having instructions always being an array of `Vec<Inst>`.

This has the potential of greatly reducing the size of Rune programs, but it comes with a performance penalty because instructions have to be decoded as they're being executed.

By default, we're still using the old array-based instructions format.

See the difference in in-memory size for the following program:

```rust
use std::iter::range;

pub fn main() {
    let it = range(0, 1000);
    let tail = 77;

    'label:
    while true {
        let value = 10;

        for n in it {
            loop {
                let value2 = 20;
                break 'label;
            }

            tail = tail + 1;
        }

        tail = tail + 1;
    }

    tail
}
```

Byte-code version: `196 bytes`.
Instruction array: `2560 bytes`.