### PR TITLE
Display instructions through derive

### DIFF
--- a/crates/rune-macros/src/inst_display.rs
+++ b/crates/rune-macros/src/inst_display.rs
@@ -1,0 +1,193 @@
+use core::mem::take;
+
+use proc_macro2::{Span, TokenStream};
+use quote::quote;
+use syn::punctuated::Punctuated;
+use syn::Token;
+
+/// The `InstDisplay` derive.
+pub struct Derive {
+    input: syn::DeriveInput,
+}
+
+impl syn::parse::Parse for Derive {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        Ok(Self {
+            input: input.parse()?,
+        })
+    }
+}
+
+impl Derive {
+    pub(super) fn expand(self) -> Result<TokenStream, Vec<syn::Error>> {
+        let mut errors = Vec::new();
+
+        let syn::Data::Enum(en) = &self.input.data else {
+            errors.push(syn::Error::new_spanned(&self.input.ident, "InstDisplay is only supported for enums"));
+            return Err(errors);
+        };
+
+        let fmt = syn::Ident::new("fmt", Span::call_site());
+        let ident = self.input.ident;
+
+        let mut variants = Vec::new();
+
+        for variant in &en.variants {
+            let variant_ident = &variant.ident;
+            let mut patterns = Vec::new();
+            let mut fmt_call = Vec::new();
+
+            for (index, f) in variant.fields.iter().enumerate() {
+                let mut display_with = None::<syn::Path>;
+
+                for a in &f.attrs {
+                    if a.path().is_ident("inst_display") {
+                        let result = a.parse_nested_meta(|meta| {
+                            if meta.path.is_ident("display_with") {
+                                meta.input.parse::<Token![=]>()?;
+                                display_with = Some(meta.input.parse()?);
+                            } else {
+                                return Err(syn::Error::new(
+                                    meta.input.span(),
+                                    "Unsupported attribute",
+                                ));
+                            }
+
+                            Ok(())
+                        });
+
+                        if let Err(error) = result {
+                            errors.push(error);
+                            continue;
+                        }
+                    }
+                }
+
+                let member = match &f.ident {
+                    Some(ident) => syn::Member::Named(ident.clone()),
+                    None => syn::Member::Unnamed(syn::Index::from(index)),
+                };
+
+                let (assign, var) = match &f.ident {
+                    Some(ident) => (false, ident.clone()),
+                    None => (true, quote::format_ident!("_{index}")),
+                };
+
+                let mut path = syn::Path {
+                    leading_colon: None,
+                    segments: Punctuated::default(),
+                };
+
+                path.segments.push(syn::PathSegment::from(var.clone()));
+
+                patterns.push(syn::FieldValue {
+                    attrs: Vec::new(),
+                    member,
+                    colon_token: assign.then(<Token![:]>::default),
+                    expr: syn::Expr::Path(syn::ExprPath {
+                        attrs: Vec::new(),
+                        qself: None,
+                        path,
+                    }),
+                });
+
+                let var_name = syn::LitStr::new(&var.to_string(), var.span());
+
+                let var = syn::Expr::Path(syn::ExprPath {
+                    attrs: Vec::new(),
+                    qself: None,
+                    path: syn::Path::from(var),
+                });
+
+                let arg = if let Some(display_with) = display_with {
+                    let mut call = syn::ExprCall {
+                        attrs: Vec::new(),
+                        func: Box::new(syn::Expr::Path(syn::ExprPath {
+                            attrs: Vec::new(),
+                            qself: None,
+                            path: display_with.clone(),
+                        })),
+                        paren_token: syn::token::Paren::default(),
+                        args: Punctuated::new(),
+                    };
+
+                    call.args.push(var);
+                    let call = syn::Expr::Call(call);
+
+                    syn::Expr::Reference(syn::ExprReference {
+                        attrs: Vec::new(),
+                        and_token: <Token![&]>::default(),
+                        mutability: None,
+                        expr: Box::new(call),
+                    })
+                } else {
+                    var
+                };
+
+                if !fmt_call.is_empty() {
+                    fmt_call.push(quote! {
+                        #fmt::Formatter::write_str(f, " ")?;
+                    });
+                } else {
+                    fmt_call.push(quote! {
+                        #fmt::Formatter::write_str(f, ", ")?;
+                    });
+                }
+
+                fmt_call.push(quote! {
+                    #fmt::Formatter::write_str(f, #var_name)?;
+                    #fmt::Formatter::write_str(f, "=")?;
+                    #fmt::Display::fmt(#arg, f)?
+                });
+            }
+
+            let variant_name = variant_name(&variant.ident.to_string());
+
+            variants.push(quote! {
+                #ident::#variant_ident { #(#patterns,)* } => {
+                    #fmt::Formatter::write_str(f, #variant_name)?;
+                    #(#fmt_call;)*
+                    Ok(())
+                }
+            });
+        }
+
+        if !errors.is_empty() {
+            return Err(errors);
+        }
+
+        let (impl_g, ty_g, where_g) = self.input.generics.split_for_impl();
+
+        Ok(quote! {
+            impl #impl_g #fmt::Display for #ident #ty_g #where_g {
+                fn fmt(&self, f: &mut #fmt::Formatter<'_>) -> #fmt::Result {
+                    match self {
+                        #(#variants,)*
+                    }
+                }
+            }
+        })
+    }
+}
+
+fn variant_name(name: &str) -> String {
+    let mut out = String::new();
+    let mut first = true;
+
+    for c in name.chars() {
+        if take(&mut first) {
+            out.extend(c.to_lowercase());
+            continue;
+        }
+
+        if c.is_uppercase() {
+            out.push('-');
+            out.extend(c.to_lowercase());
+            continue;
+        }
+
+        out.push(c);
+    }
+
+    out
+}

--- a/crates/rune-macros/src/lib.rs
+++ b/crates/rune-macros/src/lib.rs
@@ -28,6 +28,7 @@ mod any;
 mod context;
 mod from_value;
 mod function;
+mod inst_display;
 mod instrument;
 mod internals;
 mod macro_;
@@ -162,6 +163,13 @@ pub fn instrument(
         .expand()
         .unwrap_or_else(to_compile_errors)
         .into()
+}
+
+#[proc_macro_derive(InstDisplay, attributes(inst_display))]
+#[doc(hidden)]
+pub fn inst_display(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let derive = syn::parse_macro_input!(input as inst_display::Derive);
+    derive.expand().unwrap_or_else(to_compile_errors).into()
 }
 
 fn to_compile_errors(errors: Vec<syn::Error>) -> proc_macro2::TokenStream {

--- a/crates/rune/src/runtime/format.rs
+++ b/crates/rune/src/runtime/format.rs
@@ -370,6 +370,35 @@ impl FormatSpec {
     }
 }
 
+impl fmt::Display for FormatSpec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "format(fill = {fill:?}, align = {align}, flags = {flags:?}, width = {width}, precision = {precision}, format_type = {format_type})",
+            fill = self.fill,
+            align = self.align,
+            flags = self.flags,
+            width = OptionDebug(self.width.as_ref()),
+            precision = OptionDebug(self.precision.as_ref()),
+            format_type = self.format_type
+        )
+    }
+}
+
+struct OptionDebug<'a, T>(Option<&'a T>);
+
+impl<T> fmt::Display for OptionDebug<'_, T>
+where
+    T: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            Some(value) => write!(f, "{}", value),
+            None => write!(f, "?"),
+        }
+    }
+}
+
 /// The type of formatting requested.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Decode, Encode)]
 #[non_exhaustive]
@@ -495,7 +524,7 @@ pub enum Flag {
     SignPlus,
     /// Minus sign `-`.
     SignMinus,
-    /// Atlernate specifier `#`.
+    /// Alternate specifier `#`.
     Alternate,
     /// Sign-aware zero pad `0`.
     SignAwareZeroPad,

--- a/crates/rune/src/runtime/inst.rs
+++ b/crates/rune/src/runtime/inst.rs
@@ -1,6 +1,7 @@
 use core::fmt;
 
 use musli::{Decode, Encode};
+use rune_macros::InstDisplay;
 use serde::{Deserialize, Serialize};
 
 use crate::runtime::{FormatSpec, Type, Value};
@@ -87,7 +88,7 @@ impl fmt::Display for TypeCheck {
 }
 
 /// An operation in the stack-based virtual machine.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, Decode, Encode)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Decode, Encode, InstDisplay)]
 pub enum Inst {
     /// Not operator. Takes a boolean from the top of the stack  and inverts its
     /// logical value.
@@ -566,6 +567,7 @@ pub enum Inst {
     Tuple1 {
         /// First element of the tuple.
         #[musli(with = self::array::<_, 1>)]
+        #[inst_display(display_with = display_array)]
         args: [InstAddress; 1],
     },
     /// Construct a push a two-tuple value onto the stack.
@@ -579,6 +581,7 @@ pub enum Inst {
     Tuple2 {
         /// Tuple arguments.
         #[musli(with = self::array::<_, 2>)]
+        #[inst_display(display_with = display_array)]
         args: [InstAddress; 2],
     },
     /// Construct a push a three-tuple value onto the stack.
@@ -592,6 +595,7 @@ pub enum Inst {
     Tuple3 {
         /// Tuple arguments.
         #[musli(with = self::array::<_, 3>)]
+        #[inst_display(display_with = display_array)]
         args: [InstAddress; 3],
     },
     /// Construct a push a four-tuple value onto the stack.
@@ -605,6 +609,7 @@ pub enum Inst {
     Tuple4 {
         /// Tuple arguments.
         #[musli(with = self::array::<_, 4>)]
+        #[inst_display(display_with = display_array)]
         args: [InstAddress; 4],
     },
     /// Construct a push a tuple value onto the stack. The number of elements
@@ -1056,6 +1061,7 @@ pub enum Inst {
     #[musli(packed)]
     Panic {
         /// The reason for the panic.
+        #[inst_display(display_with = PanicReason::ident)]
         reason: PanicReason,
     },
 }
@@ -1100,279 +1106,6 @@ impl Inst {
     pub fn float(v: f64) -> Self {
         Self::Push {
             value: InstValue::Float(v),
-        }
-    }
-}
-
-impl fmt::Display for Inst {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Drop { offset } => {
-                write!(f, "drop offset={offset}")?;
-            }
-            Self::Not => {
-                write!(f, "not")?;
-            }
-            Self::Neg => {
-                write!(f, "neg")?;
-            }
-            Self::Call { hash, args } => {
-                write!(f, "call hash={hash}, args={args}")?;
-            }
-            Self::CallInstance { hash, args } => {
-                write!(f, "call-instance hash={hash}, args={args}")?;
-            }
-            Self::Closure { hash, count } => {
-                write!(f, "closure hash={hash}, count={count}")?;
-            }
-            Self::CallFn { args } => {
-                write!(f, "call-fn args={args}")?;
-            }
-            Self::LoadInstanceFn { hash } => {
-                write!(f, "load-instance-fn hash={hash}")?;
-            }
-            Self::IndexGet { target, index } => {
-                write!(f, "index-get target={target}, index={index}")?;
-            }
-            Self::TupleIndexGet { index } => {
-                write!(f, "tuple-index-get index={index}")?;
-            }
-            Self::TupleIndexSet { index } => {
-                write!(f, "tuple-index-set index={index}")?;
-            }
-            Self::TupleIndexGetAt { offset, index } => {
-                write!(f, "tuple-index-get-at offset={offset}, index={index}")?;
-            }
-            Self::ObjectIndexGet { slot } => {
-                write!(f, "object-index-get slot={slot}")?;
-            }
-            Self::ObjectIndexSet { slot } => {
-                write!(f, "object-index-set slot={slot}")?;
-            }
-            Self::ObjectIndexGetAt { offset, slot } => {
-                write!(f, "object-index-get-at offset={offset}, slot={slot}")?;
-            }
-            Self::IndexSet => {
-                write!(f, "index-set")?;
-            }
-            Self::Await => {
-                write!(f, "await")?;
-            }
-            Self::Select { len } => {
-                write!(f, "select len={len}")?;
-            }
-            Self::LoadFn { hash } => {
-                write!(f, "load-fn hash={hash}")?;
-            }
-            Self::Push { value } => {
-                write!(f, "push value={value}")?;
-            }
-            Self::Pop => {
-                write!(f, "pop")?;
-            }
-            Self::PopN { count } => {
-                write!(f, "pop-n count={count}")?;
-            }
-            Self::PopAndJumpIfNot { count, jump } => {
-                write!(f, "pop-and-jump-if-not count={count}, jump={jump}")?;
-            }
-            Self::Clean { count } => {
-                write!(f, "clean count={count}")?;
-            }
-            Self::Copy { offset } => {
-                write!(f, "copy offset={offset}")?;
-            }
-            Self::Move { offset } => {
-                write!(f, "move offset={offset}")?;
-            }
-            Self::Dup => {
-                write!(f, "dup")?;
-            }
-            Self::Replace { offset } => {
-                write!(f, "replace offset={offset}")?;
-            }
-            Self::Return { address, clean } => {
-                write!(f, "return address={address}, clean={clean}")?;
-            }
-            Self::ReturnUnit => {
-                write!(f, "return-unit")?;
-            }
-            Self::Jump { jump } => {
-                write!(f, "jump jump={jump}")?;
-            }
-            Self::JumpIf { jump } => {
-                write!(f, "jump-if jump={jump}")?;
-            }
-            Self::JumpIfOrPop { jump } => {
-                write!(f, "jump-if-or-pop jump={jump}")?;
-            }
-            Self::JumpIfNotOrPop { jump } => {
-                write!(f, "jump-if-not-or-pop jump={jump}")?;
-            }
-            Self::JumpIfBranch { branch, jump } => {
-                write!(f, "jump-if-branch branch={branch}, jump={jump}")?;
-            }
-            Self::Vec { count } => {
-                write!(f, "vec count={count}")?;
-            }
-            Self::Tuple1 { args: [a] } => {
-                write!(f, "tuple-1 {a}")?;
-            }
-            Self::Tuple2 { args: [a, b] } => {
-                write!(f, "tuple-2 {a}, {b}")?;
-            }
-            Self::Tuple3 { args: [a, b, c] } => {
-                write!(f, "tuple-3 {a}, {b}, {c}")?;
-            }
-            Self::Tuple4 { args: [a, b, c, d] } => {
-                write!(f, "tuple-4 {a}, {b}, {c}, {d}")?;
-            }
-            Self::Tuple { count } => {
-                write!(f, "tuple count={count}")?;
-            }
-            Self::PushTuple => {
-                write!(f, "push-tuple")?;
-            }
-            Self::UnitStruct { hash } => {
-                write!(f, "unit-struct hash={hash}")?;
-            }
-            Self::Struct { hash, slot } => {
-                write!(f, "struct hash={hash}, slot={slot}")?;
-            }
-            Self::UnitVariant { hash } => {
-                write!(f, "unit-variant hash={hash}")?;
-            }
-            Self::StructVariant { hash, slot } => {
-                write!(f, "struct-variant hash={hash}, slot={slot}")?;
-            }
-            Self::Object { slot } => {
-                write!(f, "object slot={slot}")?;
-            }
-            Self::Range { limits } => {
-                write!(f, "range limits={limits}")?;
-            }
-            Self::String { slot } => {
-                write!(f, "string slot={slot}")?;
-            }
-            Self::Bytes { slot } => {
-                write!(f, "bytes slot={slot}")?;
-            }
-            Self::StringConcat { len, size_hint } => {
-                write!(f, "string-concat len={len}, size_hint={size_hint}")?;
-            }
-            Self::Format { spec } => {
-                write!(
-                    f,
-                    "format {fill:?}, {align}, {flags:?}, {width}, {precision}, {format_type}",
-                    fill = spec.fill,
-                    align = spec.align,
-                    flags = spec.flags,
-                    width = option(&spec.width),
-                    precision = option(&spec.precision),
-                    format_type = spec.format_type
-                )?;
-            }
-            Self::IsUnit => {
-                write!(f, "is-unit")?;
-            }
-            Self::Try {
-                address,
-                clean,
-                preserve,
-            } => {
-                write!(
-                    f,
-                    "try address={address}, clean={clean}, preserve={preserve}",
-                )?;
-            }
-            Self::EqByte { byte } => {
-                write!(f, "eq-byte byte={:?}", byte)?;
-            }
-            Self::EqChar { char } => {
-                write!(f, "eq-character char={char:?}")?;
-            }
-            Self::EqInteger { integer } => {
-                write!(f, "eq-integer integer={integer}")?;
-            }
-            Self::EqBool { boolean } => {
-                write!(f, "eq-integer boolean={boolean}")?;
-            }
-            Self::EqString { slot } => {
-                write!(f, "eq-string slot={slot}")?;
-            }
-            Self::EqBytes { slot } => {
-                write!(f, "eq-bytes slot={slot}")?;
-            }
-            Self::MatchType { hash } => {
-                write!(f, "match-type hash={hash}")?;
-            }
-            Self::MatchVariant {
-                variant_hash,
-                enum_hash,
-                index,
-            } => {
-                write!(
-                    f,
-                    "match-variant variant_hash={variant_hash}, enum_hash={enum_hash}, index={index}",
-                )?;
-            }
-            Self::MatchBuiltIn { type_check } => {
-                write!(f, "match-builtin type_check={type_check}")?;
-            }
-            Self::MatchSequence {
-                type_check,
-                len,
-                exact,
-            } => {
-                write!(
-                    f,
-                    "match-sequence type_check={type_check}, len={len}, exact={exact}",
-                )?;
-            }
-            Self::MatchObject { slot, exact } => {
-                write!(f, "match-object slot={slot}, exact={exact}")?;
-            }
-            Self::Yield => {
-                write!(f, "yield")?;
-            }
-            Self::YieldUnit => {
-                write!(f, "yield-unit")?;
-            }
-            Self::Variant { variant } => {
-                write!(f, "variant variant={variant}")?;
-            }
-            Self::Op { op, a, b } => {
-                write!(f, "op op={op}, a={a}, b={b}")?;
-            }
-            Self::Assign { target, op } => {
-                write!(f, "assign target={target}, op={op}")?;
-            }
-            Self::IterNext { offset, jump } => {
-                write!(f, "iter-next offset={offset}, jump={jump}")?;
-            }
-            Self::Panic { reason } => {
-                write!(f, "panic reason={}", reason.ident())?;
-            }
-        }
-
-        return Ok(());
-
-        fn option<T>(value: &Option<T>) -> OptionDebug<'_, T> {
-            OptionDebug(value.as_ref())
-        }
-
-        struct OptionDebug<'a, T>(Option<&'a T>);
-
-        impl<'a, T> fmt::Display for OptionDebug<'a, T>
-        where
-            T: fmt::Display,
-        {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                match self.0 {
-                    Some(value) => write!(f, "{}", value),
-                    None => write!(f, "?"),
-                }
-            }
         }
     }
 }
@@ -1812,5 +1545,37 @@ mod array {
         }
 
         Ok(array)
+    }
+}
+
+fn display_array<T>(array: &[T]) -> impl fmt::Display + '_
+where
+    T: fmt::Display,
+{
+    DisplayArray(array)
+}
+
+struct DisplayArray<'a, T>(&'a [T]);
+
+impl<T> fmt::Display for DisplayArray<'_, T>
+where
+    T: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut it = self.0.iter();
+
+        write!(f, "[")?;
+        let last = it.next_back();
+
+        for value in it {
+            write!(f, "{value}, ")?;
+        }
+
+        if let Some(last) = last {
+            last.fmt(f)?;
+        }
+
+        write!(f, "]")?;
+        Ok(())
     }
 }


### PR DESCRIPTION
This replaces the fragile to maintain manual `fmt::Display` implementation on `Inst` to one which is automatically derived.