### PR TITLE
Customize hashing for hot maps

### DIFF
--- a/crates/rune/src/compile/context.rs
+++ b/crates/rune/src/compile/context.rs
@@ -8,6 +8,7 @@ use crate::compile::meta;
 #[cfg(feature = "doc")]
 use crate::compile::Docs;
 use crate::compile::{ComponentRef, ContextError, IntoComponent, Item, ItemBuf, MetaInfo, Names};
+use crate::hash;
 use crate::module::{
     Fields, InternalEnum, Module, ModuleAssociated, ModuleAttributeMacro, ModuleConstant,
     ModuleFunction, ModuleMacro, ModuleType, TypeSpecification,
@@ -86,7 +87,7 @@ pub struct Context {
     /// Store item to hash mapping.
     item_to_hash: HashMap<ItemBuf, BTreeSet<Hash>>,
     /// Registered native function handlers.
-    functions: HashMap<Hash, Arc<FunctionHandler>>,
+    functions: hash::Map<Arc<FunctionHandler>>,
     /// Information on associated types.
     #[cfg(feature = "doc")]
     associated: HashMap<Hash, Vec<Hash>>,
@@ -103,7 +104,7 @@ pub struct Context {
     /// Registered crates.
     crates: HashSet<Box<str>>,
     /// Constants visible in this context
-    constants: HashMap<Hash, ConstValue>,
+    constants: hash::Map<ConstValue>,
 }
 
 impl Context {

--- a/crates/rune/src/compile/unit_builder.rs
+++ b/crates/rune/src/compile/unit_builder.rs
@@ -12,6 +12,7 @@ use crate::no_std::sync::Arc;
 use crate::ast::{Span, Spanned};
 use crate::compile::meta;
 use crate::compile::{self, Assembly, AssemblyInst, ErrorKind, Item, Location, Pool, WithSpan};
+use crate::hash;
 use crate::query::QueryInner;
 use crate::runtime::debug::{DebugArgs, DebugSignature};
 use crate::runtime::unit::UnitEncoder;
@@ -50,7 +51,7 @@ pub(crate) struct UnitBuilder {
     /// Registered re-exports.
     reexports: HashMap<Hash, Hash>,
     /// Where functions are located in the collection of instructions.
-    functions: HashMap<Hash, UnitFn>,
+    functions: hash::Map<UnitFn>,
     /// Function by address.
     functions_rev: HashMap<usize, Hash>,
     /// A static string.
@@ -71,9 +72,9 @@ pub(crate) struct UnitBuilder {
     /// Used to detect duplicates in the collection of static object keys.
     static_object_keys_rev: HashMap<Hash, usize>,
     /// Runtime type information for types.
-    rtti: HashMap<Hash, Arc<Rtti>>,
+    rtti: hash::Map<Arc<Rtti>>,
     /// Runtime type information for variants.
-    variant_rtti: HashMap<Hash, Arc<VariantRtti>>,
+    variant_rtti: hash::Map<Arc<VariantRtti>>,
     /// The current label count.
     label_count: usize,
     /// A collection of required function hashes.
@@ -81,7 +82,7 @@ pub(crate) struct UnitBuilder {
     /// Debug info if available for unit.
     debug: Option<Box<DebugInfo>>,
     /// Constant values
-    constants: HashMap<Hash, ConstValue>,
+    constants: hash::Map<ConstValue>,
 }
 
 impl UnitBuilder {

--- a/crates/rune/src/hash.rs
+++ b/crates/rune/src/hash.rs
@@ -1,4 +1,44 @@
+use crate::no_std::collections::HashMap;
+
+use core::hash::{BuildHasher, Hasher};
+
+const SEED: u64 = 18446744073709551557u64;
+
 #[doc(inline)]
 pub use rune_core::{Hash, ToTypeHash};
 #[doc(inline)]
 pub(crate) use rune_core::{IntoHash, ParametersBuilder};
+
+/// A hash map suitable for storing values with hash keys.
+pub(crate) type Map<T> = HashMap<Hash, T, HashBuildHasher>;
+
+#[derive(Default, Clone, Copy)]
+pub(crate) struct HashBuildHasher;
+
+impl BuildHasher for HashBuildHasher {
+    type Hasher = HashHasher;
+
+    #[inline]
+    fn build_hasher(&self) -> Self::Hasher {
+        HashHasher(SEED)
+    }
+}
+
+pub(crate) struct HashHasher(u64);
+
+impl Hasher for HashHasher {
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0
+    }
+
+    #[inline]
+    fn write(&mut self, _: &[u8]) {
+        panic!("Hash hashers assume that 64-bit hashes are already random")
+    }
+
+    #[inline]
+    fn write_u64(&mut self, hash: u64) {
+        self.0 ^= hash;
+    }
+}

--- a/crates/rune/src/runtime/call.rs
+++ b/crates/rune/src/runtime/call.rs
@@ -1,11 +1,12 @@
 use core::fmt;
 
+use musli::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
 use crate::runtime::{Future, Generator, Stream, Value, Vm, VmResult};
 
 /// The calling convention of a function.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Encode, Decode)]
 #[non_exhaustive]
 pub enum Call {
     /// Function is `async` and returns a future that must be await:ed to make

--- a/crates/rune/src/runtime/inst.rs
+++ b/crates/rune/src/runtime/inst.rs
@@ -4,7 +4,7 @@ use musli::{Decode, Encode};
 use rune_macros::InstDisplay;
 use serde::{Deserialize, Serialize};
 
-use crate::runtime::{FormatSpec, Type, Value};
+use crate::runtime::{Call, FormatSpec, Type, Value};
 use crate::Hash;
 
 /// Pre-canned panic reasons.
@@ -124,6 +124,19 @@ pub enum Inst {
         hash: Hash,
         /// The number of arguments to store in the environment on the stack.
         count: usize,
+    },
+    /// Perform a function call within the same unit.
+    ///
+    /// It will construct a new stack frame which includes the last `args`
+    /// number of entries.
+    #[musli(packed)]
+    CallOffset {
+        /// The offset of the function being called in the same unit.
+        offset: usize,
+        /// The calling convention to use.
+        call: Call,
+        /// The number of arguments expected on the stack for this call.
+        args: usize,
     },
     /// Perform a function call.
     ///

--- a/crates/rune/src/runtime/runtime_context.rs
+++ b/crates/rune/src/runtime/runtime_context.rs
@@ -1,9 +1,9 @@
 use core::fmt;
 
-use crate::no_std::collections::HashMap;
 use crate::no_std::sync::Arc;
 
 use crate::compile;
+use crate::hash;
 use crate::macros::{MacroContext, TokenStream};
 use crate::runtime::{ConstValue, Stack, VmResult};
 use crate::Hash;
@@ -29,15 +29,15 @@ pub(crate) type AttributeMacroHandler = dyn Fn(&mut MacroContext, &TokenStream, 
 #[derive(Default, Clone)]
 pub struct RuntimeContext {
     /// Registered native function handlers.
-    functions: HashMap<Hash, Arc<FunctionHandler>>,
+    functions: hash::Map<Arc<FunctionHandler>>,
     /// Named constant values
-    constants: HashMap<Hash, ConstValue>,
+    constants: hash::Map<ConstValue>,
 }
 
 impl RuntimeContext {
     pub(crate) fn new(
-        functions: HashMap<Hash, Arc<FunctionHandler>>,
-        constants: HashMap<Hash, ConstValue>,
+        functions: hash::Map<Arc<FunctionHandler>>,
+        constants: hash::Map<ConstValue>,
     ) -> Self {
         Self {
             functions,

--- a/crates/rune/src/runtime/unit.rs
+++ b/crates/rune/src/runtime/unit.rs
@@ -9,13 +9,13 @@ mod storage;
 
 use core::fmt;
 
-use crate::no_std::collections::HashMap;
 use crate::no_std::prelude::*;
 use crate::no_std::sync::Arc;
 
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
+use crate::hash;
 use crate::runtime::{
     Call, ConstValue, DebugInfo, Inst, Rtti, StaticString, VariantRtti, VmError, VmErrorKind,
 };
@@ -53,7 +53,7 @@ pub struct Logic<S = DefaultStorage> {
     /// Storage for the unit.
     storage: S,
     /// Where functions are located in the collection of instructions.
-    functions: HashMap<Hash, UnitFn>,
+    functions: hash::Map<UnitFn>,
     /// A static string.
     static_strings: Vec<Arc<StaticString>>,
     /// A static byte string.
@@ -66,11 +66,11 @@ pub struct Logic<S = DefaultStorage> {
     /// All keys are sorted with the default string sort.
     static_object_keys: Vec<Box<[String]>>,
     /// Runtime information for types.
-    rtti: HashMap<Hash, Arc<Rtti>>,
+    rtti: hash::Map<Arc<Rtti>>,
     /// Runtime information for variants.
-    variant_rtti: HashMap<Hash, Arc<VariantRtti>>,
+    variant_rtti: hash::Map<Arc<VariantRtti>>,
     /// Named constants
-    constants: HashMap<Hash, ConstValue>,
+    constants: hash::Map<ConstValue>,
 }
 
 impl<S> Unit<S> {
@@ -86,14 +86,14 @@ impl<S> Unit<S> {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         storage: S,
-        functions: HashMap<Hash, UnitFn>,
+        functions: hash::Map<UnitFn>,
         static_strings: Vec<Arc<StaticString>>,
         static_bytes: Vec<Vec<u8>>,
         static_object_keys: Vec<Box<[String]>>,
-        rtti: HashMap<Hash, Arc<Rtti>>,
-        variant_rtti: HashMap<Hash, Arc<VariantRtti>>,
+        rtti: hash::Map<Arc<Rtti>>,
+        variant_rtti: hash::Map<Arc<VariantRtti>>,
         debug: Option<Box<DebugInfo>>,
-        constants: HashMap<Hash, ConstValue>,
+        constants: hash::Map<ConstValue>,
     ) -> Self {
         Self {
             logic: Logic {

--- a/crates/rune/src/runtime/vm.rs
+++ b/crates/rune/src/runtime/vm.rs
@@ -2907,6 +2907,13 @@ impl Vm {
         VmResult::Ok(())
     }
 
+    /// Call a function at the given offset with the given number of arguments.
+    #[cfg_attr(feature = "bench", inline(never))]
+    fn op_call_offset(&mut self, offset: usize, call: Call, args: usize) -> VmResult<()> {
+        vm_try!(self.call_offset_fn(offset, call, args));
+        VmResult::Ok(())
+    }
+
     #[cfg_attr(feature = "bench", inline(never))]
     fn op_call_associated(&mut self, hash: Hash, args: usize) -> VmResult<()> {
         // NB: +1 to include the instance itself.
@@ -3059,6 +3066,9 @@ impl Vm {
                 }
                 Inst::Call { hash, args } => {
                     vm_try!(self.op_call(hash, args));
+                }
+                Inst::CallOffset { offset, call, args } => {
+                    vm_try!(self.op_call_offset(offset, call, args));
                 }
                 Inst::CallAssociated { hash, args } => {
                     vm_try!(self.op_call_associated(hash, args));


### PR DESCRIPTION
With this we're seeing a 5-10% speedup compared to the default hash used for hash maps:

```
aoc_2020_1a             time:   [214.55 µs 215.35 µs 216.22 µs]
                        change: [-6.7605% -6.2809% -5.8364%] (p = 0.00 < 0.05)
                        Performance has improved.
aoc_2020_1b             time:   [757.62 µs 759.64 µs 762.21 µs]
                        change: [-12.110% -11.672% -11.268%] (p = 0.00 < 0.05)
                        Performance has improved.
aoc_2020_11a            time:   [315.06 ms 315.79 ms 316.59 ms]
                        change: [-5.5867% -5.2768% -4.9616%] (p = 0.00 < 0.05)
                        Performance has improved.
aoc_2020_19b            time:   [219.67 ms 220.34 ms 221.07 ms]
                        change: [-6.2175% -5.8469% -5.4795%] (p = 0.00 < 0.05)
                        Performance has improved.
brainfuck_hello_world   time:   [843.70 µs 845.93 µs 848.87 µs]
                        change: [-7.5888% -6.8126% -6.0949%] (p = 0.00 < 0.05)
                        Performance has improved.
brainfuck_hello_world2  time:   [8.9777 ms 8.9983 ms 9.0236 ms]
                        change: [-7.3782% -6.9379% -6.5155%] (p = 0.00 < 0.05)
                        Performance has improved.
brainfuck_fib           time:   [47.993 ms 48.117 ms 48.275 ms]
                        change: [-10.628% -9.6902% -8.7642%] (p = 0.00 < 0.05)
                        Performance has improved.
brainfuck_loopity       time:   [7.7490 ms 7.7620 ms 7.7760 ms]
                        change: [-6.7243% -6.3566% -6.0391%] (p = 0.00 < 0.05)
                        Performance has improved.
fib_15                  time:   [346.42 µs 346.97 µs 347.93 µs]
                        change: [-5.5870% -4.9540% -4.3864%] (p = 0.00 < 0.05)
                        Performance has improved.
fib_20                  time:   [3.8800 ms 3.8835 ms 3.8873 ms]
                        change: [-5.3582% -5.2084% -5.0557%] (p = 0.00 < 0.05)
                        Performance has improved.
external_functions      time:   [570.02 ns 570.28 ns 570.60 ns]
                        change: [-3.6023% -3.1358% -2.6129%] (p = 0.00 < 0.05)
                        Performance has improved.
```