### PR TITLE
WIP: More generic Function conformance

### DIFF
--- a/crates/rune/src/module.rs
+++ b/crates/rune/src/module.rs
@@ -4,6 +4,7 @@
 //! native Rust-based code.
 
 mod function_meta;
+mod function_raw_traits;
 mod function_traits;
 pub(crate) mod module;
 

--- a/crates/rune/src/module.rs
+++ b/crates/rune/src/module.rs
@@ -77,14 +77,14 @@ impl InternalEnum {
     }
 
     /// Register a new variant.
-    fn variant<C, A>(
+    fn variant<C, M>(
         &mut self,
         name: &'static str,
         type_check: TypeCheck,
         constructor: C,
     ) -> ItemMut<'_>
     where
-        C: Function<A, Plain>,
+        C: Function<M, Plain>,
     {
         let constructor: Arc<FunctionHandler> =
             Arc::new(move |stack, args| constructor.fn_call(stack, args));
@@ -335,9 +335,9 @@ where
     }
 
     /// Register a constructor method for the current variant.
-    pub fn constructor<F, A>(self, constructor: F) -> Result<Self, ContextError>
+    pub fn constructor<F, M>(self, constructor: F) -> Result<Self, ContextError>
     where
-        F: Function<A, Plain, Return = T>,
+        F: Function<M, Plain, Return = T>,
     {
         if self.constructor.is_some() {
             return Err(ContextError::VariantConstructorConflict {

--- a/crates/rune/src/module/function_meta.rs
+++ b/crates/rune/src/module/function_meta.rs
@@ -63,13 +63,13 @@ pub struct FunctionData {
 
 impl FunctionData {
     #[inline]
-    pub(crate) fn new<F, A, N, K>(name: N, f: F) -> Self
+    pub(crate) fn new<F, M, N, K>(name: N, f: F) -> Self
     where
-        F: Function<A, K>,
+        F: Function<M, K>,
         F::Return: MaybeTypeOf,
         N: IntoIterator,
         N::Item: IntoComponent,
-        A: FunctionArgs,
+        F::Arguments: FunctionArgs,
         K: FunctionKind,
     {
         Self {
@@ -82,7 +82,7 @@ impl FunctionData {
             #[cfg(feature = "doc")]
             return_type: F::Return::maybe_type_of(),
             #[cfg(feature = "doc")]
-            argument_types: A::into_box(),
+            argument_types: F::Arguments::into_box(),
         }
     }
 }
@@ -217,11 +217,11 @@ pub struct AssociatedFunctionData {
 
 impl AssociatedFunctionData {
     #[inline]
-    pub(crate) fn new<F, A, K>(name: AssociatedFunctionName, f: F) -> Self
+    pub(crate) fn new<F, M, K>(name: AssociatedFunctionName, f: F) -> Self
     where
-        F: InstanceFunction<A, K>,
+        F: InstanceFunction<M, K>,
         F::Return: MaybeTypeOf,
-        A: FunctionArgs,
+        F::Arguments: FunctionArgs,
         K: FunctionKind,
     {
         Self {
@@ -236,7 +236,7 @@ impl AssociatedFunctionData {
             #[cfg(feature = "doc")]
             return_type: F::Return::maybe_type_of(),
             #[cfg(feature = "doc")]
-            argument_types: A::into_box(),
+            argument_types: F::Arguments::into_box(),
         }
     }
 
@@ -266,11 +266,11 @@ pub enum FunctionMetaKind {
 impl FunctionMetaKind {
     #[doc(hidden)]
     #[inline]
-    pub fn function<N, F, A, K>(name: N, f: F) -> FunctionBuilder<N, F, A, K>
+    pub fn function<N, F, M, K>(name: N, f: F) -> FunctionBuilder<N, F, M, K>
     where
-        F: Function<A, K>,
+        F: Function<M, K>,
         F::Return: MaybeTypeOf,
-        A: FunctionArgs,
+        F::Arguments: FunctionArgs,
         K: FunctionKind,
     {
         FunctionBuilder {
@@ -282,12 +282,12 @@ impl FunctionMetaKind {
 
     #[doc(hidden)]
     #[inline]
-    pub fn instance<N, F, A, K>(name: N, f: F) -> Self
+    pub fn instance<N, F, M, K>(name: N, f: F) -> Self
     where
         N: ToInstance,
-        F: InstanceFunction<A, K>,
+        F: InstanceFunction<M, K>,
         F::Return: MaybeTypeOf,
-        A: FunctionArgs,
+        F::Arguments: FunctionArgs,
         K: FunctionKind,
     {
         Self::AssociatedFunction(AssociatedFunctionData::new(name.to_instance(), f))
@@ -295,17 +295,17 @@ impl FunctionMetaKind {
 }
 
 #[doc(hidden)]
-pub struct FunctionBuilder<N, F, A, K> {
+pub struct FunctionBuilder<N, F, M, K> {
     name: N,
     f: F,
-    _marker: PhantomData<(A, K)>,
+    _marker: PhantomData<(M, K)>,
 }
 
-impl<N, F, A, K> FunctionBuilder<N, F, A, K>
+impl<N, F, M, K> FunctionBuilder<N, F, M, K>
 where
-    F: Function<A, K>,
+    F: Function<M, K>,
     F::Return: MaybeTypeOf,
-    A: FunctionArgs,
+    F::Arguments: FunctionArgs,
     K: FunctionKind,
 {
     #[doc(hidden)]
@@ -337,7 +337,7 @@ where
             #[cfg(feature = "doc")]
             return_type: F::Return::maybe_type_of(),
             #[cfg(feature = "doc")]
-            argument_types: A::into_box(),
+            argument_types: F::Arguments::into_box(),
         })
     }
 }

--- a/crates/rune/src/module/function_raw_traits.rs
+++ b/crates/rune/src/module/function_raw_traits.rs
@@ -1,0 +1,158 @@
+use crate::runtime::{Stack, UnsafeFromValue, VmErrorKind, VmResult};
+
+pub type ArgumentPacket<F, M> = (
+    <F as RawFunction<M>>::RawArgumentFirst,
+    <F as RawFunction<M>>::RawArgumentSuffix,
+    <F as RawFunction<M>>::RawGuard,
+);
+
+pub trait RawFunction<Marker>: 'static + Send + Sync {
+    /// An object guarding the lifetime of the arguments.
+    #[doc(hidden)]
+    type RawGuard;
+
+    /// The first argument type.
+    #[doc(hidden)]
+    type RawArgumentFirst;
+
+    /// The argument types after the first.
+    #[doc(hidden)]
+    type RawArgumentSuffix;
+
+    /// A tuple representing the argument type.
+    #[doc(hidden)]
+    type RawArguments;
+
+    /// The raw return type of the function.
+    #[doc(hidden)]
+    type RawReturn;
+
+    /// Get the number of arguments.
+    #[doc(hidden)]
+    fn raw_args() -> usize;
+
+    /// Gets the argument packet.
+    /// Safety: The guard must live as long as the arguments are in use.
+    unsafe fn raw_get_args(
+        &self,
+        stack: &mut Stack,
+        args: usize,
+    ) -> VmResult<ArgumentPacket<Self, Marker>>;
+
+    /// Safety: We hold a reference to the stack, so we can
+    /// guarantee that it won't be modified.
+    ///
+    /// The scope is also necessary, since we mutably access `stack`
+    /// when we return below.
+    #[must_use]
+    #[doc(hidden)]
+    unsafe fn raw_call_packet(
+        &self,
+        packet: ArgumentPacket<Self, Marker>,
+    ) -> VmResult<(Self::RawReturn, Self::RawGuard)>;
+
+    /// This can be cleaned up once the arguments are no longer in use.
+    #[doc(hidden)]
+    unsafe fn raw_drop_guard(guard: Self::RawGuard);
+}
+
+#[doc(hidden)]
+pub struct NoFirstArg(());
+
+impl<U, T> RawFunction<fn() -> U> for T
+where
+    T: 'static + Send + Sync + Fn() -> U,
+{
+    type RawArgumentFirst = NoFirstArg;
+    type RawArgumentSuffix = ();
+    type RawArguments = ();
+    type RawReturn = U;
+    type RawGuard = ();
+    fn raw_args() -> usize {
+        0
+    }
+    unsafe fn raw_get_args(
+        &self,
+        _stack: &mut Stack,
+        args: usize,
+    ) -> VmResult<ArgumentPacket<T, fn() -> U>> {
+        vm_try!(check_args(0, args));
+        VmResult::Ok((NoFirstArg(()), (), ()))
+    }
+    unsafe fn raw_call_packet(
+        &self,
+        (_, _, guard): (
+            Self::RawArgumentFirst,
+            Self::RawArgumentSuffix,
+            Self::RawGuard,
+        ),
+    ) -> VmResult<(Self::RawReturn, Self::RawGuard)> {
+        VmResult::Ok((self(), guard))
+    }
+    unsafe fn raw_drop_guard(_guard: Self::RawGuard) {}
+}
+
+macro_rules! impl_register {
+  ($count:expr $(, $ty:ident $var:ident $num:expr)*) => {
+      impl<U, T, First, $($ty),*> RawFunction<fn(First, $($ty,)*) -> U> for T
+      where
+          T: 'static + Send + Sync + Fn(First, $($ty,)*) -> U,
+          First: UnsafeFromValue,
+          $($ty: UnsafeFromValue,)*
+      {
+          type RawArgumentFirst = First;
+          type RawArgumentSuffix = ($($ty,)*);
+          type RawArguments = (First, $($ty,)*);
+          type RawReturn = U;
+          type RawGuard = (First::Guard, $($ty::Guard,)*);
+          fn raw_args() -> usize {
+              $count + 1
+          }
+          unsafe fn raw_get_args(
+            &self,
+            stack: &mut Stack,
+            args: usize
+          ) -> VmResult<ArgumentPacket<T, fn(First, $($ty,)*) -> U>> {
+            vm_try!(check_args($count+1, args));
+            let [first $(, $var)*] = vm_try!(stack.drain_vec($count+1));
+
+            let first = vm_try!(First::from_value(first).with_error(|| VmErrorKind::BadArgument {
+                arg: 0,
+            }));
+
+            $(
+                let $var = vm_try!(<$ty>::from_value($var).with_error(|| VmErrorKind::BadArgument {
+                    arg: 1 + $num,
+                }));
+            )*
+
+            let guard = (first.1 $(, $var.1)*, );
+            let suffix = ( $(<$ty>::unsafe_coerce($var.0),)* );
+            let first = First::unsafe_coerce(first.0);
+
+            VmResult::Ok((first, suffix, guard))
+          }
+          unsafe fn raw_call_packet(
+              &self,
+              packet: ArgumentPacket<T, fn(First, $($ty,)*) -> U>,
+          ) -> VmResult<(Self::RawReturn, Self::RawGuard)> {
+              let (first, ($($var,)*), guard) = packet;
+              VmResult::Ok((self(first $(,$var)*), guard))
+          }
+          unsafe fn raw_drop_guard(guard: Self::RawGuard) {
+            let (inst, $($var,)*) = guard;
+              drop(inst);
+              $(drop(($var));)*
+          }
+      }
+  };
+}
+repeat_macro!(impl_register);
+
+fn check_args(expected: usize, actual: usize) -> VmResult<()> {
+    if actual == expected {
+        VmResult::Ok(())
+    } else {
+        VmResult::err(VmErrorKind::BadArgumentCount { actual, expected })
+    }
+}

--- a/crates/rune/src/module/function_traits.rs
+++ b/crates/rune/src/module/function_traits.rs
@@ -1,25 +1,17 @@
-use core::future::Future;
-
-use futures_util::never::Never;
+use futures_core::Future;
 
 use crate::{
-    runtime::{self, Stack, ToValue, TypeOf, UnsafeFromValue, VmErrorKind, VmResult},
-    Value,
+    runtime::{self, Stack, TypeOf, VmResult},
+    ToValue,
 };
+
+use super::function_raw_traits::RawFunction;
 
 /// Denotes the kind of a function, allowing the [`Function`] trait to be
 /// implemented separately for plain and async functions.
 pub trait FunctionKind {
     /// Indicates if the function is async.
     fn is_async() -> bool;
-}
-
-pub trait RawFunctionKind<Marker, F>: FunctionKind
-where
-    F: RawFunction<Marker>,
-{
-    type Return;
-    fn fn_call(ret: F::RawReturn, guard: F::Guard) -> VmResult<Value>;
 }
 
 /// Marker for plain functions.
@@ -30,20 +22,6 @@ impl FunctionKind for Plain {
     #[inline]
     fn is_async() -> bool {
         false
-    }
-}
-impl<Marker, F> RawFunctionKind<Marker, F> for Plain
-where
-    F: RawFunction<Marker>,
-    F::RawReturn: ToValue,
-{
-    type Return = F::RawReturn;
-    fn fn_call(ret: F::RawReturn, guard: F::Guard) -> VmResult<Value> {
-        // Safety: We no longer need the stack to not be modified.
-        unsafe {
-            <F as RawFunction<Marker>>::drop_guard(guard);
-        }
-        ret.to_value()
     }
 }
 
@@ -57,73 +35,21 @@ impl FunctionKind for Async {
         true
     }
 }
-impl<Marker, F> RawFunctionKind<Marker, F> for Async
-where
-    F: RawFunction<Marker>,
-    F::Guard: 'static,
-    F::RawReturn: 'static + Future,
-    <F::RawReturn as Future>::Output: ToValue,
-{
-    type Return = <F::RawReturn as Future>::Output;
-    fn fn_call(fut: F::RawReturn, guard: F::Guard) -> VmResult<Value> {
-        #[allow(unused)]
-        let ret = runtime::Future::new(async move {
-            let ret = fut.await;
-            // Safety: We no longer need the stack to not be modified at this point.
-            unsafe { <F as RawFunction<Marker>>::drop_guard(guard) };
-            let ret = vm_try!(ret.to_value());
-            VmResult::Ok(ret)
-        });
 
-        ret.to_value()
-    }
-}
-
-pub trait RawFunction<Marker>: 'static + Send + Sync {
-    /// An object guarding the lifetime of the arguments.
-    #[doc(hidden)]
-    type Guard;
-
-    /// A tuple representing the argument type.
-    #[doc(hidden)]
-    type FirstArg;
-
-    /// A tuple representing the argument type.
+/// Trait used to provide the [function][crate::module::Module::function]
+/// function.
+pub trait Function<Marker, K>: 'static + Send + Sync {
+    /// The arguments of the function.
     #[doc(hidden)]
     type Arguments;
 
-    /// The raw return type of the function.
+    /// The return type of the function.
     #[doc(hidden)]
-    type RawReturn;
+    type Return;
 
     /// Get the number of arguments.
     #[doc(hidden)]
     fn args() -> usize;
-
-    /// Safety: We hold a reference to the stack, so we can
-    /// guarantee that it won't be modified.
-    ///
-    /// The scope is also necessary, since we mutably access `stack`
-    /// when we return below.
-    #[must_use]
-    #[doc(hidden)]
-    unsafe fn fn_call_raw(
-        &self,
-        stack: &mut Stack,
-        args: usize,
-    ) -> VmResult<(Self::RawReturn, Self::Guard)>;
-
-    /// This can be cleaned up once the arguments are no longer in use.
-    #[doc(hidden)]
-    unsafe fn drop_guard(guard: Self::Guard);
-}
-
-/// Trait used to provide the [function][crate::module::Module::function]
-/// function.
-pub trait Function<Marker, K>: RawFunction<Marker> {
-    /// The return type of the function.
-    #[doc(hidden)]
-    type Return;
 
     /// Perform the vm call.
     #[doc(hidden)]
@@ -133,102 +59,45 @@ pub trait Function<Marker, K>: RawFunction<Marker> {
 /// Trait used to provide the [`associated_function`] function.
 ///
 /// [`associated_function`]: crate::module::Module::associated_function
-pub trait InstanceFunction<Marker, K>: RawFunction<Marker> {
-    /// The return type of the function.
+pub trait InstanceFunction<Marker, K>: 'static + Send + Sync {
+    /// The type of the instance.
     #[doc(hidden)]
     type Instance: TypeOf;
+
+    /// The arguments of the function.
+    #[doc(hidden)]
+    type Arguments;
 
     /// The return type of the function.
     #[doc(hidden)]
     type Return;
+
+    /// Get the number of arguments.
+    #[doc(hidden)]
+    fn args() -> usize;
 
     /// Perform the vm call.
     #[doc(hidden)]
     fn fn_call(&self, stack: &mut Stack, args: usize) -> VmResult<()>;
 }
 
-impl<U, T> RawFunction<fn() -> U> for T
-where
-    T: 'static + Send + Sync + Fn() -> U,
-{
-    type FirstArg = Never;
-    type Arguments = ();
-    type RawReturn = U;
-    type Guard = ();
-    fn args() -> usize {
-        0
-    }
-    unsafe fn fn_call_raw(&self, stack: &mut Stack, args: usize) -> VmResult<(U, Self::Guard)> {
-        vm_try!(check_args(0, args));
-        let [] = vm_try!(stack.drain_vec(0));
-        let that = self();
-        VmResult::Ok((that, ()))
-    }
-    unsafe fn drop_guard(_guard: Self::Guard) {}
-}
-
-macro_rules! impl_register {
-    ($count:expr $(, $ty:ident $var:ident $num:expr)*) => {
-        impl<U, T, First, $($ty),*> RawFunction<fn(First, $($ty,)*) -> U> for T
-        where
-            T: 'static + Send + Sync + Fn(First, $($ty,)*) -> U,
-            First: UnsafeFromValue,
-            $($ty: UnsafeFromValue,)*
-        {
-            type FirstArg = First;
-            type Arguments = (First, $($ty,)*);
-            type RawReturn = U;
-            type Guard = (First::Guard, $($ty::Guard,)*);
-            fn args() -> usize {
-                $count + 1
-            }
-            unsafe fn fn_call_raw(&self, stack: &mut Stack, args: usize) -> VmResult<(U, Self::Guard)> {
-                vm_try!(check_args($count+1, args));
-                let [first $(, $var)*] = vm_try!(stack.drain_vec($count+1));
-
-                let first = vm_try!(First::from_value(first).with_error(|| VmErrorKind::BadArgument {
-                    arg: 0,
-                }));
-
-                $(
-                    let $var = vm_try!(<$ty>::from_value($var).with_error(|| VmErrorKind::BadArgument {
-                        arg: 1 + $num,
-                    }));
-                )*
-
-                let that = self(First::unsafe_coerce(first.0), $(<$ty>::unsafe_coerce($var.0),)*);
-                VmResult::Ok((that, (first.1, $($var.1,)*)))
-            }
-            unsafe fn drop_guard(guard: Self::Guard) {
-                let (inst, $($var,)*) = guard;
-                drop(inst);
-                $(drop(($var));)*
-            }
-        }
-    };
-}
-
-fn check_args(expected: usize, actual: usize) -> VmResult<()> {
-    if actual == expected {
-        VmResult::Ok(())
-    } else {
-        VmResult::err(VmErrorKind::BadArgumentCount { actual, expected })
-    }
-}
-
 impl<T, Marker> Function<Marker, Plain> for T
 where
     T: RawFunction<Marker>,
-    Plain: RawFunctionKind<Marker, T>,
+    <T as RawFunction<Marker>>::RawReturn: ToValue,
 {
-    type Return = <Plain as RawFunctionKind<Marker, T>>::Return;
+    type Arguments = T::RawArguments;
+    type Return = <T as RawFunction<Marker>>::RawReturn;
+
+    fn args() -> usize {
+        <T as RawFunction<Marker>>::raw_args()
+    }
 
     fn fn_call(&self, stack: &mut Stack, args: usize) -> VmResult<()> {
-        let (ret, guard) =
-            vm_try!(unsafe { <T as RawFunction<Marker>>::fn_call_raw(self, stack, args) });
-
-        let ret = vm_try!(Plain::fn_call(ret, guard));
-
+        let packet = vm_try!(unsafe { T::raw_get_args(self, stack, args) });
+        let (ret, guard) = vm_try!(unsafe { T::raw_call_packet(self, packet) });
+        unsafe { T::raw_drop_guard(guard) };
+        let ret = vm_try!(ret.to_value());
         stack.push(ret);
         VmResult::Ok(())
     }
@@ -237,16 +106,31 @@ where
 impl<'a, T, Marker> Function<Marker, Async> for T
 where
     T: RawFunction<Marker>,
-    Async: RawFunctionKind<Marker, T>,
+    <T as RawFunction<Marker>>::RawGuard: 'static,
+    <T as RawFunction<Marker>>::RawReturn: 'static + Future,
+    <<T as RawFunction<Marker>>::RawReturn as Future>::Output: ToValue,
 {
-    type Return = <Async as RawFunctionKind<Marker, T>>::Return;
+    type Arguments = T::RawArguments;
+    type Return = <<T as RawFunction<Marker>>::RawReturn as Future>::Output;
+
+    fn args() -> usize {
+        <T as RawFunction<Marker>>::raw_args()
+    }
 
     fn fn_call(&self, stack: &mut Stack, args: usize) -> VmResult<()> {
-        let (ret, guard) =
-            vm_try!(unsafe { <T as RawFunction<Marker>>::fn_call_raw(self, stack, args) });
+        let packet = vm_try!(unsafe { T::raw_get_args(self, stack, args) });
+        let (fut, guard) = vm_try!(unsafe { T::raw_call_packet(self, packet) });
 
-        let ret = vm_try!(Async::fn_call(ret, guard));
+        #[allow(unused)]
+        let ret = runtime::Future::new(async move {
+            let ret = fut.await;
+            // Safety: We no longer need the stack to not be modified at this point.
+            unsafe { <T as RawFunction<Marker>>::raw_drop_guard(guard) };
+            let ret = vm_try!(ret.to_value());
+            VmResult::Ok(ret)
+        });
 
+        let ret = vm_try!(ret.to_value());
         stack.push(ret);
         VmResult::Ok(())
     }
@@ -254,22 +138,18 @@ where
 
 impl<'a, T, K, Marker> InstanceFunction<Marker, K> for T
 where
-    K: RawFunctionKind<Marker, T>,
-    T: Function<Marker, K>,
-    <T as RawFunction<Marker>>::FirstArg: TypeOf,
+    T: RawFunction<Marker> + Function<Marker, K>,
+    <T as RawFunction<Marker>>::RawArgumentFirst: TypeOf,
 {
-    type Instance = <T as RawFunction<Marker>>::FirstArg;
-    type Return = <K as RawFunctionKind<Marker, T>>::Return;
+    type Instance = <T as RawFunction<Marker>>::RawArgumentFirst;
+    type Arguments = T::Arguments;
+    type Return = <T as Function<Marker, K>>::Return;
+
+    fn args() -> usize {
+        <T as Function<Marker, K>>::args()
+    }
 
     fn fn_call(&self, stack: &mut Stack, args: usize) -> VmResult<()> {
-        let (ret, guard) =
-            vm_try!(unsafe { <T as RawFunction<Marker>>::fn_call_raw(self, stack, args) });
-
-        let ret = vm_try!(K::fn_call(ret, guard));
-
-        stack.push(ret);
-        VmResult::Ok(())
+        <T as Function<Marker, K>>::fn_call(&self, stack, args)
     }
 }
-
-repeat_macro!(impl_register);

--- a/crates/rune/src/module/module.rs
+++ b/crates/rune/src/module/module.rs
@@ -302,13 +302,13 @@ impl Module {
 
     /// Register a variant constructor for type `T`.
     #[deprecated = "Use variant_meta() instead"]
-    pub fn variant_constructor<F, A>(
+    pub fn variant_constructor<F, M>(
         &mut self,
         index: usize,
         constructor: F,
     ) -> Result<(), ContextError>
     where
-        F: Function<A, Plain>,
+        F: Function<M, Plain>,
         F::Return: Named + TypeOf,
     {
         self.variant_meta::<F::Return>(index)?
@@ -843,13 +843,13 @@ impl Module {
     ///     .docs(["Download a random quote from the internet."]);
     /// # Ok::<_, rune::Error>(())
     /// ```
-    pub fn function<F, A, N, K>(&mut self, name: N, f: F) -> Result<ItemMut<'_>, ContextError>
+    pub fn function<F, M, N, K>(&mut self, name: N, f: F) -> Result<ItemMut<'_>, ContextError>
     where
-        F: Function<A, K>,
+        F: Function<M, K>,
         F::Return: MaybeTypeOf,
         N: IntoIterator,
         N::Item: IntoComponent,
-        A: FunctionArgs,
+        F::Arguments: FunctionArgs,
         K: FunctionKind,
     {
         self.function_inner(FunctionData::new(name, f), Docs::EMPTY)
@@ -857,13 +857,13 @@ impl Module {
 
     /// See [`Module::function`].
     #[deprecated = "Use Module::function() instead"]
-    pub fn async_function<F, A, N>(&mut self, name: N, f: F) -> Result<ItemMut<'_>, ContextError>
+    pub fn async_function<F, M, N>(&mut self, name: N, f: F) -> Result<ItemMut<'_>, ContextError>
     where
-        F: Function<A, Async>,
+        F: Function<M, Async>,
         F::Return: MaybeTypeOf,
         N: IntoIterator,
         N::Item: IntoComponent,
-        A: FunctionArgs,
+        F::Arguments: FunctionArgs,
     {
         self.function_inner(FunctionData::new(name, f), Docs::EMPTY)
     }
@@ -942,16 +942,16 @@ impl Module {
     ///     .docs(["Download a thing."]);
     /// # Ok::<_, rune::Error>(())
     /// ```
-    pub fn associated_function<N, F, A, K>(
+    pub fn associated_function<N, F, M, K>(
         &mut self,
         name: N,
         f: F,
     ) -> Result<ItemMut<'_>, ContextError>
     where
         N: ToInstance,
-        F: InstanceFunction<A, K>,
+        F: InstanceFunction<M, K>,
         F::Return: MaybeTypeOf,
-        A: FunctionArgs,
+        F::Arguments: FunctionArgs,
         K: FunctionKind,
     {
         self.assoc_fn(
@@ -963,12 +963,12 @@ impl Module {
     /// See [`Module::associated_function`].
     #[deprecated = "Use Module::associated_function() instead"]
     #[inline]
-    pub fn inst_fn<N, F, A, K>(&mut self, name: N, f: F) -> Result<ItemMut<'_>, ContextError>
+    pub fn inst_fn<N, F, M, K>(&mut self, name: N, f: F) -> Result<ItemMut<'_>, ContextError>
     where
         N: ToInstance,
-        F: InstanceFunction<A, K>,
+        F: InstanceFunction<M, K>,
         F::Return: MaybeTypeOf,
-        A: FunctionArgs,
+        F::Arguments: FunctionArgs,
         K: FunctionKind,
     {
         self.associated_function(name, f)
@@ -976,12 +976,12 @@ impl Module {
 
     /// See [`Module::associated_function`].
     #[deprecated = "Use Module::associated_function() instead"]
-    pub fn async_inst_fn<N, F, A>(&mut self, name: N, f: F) -> Result<ItemMut<'_>, ContextError>
+    pub fn async_inst_fn<N, F, M>(&mut self, name: N, f: F) -> Result<ItemMut<'_>, ContextError>
     where
         N: ToInstance,
-        F: InstanceFunction<A, Async>,
+        F: InstanceFunction<M, Async>,
         F::Return: MaybeTypeOf,
-        A: FunctionArgs,
+        F::Arguments: FunctionArgs,
     {
         self.associated_function(name, f)
     }
@@ -990,7 +990,7 @@ impl Module {
     ///
     /// This returns a [`ItemMut`], which is a handle that can be used to
     /// associate more metadata with the inserted item.
-    pub fn field_function<N, F, A>(
+    pub fn field_function<N, F, M>(
         &mut self,
         protocol: Protocol,
         name: N,
@@ -998,9 +998,9 @@ impl Module {
     ) -> Result<ItemMut<'_>, ContextError>
     where
         N: ToFieldFunction,
-        F: InstanceFunction<A, Plain>,
+        F: InstanceFunction<M, Plain>,
         F::Return: MaybeTypeOf,
-        A: FunctionArgs,
+        F::Arguments: FunctionArgs,
     {
         self.assoc_fn(
             AssociatedFunctionData::new(name.to_field_function(protocol), f),
@@ -1011,7 +1011,7 @@ impl Module {
     /// See [`Module::field_function`].
     #[deprecated = "Use Module::field_function() instead"]
     #[inline]
-    pub fn field_fn<N, F, A>(
+    pub fn field_fn<N, F, M>(
         &mut self,
         protocol: Protocol,
         name: N,
@@ -1019,9 +1019,9 @@ impl Module {
     ) -> Result<ItemMut<'_>, ContextError>
     where
         N: ToFieldFunction,
-        F: InstanceFunction<A, Plain>,
+        F: InstanceFunction<M, Plain>,
         F::Return: MaybeTypeOf,
-        A: FunctionArgs,
+        F::Arguments: FunctionArgs,
     {
         self.field_function(protocol, name, f)
     }
@@ -1030,16 +1030,16 @@ impl Module {
     ///
     /// An index can either be a field inside a tuple, or a variant inside of an
     /// enum as configured with [Module::enum_meta].
-    pub fn index_function<F, A>(
+    pub fn index_function<F, M>(
         &mut self,
         protocol: Protocol,
         index: usize,
         f: F,
     ) -> Result<ItemMut<'_>, ContextError>
     where
-        F: InstanceFunction<A, Plain>,
+        F: InstanceFunction<M, Plain>,
         F::Return: MaybeTypeOf,
-        A: FunctionArgs,
+        F::Arguments: FunctionArgs,
     {
         let name = AssociatedFunctionName::index(protocol, index);
         self.assoc_fn(AssociatedFunctionData::new(name, f), Docs::EMPTY)
@@ -1048,16 +1048,16 @@ impl Module {
     /// See [`Module::index_function`].
     #[deprecated = "Use Module::index_function() instead"]
     #[inline]
-    pub fn index_fn<F, A>(
+    pub fn index_fn<F, M>(
         &mut self,
         protocol: Protocol,
         index: usize,
         f: F,
     ) -> Result<ItemMut<'_>, ContextError>
     where
-        F: InstanceFunction<A, Plain>,
+        F: InstanceFunction<M, Plain>,
         F::Return: MaybeTypeOf,
-        A: FunctionArgs,
+        F::Arguments: FunctionArgs,
     {
         self.index_function(protocol, index, f)
     }


### PR DESCRIPTION
@udoprog Hey, I'm just experimenting with making `[Instance]Function` conformance more generic. This PR is still WIP, but I wanted to give you a heads up. The idea is that `[Instance]Function` conformance can be done somewhat like this (no macros):

```rust
impl<'a, T, Marker> Function<Marker, Plain> for T
where
    T: FunctionPrefix<Marker>,
    <T as FunctionPrefix<Marker>>::RawReturn: ToValue,
{
    type Return = <T as FunctionPrefix<Marker>>::RawReturn;

    fn fn_call(&self, stack: &mut Stack, args: usize) -> VmResult<()> {
        let (ret, guard) =
            vm_try!(unsafe { <T as FunctionPrefix<Marker>>::fn_call_raw(self, stack, args) });

        unsafe {
            <T as FunctionPrefix<Marker>>::drop_guard(guard);
        }

        let ret = vm_try!(ret.to_value());
        stack.push(ret);
        VmResult::Ok(())
    }
}
```

The PR does that currently, and passes all tests, but I want to verify the next bit is possible before committing to the changes.

Please ignore any naming, it's all placeholder.

The end goal of this is that it's easier to make things conform to the various function traits, and we can easily add different convenience markers like `Async`/`Plain`.

I'm aiming to make it easier to work with the `newtype` pattern (or more complicated wrappers) when creating bindings. I think by creating a trait or two for those wrappers it should be possible to write the `associated_function` against the wrapped type (`T`) instead of the wrapper `Wrapper<T>`, and be agnostic of how the wrapper is structured.

See crates/rune/src/module/function_traits.rs for the main changes.