### PR TITLE
Update license field following SPDX 2.1 license expression standard

### DIFF
--- a/crates/rune-cli/Cargo.toml
+++ b/crates/rune-cli/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/rune"
 readme = "README.md"
 homepage = "https://github.com/rune-rs/rune"
 repository = "https://github.com/rune-rs/rune"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 keywords = ["language", "scripting", "scripting-language"]
 categories = ["parser-implementations"]
 

--- a/crates/rune-core/Cargo.toml
+++ b/crates/rune-core/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/rune"
 readme = "README.md"
 homepage = "https://github.com/rune-rs/rune"
 repository = "https://github.com/rune-rs/rune"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 keywords = ["language", "scripting", "scripting-language"]
 categories = ["parser-implementations"]
 

--- a/crates/rune-languageserver/Cargo.toml
+++ b/crates/rune-languageserver/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/rune"
 readme = "README.md"
 homepage = "https://github.com/rune-rs/rune"
 repository = "https://github.com/rune-rs/rune"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 keywords = ["language", "scripting", "scripting-language"]
 categories = ["parser-implementations"]
 

--- a/crates/rune-macros/Cargo.toml
+++ b/crates/rune-macros/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/rune"
 readme = "README.md"
 homepage = "https://github.com/rune-rs/rune"
 repository = "https://github.com/rune-rs/rune"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 keywords = ["language", "scripting", "scripting-language"]
 categories = ["parser-implementations"]
 

--- a/crates/rune-modules/Cargo.toml
+++ b/crates/rune-modules/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/rune"
 readme = "README.md"
 homepage = "https://github.com/rune-rs/rune"
 repository = "https://github.com/rune-rs/rune"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 keywords = ["language", "scripting", "scripting-language"]
 categories = ["parser-implementations"]
 

--- a/crates/rune-wasm/Cargo.toml
+++ b/crates/rune-wasm/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/rune"
 readme = "README.md"
 homepage = "https://github.com/rune-rs/rune"
 repository = "https://github.com/rune-rs/rune"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 keywords = ["language", "scripting", "scripting-language"]
 categories = ["parser-implementations"]
 

--- a/crates/rune/Cargo.toml
+++ b/crates/rune/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/rune"
 readme = "README.md"
 homepage = "https://github.com/rune-rs/rune"
 repository = "https://github.com/rune-rs/rune"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 keywords = ["language", "scripting", "scripting-language"]
 categories = ["parser-implementations"]
 


### PR DESCRIPTION
The new recommendation is to follow the SPDX 2.1 standard. This allows automatic license verification software to work properly. Reference: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields