### PR TITLE
Tuple and VecTuple incorrectly takes their values

### DIFF
--- a/crates/rune/src/runtime/tuple.rs
+++ b/crates/rune/src/runtime/tuple.rs
@@ -201,7 +201,7 @@ macro_rules! impl_tuple {
             $($ty: FromValue,)*
         {
             fn from_value(value: Value) -> VmResult<Self> {
-                let tuple = vm_try!(vm_try!(value.into_tuple()).take());
+                let tuple = vm_try!(vm_try!(value.into_tuple()).borrow_mut()).clone();
 
                 if tuple.len() != $count {
                     return VmResult::err(VmErrorKind::ExpectedTupleLength {

--- a/crates/rune/src/runtime/vec.rs
+++ b/crates/rune/src/runtime/vec.rs
@@ -183,6 +183,11 @@ impl Vec {
 
         VmResult::Ok(true)
     }
+
+    /// Access the inner values as a slice.
+    pub(crate) fn as_slice(&self) -> &[Value] {
+        &self.inner
+    }
 }
 
 impl Named for Vec {

--- a/crates/rune/src/runtime/vm_error.rs
+++ b/crates/rune/src/runtime/vm_error.rs
@@ -523,8 +523,6 @@ pub(crate) enum VmErrorKind {
     },
     #[error("Expected a tuple of length `{expected}`, but found one with length `{actual}`")]
     ExpectedTupleLength { actual: usize, expected: usize },
-    #[error("Unexpectedly ran out of items to iterate over")]
-    IterationError,
     #[error("Type `{actual}` can't be converted to a constant value")]
     ConstNotSupported { actual: TypeInfo },
     #[error("Type `{actual}` can't be converted to a hash key")]

--- a/crates/rune/src/tests.rs
+++ b/crates/rune/src/tests.rs
@@ -392,6 +392,7 @@ mod range;
 mod reference_error;
 mod result;
 mod stmt_reordering;
+mod tuple;
 mod type_name_native;
 mod type_name_rune;
 mod unit_constants;

--- a/crates/rune/src/tests/tuple.rs
+++ b/crates/rune/src/tests/tuple.rs
@@ -1,0 +1,46 @@
+prelude!();
+
+fn make_module() -> Result<Module, ContextError> {
+    let mut module = Module::new();
+    module.function(["receive_tuple"], |(_, _): (Value, Value)| ())?;
+    module.function(
+        ["receive_vec_tuple"],
+        |VecTuple((_, _)): VecTuple<(Value, Value)>| (),
+    )?;
+    Ok(module)
+}
+
+/// This ensures that as values are being unpacked from a tuple, that neither it
+/// nor its arguments are taken over by the receiving function.
+#[test]
+fn test_tuple_ownership() {
+    let m = make_module().expect("failed to make module");
+
+    rune_n! {
+        &m,
+        (),
+        () => pub fn main() {
+            let a = [];
+            let b = [];
+            let tuple = (a, b);
+            receive_tuple(tuple);
+            assert!(is_readable(tuple));
+            assert!(is_readable(a));
+            assert!(is_readable(b));
+        }
+    };
+
+    rune_n! {
+        &m,
+        (),
+        () => pub fn main() {
+            let a = [];
+            let b = [];
+            let vec = [a, b];
+            receive_vec_tuple(vec);
+            assert!(is_readable(vec));
+            assert!(is_readable(a));
+            assert!(is_readable(b));
+        }
+    };
+}


### PR DESCRIPTION
This fixes a bug where converting a value to a Rust tuple will incorrectly take ownership of it.