### PR TITLE
More macros

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,18 @@ jobs:
         RUSTFLAGS: --cfg docsrs
         RUSTDOCFLAGS: --cfg docsrs
 
+  basics:
+    runs-on: ubuntu-latest
+    needs:
+    - rustfmt
+    - clippy
+    - docs
+    steps:
+    - run: exit 0
+
   msrv:
     runs-on: ubuntu-latest
-    needs: [rustfmt, runefmt, clippy, docs]
+    needs: basics
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@1.65
@@ -55,7 +64,7 @@ jobs:
 
   no_default_features:
     runs-on: ubuntu-latest
-    needs: [rustfmt, runefmt, clippy, docs]
+    needs: basics
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable
@@ -64,7 +73,7 @@ jobs:
 
   build_feature:
     runs-on: ubuntu-latest
-    needs: [rustfmt, runefmt, clippy, docs]
+    needs: basics
     strategy:
       fail-fast: false
       matrix:
@@ -77,7 +86,7 @@ jobs:
 
   wasm:
     runs-on: ubuntu-latest
-    needs: [rustfmt, runefmt, clippy, docs]
+    needs: basics
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable

--- a/crates/rune/src/ast/expr.rs
+++ b/crates/rune/src/ast/expr.rs
@@ -309,14 +309,6 @@ impl Expr {
         })
     }
 
-    /// Try to coerce into item if applicable.
-    pub(crate) fn into_item(self) -> Result<ast::Item, Self> {
-        match self {
-            Self::MacroCall(e) => Ok(ast::Item::MacroCall(e)),
-            e => Err(e),
-        }
-    }
-
     /// Parse an expression without an eager brace.
     ///
     /// This is used to solve a syntax ambiguity when parsing expressions that

--- a/crates/rune/src/ast/stmt.rs
+++ b/crates/rune/src/ast/stmt.rs
@@ -154,33 +154,18 @@ pub struct StmtSemi {
     pub expr: ast::Expr,
     /// The semi-token associated with the expression.
     pub semi_token: T![;],
-    /// Indicates if the nested expression needs a semi or not.
-    #[rune(skip)]
-    pub needs_semi: Option<bool>,
 }
 
 impl StmtSemi {
     /// Construct a new [StmtSemi] which doesn't override
     /// [needs_semi][StmtSemi::needs_semi].
     pub(crate) fn new(expr: ast::Expr, semi_token: T![;]) -> Self {
-        Self {
-            expr,
-            semi_token,
-            needs_semi: None,
-        }
-    }
-
-    /// Modify semi requirement.
-    pub(crate) fn with_needs_semi(self, needs_semi: bool) -> Self {
-        Self {
-            needs_semi: Some(needs_semi),
-            ..self
-        }
+        Self { expr, semi_token }
     }
 
     /// Test if the statement requires a semi-colon or not.
     pub(crate) fn needs_semi(&self) -> bool {
-        self.needs_semi.unwrap_or_else(|| self.expr.needs_semi())
+        self.expr.needs_semi()
     }
 }
 

--- a/crates/rune/src/ast/stmt.rs
+++ b/crates/rune/src/ast/stmt.rs
@@ -27,29 +27,6 @@ pub enum Stmt {
     Semi(StmtSemi),
 }
 
-impl Stmt {
-    /// Get the sort key for the statement.
-    ///
-    /// This allows a collection of statements to be reordered into:
-    /// * Uses
-    /// * Items
-    /// * Macro expansions.
-    /// * The rest, expressions, local decl, etc...
-    ///
-    /// Note that the sort implementation must be stable, to make sure that
-    /// intermediate items are not affected.
-    pub(crate) fn sort_key(&self) -> StmtSortKey {
-        match self {
-            Stmt::Item(item, _) => match item {
-                ast::Item::Use(_) => StmtSortKey::Use,
-                ast::Item::MacroCall(_) => StmtSortKey::Other,
-                _ => StmtSortKey::Item,
-            },
-            _ => StmtSortKey::Other,
-        }
-    }
-}
-
 impl Peek for Stmt {
     fn peek(p: &mut Peeker<'_>) -> bool {
         matches!(p.nth(0), K![let]) || ItemOrExpr::peek(p)
@@ -85,12 +62,9 @@ impl Parse for Stmt {
             let expr = ast::Expr::parse_with_meta(p, &mut attributes, ast::expr::CALLABLE)?;
 
             // Parsed an expression which can be treated directly as an item.
-            match expr.into_item() {
-                Ok(item) => Self::Item(item, p.parse()?),
-                Err(expr) => match p.parse()? {
-                    Some(semi) => Self::Semi(StmtSemi::new(expr, semi)),
-                    None => Self::Expr(expr),
-                },
+            match p.parse()? {
+                Some(semi) => Self::Semi(StmtSemi::new(expr, semi)),
+                None => Self::Expr(expr),
             }
         };
 

--- a/crates/rune/src/compile/error.rs
+++ b/crates/rune/src/compile/error.rs
@@ -395,6 +395,8 @@ pub(crate) enum CompileErrorKind {
     },
     #[error("Use of label `{name}_{index}` which has no code location")]
     MissingLabelLocation { name: &'static str, index: usize },
+    #[error("Reached macro recursion limit at {depth}, limit is {max}")]
+    MaxMacroRecursion { depth: usize, max: usize },
 }
 
 /// Error raised during queries.

--- a/crates/rune/src/diagnostics.rs
+++ b/crates/rune/src/diagnostics.rs
@@ -245,10 +245,10 @@ impl Diagnostics {
     }
 
     /// Add a warning about an unecessary semi-colon.
-    pub(crate) fn uneccessary_semi_colon(&mut self, source_id: SourceId, span: Span) {
+    pub(crate) fn unnecessary_semi_colon(&mut self, source_id: SourceId, span: Span) {
         self.warning(
             source_id,
-            WarningDiagnosticKind::UnecessarySemiColon { span },
+            WarningDiagnosticKind::UnnecessarySemiColon { span },
         );
     }
 

--- a/crates/rune/src/diagnostics/warning.rs
+++ b/crates/rune/src/diagnostics/warning.rs
@@ -44,7 +44,7 @@ impl WarningDiagnostic {
             | WarningDiagnosticKind::RemoveTupleCallParams { context, .. }
             | WarningDiagnosticKind::NotUsed { context, .. }
             | WarningDiagnosticKind::TemplateWithoutExpansions { context, .. } => *context,
-            WarningDiagnosticKind::UnecessarySemiColon { .. } => None,
+            WarningDiagnosticKind::UnnecessarySemiColon { .. } => None,
         }
     }
 }
@@ -57,7 +57,7 @@ impl Spanned for WarningDiagnostic {
             WarningDiagnosticKind::LetPatternMightPanic { span, .. } => *span,
             WarningDiagnosticKind::TemplateWithoutExpansions { span, .. } => *span,
             WarningDiagnosticKind::RemoveTupleCallParams { span, .. } => *span,
-            WarningDiagnosticKind::UnecessarySemiColon { span, .. } => *span,
+            WarningDiagnosticKind::UnnecessarySemiColon { span, .. } => *span,
         }
     }
 }
@@ -116,7 +116,7 @@ pub enum WarningDiagnosticKind {
     },
     /// An unecessary semi-colon is used.
     #[error("Unnecessary semicolon")]
-    UnecessarySemiColon {
+    UnnecessarySemiColon {
         /// Span where the semi-colon is.
         span: Span,
     },

--- a/crates/rune/src/fmt/printer.rs
+++ b/crates/rune/src/fmt/printer.rs
@@ -1799,25 +1799,11 @@ impl<'a> Printer<'a> {
                 self.writer.newline()?;
             }
             Stmt::Semi(semi) => {
-                let StmtSemi {
-                    expr,
-                    semi_token,
-                    needs_semi,
-                } = semi;
+                let StmtSemi { expr, semi_token } = semi;
+
                 self.visit_expr(expr)?;
-
-                match needs_semi {
-                    Some(true) => {
-                        self.writer
-                            .write_spanned_raw(semi_token.span, false, false)?;
-                    }
-                    Some(false) => {}
-                    None => {
-                        self.writer
-                            .write_spanned_raw(semi_token.span, false, false)?;
-                    }
-                }
-
+                self.writer
+                    .write_spanned_raw(semi_token.span, false, false)?;
                 self.writer.newline()?;
             }
         }

--- a/crates/rune/src/worker.rs
+++ b/crates/rune/src/worker.rs
@@ -115,6 +115,7 @@ impl<'a> Worker<'a> {
                         impl_item: Default::default(),
                         source_loader: self.source_loader,
                         nested_item: None,
+                        macro_depth: 0,
                     };
 
                     if let Err(error) = index::file(&mut file, &mut indexer) {

--- a/scripts/make_function.rn
+++ b/scripts/make_function.rn
@@ -1,9 +1,11 @@
 #[test]
 pub fn test_make_function() {
-    std::experiments::make_function!(inner_fn => { "Hello World Again!" });
+    make_function!(inner_fn => { "Hello World Again!" });
 
     assert_eq!(root_fn(), "Hello World!");
     assert_eq!(inner_fn(), "Hello World Again!");
 }
 
-std::experiments::make_function!(root_fn => { "Hello World!" });
+make_function!(root_fn => { "Hello World!" });
+// NB: we put the import in the bottom to test that import resolution isn't order-dependent.
+use ::std::experiments::make_function;


### PR DESCRIPTION
After re-evaluating the loop @ModProg pointed at in [this comment](https://github.com/rune-rs/rune/issues/525#issue-1726289620). It seems like we can perform use processing before we do any expansion without much issues.

This PR implements that, so that ordering of uses is no longer a factor. I've also added a recursion limiter for macro expansion which has been in the cards for a while now.