### PR TITLE
Clean up collections access and no-std features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable
-    - run: cargo run --bin rune -- fmt --experimental --recursive --verbose --workspace tools scripts
+    - run: cargo run --bin rune -- fmt --experimental --recursive --verbose --workspace --check tools scripts
 
   clippy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
-    - run: cargo build -p rune --no-default-features
+    - run: cargo build -p rune --no-default-features --features alloc
 
   build_feature:
     runs-on: ubuntu-latest
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        feature: [capture-io, doc, cli, workspace, byte-code]
+        feature: [capture-io, doc, fmt, cli, workspace, byte-code]
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable
@@ -93,7 +93,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
-    - run: cargo build -p rune --no-default-features
+    - run: cargo build -p rune --no-default-features --features alloc
     - run: cargo test --workspace --exclude no-std-examples --all-targets
     - run: cargo test --workspace --exclude no-std-examples --doc
     - run: cargo run --bin rune -- check --recursive --experimental scripts

--- a/crates/rune-core/Cargo.toml
+++ b/crates/rune-core/Cargo.toml
@@ -14,12 +14,14 @@ keywords = ["language", "scripting", "scripting-language"]
 categories = ["parser-implementations"]
 
 [features]
+default = ["alloc"]
 doc = []
-std = []
+std = ["alloc"]
+alloc = ["serde/alloc"]
 
 [dependencies]
 twox-hash = { version = "1.6.3", default-features = false }
-serde = { version = "1.0.163", default-features = false, features = ["derive", "alloc"] }
+serde = { version = "1.0.163", default-features = false, features = ["derive"] }
 smallvec = { version = "1.10.0", default-features = false, features = ["const_new", "serde"] }
 byteorder = { version = "1.4.3", default-features = false }
 musli = { version = "0.0.42", default-features = false, optional = true }

--- a/crates/rune-core/src/error.rs
+++ b/crates/rune-core/src/error.rs
@@ -1,5 +1,6 @@
 //! Our own private error trait for use in no-std environments.
 
+#[cfg(feature = "alloc")]
 use alloc::boxed::Box;
 
 pub trait Error {
@@ -9,6 +10,7 @@ pub trait Error {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<E> Error for Box<E>
 where
     E: Error,

--- a/crates/rune-core/src/item.rs
+++ b/crates/rune-core/src/item.rs
@@ -7,7 +7,9 @@ pub use self::item::Item;
 mod iter;
 pub use self::iter::Iter;
 
+#[cfg(feature = "alloc")]
 mod component;
+#[cfg(feature = "alloc")]
 pub use self::component::Component;
 
 mod component_ref;

--- a/crates/rune-core/src/item/component_ref.rs
+++ b/crates/rune-core/src/item/component_ref.rs
@@ -2,6 +2,7 @@ use core::fmt;
 
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "alloc")]
 use crate::item::Component;
 
 /// A reference to a component of an item.
@@ -38,6 +39,7 @@ impl<'a> ComponentRef<'a> {
     }
 
     /// Coerce this [ComponentRef] into an owned [Component].
+    #[cfg(feature = "alloc")]
     pub fn to_owned(&self) -> Component {
         match *self {
             ComponentRef::Crate(s) => Component::Crate(s.into()),

--- a/crates/rune-core/src/item/into_component.rs
+++ b/crates/rune-core/src/item/into_component.rs
@@ -1,12 +1,17 @@
 use core::hash::{self, Hash};
 
+#[cfg(feature = "alloc")]
 use alloc::borrow::Cow;
+#[cfg(feature = "alloc")]
 use alloc::boxed::Box;
+#[cfg(feature = "alloc")]
 use alloc::string::String;
 
 use smallvec::SmallVec;
 
-use crate::item::{internal, Component, ComponentRef};
+#[cfg(feature = "alloc")]
+use crate::item::Component;
+use crate::item::{internal, ComponentRef};
 use crate::raw_str::RawStr;
 
 /// Trait for encoding the current type into a [Component].
@@ -16,6 +21,7 @@ pub trait IntoComponent: Sized {
 
     /// Convert into component.
     #[inline]
+    #[cfg(feature = "alloc")]
     fn into_component(self) -> Component {
         into_component(self.as_component_ref())
     }
@@ -45,6 +51,7 @@ impl IntoComponent for ComponentRef<'_> {
     }
 
     #[inline]
+    #[cfg(feature = "alloc")]
     fn into_component(self) -> Component {
         into_component(self)
     }
@@ -57,11 +64,13 @@ impl IntoComponent for &ComponentRef<'_> {
     }
 
     #[inline]
+    #[cfg(feature = "alloc")]
     fn into_component(self) -> Component {
         into_component(*self)
     }
 }
 
+#[cfg(feature = "alloc")]
 impl IntoComponent for Component {
     #[inline]
     fn as_component_ref(&self) -> ComponentRef<'_> {
@@ -74,6 +83,7 @@ impl IntoComponent for Component {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl IntoComponent for &Component {
     #[inline]
     fn as_component_ref(&self) -> ComponentRef<'_> {
@@ -93,6 +103,7 @@ macro_rules! impl_into_component_for_str {
                 ComponentRef::Str(self.as_ref())
             }
 
+            #[cfg(feature = "alloc")]
             fn into_component($slf) -> Component {
                 Component::Str($into)
             }
@@ -115,13 +126,19 @@ impl_into_component_for_str!(&str, self, self.into());
 impl_into_component_for_str!(&&str, self, (*self).into());
 impl_into_component_for_str!(RawStr, self, (*self).into());
 impl_into_component_for_str!(&RawStr, self, (**self).into());
+#[cfg(feature = "alloc")]
 impl_into_component_for_str!(String, self, self.into());
+#[cfg(feature = "alloc")]
 impl_into_component_for_str!(&String, self, self.clone().into());
+#[cfg(feature = "alloc")]
 impl_into_component_for_str!(Box<str>, self, self);
+#[cfg(feature = "alloc")]
 impl_into_component_for_str!(&Box<str>, self, self.clone());
+#[cfg(feature = "alloc")]
 impl_into_component_for_str!(Cow<'_, str>, self, self.as_ref().into());
 
 /// Convert into an owned component.
+#[cfg(feature = "alloc")]
 fn into_component(component: ComponentRef<'_>) -> Component {
     match component {
         ComponentRef::Crate(s) => Component::Crate(s.into()),

--- a/crates/rune-core/src/item/item.rs
+++ b/crates/rune-core/src/item/item.rs
@@ -1,12 +1,15 @@
-use core::fmt::{self, Write};
+use core::fmt;
 
+#[cfg(feature = "alloc")]
 use alloc::borrow::ToOwned;
-use alloc::string::String;
+#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
 use smallvec::ToSmallVec;
 
-use crate::item::{Component, ComponentRef, IntoComponent, ItemBuf, Iter};
+#[cfg(feature = "alloc")]
+use crate::item::Component;
+use crate::item::{ComponentRef, IntoComponent, ItemBuf, Iter};
 
 /// The reference to an [ItemBuf].
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -112,6 +115,7 @@ impl Item {
     }
 
     /// Construct a new vector from the current item.
+    #[cfg(feature = "alloc")]
     pub fn as_vec(&self) -> Vec<Component> {
         self.iter()
             .map(ComponentRef::into_component)
@@ -333,6 +337,7 @@ impl Default for &Item {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl ToOwned for Item {
     type Owned = ItemBuf;
 
@@ -364,17 +369,16 @@ impl fmt::Display for Item {
         let mut it = self.iter();
 
         if let Some(last) = it.next_back() {
-            let mut buf = String::new();
-
             for p in it {
-                write!(buf, "{}::", p)?;
+                write!(f, "{}::", p)?;
             }
 
-            write!(buf, "{}", last)?;
-            f.pad(&buf)
+            write!(f, "{}", last)?;
         } else {
-            f.pad("{root}")
+            f.write_str("{root}")?;
         }
+
+        Ok(())
     }
 }
 

--- a/crates/rune-core/src/item/item_buf.rs
+++ b/crates/rune-core/src/item/item_buf.rs
@@ -6,13 +6,17 @@ use core::ops::Deref;
 use core::str::FromStr;
 
 use crate::error;
+
+#[cfg(feature = "alloc")]
 use alloc::vec::{self, Vec};
 
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
 use crate::item::internal::INLINE;
-use crate::item::{Component, ComponentRef, IntoComponent, Item, Iter};
+#[cfg(feature = "alloc")]
+use crate::item::Component;
+use crate::item::{ComponentRef, IntoComponent, Item, Iter};
 
 /// The name of an item in the Rune Language.
 ///
@@ -183,9 +187,10 @@ impl ItemBuf {
     }
 
     /// Push the given component to the current item.
+    #[cfg(feature = "alloc")]
     pub fn pop(&mut self) -> Option<Component> {
         let mut it = self.iter();
-        let c = it.next_back()?.into_component();
+        let c = it.next_back()?.to_owned();
         let new_len = it.len();
         self.content.resize(new_len, 0);
         Some(c)
@@ -208,6 +213,7 @@ impl ItemBuf {
     }
 
     /// Convert into a vector from the current item.
+    #[cfg(feature = "alloc")]
     pub fn into_vec(self) -> Vec<Component> {
         self.into_iter().collect::<Vec<_>>()
     }
@@ -259,10 +265,12 @@ impl fmt::Debug for ItemBuf {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl IntoIterator for ItemBuf {
     type IntoIter = vec::IntoIter<Component>;
     type Item = Component;
 
+    #[inline]
     fn into_iter(self) -> Self::IntoIter {
         self.as_vec().into_iter()
     }

--- a/crates/rune-core/src/lib.rs
+++ b/crates/rune-core/src/lib.rs
@@ -10,6 +10,7 @@
 #[cfg(feature = "std")]
 extern crate std;
 
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 mod hash;
@@ -18,7 +19,9 @@ pub use hash::ParametersBuilder;
 pub use hash::{Hash, IntoHash, ToTypeHash};
 
 mod item;
-pub use self::item::{Component, ComponentRef, IntoComponent, Item, ItemBuf};
+#[cfg(feature = "alloc")]
+pub use self::item::Component;
+pub use self::item::{ComponentRef, IntoComponent, Item, ItemBuf};
 
 mod raw_str;
 pub use self::raw_str::RawStr;

--- a/crates/rune/Cargo.toml
+++ b/crates/rune/Cargo.toml
@@ -20,33 +20,33 @@ bench = []
 workspace = ["std", "toml", "semver", "relative-path", "serde-hashkey", "linked-hash-map"]
 doc = ["std", "rust-embed", "handlebars", "pulldown-cmark", "syntect", "sha2", "base64", "rune-core/doc", "relative-path"]
 cli = ["std", "emit", "doc", "bincode", "atty", "tracing-subscriber", "clap", "webbrowser", "capture-io", "disable-io", "languageserver", "fmt", "similar", "rand"]
-languageserver = ["lsp", "ropey", "percent-encoding", "url", "serde_json", "tokio", "tokio/macros", "tokio/io-std", "workspace", "doc"]
-byte-code = ["musli-storage"]
-capture-io = ["parking_lot"]
-disable-io = []
-fmt = []
+languageserver = ["std", "lsp", "ropey", "percent-encoding", "url", "serde_json", "tokio", "tokio/macros", "tokio/io-std", "workspace", "doc"]
+byte-code = ["alloc", "musli-storage"]
+capture-io = ["alloc", "parking_lot"]
+disable-io = ["alloc"]
+fmt = ["alloc"]
 std = ["num/std", "serde/std", "rune-core/std", "musli/std", "musli-storage/std", "alloc", "anyhow", "thiserror"]
-alloc = ["num/alloc", "serde/alloc", "serde/rc", "rune-core/alloc", "futures-util/alloc", "serde_bytes/alloc", "musli/alloc", "musli-storage?/alloc"]
+alloc = []
 
 [dependencies]
 rune-macros = { version = "=0.12.3", path = "../rune-macros" }
-rune-core = { version = "=0.12.3", path = "../rune-core", features = ["musli"] }
+rune-core = { version = "=0.12.3", path = "../rune-core", features = ["musli", "alloc"] }
 
 futures-core = { version = "0.3.28", default-features = false }
-futures-util = { version = "0.3.28", default-features = false }
+futures-util = { version = "0.3.28", default-features = false, features = ["alloc"] }
 itoa = "1.0.6"
 num = { version = "0.4.0", default-features = false, features = ["alloc"] }
 pin-project = "1.1.0"
 ryu = "1.0.13"
-serde = { version = "1.0.163", default-features = false, features = ["derive"] }
-serde_bytes = { version = "0.11.9", default-features = false }
+serde = { version = "1.0.163", default-features = false, features = ["derive", "alloc", "rc"] }
+serde_bytes = { version = "0.11.9", default-features = false, features = ["alloc"] }
 smallvec = { version = "1.10.0", default-features = false, features = ["serde", "const_new"] }
 thiserror-impl = { version = "1.0.40", default-features = false }
 tracing =  { version = "0.1.37", default-features = false, features = ["attributes"] }
 hashbrown = { version = "0.13.2", features = ["serde"] }
-musli = { version = "0.0.42", default-features = false }
+musli = { version = "0.0.42", default-features = false, features = ["alloc"] }
 
-musli-storage = { version = "0.0.42", default-features = false, optional = true }
+musli-storage = { version = "0.0.42", default-features = false, optional = true, features = ["alloc"] }
 anyhow = { version = "1.0.71", features = ["std"], optional = true }
 atty = { version = "0.2.14", optional = true }
 bincode = { version = "1.3.3", optional = true }
@@ -71,7 +71,7 @@ percent-encoding = { version = "2.2.0", optional = true }
 url = { version = "2.3.1", optional = true }
 serde_json = { version = "1.0.96", optional = true }
 linked-hash-map = { version = "0.5.6", optional = true }
-similar = { version = "2.2.1", optional = true, features = ["inline"] }
+similar = { version = "2.2.1", optional = true, features = ["inline", "bytes"] }
 sha2 = { version = "0.10.6", optional = true }
 base64 = { version = "0.21.0", optional = true }
 rand = { version = "0.8.5", optional = true }

--- a/crates/rune/Cargo.toml
+++ b/crates/rune/Cargo.toml
@@ -25,27 +25,28 @@ byte-code = ["musli-storage"]
 capture-io = ["parking_lot"]
 disable-io = []
 fmt = []
-std = ["anyhow", "thiserror", "num/std", "serde/std", "rune-core/std", "musli/std", "musli-storage/std"]
+std = ["num/std", "serde/std", "rune-core/std", "musli/std", "musli-storage/std", "alloc", "anyhow", "thiserror"]
+alloc = ["num/alloc", "serde/alloc", "serde/rc", "rune-core/alloc", "futures-util/alloc", "serde_bytes/alloc", "musli/alloc", "musli-storage?/alloc"]
 
 [dependencies]
 rune-macros = { version = "=0.12.3", path = "../rune-macros" }
 rune-core = { version = "=0.12.3", path = "../rune-core", features = ["musli"] }
 
 futures-core = { version = "0.3.28", default-features = false }
-futures-util = { version = "0.3.28", default-features = false, features = ["alloc"] }
+futures-util = { version = "0.3.28", default-features = false }
 itoa = "1.0.6"
 num = { version = "0.4.0", default-features = false, features = ["alloc"] }
 pin-project = "1.1.0"
 ryu = "1.0.13"
-serde = { version = "1.0.163", default-features = false, features = ["derive", "alloc", "rc"] }
-serde_bytes = { version = "0.11.9", default-features = false, features = ["alloc"] }
+serde = { version = "1.0.163", default-features = false, features = ["derive"] }
+serde_bytes = { version = "0.11.9", default-features = false }
 smallvec = { version = "1.10.0", default-features = false, features = ["serde", "const_new"] }
 thiserror-impl = { version = "1.0.40", default-features = false }
 tracing =  { version = "0.1.37", default-features = false, features = ["attributes"] }
 hashbrown = { version = "0.13.2", features = ["serde"] }
-musli = { version = "0.0.42", default-features = false, features = ["alloc"] }
+musli = { version = "0.0.42", default-features = false }
 
-musli-storage = { version = "0.0.42", default-features = false, optional = true, features = ["alloc"] }
+musli-storage = { version = "0.0.42", default-features = false, optional = true }
 anyhow = { version = "1.0.71", features = ["std"], optional = true }
 atty = { version = "0.2.14", optional = true }
 bincode = { version = "1.3.3", optional = true }

--- a/crates/rune/src/cli/format.rs
+++ b/crates/rune/src/cli/format.rs
@@ -95,7 +95,7 @@ pub(super) fn run<'m, I>(io: &mut Io<'_>, entry: &mut Entry<'_>, c: &Config, ent
             }
         };
 
-        let same = source.as_str() == val.as_str();
+        let same = source.as_str().as_bytes() == val;
 
         if same {
             unchanged += 1;
@@ -170,8 +170,8 @@ pub(super) fn run<'m, I>(io: &mut Io<'_>, entry: &mut Entry<'_>, c: &Config, ent
     Ok(ExitCode::Success)
 }
 
-fn diff(io: &mut Io, source: &Source, val: &str, col: &Colors) -> Result<(), anyhow::Error> {
-    let diff = TextDiff::from_lines(source.as_str(), val);
+fn diff(io: &mut Io, source: &Source, val: &[u8], col: &Colors) -> Result<(), anyhow::Error> {
+    let diff = TextDiff::from_lines(source.as_str().as_bytes(), val);
 
     for (idx, group) in diff.grouped_ops(3).iter().enumerate() {
         if idx > 0 {

--- a/crates/rune/src/compile/attrs.rs
+++ b/crates/rune/src/compile/attrs.rs
@@ -1,8 +1,8 @@
+use crate::no_std::collections::BTreeSet;
 use crate::no_std::prelude::*;
 
 use crate::ast;
 use crate::ast::{LitStr, Span, Spanned};
-use crate::collections::BTreeSet;
 use crate::compile::{self, ParseErrorKind};
 use crate::parse::{Parse, Parser, Resolve, ResolveContext};
 

--- a/crates/rune/src/compile/context.rs
+++ b/crates/rune/src/compile/context.rs
@@ -1,9 +1,9 @@
 use core::fmt;
 
+use crate::no_std::collections::{BTreeSet, HashMap, HashSet};
 use crate::no_std::prelude::*;
 use crate::no_std::sync::Arc;
 
-use crate::collections::{BTreeSet, HashMap, HashSet};
 use crate::compile::meta;
 #[cfg(feature = "doc")]
 use crate::compile::Docs;

--- a/crates/rune/src/compile/ir/eval.rs
+++ b/crates/rune/src/compile/ir/eval.rs
@@ -1,10 +1,10 @@
 use core::fmt::Write;
 use core::ops::{Add, Mul, Shl, Shr, Sub};
 
+use crate::no_std::collections::HashMap;
 use crate::no_std::prelude::*;
 
 use crate::ast::{Span, Spanned};
-use crate::collections::HashMap;
 use crate::compile::ir;
 use crate::compile::ir::{IrInterpreter, IrValue};
 use crate::compile::{self, WithSpan};

--- a/crates/rune/src/compile/ir/value.rs
+++ b/crates/rune/src/compile/ir/value.rs
@@ -1,7 +1,7 @@
+use crate::no_std::collections::HashMap;
 use crate::no_std::prelude::*;
 
 use crate::ast::Spanned;
-use crate::collections::HashMap;
 use crate::compile::{self, IrErrorKind, WithSpan};
 use crate::runtime as rt;
 use crate::runtime::{Bytes, ConstValue, Shared, TypeInfo};

--- a/crates/rune/src/compile/meta.rs
+++ b/crates/rune/src/compile/meta.rs
@@ -3,12 +3,12 @@
 use core::fmt;
 
 use crate::no_std::borrow::Cow;
+use crate::no_std::collections::HashSet;
 use crate::no_std::path::Path;
 use crate::no_std::prelude::*;
 use crate::no_std::sync::Arc;
 
 use crate::ast::{LitStr, Span};
-use crate::collections::HashSet;
 use crate::compile::attrs::Attributes;
 use crate::compile::{self, Item, ItemId, Location, MetaInfo, ModId, Pool, Visibility};
 use crate::hash::Hash;

--- a/crates/rune/src/compile/names.rs
+++ b/crates/rune/src/compile/names.rs
@@ -1,6 +1,7 @@
 use core::mem::replace;
 
-use crate::collections::BTreeMap;
+use crate::no_std::collections::BTreeMap;
+
 use crate::compile::{Component, ComponentRef, IntoComponent};
 
 /// A tree of names.

--- a/crates/rune/src/compile/pool.rs
+++ b/crates/rune/src/compile/pool.rs
@@ -2,7 +2,8 @@ use crate::no_std::prelude::*;
 
 use core::fmt;
 
-use crate::collections::HashMap;
+use crate::no_std::collections::HashMap;
+
 use crate::compile::{Item, ItemBuf, Location, Visibility};
 use crate::hash::Hash;
 

--- a/crates/rune/src/compile/prelude.rs
+++ b/crates/rune/src/compile/prelude.rs
@@ -1,6 +1,7 @@
 use crate::no_std::prelude::*;
 
-use crate::collections::HashMap;
+use crate::no_std::collections::HashMap;
+
 use crate::compile::{IntoComponent, Item, ItemBuf};
 
 /// The contents of a prelude.

--- a/crates/rune/src/compile/unit_builder.rs
+++ b/crates/rune/src/compile/unit_builder.rs
@@ -4,6 +4,7 @@
 //! metadata like function locations.
 
 use crate::no_std as std;
+use crate::no_std::collections::HashMap;
 use crate::no_std::prelude::*;
 use crate::no_std::sync::Arc;
 use crate::no_std::thiserror;
@@ -11,7 +12,6 @@ use crate::no_std::thiserror;
 use thiserror::Error;
 
 use crate::ast::Span;
-use crate::collections::HashMap;
 use crate::compile::meta;
 use crate::compile::{
     self, Assembly, AssemblyInst, CompileErrorKind, Item, Location, Pool, QueryErrorKind, WithSpan,

--- a/crates/rune/src/compile/v1/assemble.rs
+++ b/crates/rune/src/compile/v1/assemble.rs
@@ -1,12 +1,12 @@
 use core::mem::{replace, take};
 use core::ops::Neg;
 
+use crate::no_std::collections::{HashMap, HashSet};
 use crate::no_std::prelude::*;
 
 use num::ToPrimitive;
 
 use crate::ast::{self, Span, Spanned};
-use crate::collections::{HashMap, HashSet};
 use crate::compile::meta;
 use crate::compile::v1::{Assembler, GenericsParameters, Loop, Needs, Scope, Var};
 use crate::compile::{self, CompileErrorKind, Item, ParseErrorKind, WithSpan};

--- a/crates/rune/src/compile/v1/scopes.rs
+++ b/crates/rune/src/compile/v1/scopes.rs
@@ -1,9 +1,9 @@
 use core::fmt;
 
+use crate::no_std::collections::HashMap;
 use crate::no_std::prelude::*;
 
 use crate::ast::Span;
-use crate::collections::HashMap;
 use crate::compile::v1::Assembler;
 use crate::compile::{self, Assembly, CompileErrorKind, CompileVisitor, WithSpan};
 use crate::runtime::Inst;

--- a/crates/rune/src/doc/html.rs
+++ b/crates/rune/src/doc/html.rs
@@ -11,6 +11,7 @@ use std::str;
 
 use crate::no_std::prelude::*;
 use crate::no_std::borrow::Cow;
+use crate::no_std::collections::VecDeque;
 
 use anyhow::{anyhow, bail, Context as _, Error, Result};
 use relative_path::{RelativePath, RelativePathBuf};
@@ -23,7 +24,6 @@ use syntect::parsing::{SyntaxReference, SyntaxSet};
 use base64::{display::Base64Display};
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 
-use crate::collections::VecDeque;
 use crate::compile::{ComponentRef, Item, ItemBuf};
 use crate::doc::context::{Function, Kind, Signature, Meta};
 use crate::doc::templating;

--- a/crates/rune/src/doc/templating.rs
+++ b/crates/rune/src/doc/templating.rs
@@ -1,6 +1,8 @@
+use std::sync::Mutex;
+
 use crate::no_std::collections::HashMap;
 use crate::no_std::prelude::*;
-use crate::no_std::sync::{Arc, Mutex};
+use crate::no_std::sync::Arc;
 use crate::no_std::borrow::Cow;
 
 use handlebars::{

--- a/crates/rune/src/doc/visitor.rs
+++ b/crates/rune/src/doc/visitor.rs
@@ -1,6 +1,6 @@
 use crate::no_std::prelude::*;
+use crate::no_std::collections::{hash_map, HashMap};
 
-use crate::collections::{hash_map, HashMap};
 use crate::compile::{
     meta, CompileVisitor, IntoComponent, Item, ItemBuf, Location, MetaRef, Names,
 };

--- a/crates/rune/src/fmt.rs
+++ b/crates/rune/src/fmt.rs
@@ -19,21 +19,17 @@ use self::error::FormattingError;
 use self::printer::Printer;
 
 /// Format the given contents.
-pub fn layout_string(contents: String) -> Result<String, FormattingError> {
-    let s = Source::new("<memory>", contents);
+pub fn layout_string(contents: String) -> Result<Vec<u8>, FormattingError> {
+    let s = Source::memory(contents);
     layout_source(&s)
 }
 
 /// Format the given source.
-pub fn layout_source(source: &Source) -> Result<String, FormattingError> {
+pub fn layout_source(source: &Source) -> Result<Vec<u8>, FormattingError> {
     let mut parser = Parser::new(source.as_str(), SourceId::new(0), true);
 
     let ast = ast::File::parse(&mut parser)?;
     let mut printer: Printer = Printer::new(source)?;
-
     printer.visit_file(&ast)?;
-
-    let res = printer.commit().trim().to_owned() + "\n";
-
-    Ok(res)
+    Ok(printer.commit())
 }

--- a/crates/rune/src/fmt/indent_writer/tests.rs
+++ b/crates/rune/src/fmt/indent_writer/tests.rs
@@ -4,7 +4,10 @@ use super::*;
 fn test_roundtrip() {
     let mut writer = IndentedWriter::new();
     writer.write_all(b"hello\nworld\n").unwrap();
-    assert_eq!(writer.into_inner(), vec!["hello", "world", ""]);
+    assert_eq!(
+        writer.into_inner(),
+        [&b"hello"[..], &b"world"[..], &b""[..]]
+    );
 }
 
 #[test]
@@ -12,5 +15,8 @@ fn test_roundtrip_with_indent() {
     let mut writer = IndentedWriter::new();
     writer.indent();
     writer.write_all(b"hello\nworld\n").unwrap();
-    assert_eq!(writer.into_inner(), vec!["    hello", "    world", ""]);
+    assert_eq!(
+        writer.into_inner(),
+        [&b"    hello"[..], &b"    world"[..], &b""[..]]
+    );
 }

--- a/crates/rune/src/fmt/tests.rs
+++ b/crates/rune/src/fmt/tests.rs
@@ -17,7 +17,10 @@ fn test_layout_string() {
 }
 "#;
 
-    assert_eq!(layout_string(input.to_owned()).unwrap(), expected);
+    assert_eq!(
+        layout_string(input.to_owned()).unwrap(),
+        expected.as_bytes()
+    );
 }
 
 #[test]
@@ -45,7 +48,10 @@ fn foo() {
 }
 "#;
 
-    assert_eq!(layout_string(input.to_owned()).unwrap(), expected);
+    assert_eq!(
+        layout_string(input.to_owned()).unwrap(),
+        expected.as_bytes()
+    );
 }
 
 #[test]
@@ -75,5 +81,8 @@ fn foo() {
 }
 "#;
 
-    assert_eq!(layout_string(input.to_owned()).unwrap(), expected);
+    assert_eq!(
+        layout_string(input.to_owned()).unwrap(),
+        expected.as_bytes()
+    );
 }

--- a/crates/rune/src/indexing/index.rs
+++ b/crates/rune/src/indexing/index.rs
@@ -2,14 +2,13 @@ use core::num::NonZeroUsize;
 
 use core::mem::replace;
 
-use crate::no_std::collections::VecDeque;
+use crate::no_std::collections::{HashMap, VecDeque};
 use crate::no_std::path::PathBuf;
 use crate::no_std::prelude::*;
 use crate::no_std::sync::Arc;
 
 use crate::ast::{self};
 use crate::ast::{OptionSpanned, Span, Spanned};
-use crate::collections::HashMap;
 use crate::compile::attrs::Attributes;
 use crate::compile::{
     self, attrs, ir, CompileErrorKind, Doc, ItemId, Location, ModId, Options, ParseErrorKind,

--- a/crates/rune/src/indexing/index_scopes.rs
+++ b/crates/rune/src/indexing/index_scopes.rs
@@ -2,11 +2,11 @@
 
 use core::cell::RefCell;
 
+use crate::no_std::collections::{HashMap, HashSet};
 use crate::no_std::prelude::*;
 use crate::no_std::rc::Rc;
 
 use crate::ast::Span;
-use crate::collections::{HashMap, HashSet};
 use crate::compile::{self, CompileErrorKind, WithSpan};
 
 /// The kind of an indexed function.

--- a/crates/rune/src/languageserver/state.rs
+++ b/crates/rune/src/languageserver/state.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use crate::no_std::collections::HashMap;
 use crate::no_std::prelude::*;
 
 use anyhow::{anyhow, Context as _, Result};
@@ -11,7 +12,6 @@ use ropey::Rope;
 use tokio::sync::Notify;
 
 use crate::ast::{Span, Spanned};
-use crate::collections::HashMap;
 use crate::compile::meta;
 use crate::compile::{
     self, CompileVisitor, ComponentRef, Item, ItemBuf, LinkerError, Location, MetaRef, SourceMeta,

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -158,7 +158,7 @@ extern crate std;
 // This is here for forward compatibility when we can support allocation-free
 // execution.
 #[cfg(not(feature = "alloc"))]
-compile_error!("The `alloc` feature must be set when building rune");
+compile_error!("The `alloc` feature is currently required to build rune, but will change for parts of rune in the future.");
 
 #[macro_use]
 extern crate alloc;

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -154,7 +154,12 @@
 #[cfg(feature = "std")]
 #[macro_use]
 extern crate std;
-#[cfg(not(feature = "std"))]
+
+// This is here for forward compatibility when we can support allocation-free
+// execution.
+#[cfg(not(feature = "alloc"))]
+compile_error!("The `alloc` feature must be set when building rune");
+
 #[macro_use]
 extern crate alloc;
 
@@ -392,17 +397,6 @@ pub mod languageserver;
 
 cfg_doc! {
     pub mod doc;
-}
-
-/// Internal collection re-export.
-mod collections {
-    #![allow(unused)]
-
-    pub(crate) use crate::no_std::collections::{btree_map, BTreeMap};
-    pub(crate) use crate::no_std::collections::{btree_set, BTreeSet};
-    pub(crate) use crate::no_std::collections::{hash_map, HashMap};
-    pub(crate) use crate::no_std::collections::{hash_set, HashSet};
-    pub(crate) use crate::no_std::collections::{vec_deque, VecDeque};
 }
 
 /// Privately exported details.

--- a/crates/rune/src/macros/format_args.rs
+++ b/crates/rune/src/macros/format_args.rs
@@ -1,11 +1,10 @@
 use core::str;
 
-use crate::no_std::collections::{BTreeMap, BTreeSet};
+use crate::no_std::collections::{BTreeMap, BTreeSet, HashMap};
 use crate::no_std::prelude::*;
 
 use crate::ast;
 use crate::ast::{Span, Spanned};
-use crate::collections::HashMap;
 use crate::compile::{self, IrValue, WithSpan};
 use crate::macros::{quote, MacroContext, Quote};
 use crate::parse::{Parse, Parser, Peek, Peeker};

--- a/crates/rune/src/macros/storage.rs
+++ b/crates/rune/src/macros/storage.rs
@@ -3,7 +3,7 @@ use core::fmt;
 use crate::no_std::prelude::*;
 
 use crate::ast;
-use crate::collections::HashMap;
+use crate::no_std::collections::HashMap;
 
 /// A synthetic identifier which can be used to reference something in storage.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/rune/src/parse/lexer.rs
+++ b/crates/rune/src/parse/lexer.rs
@@ -1,11 +1,11 @@
 use core::fmt;
 use core::mem::take;
 
+use crate::no_std::collections::VecDeque;
 use crate::no_std::prelude::*;
 
 use crate::ast;
 use crate::ast::Span;
-use crate::collections::VecDeque;
 use crate::compile::{self, ParseErrorKind};
 use crate::SourceId;
 

--- a/crates/rune/src/query/query.rs
+++ b/crates/rune/src/query/query.rs
@@ -1,12 +1,12 @@
 use core::mem::take;
 
 use crate::no_std::borrow::Cow;
+use crate::no_std::collections::{hash_map, BTreeMap, HashMap, HashSet, VecDeque};
 use crate::no_std::prelude::*;
 use crate::no_std::sync::Arc;
 
 use crate::ast;
 use crate::ast::{Span, Spanned};
-use crate::collections::{hash_map, BTreeMap, HashMap, HashSet, VecDeque};
 use crate::compile::ir;
 use crate::compile::meta;
 use crate::compile::{

--- a/crates/rune/src/runtime/const_value.rs
+++ b/crates/rune/src/runtime/const_value.rs
@@ -1,10 +1,10 @@
 use serde::{Deserialize, Serialize};
 
+use crate::no_std::collections::HashMap;
 use crate::no_std::prelude::*;
 use crate::no_std::sync::Arc;
 use crate::no_std::vec;
 
-use crate::collections::HashMap;
 use crate::runtime::{
     Bytes, FromValue, Object, Shared, StaticString, ToValue, Tuple, TypeInfo, Value, Vec,
     VmErrorKind, VmResult,

--- a/crates/rune/src/runtime/debug.rs
+++ b/crates/rune/src/runtime/debug.rs
@@ -2,12 +2,12 @@
 
 use core::fmt;
 
+use crate::no_std::collections::HashMap;
 use crate::no_std::prelude::*;
 
 use serde::{Deserialize, Serialize};
 
 use crate::ast::Span;
-use crate::collections::HashMap;
 use crate::compile::ItemBuf;
 use crate::runtime::DebugLabel;
 use crate::{Hash, SourceId};

--- a/crates/rune/src/runtime/object.rs
+++ b/crates/rune/src/runtime/object.rs
@@ -4,10 +4,10 @@ use core::fmt;
 use core::hash;
 use core::iter;
 
+use crate::no_std::collections::{btree_map, BTreeMap};
 use crate::no_std::prelude::*;
 
 use crate as rune;
-use crate::collections::{btree_map, BTreeMap};
 use crate::compile::{ItemBuf, Named};
 use crate::module::InstallWith;
 use crate::runtime::{

--- a/crates/rune/src/runtime/runtime_context.rs
+++ b/crates/rune/src/runtime/runtime_context.rs
@@ -1,8 +1,8 @@
 use core::fmt;
 
+use crate::no_std::collections::HashMap;
 use crate::no_std::sync::Arc;
 
-use crate::collections::HashMap;
 use crate::compile;
 use crate::macros::{MacroContext, TokenStream};
 use crate::runtime::{ConstValue, Stack, VmResult};

--- a/crates/rune/src/runtime/unit.rs
+++ b/crates/rune/src/runtime/unit.rs
@@ -9,13 +9,13 @@ mod storage;
 
 use core::fmt;
 
+use crate::no_std::collections::HashMap;
 use crate::no_std::prelude::*;
+use crate::no_std::sync::Arc;
 
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-use crate::collections::HashMap;
-use crate::no_std::sync::Arc;
 use crate::runtime::{
     Call, ConstValue, DebugInfo, Inst, Rtti, StaticString, VariantRtti, VmError, VmErrorKind,
 };

--- a/crates/rune/src/runtime/vm_error.rs
+++ b/crates/rune/src/runtime/vm_error.rs
@@ -351,12 +351,12 @@ where
 }
 
 #[cfg(feature = "std")]
-impl<T> std::process::Termination for VmResult<T> {
+impl<T> ::std::process::Termination for VmResult<T> {
     #[inline]
-    fn report(self) -> std::process::ExitCode {
+    fn report(self) -> ::std::process::ExitCode {
         match self {
-            VmResult::Ok(_) => std::process::ExitCode::SUCCESS,
-            VmResult::Err(_) => std::process::ExitCode::FAILURE,
+            VmResult::Ok(_) => ::std::process::ExitCode::SUCCESS,
+            VmResult::Err(_) => ::std::process::ExitCode::FAILURE,
         }
     }
 }

--- a/crates/rune/src/shared/consts.rs
+++ b/crates/rune/src/shared/consts.rs
@@ -3,7 +3,8 @@
 //! This maps the item of a global constant to its value. It's also used to
 //! detect resolution cycles during constant evaluation.
 
-use crate::collections::{HashMap, HashSet};
+use crate::no_std::collections::{HashMap, HashSet};
+
 use crate::compile::ItemId;
 use crate::runtime::ConstValue;
 

--- a/crates/rune/src/shared/scopes.rs
+++ b/crates/rune/src/shared/scopes.rs
@@ -1,9 +1,8 @@
+use crate::no_std::collections::HashMap;
 use crate::no_std::prelude::*;
 
 /// Error indicating that a local variable is missing.
 pub(crate) struct MissingLocal<'a>(pub(crate) &'a str);
-
-use crate::collections::HashMap;
 
 /// A hierarchy of constant scopes.
 pub(crate) struct Scopes<T> {

--- a/crates/rune/src/source.rs
+++ b/crates/rune/src/source.rs
@@ -228,7 +228,7 @@ impl Source {
         }
     }
 
-    #[cfg(feature = "workspace")]
+    #[cfg(any(feature = "workspace", feature = "fmt"))]
     pub(crate) fn len(&self) -> usize {
         self.source.len()
     }

--- a/crates/rune/src/worker.rs
+++ b/crates/rune/src/worker.rs
@@ -2,10 +2,11 @@
 
 use crate::no_std::prelude::*;
 
+use crate::no_std::collections::HashMap;
+use crate::no_std::collections::VecDeque;
+
 use crate::ast;
 use crate::ast::Span;
-use crate::collections::HashMap;
-use crate::collections::VecDeque;
 use crate::compile::{ModId, Options, SourceLoader};
 use crate::indexing::index;
 use crate::indexing::{IndexScopes, Indexer};

--- a/crates/rune/src/worker/import.rs
+++ b/crates/rune/src/worker/import.rs
@@ -1,10 +1,10 @@
 use core::mem::take;
 
+use crate::no_std::collections::VecDeque;
 use crate::no_std::prelude::*;
 
 use crate::ast;
 use crate::ast::Spanned;
-use crate::collections::VecDeque;
 use crate::compile::{self, CompileErrorKind, ItemBuf, ModId, Visibility};
 use crate::parse::Resolve;
 use crate::query::Query;

--- a/no-std-examples/Cargo.toml
+++ b/no-std-examples/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 std = ["rune/std"]
 
 [dependencies]
-rune = { path = "../crates/rune", default-features = false }
+rune = { path = "../crates/rune", default-features = false, features = ["alloc"] }
 wee_alloc = "0.4.5"

--- a/no-std-examples/examples/no_std_minimal.rs
+++ b/no-std-examples/examples/no_std_minimal.rs
@@ -33,6 +33,12 @@ use rune::{Diagnostics, Vm};
 static mut BUDGET: usize = usize::MAX;
 static mut RAW_ENV: RawEnv = RawEnv::null();
 
+/// Necessary hook to abort the current process.
+#[no_mangle]
+extern "C" fn __rune_abort() -> ! {
+    core::intrinsics::abort()
+}
+
 #[no_mangle]
 extern "C" fn __rune_budget_take() -> bool {
     // SAFETY: this is only ever executed in a singlethreaded environment.


### PR DESCRIPTION
Adds the `alloc` feature which is required through a `compiler_error!` to be enabled.

This will be implemented once we can provide allocation-free virtual machine execution.