### PR TITLE
Ensure that ItemMeta is registered for root items (fix #521)

### DIFF
--- a/crates/rune/src/compile.rs
+++ b/crates/rune/src/compile.rs
@@ -125,7 +125,13 @@ pub(crate) fn compile(
 
     // Queue up the initial sources to be loaded.
     for source_id in worker.q.sources.source_ids() {
-        let mod_item = match worker.q.insert_root_mod(source_id, Span::empty()) {
+        // Unique identifier for the root module in this source context.
+        let root_item_id = worker.q.gen.next();
+
+        let mod_item = match worker
+            .q
+            .insert_root_mod(root_item_id, source_id, Span::empty())
+        {
             Ok(result) => result,
             Err(error) => {
                 worker.diagnostics.error(source_id, error);
@@ -137,6 +143,7 @@ pub(crate) fn compile(
             kind: LoadFileKind::Root,
             source_id,
             mod_item,
+            mod_item_id: root_item_id,
         });
     }
 

--- a/crates/rune/src/indexing/index.rs
+++ b/crates/rune/src/indexing/index.rs
@@ -374,11 +374,7 @@ impl<'a> Indexer<'a> {
             .q
             .insert_path(self.mod_item, self.impl_item, &self.items.item());
         ast.path.id.set(id);
-
-        let id = self
-            .items
-            .id()
-            .map_err(|e| compile::Error::msg(ast.span(), e))?;
+        let id = self.items.id().with_span(ast.span())?;
 
         let item = self.q.item_for((ast.span(), id))?;
 
@@ -558,6 +554,8 @@ impl<'a> Indexer<'a> {
 
         let visibility = ast_to_visibility(&item_mod.visibility)?;
 
+        let mod_item_id = self.items.id().with_span(span)?;
+
         let mod_item = self.q.insert_mod(
             &self.items,
             Location::new(self.source_id, item_mod.name_span()),
@@ -566,7 +564,7 @@ impl<'a> Indexer<'a> {
             docs,
         )?;
 
-        item_mod.id.set(self.items.id().with_span(span)?);
+        item_mod.id.set(mod_item_id);
 
         let source = self
             .source_loader
@@ -591,6 +589,7 @@ impl<'a> Indexer<'a> {
             },
             source_id,
             mod_item,
+            mod_item_id,
         });
 
         Ok(())

--- a/crates/rune/src/query/query.rs
+++ b/crates/rune/src/query/query.rs
@@ -186,18 +186,32 @@ impl<'a> Query<'a> {
     /// Insert module and associated metadata.
     pub(crate) fn insert_root_mod(
         &mut self,
+        item_id: NonZeroId,
         source_id: SourceId,
         spanned: Span,
     ) -> compile::Result<ModId> {
-        let query_mod = self.pool.alloc_module(ModMeta {
-            location: Location::new(source_id, spanned),
+        let location = Location::new(source_id, spanned);
+
+        let module = self.pool.alloc_module(ModMeta {
+            location,
             item: ItemId::default(),
             visibility: Visibility::Public,
             parent: None,
         });
 
+        self.inner.items.insert(
+            item_id,
+            ItemMeta {
+                id: Id::new(item_id),
+                location,
+                item: ItemId::default(),
+                visibility: Visibility::Public,
+                module,
+            },
+        );
+
         self.insert_name(ItemId::default());
-        Ok(query_mod)
+        Ok(module)
     }
 
     /// Inserts an item that *has* to be unique, else cause an error.

--- a/crates/rune/src/shared/items.rs
+++ b/crates/rune/src/shared/items.rs
@@ -36,12 +36,12 @@ pub(crate) struct Items<'a> {
 
 impl<'a> Items<'a> {
     /// Construct a new items manager.
-    pub(crate) fn new(item: &Item, gen: &'a Gen) -> Self {
+    pub(crate) fn new(item: &Item, id: NonZeroId, gen: &'a Gen) -> Self {
         Self {
             inner: Rc::new(RefCell::new(Inner {
                 id: item.last().and_then(ComponentRef::id).unwrap_or_default(),
                 item: item.to_owned(),
-                ids: Vec::new(),
+                ids: vec![id],
                 gen,
             })),
         }

--- a/crates/rune/src/worker.rs
+++ b/crates/rune/src/worker.rs
@@ -98,7 +98,6 @@ impl<'a> Worker<'a> {
                         LoadFileKind::Module { root } => root,
                     };
 
-                    tracing::trace!("load file: {}", item);
                     let items = Items::new(item, mod_item_id, self.q.gen);
 
                     let mut indexer = Indexer {

--- a/crates/rune/src/worker.rs
+++ b/crates/rune/src/worker.rs
@@ -67,6 +67,7 @@ impl<'a> Worker<'a> {
                     kind,
                     source_id,
                     mod_item,
+                    mod_item_id,
                 } => {
                     let item = self.q.pool.module_item(mod_item);
                     tracing::trace!("load file: {}", item);
@@ -98,7 +99,7 @@ impl<'a> Worker<'a> {
                     };
 
                     tracing::trace!("load file: {}", item);
-                    let items = Items::new(item, self.q.gen);
+                    let items = Items::new(item, mod_item_id, self.q.gen);
 
                     let mut indexer = Indexer {
                         root,

--- a/crates/rune/src/worker/task.rs
+++ b/crates/rune/src/worker/task.rs
@@ -1,6 +1,7 @@
 use crate::no_std::path::PathBuf;
 
 use crate::compile::ModId;
+use crate::parse::NonZeroId;
 use crate::worker::{Import, WildcardImport};
 use crate::SourceId;
 
@@ -15,6 +16,8 @@ pub(crate) enum Task {
         source_id: SourceId,
         /// The item of the file to load.
         mod_item: ModId,
+        /// Unique item stack identifier.
+        mod_item_id: NonZeroId,
     },
     /// Expand a single import.
     ExpandImport(Import),

--- a/scripts/make_function.rn
+++ b/scripts/make_function.rn
@@ -1,0 +1,9 @@
+#[test]
+pub fn test_make_function() {
+    std::experiments::make_function!(inner_fn => { "Hello World Again!" });
+
+    assert_eq!(root_fn(), "Hello World!");
+    assert_eq!(inner_fn(), "Hello World Again!");
+}
+
+std::experiments::make_function!(root_fn => { "Hello World!" });


### PR DESCRIPTION
Due to past refactoring, `ItemMeta` is missing for the root module, meaning any macro which expands into the root will end up erroring as described in #521.

This ensures that root item meta is setup as appropriate and adds a test to make sure item expansion works on all relevant code locations for functions.

There is a bit of "identifier soup" going on right now which I'd like to refactor some time in the future, namely items have two kinds of identifiers:

* One which is associated with its allocation in the item pool (allowing for deduplicating item allocations).
* One which associated context metadata to the item, such as its visibility, which module its in, the source location it belongs to. This is what's being referenced by ast items such as ItemFn::id.

The second one is what's being associated with the opaque ast id you can see all over the place, and is the one which was missing. We just had to make sure item meta was present for it and that the Items stack which is used to build items are seeded correctly with identifiers.

Thanks to @ModProg for finding and reporting the issue!