### PR TITLE
vscode: pass extra env when validating

### DIFF
--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -166,7 +166,7 @@ export class Ctx {
             });
         });
 
-        if (code != 0) {
+        if (code !== 0) {
             let e = new Error(`cargo --version: failed (${code})`);
             // Smuggle details.
             (e as any).details = err;
@@ -230,13 +230,13 @@ export class Ctx {
 
                 let output = JSON.parse(data) as ReasonOutput;
 
-                if (output.reason == "compiler-artifact") {
+                if (output.reason === "compiler-artifact") {
                     let artifact = output as CompilerArtifact;
                     this.statusBar.text = `rune: cargo (${artifact.target.name})`;
 
                     let [id, ...rest] = artifact.package_id.split(" ");
 
-                    if (id == name && artifact.target.kind.includes("bin")) {
+                    if (id === name && artifact.target.kind.includes("bin")) {
                         executable = artifact.executable;
                     }
                 }

--- a/editors/code/src/ctx.ts
+++ b/editors/code/src/ctx.ts
@@ -124,7 +124,7 @@ export class Ctx {
 
         log.info("Using server binary at", binary.path);
 
-        if (!isValidExecutable(binary.path)) {
+        if (!isValidExecutable(binary.path, this.config.serverExtraEnv)) {
             if (this.config.serverPath) {
                 throw new Error(`Failed to execute ${binary.path} --version. \`config.server.path\` has been set explicitly.\
                 Consider removing this config or making a valid server binary available at that path.`);

--- a/editors/code/src/util.ts
+++ b/editors/code/src/util.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { strict as nativeAssert } from "assert";
 import { exec, ExecOptions, spawnSync } from "child_process";
+import { Env, substituteVariablesInEnv } from "./config";
 import { inspect } from "util";
 
 export function assert(condition: boolean, explanation: string): asserts condition {
@@ -60,10 +61,13 @@ export const log = new (class {
     }
 })();
 
-export function isValidExecutable(path: string): boolean {
+export function isValidExecutable(path: string, extraEnv: Env): boolean {
     log.debug("Checking availability of a binary at", path);
 
-    const res = spawnSync(path, ["--version"], { encoding: "utf8" });
+    const newEnv = substituteVariablesInEnv(Object.assign({}, process.env, extraEnv));
+    log.debug('newEnv', newEnv);
+
+    const res = spawnSync(path, ["--version"], { encoding: "utf8", env: newEnv });
 
     const printOutput = res.error && (res.error as any).code !== "ENOENT" ? log.warn : log.debug;
     printOutput(path, "--version:", res);


### PR DESCRIPTION
The extra env variables were only passed for launching the language server not when validating the executable is working.

I also fixed JS warnings for non type-safe compares.