### PR TITLE
Allow impl item from anywhere

### DIFF
--- a/crates/rune/src/ast/path.rs
+++ b/crates/rune/src/ast/path.rs
@@ -1,5 +1,3 @@
-use core::iter;
-
 use crate::ast::prelude::*;
 
 #[test]
@@ -81,20 +79,6 @@ impl Path {
         }
 
         None
-    }
-
-    /// Iterate over all components in path.
-    pub(crate) fn as_components(&self) -> impl Iterator<Item = &'_ PathSegment> + '_ {
-        let mut first = Some(&self.first);
-        let mut it = self.rest.iter();
-
-        iter::from_fn(move || {
-            if let Some(first) = first.take() {
-                return Some(first);
-            }
-
-            Some(&it.next()?.1)
-        })
     }
 }
 

--- a/crates/rune/src/cli.rs
+++ b/crates/rune/src/cli.rs
@@ -384,7 +384,7 @@ enum Command {
 }
 
 impl Command {
-    const ALL: [&str; 8] = [
+    const ALL: [&'static str; 8] = [
         "check",
         "doc",
         "test",

--- a/crates/rune/src/compile/compile.rs
+++ b/crates/rune/src/compile/compile.rs
@@ -8,6 +8,7 @@ use crate::compile::{
     SourceLoader, UnitBuilder,
 };
 use crate::hir;
+use crate::indexing::FunctionAst;
 use crate::macros::Storage;
 use crate::parse::Resolve;
 use crate::query::{Build, BuildEntry, GenericsParameters, Query, Used};
@@ -175,121 +176,88 @@ impl<'arena> CompileBuildEntry<'_, 'arena> {
                     ));
                 }
             }
-            Build::EmptyFunction(f) => {
-                tracing::trace!("empty function: {}", self.q.pool.item(item_meta.item));
-
-                use self::v1::assemble;
-
-                let span = &f.span;
-
-                let arena = hir::Arena::new();
-                let mut cx = hir::lowering::Ctxt::with_query(
-                    &arena,
-                    self.q.borrow(),
-                    item_meta.location.source_id,
-                );
-                let hir = hir::lowering::empty_fn(&mut cx, &f.ast, &f.span)?;
-                let mut c = self.compiler1(location, span, &mut asm);
-                assemble::fn_from_item_fn(&mut c, &hir, false)?;
-
-                if !self.q.is_used(&item_meta) {
-                    self.q.diagnostics.not_used(location.source_id, span, None);
-                } else {
-                    self.q.unit.new_function(
-                        location,
-                        self.q.pool.item(item_meta.item),
-                        0,
-                        asm,
-                        f.call,
-                        Box::default(),
-                        unit_storage,
-                    )?;
-                }
-            }
             Build::Function(f) => {
                 tracing::trace!("function: {}", self.q.pool.item(item_meta.item));
 
                 use self::v1::assemble;
 
-                let args =
-                    format_fn_args(self.q.sources, location, f.ast.args.iter().map(|(a, _)| a))?;
+                // For instance functions, we are required to know the type hash
+                // of the type it is associated with to perform the proper
+                // naming of the function.
+                let type_hash = if f.is_instance {
+                    let Some(impl_item) =
+                        f.impl_item.and_then(|item| self.q.inner.items.get(&item))
+                    else {
+                        return Err(compile::Error::msg(
+                            &f.ast,
+                            "Impl item has not been expanded",
+                        ));
+                    };
 
-                let span = &*f.ast;
-                let count = f.ast.args.len();
+                    let meta = self.q.lookup_meta(
+                        &location,
+                        impl_item.item,
+                        GenericsParameters::default(),
+                    )?;
+
+                    let Some(type_hash) = meta.type_hash_of() else {
+                        return Err(compile::Error::expected_meta(
+                            &f.ast,
+                            meta.info(self.q.pool),
+                            "type for associated function",
+                        ));
+                    };
+
+                    Some(type_hash)
+                } else {
+                    None
+                };
+
+                let (args, span): (_, &dyn Spanned) = match &f.ast {
+                    FunctionAst::Item(ast) => {
+                        let args = format_fn_args(
+                            self.q.sources,
+                            location,
+                            ast.args.iter().map(|(a, _)| a),
+                        )?;
+                        (args, ast)
+                    }
+                    FunctionAst::Empty(.., span) => (Box::default(), span),
+                };
 
                 let arena = hir::Arena::new();
+
                 let mut cx = hir::lowering::Ctxt::with_query(
                     &arena,
                     self.q.borrow(),
                     item_meta.location.source_id,
                 );
-                let hir = hir::lowering::item_fn(&mut cx, &f.ast)?;
+
+                let hir = match &f.ast {
+                    FunctionAst::Item(ast) => hir::lowering::item_fn(&mut cx, ast)?,
+                    FunctionAst::Empty(ast, span) => hir::lowering::empty_fn(&mut cx, ast, &span)?,
+                };
+
+                let count = hir.args.len();
+
                 let mut c = self.compiler1(location, span, &mut asm);
-                assemble::fn_from_item_fn(&mut c, &hir, false)?;
+                assemble::fn_from_item_fn(&mut c, &hir, f.is_instance)?;
 
                 if !self.q.is_used(&item_meta) {
                     self.q.diagnostics.not_used(location.source_id, span, None);
                 } else {
+                    let instance = match (type_hash, &f.ast) {
+                        (Some(type_hash), FunctionAst::Item(ast)) => {
+                            let name = ast.name.resolve(resolve_context!(self.q))?;
+                            Some((type_hash, name))
+                        }
+                        _ => None,
+                    };
+
                     self.q.unit.new_function(
                         location,
                         self.q.pool.item(item_meta.item),
-                        count,
-                        asm,
-                        f.call,
-                        args,
-                        unit_storage,
-                    )?;
-                }
-            }
-            Build::InstanceFunction(f) => {
-                tracing::trace!("instance function: {}", self.q.pool.item(item_meta.item));
-
-                use self::v1::assemble;
-
-                let args =
-                    format_fn_args(self.q.sources, location, f.ast.args.iter().map(|(a, _)| a))?;
-
-                let count = f.ast.args.len();
-
-                let arena = hir::Arena::new();
-                let mut c = self.compiler1(location, &f.ast, &mut asm);
-
-                let Some(impl_item) = c.q.inner.items.get(&f.impl_item) else {
-                    return Err(compile::Error::msg(
-                        &f.ast,
-                        "Impl item has not been expanded",
-                    ));
-                };
-
-                let meta =
-                    c.q.lookup_meta(&location, impl_item.item, GenericsParameters::default())?;
-
-                let Some(type_hash) = meta.type_hash_of() else {
-                    return Err(compile::Error::expected_meta(
-                        &f.ast,
-                        meta.info(c.q.pool),
-                        "type for associated function",
-                    ));
-                };
-
-                let mut cx = hir::lowering::Ctxt::with_query(
-                    &arena,
-                    c.q.borrow(),
-                    item_meta.location.source_id,
-                );
-                let hir = hir::lowering::item_fn(&mut cx, &f.ast)?;
-                assemble::fn_from_item_fn(&mut c, &hir, true)?;
-
-                if !c.q.is_used(&item_meta) {
-                    c.q.diagnostics.not_used(location.source_id, &f.ast, None);
-                } else {
-                    let name = f.ast.name.resolve(resolve_context!(self.q))?;
-
-                    self.q.unit.new_instance_function(
-                        location,
-                        self.q.pool.item(item_meta.item),
-                        type_hash,
-                        name,
+                        instance,
                         count,
                         asm,
                         f.call,
@@ -328,6 +296,7 @@ impl<'arena> CompileBuildEntry<'_, 'arena> {
                     self.q.unit.new_function(
                         location,
                         self.q.pool.item(item_meta.item),
+                        None,
                         closure.ast.args.len(),
                         asm,
                         closure.call,
@@ -363,6 +332,7 @@ impl<'arena> CompileBuildEntry<'_, 'arena> {
                     self.q.unit.new_function(
                         location,
                         self.q.pool.item(item_meta.item),
+                        None,
                         args,
                         asm,
                         b.call,

--- a/crates/rune/src/compile/context.rs
+++ b/crates/rune/src/compile/context.rs
@@ -640,10 +640,15 @@ impl Context {
             hash,
             item: Some(item),
             kind: meta::Kind::Function {
+                associated: None,
+                signature,
                 is_test: false,
                 is_bench: false,
-                signature,
                 parameters: Hash::EMPTY,
+                #[cfg(feature = "doc")]
+                container: None,
+                #[cfg(feature = "doc")]
+                parameter_types: Vec::new(),
             },
             #[cfg(feature = "doc")]
             docs: f.docs.clone(),
@@ -722,7 +727,7 @@ impl Context {
         // should not be mixed in again.
         let hash = assoc
             .name
-            .kind
+            .associated
             .hash(assoc.container.hash)
             .with_function_parameters(assoc.name.function_parameters);
 
@@ -751,7 +756,7 @@ impl Context {
         //
         // The other alternatives are protocol functions (which are not free)
         // and plain hashes.
-        let item = if let meta::AssociatedKind::Instance(name) = &assoc.name.kind {
+        let item = if let meta::AssociatedKind::Instance(name) = &assoc.name.associated {
             let item = info.item.extended(name.as_ref());
 
             let hash = Hash::type_hash(&item)
@@ -772,14 +777,16 @@ impl Context {
         self.install_meta(ContextMeta {
             hash,
             item,
-            kind: meta::Kind::AssociatedFunction {
-                kind: assoc.name.kind.clone(),
+            kind: meta::Kind::Function {
+                associated: Some(assoc.name.associated.clone()),
                 signature,
+                is_test: false,
+                is_bench: false,
                 parameters: Hash::EMPTY
                     .with_type_parameters(info.type_parameters)
                     .with_function_parameters(assoc.name.function_parameters),
                 #[cfg(feature = "doc")]
-                container: assoc.container.hash,
+                container: Some(assoc.container.hash),
                 #[cfg(feature = "doc")]
                 parameter_types: assoc.name.parameter_types.clone(),
             },

--- a/crates/rune/src/compile/meta.rs
+++ b/crates/rune/src/compile/meta.rs
@@ -117,7 +117,6 @@ impl Meta {
             Kind::Struct { .. } => Some(self.hash),
             Kind::Enum { .. } => Some(self.hash),
             Kind::Function { .. } => Some(self.hash),
-            Kind::AssociatedFunction { .. } => Some(self.hash),
             Kind::Closure { .. } => Some(self.hash),
             Kind::AsyncBlock { .. } => Some(self.hash),
             Kind::Variant { .. } => None,
@@ -183,6 +182,9 @@ pub enum Kind {
     AttributeMacro,
     /// A function declaration.
     Function {
+        /// The associated kind of the function, if it is an associated
+        /// function.
+        associated: Option<AssociatedKind>,
         /// Native signature for this function.
         signature: Signature,
         /// Whether this function has a `#[test]` annotation
@@ -191,18 +193,9 @@ pub enum Kind {
         is_bench: bool,
         /// Hash of generic parameters.
         parameters: Hash,
-    },
-    /// An associated function.
-    AssociatedFunction {
-        /// The name of the instance function.
-        kind: AssociatedKind,
-        /// Native signature for this function.
-        signature: Signature,
-        /// Parameters hash.
-        parameters: Hash,
         /// The container of the associated function.
         #[cfg(feature = "doc")]
-        container: Hash,
+        container: Option<Hash>,
         /// Parameter types.
         #[cfg(feature = "doc")]
         parameter_types: Vec<Hash>,
@@ -242,7 +235,6 @@ impl Kind {
             Kind::Struct { constructor, .. } => constructor.as_ref(),
             Kind::Variant { constructor, .. } => constructor.as_ref(),
             Kind::Function { signature, .. } => Some(signature),
-            Kind::AssociatedFunction { signature, .. } => Some(signature),
             _ => None,
         }
     }
@@ -251,7 +243,6 @@ impl Kind {
     pub(crate) fn as_parameters(&self) -> Hash {
         match self {
             Kind::Function { parameters, .. } => *parameters,
-            Kind::AssociatedFunction { parameters, .. } => *parameters,
             Kind::Type { parameters, .. } => *parameters,
             Kind::Enum { parameters, .. } => *parameters,
             Kind::Struct { parameters, .. } => *parameters,
@@ -264,7 +255,7 @@ impl Kind {
     pub(crate) fn associated_container(&self) -> Option<Hash> {
         match self {
             Kind::Variant { enum_hash, .. } => Some(*enum_hash),
-            Kind::AssociatedFunction { container, .. } => Some(*container),
+            Kind::Function { container, .. } => *container,
             _ => None,
         }
     }

--- a/crates/rune/src/compile/meta_info.rs
+++ b/crates/rune/src/compile/meta_info.rs
@@ -120,8 +120,13 @@ impl MetaInfoKind {
             meta::Kind::Enum { .. } => MetaInfoKind::Enum,
             meta::Kind::Macro { .. } => MetaInfoKind::Macro,
             meta::Kind::AttributeMacro { .. } => MetaInfoKind::AttributeMacro,
-            meta::Kind::Function { .. } => MetaInfoKind::Function,
-            meta::Kind::AssociatedFunction { .. } => MetaInfoKind::Associated,
+            meta::Kind::Function {
+                associated: None, ..
+            } => MetaInfoKind::Function,
+            meta::Kind::Function {
+                associated: Some(..),
+                ..
+            } => MetaInfoKind::Associated,
             meta::Kind::Closure { .. } => MetaInfoKind::Closure,
             meta::Kind::AsyncBlock { .. } => MetaInfoKind::AsyncBlock,
             meta::Kind::Const { .. } => MetaInfoKind::Const,

--- a/crates/rune/src/hashbrown/table.rs
+++ b/crates/rune/src/hashbrown/table.rs
@@ -166,7 +166,7 @@ impl<'a, V> iter::Iterator for Iter<'a, V> {
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         // SAFETY: we're still holding onto the `RawRef` guard.
-        unsafe { Some(self.iter.next()?.as_ref().clone()) }
+        unsafe { Some(self.iter.next()?.as_ref()) }
     }
 
     #[inline]

--- a/crates/rune/src/hir/lowering.rs
+++ b/crates/rune/src/hir/lowering.rs
@@ -1423,9 +1423,7 @@ fn expr_path_meta<'hir>(
                 fields: meta::Fields::Unnamed(..),
                 ..
             } => Ok(hir::ExprKind::Fn(meta.hash)),
-            meta::Kind::Function { .. } | meta::Kind::AssociatedFunction { .. } => {
-                Ok(hir::ExprKind::Fn(meta.hash))
-            }
+            meta::Kind::Function { .. } => Ok(hir::ExprKind::Fn(meta.hash)),
             meta::Kind::Const { .. } => Ok(hir::ExprKind::Const(meta.hash)),
             meta::Kind::Struct { .. } | meta::Kind::Type { .. } | meta::Kind::Enum { .. } => {
                 Ok(hir::ExprKind::Type(Type::new(meta.hash)))
@@ -1689,7 +1687,7 @@ fn expr_call<'hir>(
                             );
                         }
                     }
-                    meta::Kind::Function { .. } | meta::Kind::AssociatedFunction { .. } => (),
+                    meta::Kind::Function { .. } => (),
                     meta::Kind::ConstFn { id, .. } => {
                         let id = *id;
                         let from = cx.q.item_for(ast.id).with_span(ast)?;

--- a/crates/rune/src/hir/lowering.rs
+++ b/crates/rune/src/hir/lowering.rs
@@ -13,7 +13,7 @@ use crate::hash::{Hash, ParametersBuilder};
 use crate::hir;
 use crate::indexing;
 use crate::parse::Resolve;
-use crate::query::{self, Build, BuildEntry, GenericsParameters, Named, Query, Used};
+use crate::query::{self, Build, BuildEntry, GenericsParameters, Named, Query};
 use crate::runtime::{Type, TypeCheck};
 use crate::SourceId;
 
@@ -270,13 +270,13 @@ fn expr_call_closure<'hir>(
             expr(cx, &ast.body)?;
             let layer = cx.scopes.pop().with_span(&ast.body)?;
 
+            cx.q.set_used(&meta.item_meta);
             cx.q.inner.queue.push_back(BuildEntry {
                 item_meta: meta.item_meta,
                 build: Build::Closure(indexing::Closure {
                     ast: Box::new(ast.clone()),
                     call,
                 }),
-                used: Used::Used,
             });
 
             cx.q.insert_captures(meta.hash, layer.captures());
@@ -925,13 +925,13 @@ pub(crate) fn expr_block<'hir>(
 
                     cx.q.insert_captures(meta.hash, layer.captures());
 
+                    cx.q.set_used(&meta.item_meta);
                     cx.q.inner.queue.push_back(BuildEntry {
                         item_meta: meta.item_meta,
                         build: Build::AsyncBlock(indexing::AsyncBlock {
                             ast: ast.block.clone(),
                             call,
                         }),
-                        used: Used::Used,
                     });
 
                     iter!(layer.captures())

--- a/crates/rune/src/indexing.rs
+++ b/crates/rune/src/indexing.rs
@@ -69,6 +69,9 @@ pub(crate) struct Function {
     pub(crate) is_test: bool,
     /// If this is a bench function.
     pub(crate) is_bench: bool,
+    /// The impl item this function is registered in.
+    #[allow(unused)]
+    pub(crate) impl_item: Option<NonZeroId>,
 }
 
 #[derive(Debug, Clone)]
@@ -88,7 +91,7 @@ pub(crate) struct InstanceFunction {
     /// The calling convention of the function.
     pub(crate) call: Call,
     /// The item of the instance function.
-    pub(crate) impl_item: ItemId,
+    pub(crate) impl_item: NonZeroId,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/rune/src/indexing/index.rs
+++ b/crates/rune/src/indexing/index.rs
@@ -804,14 +804,14 @@ pub(crate) fn item_fn_immediate(
         if is_test {
             return Err(compile::Error::msg(
                 &ast,
-                "The #[test] attribute is not supported on member functions",
+                "The #[test] attribute is not supported on functions receiving `self`",
             ));
         }
 
         if is_bench {
             return Err(compile::Error::msg(
                 &ast,
-                "The #[bench] attribute is not supported on member functions",
+                "The #[bench] attribute is not supported on functions receiving `self`",
             ));
         }
 
@@ -831,9 +831,9 @@ pub(crate) fn item_fn_immediate(
             }),
         });
     } else {
-        // NB: it's only a public item in the sense of exporting it if it's not
+        // NB: It's only a public item in the sense of exporting it if it's not
         // inside of a nested item.
-        let is_public = item_meta.is_public(idx.q.pool) && idx.nested_item.is_none();
+        let is_exported = item_meta.is_public(idx.q.pool) && idx.nested_item.is_none();
 
         let entry = indexing::Entry {
             item_meta,
@@ -846,7 +846,7 @@ pub(crate) fn item_fn_immediate(
             }),
         };
 
-        if is_public || is_test || is_bench {
+        if is_exported || is_test || is_bench {
             idx.q.index_and_build(entry);
         } else {
             idx.q.index(entry);

--- a/crates/rune/src/languageserver/completion.rs
+++ b/crates/rune/src/languageserver/completion.rs
@@ -88,8 +88,8 @@ pub(super) fn complete_native_instance_data(
         let (prefix, kind, n) = match (&meta.item, &meta.kind) {
             (
                 Some(item),
-                meta::Kind::AssociatedFunction {
-                    kind: meta::AssociatedKind::Instance(name),
+                meta::Kind::Function {
+                    associated: Some(meta::AssociatedKind::Instance(name)),
                     ..
                 },
             ) => (item, CompletionItemKind::FUNCTION, name),

--- a/crates/rune/src/languageserver/state.rs
+++ b/crates/rune/src/languageserver/state.rs
@@ -932,8 +932,13 @@ impl CompileVisitor for Visitor {
                 ..
             } => DefinitionKind::StructVariant,
             meta::Kind::Enum { .. } => DefinitionKind::Enum,
-            meta::Kind::Function { .. } => DefinitionKind::Function,
-            meta::Kind::AssociatedFunction { .. } => DefinitionKind::AssociatedFunction,
+            meta::Kind::Function {
+                associated: None, ..
+            } => DefinitionKind::Function,
+            meta::Kind::Function {
+                associated: Some(..),
+                ..
+            } => DefinitionKind::AssociatedFunction,
             _ => return,
         };
 

--- a/crates/rune/src/module/function_meta.rs
+++ b/crates/rune/src/module/function_meta.rs
@@ -151,7 +151,7 @@ impl AttributeMacroData {
 #[doc(hidden)]
 pub struct AssociatedFunctionName {
     /// The name of the instance function.
-    pub kind: meta::AssociatedKind,
+    pub associated: meta::AssociatedKind,
     /// Parameters hash.
     pub function_parameters: Hash,
     #[cfg(feature = "doc")]
@@ -161,7 +161,7 @@ pub struct AssociatedFunctionName {
 impl AssociatedFunctionName {
     pub(crate) fn index(protocol: Protocol, index: usize) -> Self {
         Self {
-            kind: meta::AssociatedKind::IndexFn(protocol, index),
+            associated: meta::AssociatedKind::IndexFn(protocol, index),
             function_parameters: Hash::EMPTY,
             #[cfg(feature = "doc")]
             parameter_types: vec![],
@@ -186,7 +186,7 @@ impl ToInstance for &'static str {
     #[inline]
     fn to_instance(self) -> AssociatedFunctionName {
         AssociatedFunctionName {
-            kind: meta::AssociatedKind::Instance(Cow::Borrowed(self)),
+            associated: meta::AssociatedKind::Instance(Cow::Borrowed(self)),
             function_parameters: Hash::EMPTY,
             #[cfg(feature = "doc")]
             parameter_types: vec![],
@@ -198,7 +198,7 @@ impl ToFieldFunction for &'static str {
     #[inline]
     fn to_field_function(self, protocol: Protocol) -> AssociatedFunctionName {
         AssociatedFunctionName {
-            kind: meta::AssociatedKind::FieldFn(protocol, Cow::Borrowed(self)),
+            associated: meta::AssociatedKind::FieldFn(protocol, Cow::Borrowed(self)),
             function_parameters: Hash::EMPTY,
             #[cfg(feature = "doc")]
             parameter_types: vec![],
@@ -256,7 +256,7 @@ impl AssociatedFunctionData {
     pub(crate) fn assoc_key(&self) -> AssociatedKey {
         AssociatedKey {
             type_hash: self.container.hash,
-            kind: self.name.kind.clone(),
+            kind: self.name.associated.clone(),
             parameters: self.name.function_parameters,
         }
     }

--- a/crates/rune/src/module/module.rs
+++ b/crates/rune/src/module/module.rs
@@ -1304,7 +1304,7 @@ impl Module {
         docs: Docs,
     ) -> Result<ItemFnMut<'_>, ContextError> {
         if !self.names.insert(Name::Associated(data.assoc_key())) {
-            return Err(match data.name.kind {
+            return Err(match data.name.associated {
                 meta::AssociatedKind::Protocol(protocol) => {
                     ContextError::ConflictingProtocolFunction {
                         type_info: data.container_type_info,

--- a/crates/rune/src/params.rs
+++ b/crates/rune/src/params.rs
@@ -14,7 +14,7 @@ where
         let info = self.name.to_instance();
 
         AssociatedFunctionName {
-            kind: info.kind,
+            associated: info.associated,
             function_parameters: Hash::parameters(self.parameters.iter().map(|t| t.hash)),
             #[cfg(feature = "doc")]
             parameter_types: self.parameters.iter().map(|t| t.hash).collect(),
@@ -31,7 +31,7 @@ where
         let info = self.name.to_field_function(protocol);
 
         AssociatedFunctionName {
-            kind: info.kind,
+            associated: info.associated,
             function_parameters: Hash::parameters(self.parameters.iter().map(|p| p.hash)),
             #[cfg(feature = "doc")]
             parameter_types: self.parameters.iter().map(|p| p.hash).collect(),

--- a/crates/rune/src/query.rs
+++ b/crates/rune/src/query.rs
@@ -6,6 +6,7 @@ mod query;
 use core::fmt;
 use core::num::NonZeroUsize;
 
+use crate::no_std::path::PathBuf;
 use crate::no_std::prelude::*;
 
 pub(crate) use self::query::{MissingId, Query, QueryInner};
@@ -14,10 +15,11 @@ use crate as rune;
 use crate::ast;
 use crate::ast::{Span, Spanned};
 use crate::compile::ir;
-use crate::compile::{ItemId, ItemMeta, ModId};
+use crate::compile::{ItemId, ItemMeta, Location, ModId};
 use crate::hash::Hash;
 use crate::hir;
 use crate::indexing;
+use crate::parse::NonZeroId;
 use crate::runtime::format;
 
 /// Indication whether a value is being evaluated because it's being used or not.
@@ -44,6 +46,8 @@ impl Default for Used {
 
 /// The result of calling [Query::convert_path].
 pub(crate) struct Named<'ast> {
+    /// Module named item belongs to.
+    pub(crate) module: ModId,
     /// The path resolved to the given item.
     pub(crate) item: ItemId,
     /// Trailing parameters.
@@ -144,12 +148,33 @@ pub(crate) struct BuildEntry {
     pub(crate) build: Build,
 }
 
+/// An implementation function.
+pub(crate) struct QueryImplFn {
+    /// Ast for declaration.
+    pub(crate) ast: Box<ast::ItemFn>,
+}
+
+pub(crate) struct ItemImplEntry {
+    /// Non-expanded ast of the path.
+    pub(crate) path: Box<ast::Path>,
+    /// Location where the item impl is defined and is being expanded.
+    pub(crate) location: Location,
+    /// The item impl being expanded.
+    pub(crate) id: NonZeroId,
+    ///See [Indexer][crate::indexing::Indexer].
+    pub(crate) root: Option<PathBuf>,
+    ///See [Indexer][crate::indexing::Indexer].
+    pub(crate) nested_item: Option<Span>,
+    /// See [Indexer][crate::indexing::Indexer].
+    pub(crate) macro_depth: usize,
+}
+
 /// Query information for a path.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct QueryPath {
     pub(crate) module: ModId,
+    pub(crate) impl_item: Option<NonZeroId>,
     pub(crate) item: ItemId,
-    pub(crate) impl_item: Option<ItemId>,
 }
 
 /// A compiled constant function.

--- a/crates/rune/src/query.rs
+++ b/crates/rune/src/query.rs
@@ -124,9 +124,7 @@ pub(crate) struct BuiltInLine {
 /// An entry in the build queue.
 #[derive(Debug, Clone)]
 pub(crate) enum Build {
-    EmptyFunction(indexing::EmptyFunction),
     Function(indexing::Function),
-    InstanceFunction(indexing::InstanceFunction),
     Closure(indexing::Closure),
     AsyncBlock(indexing::AsyncBlock),
     Unused,

--- a/crates/rune/src/query.rs
+++ b/crates/rune/src/query.rs
@@ -142,8 +142,6 @@ pub(crate) enum Build {
 pub(crate) struct BuildEntry {
     /// The item of the build entry.
     pub(crate) item_meta: ItemMeta,
-    /// If the queued up entry was unused or not.
-    pub(crate) used: Used,
     /// The build entry.
     pub(crate) build: Build,
 }

--- a/crates/rune/src/runtime/protocol.rs
+++ b/crates/rune/src/runtime/protocol.rs
@@ -9,7 +9,7 @@ impl ToInstance for Protocol {
     #[inline]
     fn to_instance(self) -> AssociatedFunctionName {
         AssociatedFunctionName {
-            kind: meta::AssociatedKind::Protocol(self),
+            associated: meta::AssociatedKind::Protocol(self),
             function_parameters: Hash::EMPTY,
             #[cfg(feature = "doc")]
             parameter_types: vec![],

--- a/crates/rune/src/runtime/static_string.rs
+++ b/crates/rune/src/runtime/static_string.rs
@@ -26,7 +26,7 @@ impl cmp::Eq for StaticString {}
 
 impl cmp::PartialOrd for StaticString {
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-        self.inner.partial_cmp(&other.inner)
+        Some(self.cmp(other))
     }
 }
 

--- a/crates/rune/src/runtime/value.rs
+++ b/crates/rune/src/runtime/value.rs
@@ -191,7 +191,7 @@ impl hash::Hash for VariantRtti {
 
 impl PartialOrd for VariantRtti {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.hash.partial_cmp(&other.hash)
+        Some(self.cmp(other))
     }
 }
 
@@ -227,7 +227,7 @@ impl hash::Hash for Rtti {
 
 impl PartialOrd for Rtti {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.hash.partial_cmp(&other.hash)
+        Some(self.cmp(other))
     }
 }
 

--- a/crates/rune/src/tests.rs
+++ b/crates/rune/src/tests.rs
@@ -379,6 +379,7 @@ mod core_macros;
 mod custom_macros;
 mod derive_from_to_value;
 mod destructuring;
+mod esoteric_impls;
 mod external_constructor;
 mod external_generic;
 mod external_match;

--- a/crates/rune/src/tests.rs
+++ b/crates/rune/src/tests.rs
@@ -172,7 +172,7 @@ where
 macro_rules! expected {
     ($name:literal, $expected:pat, $actual:expr) => {
         panic!(
-            "Did not get expected {}\nExpected: {}\n  Actual: {:?}",
+            "Did not match expected {}\nExpected: {}\n  Actual: {:?}",
             $name,
             stringify!($expected),
             $actual

--- a/crates/rune/src/tests/esoteric_impls.rs
+++ b/crates/rune/src/tests/esoteric_impls.rs
@@ -1,0 +1,60 @@
+prelude!();
+
+#[test]
+fn impl_in_other_mod() {
+    rune! {
+        struct Foo;
+
+        mod lol {
+            use super::Foo;
+
+            impl Foo {
+                fn lol(self) {
+                    2
+                }
+            }
+        }
+
+        pub fn main() {
+            assert_eq!(Foo.lol(), 2);
+        }
+    }
+}
+
+#[test]
+fn impl_in_super() {
+    rune! {
+        struct Foo;
+
+        mod lol {
+            impl super::Foo {
+                fn lol(self) {
+                    3
+                }
+            }
+        }
+
+        pub fn main() {
+            assert_eq!(Foo.lol(), 3);
+        }
+    }
+}
+
+#[test]
+fn impl_in_block() {
+    rune! {
+        struct Foo;
+
+        pub fn main() {
+            let value = {
+                impl Foo {
+                    fn lol(self) {
+                        4
+                    }
+                }
+            };
+
+            assert_eq!(Foo.lol(), 4);
+        }
+    }
+}

--- a/crates/rune/src/tests/esoteric_impls.rs
+++ b/crates/rune/src/tests/esoteric_impls.rs
@@ -1,5 +1,7 @@
 prelude!();
 
+use ErrorKind::*;
+
 #[test]
 fn impl_in_other_mod() {
     rune! {
@@ -56,5 +58,23 @@ fn impl_in_block() {
 
             assert_eq!(Foo.lol(), 4);
         }
+    }
+}
+
+#[test]
+fn deny_self_impl() {
+    assert_errors! {
+        r#"
+        struct Foo;
+
+        impl Foo {
+            fn a() {
+                impl Self {
+                    fn b(self) {}
+                }
+            }
+        }
+        "#,
+        span!(83, 87), UnsupportedSelfType,
     }
 }

--- a/crates/rune/src/worker.rs
+++ b/crates/rune/src/worker.rs
@@ -173,7 +173,11 @@ impl<'a, 'arena> Worker<'a, 'arena> {
                 tracing::trace!(?entry.id, "next impl item entry");
 
                 let process = || {
-                    let named = self.q.convert_path(&entry.path)?;
+                    // We conservatively deny `Self` impl since that is what
+                    // Rust does, and at some point in the future we might
+                    // introduce bounds which would not be communicated through
+                    // `Self`.
+                    let named = self.q.convert_path_with(&entry.path, true)?;
 
                     if let Some((spanned, _)) = named.parameters.into_iter().flatten().next() {
                         return Err(compile::Error::new(

--- a/crates/rune/src/worker.rs
+++ b/crates/rune/src/worker.rs
@@ -7,11 +7,11 @@ use crate::no_std::collections::VecDeque;
 
 use crate::ast;
 use crate::ast::Span;
-use crate::compile::ModId;
+use crate::compile::{self, ModId};
 use crate::indexing::index;
 use crate::indexing::items::Items;
 use crate::indexing::{IndexItem, Indexer, Scopes};
-use crate::query::Query;
+use crate::query::{GenericsParameters, Query};
 use crate::SourceId;
 
 mod import;
@@ -41,120 +41,191 @@ impl<'a, 'arena> Worker<'a, 'arena> {
         }
     }
 
-    /// Run the worker until the task queue is empty.
-    pub(crate) fn run(&mut self) {
+    /// Perform indexing in the worker.
+    pub(crate) fn index(&mut self) {
         // NB: defer wildcard expansion until all other imports have been
         // indexed.
         let mut wildcard_imports = Vec::new();
 
-        while let Some(task) = self.queue.pop_front() {
-            match task {
-                Task::LoadFile {
-                    kind,
-                    source_id,
-                    mod_item,
-                    mod_item_id,
-                } => {
-                    let item = self.q.pool.module_item(mod_item);
-                    tracing::trace!("load file: {}", item);
+        while !self.queue.is_empty() {
+            // Prioritise processing the indexing queue. This ensures that files
+            // and imports are loaded which might be used by subsequent steps.
+            // We only advance wildcard imports and impl items once this is
+            // empty.
+            //
+            // Language semantics also ensures that once this queue is drained,
+            // every item which might affect the behavior of imports has been
+            // indexed.
+            while let Some(task) = self.queue.pop_front() {
+                match task {
+                    Task::LoadFile {
+                        kind,
+                        source_id,
+                        mod_item,
+                        mod_item_id,
+                    } => {
+                        let item = self.q.pool.module_item(mod_item);
+                        tracing::trace!("load file: {}", item);
 
-                    let Some(source) = self.q.sources.get(source_id) else {
-                        self.q
-                            .diagnostics
-                            .internal(source_id, "Missing queued source by id");
-                        continue;
-                    };
+                        let Some(source) = self.q.sources.get(source_id) else {
+                            self.q
+                                .diagnostics
+                                .internal(source_id, "Missing queued source by id");
+                            continue;
+                        };
 
-                    let root = match kind {
-                        LoadFileKind::Root => source.path().map(ToOwned::to_owned),
-                        LoadFileKind::Module { root } => root,
-                    };
+                        let root = match kind {
+                            LoadFileKind::Root => source.path().map(ToOwned::to_owned),
+                            LoadFileKind::Module { root } => root,
+                        };
 
-                    let items = Items::new(item, mod_item_id, self.q.gen);
+                        let items = Items::new(item, mod_item_id, self.q.gen);
 
-                    macro_rules! indexer {
-                        () => {
-                            Indexer {
-                                q: self.q.borrow(),
-                                root,
+                        macro_rules! indexer {
+                            () => {
+                                Indexer {
+                                    q: self.q.borrow(),
+                                    root,
+                                    source_id,
+                                    items,
+                                    scopes: Scopes::default(),
+                                    item: IndexItem::new(mod_item),
+                                    nested_item: None,
+                                    macro_depth: 0,
+                                    loaded: Some(&mut self.loaded),
+                                    queue: Some(&mut self.queue),
+                                }
+                            };
+                        }
+
+                        if self.q.options.function_body {
+                            let ast = match crate::parse::parse_all::<ast::EmptyBlock>(
+                                source.as_str(),
                                 source_id,
-                                items,
-                                scopes: Scopes::default(),
-                                item: IndexItem::new(mod_item),
-                                nested_item: None,
-                                macro_depth: 0,
-                                loaded: Some(&mut self.loaded),
-                                queue: Some(&mut self.queue),
+                                true,
+                            ) {
+                                Ok(ast) => ast,
+                                Err(error) => {
+                                    self.q.diagnostics.error(source_id, error);
+                                    continue;
+                                }
+                            };
+
+                            let span = Span::new(0, source.len());
+                            let mut idx = indexer!();
+
+                            if let Err(error) = index::empty_block_fn(&mut idx, ast, &span) {
+                                idx.q.diagnostics.error(source_id, error);
                             }
-                        };
-                    }
+                        } else {
+                            let mut ast = match crate::parse::parse_all::<ast::File>(
+                                source.as_str(),
+                                source_id,
+                                true,
+                            ) {
+                                Ok(ast) => ast,
+                                Err(error) => {
+                                    self.q.diagnostics.error(source_id, error);
+                                    continue;
+                                }
+                            };
 
-                    if self.q.options.function_body {
-                        let ast = match crate::parse::parse_all::<ast::EmptyBlock>(
-                            source.as_str(),
-                            source_id,
-                            true,
-                        ) {
-                            Ok(ast) => ast,
-                            Err(error) => {
-                                self.q.diagnostics.error(source_id, error);
-                                continue;
+                            let mut idx = indexer!();
+
+                            if let Err(error) = index::file(&mut idx, &mut ast) {
+                                idx.q.diagnostics.error(source_id, error);
                             }
-                        };
-
-                        let span = Span::new(0, source.len());
-                        let mut idx = indexer!();
-
-                        if let Err(error) = index::empty_block_fn(&mut idx, ast, &span) {
-                            idx.q.diagnostics.error(source_id, error);
-                        }
-                    } else {
-                        let mut ast = match crate::parse::parse_all::<ast::File>(
-                            source.as_str(),
-                            source_id,
-                            true,
-                        ) {
-                            Ok(ast) => ast,
-                            Err(error) => {
-                                self.q.diagnostics.error(source_id, error);
-                                continue;
-                            }
-                        };
-
-                        let mut idx = indexer!();
-
-                        if let Err(error) = index::file(&mut idx, &mut ast) {
-                            idx.q.diagnostics.error(source_id, error);
                         }
                     }
-                }
-                Task::ExpandImport(import) => {
-                    tracing::trace!("expand import");
+                    Task::ExpandImport(import) => {
+                        tracing::trace!("expand import");
 
-                    let source_id = import.source_id;
-                    let queue = &mut self.queue;
+                        let source_id = import.source_id;
+                        let queue = &mut self.queue;
 
-                    let result = import.process(&mut self.q, &mut |task| {
-                        queue.push_back(task);
-                    });
+                        let result = import.process(&mut self.q, &mut |task| {
+                            queue.push_back(task);
+                        });
 
-                    if let Err(error) = result {
-                        self.q.diagnostics.error(source_id, error);
+                        if let Err(error) = result {
+                            self.q.diagnostics.error(source_id, error);
+                        }
                     }
-                }
-                Task::ExpandWildcardImport(wildcard_import) => {
-                    tracing::trace!("expand wildcard import");
-
-                    wildcard_imports.push(wildcard_import);
+                    Task::ExpandWildcardImport(wildcard_import) => {
+                        tracing::trace!("expand wildcard import");
+                        wildcard_imports.push(wildcard_import);
+                    }
                 }
             }
-        }
 
-        for mut wildcard_import in wildcard_imports {
-            if let Err(error) = wildcard_import.process_local(&mut self.q) {
-                self.q
-                    .diagnostics
-                    .error(wildcard_import.location.source_id, error);
+            // Process discovered wildcard imports, since they might be used
+            // during impl items below.
+            for mut wildcard_import in wildcard_imports.drain(..) {
+                if let Err(error) = wildcard_import.process_local(&mut self.q) {
+                    self.q
+                        .diagnostics
+                        .error(wildcard_import.location.source_id, error);
+                }
+            }
+
+            // Expand impl items since they might be non-local. We need to look up the metadata associated with the item.
+            while let Some(entry) = self.q.next_impl_item_entry() {
+                tracing::trace!(?entry.id, "next impl item entry");
+
+                let process = || {
+                    let named = self.q.convert_path(&entry.path)?;
+
+                    if let Some((spanned, _)) = named.parameters.into_iter().flatten().next() {
+                        return Err(compile::Error::new(
+                            spanned.span(),
+                            compile::ErrorKind::UnsupportedGenerics,
+                        ));
+                    }
+
+                    let meta = self.q.lookup_meta(
+                        &entry.location,
+                        named.item,
+                        GenericsParameters::default(),
+                    )?;
+
+                    // TODO: this should not be necessary, since the item being
+                    // referenced should already have been inserted at this
+                    // point.
+                    self.q.inner.items.insert(meta.item_meta.id, meta.item_meta);
+
+                    let item = self.q.pool.item(meta.item_meta.item);
+                    let items = Items::new(item, meta.item_meta.id, self.q.gen);
+
+                    let mut idx = Indexer {
+                        q: self.q.borrow(),
+                        root: entry.root,
+                        source_id: entry.location.source_id,
+                        items,
+                        scopes: Scopes::default(),
+                        item: IndexItem::with_impl_item(named.module, meta.item_meta.id),
+                        nested_item: entry.nested_item,
+                        macro_depth: entry.macro_depth,
+                        loaded: Some(&mut self.loaded),
+                        queue: Some(&mut self.queue),
+                    };
+
+                    let removed = idx
+                        .q
+                        .inner
+                        .impl_functions
+                        .remove(&entry.id)
+                        .unwrap_or_default();
+
+                    for f in removed {
+                        index::item_fn_immediate(&mut idx, *f.ast)?;
+                    }
+
+                    Ok::<_, compile::Error>(())
+                };
+
+                if let Err(error) = process() {
+                    self.q.diagnostics.error(entry.location.source_id, error);
+                }
             }
         }
     }

--- a/crates/rune/src/worker.rs
+++ b/crates/rune/src/worker.rs
@@ -11,7 +11,7 @@ use crate::compile::{self, ModId};
 use crate::indexing::index;
 use crate::indexing::items::Items;
 use crate::indexing::{IndexItem, Indexer, Scopes};
-use crate::query::{GenericsParameters, Query};
+use crate::query::{GenericsParameters, Query, Used};
 use crate::SourceId;
 
 mod import;
@@ -177,7 +177,9 @@ impl<'a, 'arena> Worker<'a, 'arena> {
                     // Rust does, and at some point in the future we might
                     // introduce bounds which would not be communicated through
                     // `Self`.
-                    let named = self.q.convert_path_with(&entry.path, true)?;
+                    let named =
+                        self.q
+                            .convert_path_with(&entry.path, true, Used::Used, Used::Unused)?;
 
                     if let Some((spanned, _)) = named.parameters.into_iter().flatten().next() {
                         return Err(compile::Error::new(


### PR DESCRIPTION
Like the title says, support adding an `impl <type>` block anywhere and have it being handled correctly.

Like:

```rust
struct Foo;

pub fn main() {
    let value = {
        impl Foo {
            fn lol(self) {
                4
            }
        }
    };

    assert_eq!(Foo.lol(), 4);
}
```

This required the introduction of an intermediary step during indexing. We collect all impl blocks, and once the indexing queue is empty we start processing them. This ensures that imports are visible to the impl blocks and any other items (local or otherwise) which might affect the impl target. Luckily anything *inside* of the impl block itself can never be used as a target.