### PR TITLE
Allow underscores at the start of a variable

### DIFF
--- a/crates/rune/src/ast/ident.rs
+++ b/crates/rune/src/ast/ident.rs
@@ -6,6 +6,7 @@ fn ast_parse() {
 
     rt::<ast::Ident>("foo");
     rt::<ast::Ident>("a42");
+    rt::<ast::Ident>("_ignored");
 }
 
 /// An identifier, like `foo` or `Hello`.

--- a/crates/rune/src/parse/lexer.rs
+++ b/crates/rune/src/parse/lexer.rs
@@ -143,10 +143,17 @@ impl<'a> Lexer<'a> {
             self.iter.next();
         }
 
-        let (ident, span) = self.iter.source_from(start);
-        let kind = ast::Kind::from_keyword(ident)
-            .unwrap_or(ast::Kind::Ident(ast::LitSource::Text(self.source_id)));
-        Ok(Some(ast::Token { kind, span }))
+        match self.iter.source_from(start) {
+            ("_", span) => Ok(Some(ast::Token {
+                span,
+                kind: ast::Kind::Underscore,
+            })),
+            (ident, span) => {
+                let kind = ast::Kind::from_keyword(ident)
+                    .unwrap_or(ast::Kind::Ident(ast::LitSource::Text(self.source_id)));
+                Ok(Some(ast::Token { kind, span }))
+            }
+        }
     }
 
     /// Consume a number literal.
@@ -781,7 +788,6 @@ impl<'a> Lexer<'a> {
                     }
                     '[' => ast::Kind::Open(ast::Delimiter::Bracket),
                     ']' => ast::Kind::Close(ast::Delimiter::Bracket),
-                    '_' => ast::Kind::Underscore,
                     ',' => ast::Kind::Comma,
                     ':' => ast::Kind::Colon,
                     '#' => ast::Kind::Pound,
@@ -803,7 +809,7 @@ impl<'a> Lexer<'a> {
                     '@' => ast::Kind::At,
                     '$' => ast::Kind::Dollar,
                     '~' => ast::Kind::Tilde,
-                    'a'..='z' | 'A'..='Z' => {
+                    '_' | 'a'..='z' | 'A'..='Z' => {
                         return self.next_ident(start);
                     }
                     '0'..='9' => {

--- a/crates/rune/src/tests/vm_assign_exprs.rs
+++ b/crates/rune/src/tests/vm_assign_exprs.rs
@@ -10,6 +10,24 @@ fn test_basic_assign() {
 }
 
 #[test]
+fn test_assign_underscore() {
+    let out: i64 = rune! {
+        pub fn main() { let _a = 0; _a = 42; _a }
+    };
+
+    assert_eq!(out, 42);
+}
+
+#[test]
+fn test_assign_underscores() {
+    let out: i64 = rune! {
+        pub fn main() { let ___ = 0; ___ = 42; ___ }
+    };
+
+    assert_eq!(out, 42);
+}
+
+#[test]
 fn test_assign_anon_object() {
     let out: i64 = rune! {
         pub fn main() { let a = #{}; a.foo = #{}; a.foo.bar = 42; a.foo.bar }


### PR DESCRIPTION
Allow one or more underscores at the start of a variable name, like so:
```rust
fn main() {
    let _a = 0;
    _a = 42;
    _a
}
```
This changes the lexer to allow underscores at the start of an identifier, and only emits `ask::Kind::Underscore` if it's strictly `_`.

Interestingly, [this seems to match the behavior in Rust](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=c1e565a5f473afbf4f1ff4472177a9ac). They both treat more than one underscore as a valid identifier. So this would work in both Rust and Rune:
```rust
fn main() {
    let ___ = 0;
    ___ = 42;
    ___
}
```
(Assuming you mark `___` as `mut` in Rust.)

Personally, I find this behavior odd. But maybe matching the Rust compiler behavior is best?

Fixes #435.