### PR TITLE
fix languageserver for neovim by not borrowing method in IncomingMessage

### DIFF
--- a/crates/rune/src/compile/context.rs
+++ b/crates/rune/src/compile/context.rs
@@ -237,7 +237,7 @@ impl Context {
     }
 
     /// Iterate over all available functions in the [Context].
-    #[cfg(feature = "cli")]
+    #[cfg(any(feature = "cli", feature = "languageserver"))]
     pub(crate) fn iter_functions(&self) -> impl Iterator<Item = (&ContextMeta, &meta::Signature)> {
         self.meta.iter().flat_map(|meta| {
             let signature = meta.kind.as_signature()?;

--- a/crates/rune/src/languageserver.rs
+++ b/crates/rune/src/languageserver.rs
@@ -54,7 +54,7 @@ pub async fn run(context: Context, options: Options) -> Result<()> {
                     None => break,
                 };
 
-                let incoming: envelope::IncomingMessage<'_> = serde_json::from_slice(frame.content)?;
+                let incoming: envelope::IncomingMessage = serde_json::from_slice(frame.content)?;
                 tracing::trace!(?incoming);
 
                 // If server is not initialized, reject incoming requests.
@@ -73,7 +73,7 @@ pub async fn run(context: Context, options: Options) -> Result<()> {
 
                 macro_rules! handle {
                     ($(req($req_ty:ty, $req_handle:ident)),* $(, notif($notif_ty:ty, $notif_handle:ident))* $(,)?) => {
-                        match incoming.method {
+                        match incoming.method.as_str() {
                             $(<$req_ty>::METHOD => {
                                 let params = <$req_ty as Request>::Params::deserialize(incoming.params)?;
                                 let result = $req_handle(&mut state, params).await?;

--- a/crates/rune/src/languageserver/envelope.rs
+++ b/crates/rune/src/languageserver/envelope.rs
@@ -14,12 +14,11 @@ pub(super) enum RequestId {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-pub(super) struct IncomingMessage<'a> {
+pub(super) struct IncomingMessage {
     #[allow(unused)]
     pub(super) jsonrpc: V2,
     pub(super) id: Option<RequestId>,
-    #[serde(borrow)]
-    pub(super) method: &'a str,
+    pub(super) method: String,
     #[serde(default)]
     pub(super) params: serde_json::Value,
 }


### PR DESCRIPTION
- add Context::iter_functions to languageserver feature
- fix languageserver for neovim by not borrowing method in IncomingMessage
