### PR TITLE
fix and add tests for macrocall whitespace

### DIFF
--- a/crates/rune/src/fmt.rs
+++ b/crates/rune/src/fmt.rs
@@ -31,5 +31,5 @@ pub fn layout_source(source: &Source) -> Result<Vec<u8>, FormattingError> {
     let ast = ast::File::parse(&mut parser)?;
     let mut printer: Printer = Printer::new(source)?;
     printer.visit_file(&ast)?;
-    Ok(printer.commit())
+    printer.commit()
 }

--- a/crates/rune/src/fmt/indent_writer.rs
+++ b/crates/rune/src/fmt/indent_writer.rs
@@ -136,7 +136,7 @@ impl<'a> SpanInjectionWriter<'a> {
     }
 
     pub(super) fn into_inner(mut self) -> Result<Vec<Vec<u8>>, FormattingError> {
-        while self.queued_spans.len() > 0 {
+        while !self.queued_spans.is_empty() {
             let span = self.queued_spans.remove(0);
             match span {
                 ResolvedSpan::Empty(_) => {

--- a/crates/rune/src/fmt/indent_writer.rs
+++ b/crates/rune/src/fmt/indent_writer.rs
@@ -96,6 +96,7 @@ impl Write for IndentedWriter {
     }
 }
 
+#[derive(Debug)]
 enum ResolvedSpan {
     Empty(EmptyLine),
     Comment(Comment),
@@ -134,8 +135,25 @@ impl<'a> SpanInjectionWriter<'a> {
         })
     }
 
-    pub(super) fn into_inner(self) -> Vec<Vec<u8>> {
-        self.writer.into_inner()
+    pub(super) fn into_inner(mut self) -> Result<Vec<Vec<u8>>, FormattingError> {
+        while self.queued_spans.len() > 0 {
+            let span = self.queued_spans.remove(0);
+            match span {
+                ResolvedSpan::Empty(_) => {
+                    writeln!(self.writer)?;
+                }
+                ResolvedSpan::Comment(comment) => {
+                    if comment.on_new_line {
+                        writeln!(self.writer, "{}", self.resolve(comment.span)?)?;
+                    } else {
+                        self.extend_previous_line(b" ");
+                        self.extend_previous_line(self.resolve(comment.span)?.as_bytes());
+                    }
+                }
+            }
+        }
+
+        Ok(self.writer.into_inner())
     }
 
     fn extend_previous_line(&mut self, text: &[u8]) {

--- a/crates/rune/src/fmt/printer.rs
+++ b/crates/rune/src/fmt/printer.rs
@@ -36,8 +36,8 @@ impl<'a> Printer<'a> {
         Ok(Self { writer, source })
     }
 
-    pub(super) fn commit(self) -> Vec<u8> {
-        let inner = self.writer.into_inner();
+    pub(super) fn commit(self) -> Result<Vec<u8>> {
+        let inner = self.writer.into_inner()?;
 
         let mut out = Vec::new();
 
@@ -62,7 +62,7 @@ impl<'a> Printer<'a> {
             out.push(b'\n');
         }
 
-        out
+        Ok(out)
     }
 
     pub(super) fn resolve(&self, span: Span) -> Result<&'a str> {
@@ -685,7 +685,7 @@ impl<'a> Printer<'a> {
         self.writer.write_spanned_raw(close.span, false, false)?;
 
         if let Some(semi) = semi {
-            self.writer.write_spanned_raw(semi.span, false, false)?;
+            self.writer.write_spanned_raw(semi.span, true, false)?;
         }
 
         Ok(())

--- a/crates/rune/src/fmt/tests.rs
+++ b/crates/rune/src/fmt/tests.rs
@@ -86,3 +86,69 @@ fn foo() {
         expected.as_bytes()
     );
 }
+
+#[test]
+fn test_macrocall_whitespace() {
+    let input = r#"
+        fn main() {
+            foo!();
+
+            1 + 2
+        }
+        "#;
+
+    let expected = r#"fn main() {
+    foo!();
+
+    1 + 2
+}
+"#;
+
+    let output = layout_string(input.to_owned()).unwrap();
+    let output = layout_string(String::from_utf8(output).unwrap()).unwrap();
+    assert_eq!(std::str::from_utf8(&output).unwrap(), expected);
+}
+
+#[test]
+fn test_macrocall_whitespace2() {
+    let input = r#"make_function!(root_fn => { "Hello World!" });
+// NB: we put the import in the bottom to test that import resolution isn't order-dependent.
+"#;
+
+    let expected = r#"make_function!(root_fn => { "Hello World!" });
+// NB: we put the import in the bottom to test that import resolution isn't order-dependent.
+"#;
+
+    let output = layout_string(input.to_owned()).unwrap();
+    assert_eq!(std::str::from_utf8(&output).unwrap(), expected);
+    let output = layout_string(String::from_utf8(output).unwrap()).unwrap();
+    assert_eq!(std::str::from_utf8(&output).unwrap(), expected);
+    let output = layout_string(String::from_utf8(output).unwrap()).unwrap();
+    assert_eq!(std::str::from_utf8(&output).unwrap(), expected);
+}
+
+#[test]
+fn test_macrocall_whitespace3() {
+    let input = r#"make_function!(root_fn => { "Hello World!" });
+
+
+
+
+// NB: we put the import in the bottom to test that import resolution isn't order-dependent.
+"#;
+
+    let expected = r#"make_function!(root_fn => { "Hello World!" });
+
+
+
+
+// NB: we put the import in the bottom to test that import resolution isn't order-dependent.
+"#;
+
+    let output = layout_string(input.to_owned()).unwrap();
+    assert_eq!(std::str::from_utf8(&output).unwrap(), expected);
+    let output = layout_string(String::from_utf8(output).unwrap()).unwrap();
+    assert_eq!(std::str::from_utf8(&output).unwrap(), expected);
+    let output = layout_string(String::from_utf8(output).unwrap()).unwrap();
+    assert_eq!(std::str::from_utf8(&output).unwrap(), expected);
+}


### PR DESCRIPTION
Also found another small bug where any whitespace and comments at EOF would disappear; as it would be after the last span we re-emit from the AST. These are now unconditionally re-emitted during commit.