### PR TITLE
fix(docs): replace field_function with field_fn

### DIFF
--- a/book/src/field_functions.md
+++ b/book/src/field_functions.md
@@ -48,7 +48,7 @@ are:
 | [`Protocol::SHR_ASSIGN`] | `#[rune(shr_assign)]` | The `>>=` operation. |
 | [`Protocol::REM_ASSIGN`] | `#[rune(rem_assign)]` | The `%=` operation. |
 
-The manual way to register these functions is to use the new `Module::field_function`
+The manual way to register these functions is to use the new `Module::field_fn`
 function. This clearly showcases that there's no relationship between the field
 used and the function registered:
 
@@ -67,7 +67,7 @@ impl External {
 }
 
 let mut module = Module::new();
-module.field_function(Protocol::GET, "field", External::field_get)?;
+module.field_fn(Protocol::GET, "field", External::field_get)?;
 ```
 
 Would allow for this in Rune:


### PR DESCRIPTION
It looks like there is a typo in the function name referring to https://docs.rs/rune/0.12.3/rune/compile/struct.Module.html#method.field_fn.

Moreover in the example, External is an empty struct, not sure if that's wanted.