### PR TITLE
Improve diagnostics

### DIFF
--- a/crates/rune-core/src/protocol.rs
+++ b/crates/rune-core/src/protocol.rs
@@ -89,7 +89,7 @@ macro_rules! define {
     (
         $(
             $(#[$($meta:meta)*])*
-            $vis:vis const $ident:ident: Protocol = Protocol {
+            $vis:vis const [$ident:ident, $hash_ident:ident]: Protocol = Protocol {
                 name: $name:expr,
                 hash: $hash:expr,
                 repr: $repr:expr,
@@ -107,14 +107,28 @@ macro_rules! define {
                 #[cfg(feature = "doc")]
                 doc: &$doc,
             };
+
+            $vis const $hash_ident: Hash = Hash::new($hash);
         )*
+
+        /// Look up protocol for the given hash.
+        pub fn from_hash(hash: Hash) -> Option<Self> {
+            match hash {
+                $(
+                    Self::$hash_ident => {
+                        Some(Self::$ident)
+                    },
+                )*
+                _ => None,
+            }
+        }
     }
 }
 
 impl Protocol {
     define! {
         /// The function to access a field.
-        pub const GET: Protocol = Protocol {
+        pub const [GET, GET_HASH]: Protocol = Protocol {
             name: "get",
             hash: 0x504007af1a8485a4,
             repr: Some("let output = $value"),
@@ -122,7 +136,7 @@ impl Protocol {
         };
 
         /// The function to set a field.
-        pub const SET: Protocol = Protocol {
+        pub const [SET, SET_HASH]: Protocol = Protocol {
             name: "set",
             hash: 0x7d13d47fd8efef5a,
             repr: Some("$value = input"),
@@ -130,7 +144,7 @@ impl Protocol {
         };
 
         /// The function to access an index.
-        pub const INDEX_GET: Protocol = Protocol {
+        pub const [INDEX_GET, INDEX_GET_HASH]: Protocol = Protocol {
             name: "index_get",
             hash: 0xadb5b27e2a4d2dec,
             repr: Some("let output = $value[index]"),
@@ -138,7 +152,7 @@ impl Protocol {
         };
 
         /// The function to set an index.
-        pub const INDEX_SET: Protocol = Protocol {
+        pub const [INDEX_SET, INDEX_SET_HASH]: Protocol = Protocol {
             name: "index_set",
             hash: 0x162943f7bd03ad36,
             repr: Some("$value[index] = input"),
@@ -146,7 +160,7 @@ impl Protocol {
         };
 
         /// Check two types for partial equality.
-        pub const PARTIAL_EQ: Protocol = Protocol {
+        pub const [PARTIAL_EQ, PARTIAL_EQ_HASH]: Protocol = Protocol {
             name: "partial_eq",
             hash: 0x4b6bc4701445e318,
             repr: Some("if $value == b { }"),
@@ -154,7 +168,7 @@ impl Protocol {
         };
 
         /// Check two types for total equality.
-        pub const EQ: Protocol = Protocol {
+        pub const [EQ, EQ_HASH]: Protocol = Protocol {
             name: "eq",
             hash: 0x418f5becbf885806,
             repr: Some("if $value == b { }"),
@@ -162,7 +176,7 @@ impl Protocol {
         };
 
         /// Perform an partial comparison between two values.
-        pub const PARTIAL_CMP: Protocol = Protocol {
+        pub const [PARTIAL_CMP, PARTIAL_CMP_HASH]: Protocol = Protocol {
             name: "partial_cmp",
             hash: 0x8d4430991253343c,
             repr: Some("if $value < b { }"),
@@ -170,7 +184,7 @@ impl Protocol {
         };
 
         /// Perform an total comparison between two values.
-        pub const CMP: Protocol = Protocol {
+        pub const [CMP, CMP_HASH]: Protocol = Protocol {
             name: "cmp",
             hash: 0x240f1b75466cd1a3,
             repr: Some("if $value < b { }"),
@@ -178,7 +192,7 @@ impl Protocol {
         };
 
         /// The function to implement for the addition operation.
-        pub const ADD: Protocol = Protocol {
+        pub const [ADD, ADD_HASH]: Protocol = Protocol {
             name: "add",
             hash: 0xe4ecf51fa0bf1076,
             repr: Some("let output = $value + b"),
@@ -188,7 +202,7 @@ impl Protocol {
         };
 
         /// The function to implement for the addition assign operation.
-        pub const ADD_ASSIGN: Protocol = Protocol {
+        pub const [ADD_ASSIGN, ADD_ASSIGN_HASH]: Protocol = Protocol {
             name: "add_assign",
             hash: 0x42451ccb0a2071a9,
             repr: Some("$value += b"),
@@ -198,7 +212,7 @@ impl Protocol {
         };
 
         /// The function to implement for the subtraction operation.
-        pub const SUB: Protocol = Protocol {
+        pub const [SUB, SUB_HASH]: Protocol = Protocol {
             name: "sub",
             hash: 0x6fa86a5f18d0bf71,
             repr: Some("let output = $value - b"),
@@ -208,7 +222,7 @@ impl Protocol {
         };
 
         /// The function to implement for the subtraction assign operation.
-        pub const SUB_ASSIGN: Protocol = Protocol {
+        pub const [SUB_ASSIGN, SUB_ASSIGN_HASH]: Protocol = Protocol {
             name: "sub_assign",
             hash: 0x5939bb56a1415284,
             repr: Some("$value -= b"),
@@ -218,7 +232,7 @@ impl Protocol {
         };
 
         /// The function to implement for the multiply operation.
-        pub const MUL: Protocol = Protocol {
+        pub const [MUL, MUL_HASH]: Protocol = Protocol {
             name: "mul",
             hash: 0xb09e99dc94091d1c,
             repr: Some("let output = $value * b"),
@@ -228,7 +242,7 @@ impl Protocol {
         };
 
         /// The function to implement for the multiply assign operation.
-        pub const MUL_ASSIGN: Protocol = Protocol {
+        pub const [MUL_ASSIGN, MUL_ASSIGN_HASH]: Protocol = Protocol {
             name: "mul_assign",
             hash: 0x29a54b727f980ebf,
             repr: Some("$value *= b"),
@@ -238,7 +252,7 @@ impl Protocol {
         };
 
         /// The function to implement for the division operation.
-        pub const DIV: Protocol = Protocol {
+        pub const [DIV, DIV_HASH]: Protocol = Protocol {
             name: "div",
             hash: 0xf26d6eea1afca6e8,
             repr: Some("let output = $value / b"),
@@ -248,7 +262,7 @@ impl Protocol {
         };
 
         /// The function to implement for the division assign operation.
-        pub const DIV_ASSIGN: Protocol = Protocol {
+        pub const [DIV_ASSIGN, DIV_ASSIGN_HASH]: Protocol = Protocol {
             name: "div_assign",
             hash: 0x4dd087a8281c04e6,
             repr: Some("$value /= b"),
@@ -258,7 +272,7 @@ impl Protocol {
         };
 
         /// The function to implement for the remainder operation.
-        pub const REM: Protocol = Protocol {
+        pub const [REM, REM_HASH]: Protocol = Protocol {
             name: "rem",
             hash: 0x5c6293639c74e671,
             repr: Some("let output = $value % b"),
@@ -268,7 +282,7 @@ impl Protocol {
         };
 
         /// The function to implement for the remainder assign operation.
-        pub const REM_ASSIGN: Protocol = Protocol {
+        pub const [REM_ASSIGN, REM_ASSIGN_HASH]: Protocol = Protocol {
             name: "rem_assign",
             hash: 0x3a8695980e77baf4,
             repr: Some("$value %= b"),
@@ -278,7 +292,7 @@ impl Protocol {
         };
 
         /// The function to implement for the bitwise and operation.
-        pub const BIT_AND: Protocol = Protocol {
+        pub const [BIT_AND, BIT_AND_HASH]: Protocol = Protocol {
             name: "bit_and",
             hash: 0x0e11f20d940eebe8,
             repr: Some("let output = $value & b"),
@@ -288,7 +302,7 @@ impl Protocol {
         };
 
         /// The function to implement for the bitwise and assign operation.
-        pub const BIT_AND_ASSIGN: Protocol = Protocol {
+        pub const [BIT_AND_ASSIGN, BIT_AND_ASSIGN_HASH]: Protocol = Protocol {
             name: "bit_and_assign",
             hash: 0x95cb1ba235dfb5ec,
             repr: Some("$value &= b"),
@@ -298,7 +312,7 @@ impl Protocol {
         };
 
         /// The function to implement for the bitwise xor operation.
-        pub const BIT_XOR: Protocol = Protocol {
+        pub const [BIT_XOR, BIT_XOR_HASH]: Protocol = Protocol {
             name: "bit_xor",
             hash: 0xa3099c54e1de4cbf,
             repr: Some("let output = $value ^ b"),
@@ -308,7 +322,7 @@ impl Protocol {
         };
 
         /// The function to implement for the bitwise xor assign operation.
-        pub const BIT_XOR_ASSIGN: Protocol = Protocol {
+        pub const [BIT_XOR_ASSIGN, BIT_XOR_ASSIGN_HASH]: Protocol = Protocol {
             name: "bit_xor_assign",
             hash: 0x01fa9706738f9867,
             repr: Some("$value ^= b"),
@@ -318,7 +332,7 @@ impl Protocol {
         };
 
         /// The function to implement for the bitwise or operation.
-        pub const BIT_OR: Protocol = Protocol {
+        pub const [BIT_OR, BIT_OR_HASH]: Protocol = Protocol {
             name: "bit_or",
             hash: 0x05010afceb4a03d0,
             repr: Some("let output = $value | b"),
@@ -328,7 +342,7 @@ impl Protocol {
         };
 
         /// The function to implement for the bitwise xor assign operation.
-        pub const BIT_OR_ASSIGN: Protocol = Protocol {
+        pub const [BIT_OR_ASSIGN, BIT_OR_ASSIGN_HASH]: Protocol = Protocol {
             name: "bit_or_assign",
             hash: 0x606d79ff1750a7ec,
             repr: Some("$value |= b"),
@@ -338,7 +352,7 @@ impl Protocol {
         };
 
         /// The function to implement for the bitwise shift left operation.
-        pub const SHL: Protocol = Protocol {
+        pub const [SHL, SHL_HASH]: Protocol = Protocol {
             name: "shl",
             hash: 0x6845f7d0cc9e002d,
             repr: Some("let output = $value << b"),
@@ -348,7 +362,7 @@ impl Protocol {
         };
 
         /// The function to implement for the bitwise shift left assign operation.
-        pub const SHL_ASSIGN: Protocol = Protocol {
+        pub const [SHL_ASSIGN, SHL_ASSIGN_HASH]: Protocol = Protocol {
             name: "shl_assign",
             hash: 0xdc4702d0307ba27b,
             repr: Some("$value <<= b"),
@@ -358,7 +372,7 @@ impl Protocol {
         };
 
         /// The function to implement for the bitwise shift right operation.
-        pub const SHR: Protocol = Protocol {
+        pub const [SHR, SHR_HASH]: Protocol = Protocol {
             name: "shr",
             hash: 0x6b485e8e6e58fbc8,
             repr: Some("let output = $value >> b"),
@@ -368,7 +382,7 @@ impl Protocol {
         };
 
         /// The function to implement for the bitwise shift right assign operation.
-        pub const SHR_ASSIGN: Protocol = Protocol {
+        pub const [SHR_ASSIGN, SHR_ASSIGN_HASH]: Protocol = Protocol {
             name: "shr_assign",
             hash: 0x61ff7c46ff00e74a,
             repr: Some("$value >>= b"),
@@ -378,7 +392,7 @@ impl Protocol {
         };
 
         /// Protocol function used by template strings.
-        pub const STRING_DISPLAY: Protocol = Protocol {
+        pub const [STRING_DISPLAY, STRING_DISPLAY_HASH]: Protocol = Protocol {
             name: "string_display",
             hash: 0x811b62957ea9d9f9,
             repr: Some("println(\"{}\", $value)"),
@@ -386,7 +400,7 @@ impl Protocol {
         };
 
         /// Protocol function used by custom debug impls.
-        pub const STRING_DEBUG: Protocol = Protocol {
+        pub const [STRING_DEBUG, STRING_DEBUG_HASH]: Protocol = Protocol {
             name: "string_debug",
             hash: 0x4064e3867aaa0717,
             repr: Some("println(\"{:?}\", $value)"),
@@ -394,7 +408,7 @@ impl Protocol {
         };
 
         /// Function used to convert an argument into an iterator.
-        pub const INTO_ITER: Protocol = Protocol {
+        pub const [INTO_ITER, INTO_ITER_HASH]: Protocol = Protocol {
             name: "into_iter",
             hash: 0x15a85c8d774b4065,
             repr: Some("for item in $value { }"),
@@ -402,7 +416,7 @@ impl Protocol {
         };
 
         /// The function to call to continue iteration.
-        pub const NEXT: Protocol = Protocol {
+        pub const [NEXT, NEXT_HASH]: Protocol = Protocol {
             name: "next",
             hash: 0xc3cde069de2ba320,
             repr: None,
@@ -412,7 +426,7 @@ impl Protocol {
         /// Function used to convert an argument into a future.
         ///
         /// Signature: `fn(Value) -> Future`.
-        pub const INTO_FUTURE: Protocol = Protocol {
+        pub const [INTO_FUTURE, INTO_FUTURE_HASH]: Protocol = Protocol {
             name: "into_future",
             hash: 0x596e6428deabfda2,
             repr: Some("value.await"),
@@ -420,7 +434,7 @@ impl Protocol {
         };
 
         /// Coerce a value into a type name. This is stored as a constant.
-        pub const INTO_TYPE_NAME: Protocol = Protocol {
+        pub const [INTO_TYPE_NAME, INTO_TYPE_NAME_HASH]: Protocol = Protocol {
             name: "into_type_name",
             hash: 0xbffd08b816c24682,
             repr: None,
@@ -432,7 +446,7 @@ impl Protocol {
         /// Function used to test if a value is a specific variant.
         ///
         /// Signature: `fn(self, usize) -> bool`.
-        pub const IS_VARIANT: Protocol = Protocol {
+        pub const [IS_VARIANT, IS_VARIANT_HASH]: Protocol = Protocol {
             name: "is_variant",
             hash: 0xc030d82bbd4dabe8,
             repr: None,
@@ -446,7 +460,7 @@ impl Protocol {
         /// Note that it uses the `Result` like [`std::ops::Try`] uses
         /// [`ControlFlow`](std::ops::ControlFlow) i.e., for `Result::<T, E>`
         /// it should return `Result<T, Result<(), E>>`
-        pub const TRY: Protocol = Protocol {
+        pub const [TRY, TRY_HASH]: Protocol = Protocol {
             name: "try",
             hash: 0x5da1a80787003354,
             repr: Some("value?"),

--- a/crates/rune-macros/src/any.rs
+++ b/crates/rune-macros/src/any.rs
@@ -582,7 +582,10 @@ where
 
             #[inline]
             fn type_info() -> #type_info {
-                #type_info::Any(#any_type_info::new(#raw_str::from_str(core::any::type_name::<Self>())))
+                #type_info::Any(#any_type_info::__private_new(
+                    #raw_str::from_str(core::any::type_name::<Self>()),
+                    <Self as #type_of>::type_hash(),
+                ))
             }
         }
 

--- a/crates/rune/src/compile/unit_builder.rs
+++ b/crates/rune/src/compile/unit_builder.rs
@@ -83,15 +83,23 @@ pub(crate) struct UnitBuilder {
     debug: Option<Box<DebugInfo>>,
     /// Constant values
     constants: hash::Map<ConstValue>,
+    /// Hash to identifiers.
+    hash_to_ident: HashMap<Hash, Box<str>>,
 }
 
 impl UnitBuilder {
+    /// Insert an identifier for debug purposes.
+    pub(crate) fn insert_debug_ident(&mut self, ident: &str) {
+        self.hash_to_ident.insert(Hash::ident(ident), ident.into());
+    }
+
     /// Convert into a runtime unit, shedding our build metadata in the process.
     ///
     /// Returns `None` if the builder is still in use.
     pub(crate) fn build<S>(mut self, span: Span, storage: S) -> compile::Result<Unit<S>> {
         if let Some(debug) = &mut self.debug {
             debug.functions_rev = self.functions_rev;
+            debug.hash_to_ident = self.hash_to_ident;
         }
 
         for (from, to) in self.reexports {

--- a/crates/rune/src/exported_macros.rs
+++ b/crates/rune/src/exported_macros.rs
@@ -1,5 +1,6 @@
-/// Helper to perform the try operation over
-/// [`VmResult`][crate::runtime::VmResult].
+/// Helper to perform the try operation over [`VmResult`].
+///
+/// [`VmResult`]: crate::runtime::VmResult
 #[macro_export]
 macro_rules! vm_try {
     ($expr:expr) => {
@@ -8,6 +9,19 @@ macro_rules! vm_try {
             $crate::runtime::VmResult::Err(err) => {
                 return $crate::runtime::VmResult::Err($crate::runtime::VmError::from(err))
             }
+        }
+    };
+}
+
+/// Helper macro to perform a `write!` in a context which errors with
+/// [`VmResult`] and returns `VmResult<Result<_, E>>` on write errors.
+///
+/// [`VmResult`]: crate::runtime::VmResult
+#[macro_export]
+macro_rules! vm_write {
+    ($($tt:tt)*) => {
+        if let core::result::Result::Err(error) = core::write!($($tt)*) {
+            return VmResult::Ok(core::result::Result::Err(error));
         }
     };
 }

--- a/crates/rune/src/hir/lowering.rs
+++ b/crates/rune/src/hir/lowering.rs
@@ -1692,8 +1692,12 @@ fn expr_call<'hir>(
             }) => {
                 let hash = match expr_field {
                     hir::ExprField::Index(index) => Hash::index(index),
-                    hir::ExprField::Ident(ident) => Hash::ident(ident),
+                    hir::ExprField::Ident(ident) => {
+                        cx.q.unit.insert_debug_ident(ident);
+                        Hash::ident(ident)
+                    }
                     hir::ExprField::IdentGenerics(ident, hash) => {
+                        cx.q.unit.insert_debug_ident(ident);
                         Hash::ident(ident).with_function_parameters(hash)
                     }
                 };

--- a/crates/rune/src/modules/collections/hash_map.rs
+++ b/crates/rune/src/modules/collections/hash_map.rs
@@ -464,36 +464,23 @@ impl HashMap {
         s: &mut String,
         caller: &mut impl ProtocolCaller,
     ) -> VmResult<fmt::Result> {
-        if let Err(fmt::Error) = write!(s, "{{") {
-            return VmResult::Ok(Err(fmt::Error));
-        }
+        vm_write!(s, "{{");
 
         let mut it = self.map.iter().peekable();
 
         while let Some((key, value)) = it.next() {
-            if let Err(fmt::Error) = write!(s, "{:?}", key) {
-                return VmResult::Ok(Err(fmt::Error));
-            }
-
-            if let Err(fmt::Error) = write!(s, ": ") {
-                return VmResult::Ok(Err(fmt::Error));
-            }
+            vm_write!(s, "{:?}: ", key);
 
             if let Err(fmt::Error) = vm_try!(value.string_debug_with(s, caller)) {
                 return VmResult::Ok(Err(fmt::Error));
             }
 
             if it.peek().is_some() {
-                if let Err(fmt::Error) = write!(s, ", ") {
-                    return VmResult::Ok(Err(fmt::Error));
-                }
+                vm_write!(s, ", ");
             }
         }
 
-        if let Err(fmt::Error) = write!(s, "}}") {
-            return VmResult::Ok(Err(fmt::Error));
-        }
-
+        vm_write!(s, "}}");
         VmResult::Ok(Ok(()))
     }
 

--- a/crates/rune/src/modules/collections/hash_set.rs
+++ b/crates/rune/src/modules/collections/hash_set.rs
@@ -343,28 +343,19 @@ impl HashSet {
         s: &mut String,
         _: &mut impl ProtocolCaller,
     ) -> VmResult<fmt::Result> {
-        if let Err(fmt::Error) = write!(s, "{{") {
-            return VmResult::Ok(Err(fmt::Error));
-        }
+        vm_write!(s, "{{");
 
         let mut it = self.set.iter().peekable();
 
         while let Some(value) = it.next() {
-            if let Err(fmt::Error) = write!(s, "{:?}", value) {
-                return VmResult::Ok(Err(fmt::Error));
-            }
+            vm_write!(s, "{:?}", value);
 
             if it.peek().is_some() {
-                if let Err(fmt::Error) = write!(s, ", ") {
-                    return VmResult::Ok(Err(fmt::Error));
-                }
+                vm_write!(s, ", ");
             }
         }
 
-        if let Err(fmt::Error) = write!(s, "}}") {
-            return VmResult::Ok(Err(fmt::Error));
-        }
-
+        vm_write!(s, "}}");
         VmResult::Ok(Ok(()))
     }
 

--- a/crates/rune/src/modules/collections/vec_deque.rs
+++ b/crates/rune/src/modules/collections/vec_deque.rs
@@ -530,11 +530,9 @@ impl VecDeque {
         s: &mut String,
         caller: &mut impl ProtocolCaller,
     ) -> VmResult<fmt::Result> {
-        if let Err(fmt::Error) = write!(s, "[") {
-            return VmResult::Ok(Err(fmt::Error));
-        }
-
         let mut it = self.inner.iter().peekable();
+
+        vm_write!(s, "[");
 
         while let Some(value) = it.next() {
             if let Err(fmt::Error) = vm_try!(value.string_debug_with(s, caller)) {
@@ -542,16 +540,11 @@ impl VecDeque {
             }
 
             if it.peek().is_some() {
-                if let Err(fmt::Error) = write!(s, ", ") {
-                    return VmResult::Ok(Err(fmt::Error));
-                }
+                vm_write!(s, ", ");
             }
         }
 
-        if let Err(fmt::Error) = write!(s, "]") {
-            return VmResult::Ok(Err(fmt::Error));
-        }
-
+        vm_write!(s, "]");
         VmResult::Ok(Ok(()))
     }
 

--- a/crates/rune/src/modules/future.rs
+++ b/crates/rune/src/modules/future.rs
@@ -63,7 +63,10 @@ where
         let future = match value {
             Value::Future(future) => vm_try!(future.clone().into_mut()),
             value => {
-                return VmResult::err(vm_try!(VmErrorKind::bad_argument::<Future>(index, value)))
+                return VmResult::err([
+                    VmErrorKind::expected::<Future>(vm_try!(value.type_info())),
+                    VmErrorKind::bad_argument(index),
+                ])
             }
         };
 
@@ -94,7 +97,10 @@ async fn join(value: Value) -> VmResult<Value> {
                 try_join_impl(vec.iter(), vec.len(), Value::vec).await
             ))
         }
-        value => VmResult::err(vm_try!(VmErrorKind::bad_argument::<Vec<Value>>(0, &value))),
+        actual => VmResult::err([
+            VmErrorKind::bad_argument(0),
+            VmErrorKind::expected::<Vec<Value>>(vm_try!(actual.type_info())),
+        ]),
     }
 }
 

--- a/crates/rune/src/modules/string.rs
+++ b/crates/rune/src/modules/string.rs
@@ -762,7 +762,12 @@ fn split(this: &str, value: Value) -> VmResult<Iterator> {
 
             lines
         }
-        value => return VmResult::err(vm_try!(VmErrorKind::bad_argument::<String>(0, &value))),
+        actual => {
+            return VmResult::err([
+                VmErrorKind::expected::<String>(vm_try!(actual.type_info())),
+                VmErrorKind::bad_argument(0),
+            ])
+        }
     };
 
     VmResult::Ok(Iterator::from_double_ended(

--- a/crates/rune/src/runtime.rs
+++ b/crates/rune/src/runtime.rs
@@ -167,8 +167,8 @@ mod vm_call;
 pub(crate) use self::vm_call::VmCall;
 
 mod vm_error;
-pub(crate) use self::vm_error::VmErrorKind;
 pub use self::vm_error::{try_result, TryFromResult, VmError, VmIntegerRepr, VmResult};
+pub(crate) use self::vm_error::{VmErrorAt, VmErrorKind};
 
 mod vm_execution;
 pub use self::vm_execution::{ExecutionState, VmExecution, VmSendExecution};

--- a/crates/rune/src/runtime/any_obj.rs
+++ b/crates/rune/src/runtime/any_obj.rs
@@ -481,7 +481,10 @@ impl AnyObj {
 
     /// Access full type info for type.
     pub fn type_info(&self) -> TypeInfo {
-        TypeInfo::Any(AnyTypeInfo::new((self.vtable.type_name)()))
+        TypeInfo::Any(AnyTypeInfo::__private_new(
+            (self.vtable.type_name)(),
+            (self.vtable.type_hash)(),
+        ))
     }
 }
 

--- a/crates/rune/src/runtime/awaited.rs
+++ b/crates/rune/src/runtime/awaited.rs
@@ -14,11 +14,11 @@ impl Awaited {
     pub(crate) async fn into_vm(self, vm: &mut Vm) -> VmResult<()> {
         match self {
             Self::Future(future) => {
-                let value = vm_try!(vm_try!(future.borrow_mut()).await);
+                let value = vm_try!(vm_try!(future.borrow_mut()).await.with_vm(vm));
                 vm.stack_mut().push(value);
             }
             Self::Select(select) => {
-                let (branch, value) = vm_try!(select.await);
+                let (branch, value) = vm_try!(select.await.with_vm(vm));
                 vm.stack_mut().push(value);
                 vm.stack_mut().push(vm_try!(ToValue::to_value(branch)));
             }

--- a/crates/rune/src/runtime/debug.rs
+++ b/crates/rune/src/runtime/debug.rs
@@ -9,8 +9,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::ast::Span;
 use crate::compile::ItemBuf;
+use crate::hash::Hash;
 use crate::runtime::DebugLabel;
-use crate::{Hash, SourceId};
+use crate::SourceId;
 
 /// Debug information about a unit.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -22,6 +23,8 @@ pub struct DebugInfo {
     pub functions: HashMap<Hash, DebugSignature>,
     /// Reverse lookup of a function.
     pub functions_rev: HashMap<usize, Hash>,
+    /// Hash to identifier.
+    pub hash_to_ident: HashMap<Hash, Box<str>>,
 }
 
 impl DebugInfo {
@@ -35,6 +38,11 @@ impl DebugInfo {
         let hash = *self.functions_rev.get(&ip)?;
         let signature = self.functions.get(&hash)?;
         Some((hash, signature))
+    }
+
+    /// Access an identifier for the given hash - if it exists.
+    pub fn ident_for_hash(&self, hash: Hash) -> Option<&str> {
+        Some(self.hash_to_ident.get(&hash)?)
     }
 }
 

--- a/crates/rune/src/runtime/protocol_caller.rs
+++ b/crates/rune/src/runtime/protocol_caller.rs
@@ -66,9 +66,8 @@ impl ProtocolCaller for EnvProtocolCaller {
                 return call.call_with_vm(vm);
             }
 
-            let handler = match context.function(hash) {
-                Some(handler) => handler,
-                None => return VmResult::err(VmErrorKind::MissingFunction { hash }),
+            let Some(handler) = context.function(hash) else {
+                return VmResult::err(VmErrorKind::MissingInstanceFunction { hash, instance: vm_try!(target.type_info()) });
             };
 
             let mut stack = Stack::with_capacity(count);

--- a/crates/rune/src/runtime/vec.rs
+++ b/crates/rune/src/runtime/vec.rs
@@ -216,11 +216,8 @@ impl Vec {
         s: &mut String,
         caller: &mut impl ProtocolCaller,
     ) -> VmResult<fmt::Result> {
-        if let Err(fmt::Error) = write!(s, "[") {
-            return VmResult::Ok(Err(fmt::Error));
-        }
-
         let mut it = this.iter().peekable();
+        vm_write!(s, "[");
 
         while let Some(value) = it.next() {
             if let Err(fmt::Error) = vm_try!(value.string_debug_with(s, caller)) {
@@ -228,16 +225,11 @@ impl Vec {
             }
 
             if it.peek().is_some() {
-                if let Err(fmt::Error) = write!(s, ", ") {
-                    return VmResult::Ok(Err(fmt::Error));
-                }
+                vm_write!(s, ", ");
             }
         }
 
-        if let Err(fmt::Error) = write!(s, "]") {
-            return VmResult::Ok(Err(fmt::Error));
-        }
-
+        vm_write!(s, "]");
         VmResult::Ok(Ok(()))
     }
 

--- a/crates/rune/src/tests/bug_344.rs
+++ b/crates/rune/src/tests/bug_344.rs
@@ -193,7 +193,10 @@ impl TypeOf for GuardCheck {
 
     #[inline]
     fn type_info() -> TypeInfo {
-        TypeInfo::Any(AnyTypeInfo::new(<Self as Named>::BASE_NAME))
+        TypeInfo::Any(AnyTypeInfo::__private_new(
+            <Self as Named>::BASE_NAME,
+            <Self as TypeOf>::type_hash(),
+        ))
     }
 }
 


### PR DESCRIPTION
This improves two aspects of diagnostics, the first one is when we use a protocol function then the corresponding protocol function will be added as a note (if it is known):

![image](https://github.com/rune-rs/rune/assets/111092/68831d22-8063-4eca-8dce-ac12e27a75d8)

The second is instance functions which have identifiers registered in the source, they now get a similar note which should be more helpful:

![image](https://github.com/rune-rs/rune/assets/111092/c3a5b430-7f9b-4d55-9642-c2408771719c)

Still upcoming is to provide diagnostics for full items like `HashMap::new`.