### PR TITLE
Stop relying on layout of TypeId

### DIFF
--- a/crates/rune/src/modules/any.rs
+++ b/crates/rune/src/modules/any.rs
@@ -1,18 +1,17 @@
 //! `std::any` module.
 
-use crate::runtime::{Protocol, Value};
-use crate::{Any, ContextError, Module};
-use std::any::TypeId as StdTypeId;
+use crate::runtime::{Protocol, Value, VmError};
+use crate::{Any, ContextError, Hash, Module};
 use std::fmt;
 use std::fmt::Write;
 
 #[derive(Any, Debug)]
 #[rune(module = "crate")]
 #[repr(transparent)]
-struct TypeId(StdTypeId);
+struct TypeId(Hash);
 
-fn type_id_of_val(item: Value) -> TypeId {
-    unsafe { std::mem::transmute(item.type_hash().expect("no type known for item!")) }
+fn type_id_of_val(item: Value) -> Result<TypeId, VmError> {
+    Ok(TypeId(item.type_hash()?))
 }
 
 fn format_type_id(item: &TypeId, buf: &mut String) -> fmt::Result {


### PR DESCRIPTION
Since this will change soon:

https://github.com/rust-lang/rust/pull/109953

This is a backported fix since this will cause a breakage in the next stable Rust version being released, at which point you'll need to have updated Rune.

Note that this does not affect the next release, since it no longer relies on the layout of TypeId's.