### PR TITLE
Less unsafe from value

### DIFF
--- a/crates/rune-macros/src/any.rs
+++ b/crates/rune-macros/src/any.rs
@@ -579,7 +579,7 @@ where
             type Guard = #raw_into_ref;
 
             #[inline]
-            fn from_value(value: #value) -> #vm_result<(Self::Output, Self::Guard)> {
+            fn unsafe_from_value(value: #value) -> #vm_result<(Self::Output, Self::Guard)> {
                 value.into_any_ptr()
             }
 
@@ -593,7 +593,7 @@ where
             type Output = *mut #ident  #type_generics;
             type Guard = #raw_into_mut;
 
-            fn from_value(value: #value) -> #vm_result<(Self::Output, Self::Guard)> {
+            fn unsafe_from_value(value: #value) -> #vm_result<(Self::Output, Self::Guard)> {
                 value.into_any_mut()
             }
 

--- a/crates/rune/src/module/function_traits.rs
+++ b/crates/rune/src/module/function_traits.rs
@@ -17,7 +17,7 @@ macro_rules! check_args {
 macro_rules! unsafe_vars {
     ($count:expr, $($ty:ty, $var:ident, $num:expr,)*) => {
         $(
-            let $var = vm_try!(<$ty>::from_value($var).with_error(|| VmErrorKind::BadArgument {
+            let $var = vm_try!(<$ty>::unsafe_from_value($var).with_error(|| VmErrorKind::BadArgument {
                 arg: $num,
             }));
         )*
@@ -34,12 +34,12 @@ macro_rules! drop_stack_guards {
 // Expand to instance variable bindings.
 macro_rules! unsafe_inst_vars {
     ($inst:ident, $count:expr, $($ty:ty, $var:ident, $num:expr,)*) => {
-        let $inst = vm_try!(Instance::from_value($inst).with_error(|| VmErrorKind::BadArgument {
+        let $inst = vm_try!(Instance::unsafe_from_value($inst).with_error(|| VmErrorKind::BadArgument {
             arg: 0,
         }));
 
         $(
-            let $var = vm_try!(<$ty>::from_value($var).with_error(|| VmErrorKind::BadArgument {
+            let $var = vm_try!(<$ty>::unsafe_from_value($var).with_error(|| VmErrorKind::BadArgument {
                 arg: 1 + $num,
             }));
         )*

--- a/crates/rune/src/runtime/bytes.rs
+++ b/crates/rune/src/runtime/bytes.rs
@@ -12,9 +12,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::compile::Named;
 use crate::module::InstallWith;
-use crate::runtime::{
-    FromValue, Mut, RawMut, RawRef, RawStr, Ref, UnsafeFromValue, Value, VmResult,
-};
+use crate::runtime::{RawRef, RawStr, Ref, UnsafeFromValue, Value, VmResult};
 
 /// A vector of bytes.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
@@ -266,49 +264,13 @@ impl AsRef<[u8]> for Bytes {
     }
 }
 
-impl FromValue for Bytes {
-    fn from_value(value: Value) -> VmResult<Self> {
-        let bytes = vm_try!(value.into_bytes());
-        let bytes = vm_try!(bytes.borrow_ref());
-        VmResult::Ok(bytes.clone())
-    }
-}
-
-impl<'a> UnsafeFromValue for &'a Bytes {
-    type Output = *const Bytes;
-    type Guard = RawRef;
-
-    fn from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
-        let bytes = vm_try!(value.into_bytes());
-        let bytes = vm_try!(bytes.into_ref());
-        VmResult::Ok(Ref::into_raw(bytes))
-    }
-
-    unsafe fn unsafe_coerce(output: Self::Output) -> Self {
-        &*output
-    }
-}
-
-impl<'a> UnsafeFromValue for &'a mut Bytes {
-    type Output = *mut Bytes;
-    type Guard = RawMut;
-
-    fn from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
-        let bytes = vm_try!(value.into_bytes());
-        let bytes = vm_try!(bytes.into_mut());
-        VmResult::Ok(Mut::into_raw(bytes))
-    }
-
-    unsafe fn unsafe_coerce(output: Self::Output) -> Self {
-        &mut *output
-    }
-}
+from_value!(Bytes, into_bytes);
 
 impl<'a> UnsafeFromValue for &'a [u8] {
     type Output = *const [u8];
     type Guard = RawRef;
 
-    fn from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
+    fn unsafe_from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
         let bytes = vm_try!(value.into_bytes());
         let bytes = vm_try!(bytes.into_ref());
         let (value, guard) = Ref::into_raw(bytes);

--- a/crates/rune/src/runtime/from_value.rs
+++ b/crates/rune/src/runtime/from_value.rs
@@ -137,7 +137,7 @@ pub trait UnsafeFromValue: Sized {
     ///
     /// You must also make sure that the returned value does not outlive the
     /// guard.
-    fn from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)>;
+    fn unsafe_from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)>;
 
     /// Coerce the output of an unsafe from value into the final output type.
     ///
@@ -191,7 +191,7 @@ where
     type Output = T;
     type Guard = ();
 
-    fn from_value(value: Value) -> VmResult<(Self, Self::Guard)> {
+    fn unsafe_from_value(value: Value) -> VmResult<(Self, Self::Guard)> {
         VmResult::Ok((vm_try!(T::from_value(value)), ()))
     }
 
@@ -227,7 +227,7 @@ impl UnsafeFromValue for &Option<Value> {
     type Output = *const Option<Value>;
     type Guard = RawRef;
 
-    fn from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
+    fn unsafe_from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
         let option = vm_try!(value.into_option());
         let option = vm_try!(option.into_ref());
         VmResult::Ok(Ref::into_raw(option))
@@ -242,7 +242,7 @@ impl UnsafeFromValue for &mut Option<Value> {
     type Output = *mut Option<Value>;
     type Guard = RawMut;
 
-    fn from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
+    fn unsafe_from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
         let option = vm_try!(value.into_option());
         let option = vm_try!(option.into_mut());
         VmResult::Ok(Mut::into_raw(option))
@@ -303,7 +303,7 @@ impl UnsafeFromValue for &str {
     type Output = *const str;
     type Guard = StrGuard;
 
-    fn from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
+    fn unsafe_from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
         VmResult::Ok(match value {
             Value::String(string) => {
                 let string = vm_try!(string.into_ref());
@@ -330,7 +330,7 @@ impl UnsafeFromValue for &mut str {
     type Output = *mut str;
     type Guard = Option<RawMut>;
 
-    fn from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
+    fn unsafe_from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
         match value {
             Value::String(string) => {
                 let string = vm_try!(string.into_mut());
@@ -352,7 +352,7 @@ impl UnsafeFromValue for &String {
     type Output = *const String;
     type Guard = StrGuard;
 
-    fn from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
+    fn unsafe_from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
         VmResult::Ok(match value {
             Value::String(string) => {
                 let string = vm_try!(string.into_ref());
@@ -375,7 +375,7 @@ impl UnsafeFromValue for &mut String {
     type Output = *mut String;
     type Guard = RawMut;
 
-    fn from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
+    fn unsafe_from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
         VmResult::Ok(match value {
             Value::String(string) => {
                 let string = vm_try!(string.into_mut());
@@ -410,7 +410,7 @@ impl UnsafeFromValue for &Result<Value, Value> {
     type Output = *const Result<Value, Value>;
     type Guard = RawRef;
 
-    fn from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
+    fn unsafe_from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
         let result = vm_try!(value.into_result());
         let result = vm_try!(result.into_ref());
         VmResult::Ok(Ref::into_raw(result))
@@ -425,7 +425,7 @@ impl UnsafeFromValue for &mut Result<Value, Value> {
     type Output = *mut Result<Value, Value>;
     type Guard = RawMut;
 
-    fn from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
+    fn unsafe_from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
         let result = vm_try!(value.into_result());
         let result = vm_try!(result.into_mut());
         VmResult::Ok(Mut::into_raw(result))

--- a/crates/rune/src/runtime/function.rs
+++ b/crates/rune/src/runtime/function.rs
@@ -7,9 +7,8 @@ use crate::no_std::sync::Arc;
 use crate::compile::Named;
 use crate::module::{self, InstallWith};
 use crate::runtime::{
-    Args, Call, ConstValue, FromValue, FunctionHandler, RawRef, RawStr, Ref, Rtti, RuntimeContext,
-    Shared, Stack, Tuple, Unit, UnsafeFromValue, Value, VariantRtti, Vm, VmCall, VmErrorKind,
-    VmHalt, VmResult,
+    Args, Call, ConstValue, FromValue, FunctionHandler, RawStr, Rtti, RuntimeContext, Stack, Tuple,
+    Unit, Value, VariantRtti, Vm, VmCall, VmErrorKind, VmHalt, VmResult,
 };
 use crate::shared::AssertSend;
 use crate::Hash;
@@ -906,43 +905,7 @@ impl Named for Function {
     const BASE_NAME: RawStr = RawStr::from_str("Function");
 }
 
-impl FromValue for Function {
-    fn from_value(value: Value) -> VmResult<Self> {
-        let function = vm_try!(value.into_function());
-        let function = vm_try!(function.take());
-        VmResult::Ok(function)
-    }
-}
-
-impl FromValue for Shared<Function> {
-    #[inline]
-    fn from_value(value: Value) -> VmResult<Self> {
-        value.into_function()
-    }
-}
-
-impl FromValue for Ref<Function> {
-    fn from_value(value: Value) -> VmResult<Self> {
-        let function = vm_try!(value.into_function());
-        let function = vm_try!(function.into_ref());
-        VmResult::Ok(function)
-    }
-}
-
-impl UnsafeFromValue for &Function {
-    type Output = *const Function;
-    type Guard = RawRef;
-
-    fn from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
-        let function = vm_try!(value.into_function());
-        let (function, guard) = Ref::into_raw(vm_try!(function.into_ref()));
-        VmResult::Ok((function, guard))
-    }
-
-    unsafe fn unsafe_coerce(output: Self::Output) -> Self {
-        &*output
-    }
-}
+from_value!(Function, into_function);
 
 fn check_args(actual: usize, expected: usize) -> VmResult<()> {
     if actual != expected {

--- a/crates/rune/src/runtime/future.rs
+++ b/crates/rune/src/runtime/future.rs
@@ -7,10 +7,7 @@ use crate::no_std::prelude::*;
 
 use crate::compile::Named;
 use crate::module::InstallWith;
-use crate::runtime::{
-    FromValue, Mut, RawMut, RawRef, RawStr, Ref, Shared, ToValue, UnsafeFromValue, Value,
-    VmErrorKind, VmResult,
-};
+use crate::runtime::{RawStr, ToValue, Value, VmErrorKind, VmResult};
 
 use pin_project::pin_project;
 
@@ -113,49 +110,7 @@ where
     }
 }
 
-impl FromValue for Shared<Future> {
-    #[inline]
-    fn from_value(value: Value) -> VmResult<Self> {
-        value.into_shared_future()
-    }
-}
-
-impl FromValue for Future {
-    #[inline]
-    fn from_value(value: Value) -> VmResult<Self> {
-        value.into_future()
-    }
-}
-
-impl UnsafeFromValue for &Future {
-    type Output = *const Future;
-    type Guard = RawRef;
-
-    fn from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
-        let future = vm_try!(value.into_shared_future());
-        let (future, guard) = Ref::into_raw(vm_try!(future.into_ref()));
-        VmResult::Ok((future, guard))
-    }
-
-    unsafe fn unsafe_coerce(output: Self::Output) -> Self {
-        &*output
-    }
-}
-
-impl UnsafeFromValue for &mut Future {
-    type Output = *mut Future;
-    type Guard = RawMut;
-
-    fn from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
-        let future = vm_try!(value.into_shared_future());
-        let future = vm_try!(future.into_mut());
-        VmResult::Ok(Mut::into_raw(future))
-    }
-
-    unsafe fn unsafe_coerce(output: Self::Output) -> Self {
-        &mut *output
-    }
-}
+from_value!(Future, into_future);
 
 impl Named for Future {
     const BASE_NAME: RawStr = RawStr::from_str("Future");

--- a/crates/rune/src/runtime/generator.rs
+++ b/crates/rune/src/runtime/generator.rs
@@ -4,8 +4,7 @@ use core::iter;
 use crate::compile::Named;
 use crate::module::InstallWith;
 use crate::runtime::{
-    FromValue, GeneratorState, Iterator, Mut, RawMut, RawRef, RawStr, Ref, Shared, UnsafeFromValue,
-    Value, Vm, VmErrorKind, VmExecution, VmResult,
+    GeneratorState, Iterator, RawStr, Value, Vm, VmErrorKind, VmExecution, VmResult,
 };
 
 /// A generator with a stored virtual machine.
@@ -127,47 +126,4 @@ where
 
 impl<T> InstallWith for Generator<T> where T: AsMut<Vm> {}
 
-impl FromValue for Shared<Generator<Vm>> {
-    #[inline]
-    fn from_value(value: Value) -> VmResult<Self> {
-        value.into_generator()
-    }
-}
-
-impl FromValue for Generator<Vm> {
-    fn from_value(value: Value) -> VmResult<Self> {
-        let generator = vm_try!(value.into_generator());
-        let generator = vm_try!(generator.take());
-        VmResult::Ok(generator)
-    }
-}
-
-impl UnsafeFromValue for &Generator<Vm> {
-    type Output = *const Generator<Vm>;
-    type Guard = RawRef;
-
-    fn from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
-        let generator = vm_try!(value.into_generator());
-        let (generator, guard) = Ref::into_raw(vm_try!(generator.into_ref()));
-        VmResult::Ok((generator, guard))
-    }
-
-    unsafe fn unsafe_coerce(output: Self::Output) -> Self {
-        &*output
-    }
-}
-
-impl UnsafeFromValue for &mut Generator<Vm> {
-    type Output = *mut Generator<Vm>;
-    type Guard = RawMut;
-
-    fn from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
-        let generator = vm_try!(value.into_generator());
-        let generator = vm_try!(generator.into_mut());
-        VmResult::Ok(Mut::into_raw(generator))
-    }
-
-    unsafe fn unsafe_coerce(output: Self::Output) -> Self {
-        &mut *output
-    }
-}
+from_value!(Generator<Vm>, into_generator);

--- a/crates/rune/src/runtime/generator_state.rs
+++ b/crates/rune/src/runtime/generator_state.rs
@@ -1,8 +1,6 @@
 use crate::compile::Named;
 use crate::module::InstallWith;
-use crate::runtime::{
-    FromValue, Mut, RawMut, RawRef, RawStr, Ref, Shared, UnsafeFromValue, Value, VmResult,
-};
+use crate::runtime::{RawStr, Value, VmResult};
 
 /// The state of a generator.
 ///
@@ -70,50 +68,7 @@ impl GeneratorState {
     }
 }
 
-impl FromValue for Shared<GeneratorState> {
-    #[inline]
-    fn from_value(value: Value) -> VmResult<Self> {
-        value.into_generator_state()
-    }
-}
-
-impl FromValue for GeneratorState {
-    fn from_value(value: Value) -> VmResult<Self> {
-        let state = vm_try!(value.into_generator_state());
-        let state = vm_try!(state.take());
-        VmResult::Ok(state)
-    }
-}
-
-impl UnsafeFromValue for &GeneratorState {
-    type Output = *const GeneratorState;
-    type Guard = RawRef;
-
-    fn from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
-        let state = vm_try!(value.into_generator_state());
-        let (state, guard) = Ref::into_raw(vm_try!(state.into_ref()));
-        VmResult::Ok((state, guard))
-    }
-
-    unsafe fn unsafe_coerce(output: Self::Output) -> Self {
-        &*output
-    }
-}
-
-impl UnsafeFromValue for &mut GeneratorState {
-    type Output = *mut GeneratorState;
-    type Guard = RawMut;
-
-    fn from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
-        let state = vm_try!(value.into_generator_state());
-        let state = vm_try!(state.into_mut());
-        VmResult::Ok(Mut::into_raw(state))
-    }
-
-    unsafe fn unsafe_coerce(output: Self::Output) -> Self {
-        &mut *output
-    }
-}
+from_value!(GeneratorState, into_generator_state);
 
 impl Named for GeneratorState {
     const BASE_NAME: RawStr = RawStr::from_str("GeneratorState");

--- a/crates/rune/src/runtime/iterator.rs
+++ b/crates/rune/src/runtime/iterator.rs
@@ -7,10 +7,7 @@ use crate::no_std::vec;
 
 use crate::compile::Named;
 use crate::module::InstallWith;
-use crate::runtime::{
-    FromValue, Function, Mut, Panic, RawMut, RawRef, RawStr, Ref, ToValue, UnsafeFromValue, Value,
-    VmErrorKind, VmResult,
-};
+use crate::runtime::{FromValue, Function, Panic, RawStr, ToValue, Value, VmErrorKind, VmResult};
 
 // Note: A fair amount of code in this module is duplicated from the Rust
 // project under the MIT license.
@@ -393,39 +390,7 @@ impl Named for Iterator {
 
 impl InstallWith for Iterator {}
 
-impl FromValue for Iterator {
-    fn from_value(value: Value) -> VmResult<Self> {
-        VmResult::Ok(vm_try!(vm_try!(value.into_iterator()).take()))
-    }
-}
-
-impl<'a> UnsafeFromValue for &'a Iterator {
-    type Output = *const Iterator;
-    type Guard = RawRef;
-
-    fn from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
-        let iterator = vm_try!(value.into_iterator());
-        VmResult::Ok(Ref::into_raw(vm_try!(iterator.into_ref())))
-    }
-
-    unsafe fn unsafe_coerce(output: Self::Output) -> Self {
-        &*output
-    }
-}
-
-impl<'a> UnsafeFromValue for &'a mut Iterator {
-    type Output = *mut Iterator;
-    type Guard = RawMut;
-
-    fn from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
-        let iterator = vm_try!(value.into_iterator());
-        VmResult::Ok(Mut::into_raw(vm_try!(iterator.into_mut())))
-    }
-
-    unsafe fn unsafe_coerce(output: Self::Output) -> Self {
-        &mut *output
-    }
-}
+from_value!(Iterator, into_iterator);
 
 /// The inner representation of an [Iterator]. It handles all the necessary
 /// dynamic dispatch to support dynamic iterators.

--- a/crates/rune/src/runtime/object.rs
+++ b/crates/rune/src/runtime/object.rs
@@ -10,10 +10,7 @@ use crate::no_std::prelude::*;
 use crate as rune;
 use crate::compile::{ItemBuf, Named};
 use crate::module::InstallWith;
-use crate::runtime::{
-    FromValue, Iterator, Mut, RawMut, RawRef, RawStr, Ref, ToValue, UnsafeFromValue, Value, Vm,
-    VmResult,
-};
+use crate::runtime::{FromValue, Iterator, RawStr, ToValue, Value, Vm, VmResult};
 
 /// An owning iterator over the entries of a `Object`.
 ///
@@ -352,59 +349,7 @@ impl iter::FromIterator<(String, Value)> for Object {
     }
 }
 
-impl FromValue for Object {
-    fn from_value(value: Value) -> VmResult<Self> {
-        let object = vm_try!(value.into_object());
-        let object = vm_try!(object.take());
-        VmResult::Ok(object)
-    }
-}
-
-impl FromValue for Mut<Object> {
-    fn from_value(value: Value) -> VmResult<Self> {
-        let object = vm_try!(value.into_object());
-        let object = vm_try!(object.into_mut());
-        VmResult::Ok(object)
-    }
-}
-
-impl FromValue for Ref<Object> {
-    fn from_value(value: Value) -> VmResult<Self> {
-        let object = vm_try!(value.into_object());
-        let object = vm_try!(object.into_ref());
-        VmResult::Ok(object)
-    }
-}
-
-impl UnsafeFromValue for &Object {
-    type Output = *const Object;
-    type Guard = RawRef;
-
-    fn from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
-        let object = vm_try!(value.into_object());
-        let object = vm_try!(object.into_ref());
-        VmResult::Ok(Ref::into_raw(object))
-    }
-
-    unsafe fn unsafe_coerce(output: Self::Output) -> Self {
-        &*output
-    }
-}
-
-impl UnsafeFromValue for &mut Object {
-    type Output = *mut Object;
-    type Guard = RawMut;
-
-    fn from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
-        let object = vm_try!(value.into_object());
-        let object = vm_try!(object.into_mut());
-        VmResult::Ok(Mut::into_raw(object))
-    }
-
-    unsafe fn unsafe_coerce(output: Self::Output) -> Self {
-        &mut *output
-    }
-}
+from_value!(Object, into_object);
 
 impl Named for Object {
     const BASE_NAME: RawStr = RawStr::from_str("Object");

--- a/crates/rune/src/runtime/range.rs
+++ b/crates/rune/src/runtime/range.rs
@@ -5,8 +5,7 @@ use crate as rune;
 use crate::compile::Named;
 use crate::module::InstallWith;
 use crate::runtime::{
-    FromValue, Iterator, Mut, Panic, RawMut, RawRef, RawStr, Ref, ToValue, UnsafeFromValue, Value,
-    Vm, VmErrorKind, VmResult,
+    FromValue, Iterator, Panic, RawStr, ToValue, Value, Vm, VmErrorKind, VmResult,
 };
 
 /// Struct representing a dynamic anonymous object.
@@ -235,57 +234,7 @@ where
     }
 }
 
-impl FromValue for Range {
-    fn from_value(value: Value) -> VmResult<Self> {
-        VmResult::Ok(vm_try!(vm_try!(value.into_range()).take()))
-    }
-}
-
-impl FromValue for Mut<Range> {
-    fn from_value(value: Value) -> VmResult<Self> {
-        let object = vm_try!(value.into_range());
-        let object = vm_try!(object.into_mut());
-        VmResult::Ok(object)
-    }
-}
-
-impl FromValue for Ref<Range> {
-    fn from_value(value: Value) -> VmResult<Self> {
-        let object = vm_try!(value.into_range());
-        let object = vm_try!(object.into_ref());
-        VmResult::Ok(object)
-    }
-}
-
-impl UnsafeFromValue for &Range {
-    type Output = *const Range;
-    type Guard = RawRef;
-
-    fn from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
-        let object = vm_try!(value.into_range());
-        let object = vm_try!(object.into_ref());
-        VmResult::Ok(Ref::into_raw(object))
-    }
-
-    unsafe fn unsafe_coerce(output: Self::Output) -> Self {
-        &*output
-    }
-}
-
-impl UnsafeFromValue for &mut Range {
-    type Output = *mut Range;
-    type Guard = RawMut;
-
-    fn from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
-        let object = vm_try!(value.into_range());
-        let object = vm_try!(object.into_mut());
-        VmResult::Ok(Mut::into_raw(object))
-    }
-
-    unsafe fn unsafe_coerce(output: Self::Output) -> Self {
-        &mut *output
-    }
-}
+from_value!(Range, into_range);
 
 impl Named for Range {
     const BASE_NAME: RawStr = RawStr::from_str("Range");

--- a/crates/rune/src/runtime/stream.rs
+++ b/crates/rune/src/runtime/stream.rs
@@ -2,10 +2,7 @@ use core::fmt;
 
 use crate::compile::Named;
 use crate::module::InstallWith;
-use crate::runtime::{
-    FromValue, GeneratorState, Mut, RawMut, RawRef, RawStr, Ref, Shared, UnsafeFromValue, Value,
-    Vm, VmErrorKind, VmExecution, VmResult,
-};
+use crate::runtime::{GeneratorState, RawStr, Value, Vm, VmErrorKind, VmExecution, VmResult};
 
 /// A stream with a stored virtual machine.
 pub struct Stream<T>
@@ -91,45 +88,4 @@ where
     }
 }
 
-impl FromValue for Shared<Stream<Vm>> {
-    #[inline]
-    fn from_value(value: Value) -> VmResult<Self> {
-        value.into_stream()
-    }
-}
-
-impl FromValue for Stream<Vm> {
-    fn from_value(value: Value) -> VmResult<Self> {
-        let stream = vm_try!(value.into_stream());
-        VmResult::Ok(vm_try!(stream.take()))
-    }
-}
-
-impl UnsafeFromValue for &Stream<Vm> {
-    type Output = *const Stream<Vm>;
-    type Guard = RawRef;
-
-    fn from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
-        let stream = vm_try!(value.into_stream());
-        let (stream, guard) = Ref::into_raw(vm_try!(stream.into_ref()));
-        VmResult::Ok((stream, guard))
-    }
-
-    unsafe fn unsafe_coerce(output: Self::Output) -> Self {
-        &*output
-    }
-}
-
-impl UnsafeFromValue for &mut Stream<Vm> {
-    type Output = *mut Stream<Vm>;
-    type Guard = RawMut;
-
-    fn from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
-        let stream = vm_try!(value.into_stream());
-        VmResult::Ok(Mut::into_raw(vm_try!(stream.into_mut())))
-    }
-
-    unsafe fn unsafe_coerce(output: Self::Output) -> Self {
-        &mut *output
-    }
-}
+from_value!(Stream<Vm>, into_stream);

--- a/crates/rune/src/runtime/value.rs
+++ b/crates/rune/src/runtime/value.rs
@@ -512,28 +512,7 @@ impl Value {
         Iterator::from_value(value)
     }
 
-    /// Coerce into future, or convert into a future using the
-    /// [Protocol::INTO_FUTURE] protocol.
-    ///
-    /// You must use [Vm::with] to specify which virtual machine this function
-    /// is called inside.
-    ///
-    /// # Errors
-    ///
-    /// This function errors in case the provided type cannot be converted into
-    /// a future without the use of a [`Vm`] and one is not provided through the
-    /// environment.
-    pub fn into_future(self) -> VmResult<Future> {
-        let target = match self {
-            Value::Future(fut) => return VmResult::Ok(vm_try!(fut.take())),
-            target => target,
-        };
-
-        let value = vm_try!(EnvProtocolCaller.call_protocol_fn(Protocol::INTO_FUTURE, target, ()));
-        Future::from_value(value)
-    }
-
-    /// Coerce into a shared future, or convert into a future using the
+    /// Coerce into a future, or convert into a future using the
     /// [Protocol::INTO_FUTURE] protocol.
     ///
     /// You must use [Vm::with] to specify which virtual machine this function
@@ -545,7 +524,7 @@ impl Value {
     /// a future without the use of a [`Vm`] and one is not provided through the
     /// environment.
     #[inline]
-    pub fn into_shared_future(self) -> VmResult<Shared<Future>> {
+    pub fn into_future(self) -> VmResult<Shared<Future>> {
         let target = match self {
             Value::Future(future) => return VmResult::Ok(future),
             target => target,

--- a/crates/rune/src/runtime/vm.rs
+++ b/crates/rune/src/runtime/vm.rs
@@ -1460,7 +1460,7 @@ impl Vm {
     #[cfg_attr(feature = "bench", inline(never))]
     fn op_await(&mut self) -> VmResult<Shared<Future>> {
         let value = vm_try!(self.stack.pop());
-        value.into_shared_future()
+        value.into_future()
     }
 
     #[cfg_attr(feature = "bench", inline(never))]
@@ -1468,7 +1468,7 @@ impl Vm {
         let futures = futures_util::stream::FuturesUnordered::new();
 
         for (branch, value) in vm_try!(self.stack.drain(len)).enumerate() {
-            let future = vm_try!(vm_try!(value.into_shared_future()).into_mut());
+            let future = vm_try!(vm_try!(value.into_future()).into_mut());
 
             if !future.is_completed() {
                 futures.push(SelectFuture::new(branch, future));

--- a/crates/rune/src/tests/bug_344.rs
+++ b/crates/rune/src/tests/bug_344.rs
@@ -85,7 +85,7 @@ fn bug_344_async_function() -> Result<()> {
     let mut stack = Stack::new();
     stack.push(GuardCheck::new());
     function(&mut stack, 1).into_result()?;
-    let future = stack.pop()?.into_future().into_result()?;
+    let future = stack.pop()?.into_future().into_result()?.take()?;
     assert_eq!(
         block_on(future)
             .into_result()?
@@ -121,7 +121,7 @@ fn bug_344_async_inst_fn() -> Result<()> {
     stack.push(GuardCheck::new());
     function(&mut stack, 2).into_result()?;
 
-    let future = stack.pop()?.into_future().into_result()?;
+    let future = stack.pop()?.into_future().into_result()?.take()?;
     assert_eq!(
         block_on(future)
             .into_result()?
@@ -204,7 +204,7 @@ impl UnsafeFromValue for &GuardCheck {
     type Output = *const GuardCheck;
     type Guard = Guard;
 
-    fn from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
+    fn unsafe_from_value(value: Value) -> VmResult<(Self::Output, Self::Guard)> {
         let (output, guard) = vm_try!(value.into_any_ptr::<GuardCheck>());
 
         let guard = Guard {


### PR DESCRIPTION
This replaces most `UnsafeFromValue` implementations with a macro. `UnsafeFromValue::from_value` has been renamed since it conflicts with `FromValue::from_value` when both are in scope, which is annoying.

Also unifies the behavior of `Value` to owned value conversion across all internal types so that the value is taken, rather than cloned as it was for some.