### PR TITLE
implement Parse for TokenStream

### DIFF
--- a/crates/rune/src/ast/token.rs
+++ b/crates/rune/src/ast/token.rs
@@ -3,8 +3,9 @@ use core::fmt;
 use core::ops::Neg;
 
 use crate::ast::{Kind, Span, Spanned};
+use crate::compile;
 use crate::macros::{MacroContext, SyntheticId, ToTokens, TokenStream};
-use crate::parse::{Expectation, IntoExpectation};
+use crate::parse::{Expectation, IntoExpectation, Parse, Parser, Peek};
 use crate::SourceId;
 
 /// A single token encountered during parsing.
@@ -145,6 +146,18 @@ impl Token {
         fn bytes_escape_default(bytes: &[u8]) -> impl Iterator<Item = u8> + '_ {
             bytes.iter().copied().flat_map(ascii::escape_default)
         }
+    }
+}
+
+impl Parse for Token {
+    fn parse(p: &mut Parser) -> compile::Result<Self> {
+        p.next()
+    }
+}
+
+impl Peek for Token {
+    fn peek(p: &mut super::prelude::Peeker<'_>) -> bool {
+        !p.is_eof()
     }
 }
 

--- a/crates/rune/src/macros/token_stream.rs
+++ b/crates/rune/src/macros/token_stream.rs
@@ -1,12 +1,14 @@
 use core::fmt;
 use core::slice;
 
+use crate::compile;
 use crate::no_std::prelude::*;
 use crate::no_std::vec;
 
 use crate::ast;
 use crate::ast::{OptionSpanned, Span};
 use crate::macros::MacroContext;
+use crate::parse::{Parse, Parser};
 
 /// A token stream.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -52,6 +54,12 @@ impl TokenStream {
 impl From<Vec<ast::Token>> for TokenStream {
     fn from(stream: Vec<ast::Token>) -> Self {
         Self { stream }
+    }
+}
+
+impl Parse for TokenStream {
+    fn parse(p: &mut Parser) -> compile::Result<Self> {
+        Ok(Self { stream: p.parse()? })
     }
 }
 


### PR DESCRIPTION
This matches rust and allows easy capturing of remaining tokens to e.g.
forward them.
