### PR TITLE
Add operators to Byte and Bool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,8 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - run: cargo doc -p rune --all-features
       env:
-        RUSTFLAGS: --cfg docsrs
-        RUSTDOCFLAGS: --cfg docsrs
+        RUSTFLAGS: --cfg rune_docsrs
+        RUSTDOCFLAGS: --cfg rune_docsrs
 
   basics:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@1.71
+    - uses: dtolnay/rust-toolchain@1.74
       with:
         components: clippy
     - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -32,8 +32,8 @@ jobs:
     - run: cargo +nightly doc -p rune --all-features
       env:
         RUST_LOG: rune=info
-        RUSTFLAGS: --cfg docsrs
-        RUSTDOCFLAGS: --cfg docsrs
+        RUSTFLAGS: --cfg rune_docsrs
+        RUSTDOCFLAGS: --cfg rune_docsrs
     - run: mv target/doc target/site/api
     - uses: peaceiris/actions-gh-pages@v3
       with:

--- a/crates/rune/Cargo.toml
+++ b/crates/rune/Cargo.toml
@@ -81,4 +81,4 @@ trybuild = "1.0.80"
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "rune_docsrs"]

--- a/crates/rune/src/internal_macros.rs
+++ b/crates/rune/src/internal_macros.rs
@@ -75,7 +75,7 @@ macro_rules! cfg_emit {
     ($($item:item)*) => {
         $(
             #[cfg(feature = "emit")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "emit")))]
+            #[cfg_attr(rune_docsrs, doc(cfg(feature = "emit")))]
             $item
         )*
     }
@@ -85,7 +85,7 @@ macro_rules! cfg_workspace {
     ($($item:item)*) => {
         $(
             #[cfg(feature = "workspace")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "workspace")))]
+            #[cfg_attr(rune_docsrs, doc(cfg(feature = "workspace")))]
             $item
         )*
     }
@@ -95,7 +95,7 @@ macro_rules! cfg_cli {
     ($($item:item)*) => {
         $(
             #[cfg(feature = "cli")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "cli")))]
+            #[cfg_attr(rune_docsrs, doc(cfg(feature = "cli")))]
             $item
         )*
     }
@@ -105,7 +105,7 @@ macro_rules! cfg_doc {
     ($($item:item)*) => {
         $(
             #[cfg(feature = "doc")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "doc")))]
+            #[cfg_attr(rune_docsrs, doc(cfg(feature = "doc")))]
             $item
         )*
     }
@@ -115,7 +115,7 @@ macro_rules! cfg_std {
     ($($item:item)*) => {
         $(
             #[cfg(feature = "std")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+            #[cfg_attr(rune_docsrs, doc(cfg(feature = "std")))]
             $item
         )*
     }

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -141,7 +141,7 @@
 #![allow(clippy::type_complexity)]
 #![allow(clippy::module_inception)]
 #![allow(clippy::self_named_constructors)]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(rune_docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "std")]
 #[macro_use]

--- a/crates/rune/src/runtime/vm.rs
+++ b/crates/rune/src/runtime/vm.rs
@@ -1708,6 +1708,7 @@ impl Vm {
         let value = match value {
             Value::Bool(value) => Value::from(!value),
             Value::Integer(value) => Value::from(!value),
+            Value::Byte(value) => Value::from(!value),
             other => {
                 let operand = vm_try!(other.type_info());
                 return err(VmErrorKind::UnsupportedUnaryOperation { op: "!", operand });

--- a/crates/rune/src/runtime/vm.rs
+++ b/crates/rune/src/runtime/vm.rs
@@ -1421,7 +1421,7 @@ impl Vm {
         protocol: Protocol,
         error: fn() -> VmErrorKind,
         integer_op: fn(i64, i64) -> Option<i64>,
-        byte_op: fn(u8, u8) -> Option<u8>,
+        byte_op: fn(u8, i64) -> Option<u8>,
         lhs: InstAddress,
         rhs: InstAddress,
     ) -> VmResult<()> {
@@ -1434,7 +1434,7 @@ impl Vm {
                 vm_try!(self.stack.push(Value::from(integer)));
                 return VmResult::Ok(());
             }
-            (Value::Byte(lhs), Value::Byte(rhs)) => {
+            (Value::Byte(lhs), Value::Integer(rhs)) => {
                 let byte = vm_try!(byte_op(lhs, rhs).ok_or_else(error));
                 vm_try!(self.stack.push(Value::from(byte)));
                 return VmResult::Ok(());

--- a/crates/rune/src/runtime/vm.rs
+++ b/crates/rune/src/runtime/vm.rs
@@ -1460,7 +1460,7 @@ impl Vm {
         protocol: Protocol,
         error: fn() -> VmErrorKind,
         integer_op: fn(i64, i64) -> Option<i64>,
-        byte_op: fn(u8, u8) -> Option<u8>,
+        byte_op: fn(u8, i64) -> Option<u8>,
     ) -> VmResult<()> {
         let lhs;
         let mut guard;
@@ -1472,7 +1472,7 @@ impl Vm {
                     *lhs = out;
                     return VmResult::Ok(());
                 }
-                (Value::Byte(lhs), Value::Byte(rhs)) => {
+                (Value::Byte(lhs), Value::Integer(rhs)) => {
                     let out = vm_try!(byte_op(*lhs, rhs).ok_or_else(error));
                     *lhs = out;
                     return VmResult::Ok(());

--- a/crates/rune/src/runtime/vm.rs
+++ b/crates/rune/src/runtime/vm.rs
@@ -1343,10 +1343,12 @@ impl Vm {
     }
 
     /// Internal impl of a numeric operation.
-    fn internal_infallible_bitwise(
+    fn internal_infallible_bitwise_bool(
         &mut self,
         protocol: Protocol,
         integer_op: fn(i64, i64) -> i64,
+        byte_op: fn(u8, u8) -> u8,
+        bool_op: fn(bool, bool) -> bool,
         lhs: InstAddress,
         rhs: InstAddress,
     ) -> VmResult<()> {
@@ -1358,36 +1360,8 @@ impl Vm {
                 vm_try!(self.stack.push(Value::from(integer_op(lhs, rhs))));
                 return VmResult::Ok(());
             }
-            (lhs, rhs) => (lhs, rhs),
-        };
-
-        if let CallResult::Unsupported(lhs) = vm_try!(self.call_instance_fn(lhs, protocol, (&rhs,)))
-        {
-            return err(VmErrorKind::UnsupportedBinaryOperation {
-                op: protocol.name,
-                lhs: vm_try!(lhs.type_info()),
-                rhs: vm_try!(rhs.type_info()),
-            });
-        }
-
-        VmResult::Ok(())
-    }
-
-    /// Internal impl of a numeric operation.
-    fn internal_infallible_bitwise_bool(
-        &mut self,
-        protocol: Protocol,
-        integer_op: fn(i64, i64) -> i64,
-        bool_op: fn(bool, bool) -> bool,
-        lhs: InstAddress,
-        rhs: InstAddress,
-    ) -> VmResult<()> {
-        let rhs = vm_try!(self.stack.address(rhs));
-        let lhs = vm_try!(self.stack.address(lhs));
-
-        let (lhs, rhs) = match (lhs, rhs) {
-            (Value::Integer(lhs), Value::Integer(rhs)) => {
-                vm_try!(self.stack.push(Value::from(integer_op(lhs, rhs))));
+            (Value::Byte(lhs), Value::Byte(rhs)) => {
+                vm_try!(self.stack.push(Value::from(byte_op(lhs, rhs))));
                 return VmResult::Ok(());
             }
             (Value::Bool(lhs), Value::Bool(rhs)) => {
@@ -1414,6 +1388,8 @@ impl Vm {
         target: InstTarget,
         protocol: Protocol,
         integer_op: fn(&mut i64, i64),
+        byte_op: fn(&mut u8, u8),
+        bool_op: fn(&mut bool, bool),
     ) -> VmResult<()> {
         let lhs;
         let mut guard;
@@ -1422,6 +1398,14 @@ impl Vm {
             TargetValue::Value(lhs, rhs) => match (lhs, rhs) {
                 (Value::Integer(lhs), Value::Integer(rhs)) => {
                     integer_op(lhs, rhs);
+                    return VmResult::Ok(());
+                }
+                (Value::Byte(lhs), Value::Byte(rhs)) => {
+                    byte_op(lhs, rhs);
+                    return VmResult::Ok(());
+                }
+                (Value::Bool(lhs), Value::Bool(rhs)) => {
+                    bool_op(lhs, rhs);
                     return VmResult::Ok(());
                 }
                 (lhs, rhs) => TargetFallback::Value(lhs.clone(), rhs),
@@ -1437,6 +1421,7 @@ impl Vm {
         protocol: Protocol,
         error: fn() -> VmErrorKind,
         integer_op: fn(i64, i64) -> Option<i64>,
+        byte_op: fn(u8, u8) -> Option<u8>,
         lhs: InstAddress,
         rhs: InstAddress,
     ) -> VmResult<()> {
@@ -1447,6 +1432,11 @@ impl Vm {
             (Value::Integer(lhs), Value::Integer(rhs)) => {
                 let integer = vm_try!(integer_op(lhs, rhs).ok_or_else(error));
                 vm_try!(self.stack.push(Value::from(integer)));
+                return VmResult::Ok(());
+            }
+            (Value::Byte(lhs), Value::Byte(rhs)) => {
+                let byte = vm_try!(byte_op(lhs, rhs).ok_or_else(error));
+                vm_try!(self.stack.push(Value::from(byte)));
                 return VmResult::Ok(());
             }
             (lhs, rhs) => (lhs, rhs),
@@ -1470,6 +1460,7 @@ impl Vm {
         protocol: Protocol,
         error: fn() -> VmErrorKind,
         integer_op: fn(i64, i64) -> Option<i64>,
+        byte_op: fn(u8, u8) -> Option<u8>,
     ) -> VmResult<()> {
         let lhs;
         let mut guard;
@@ -1478,6 +1469,11 @@ impl Vm {
             TargetValue::Value(lhs, rhs) => match (lhs, rhs) {
                 (Value::Integer(lhs), Value::Integer(rhs)) => {
                     let out = vm_try!(integer_op(*lhs, rhs).ok_or_else(error));
+                    *lhs = out;
+                    return VmResult::Ok(());
+                }
+                (Value::Byte(lhs), Value::Byte(rhs)) => {
+                    let out = vm_try!(byte_op(*lhs, rhs).ok_or_else(error));
                     *lhs = out;
                     return VmResult::Ok(());
                 }
@@ -1797,6 +1793,7 @@ impl Vm {
                 vm_try!(self.internal_infallible_bitwise_bool(
                     Protocol::BIT_AND,
                     i64::bitand,
+                    u8::bitand,
                     bool::bitand,
                     lhs,
                     rhs,
@@ -1807,6 +1804,7 @@ impl Vm {
                 vm_try!(self.internal_infallible_bitwise_bool(
                     Protocol::BIT_XOR,
                     i64::bitxor,
+                    u8::bitxor,
                     bool::bitxor,
                     lhs,
                     rhs,
@@ -1817,6 +1815,7 @@ impl Vm {
                 vm_try!(self.internal_infallible_bitwise_bool(
                     Protocol::BIT_OR,
                     i64::bitor,
+                    u8::bitor,
                     bool::bitor,
                     lhs,
                     rhs,
@@ -1827,12 +1826,20 @@ impl Vm {
                     Protocol::SHL,
                     || VmErrorKind::Overflow,
                     |a, b| a.checked_shl(u32::try_from(b).ok()?),
+                    |a, b| a.checked_shl(u32::try_from(b).ok()?),
                     lhs,
                     rhs,
                 ));
             }
             InstOp::Shr => {
-                vm_try!(self.internal_infallible_bitwise(Protocol::SHR, ops::Shr::shr, lhs, rhs));
+                vm_try!(self.internal_bitwise(
+                    Protocol::SHR,
+                    || VmErrorKind::Underflow,
+                    |a, b| a.checked_shr(u32::try_from(b).ok()?),
+                    |a, b| a.checked_shr(u32::try_from(b).ok()?),
+                    lhs,
+                    rhs
+                ));
             }
             InstOp::Gt => {
                 vm_try!(self.internal_boolean_ops(
@@ -1958,6 +1965,8 @@ impl Vm {
                     target,
                     Protocol::BIT_AND_ASSIGN,
                     ops::BitAndAssign::bitand_assign,
+                    ops::BitAndAssign::bitand_assign,
+                    ops::BitAndAssign::bitand_assign,
                 ));
             }
             InstAssignOp::BitXor => {
@@ -1965,12 +1974,16 @@ impl Vm {
                     target,
                     Protocol::BIT_XOR_ASSIGN,
                     ops::BitXorAssign::bitxor_assign,
+                    ops::BitXorAssign::bitxor_assign,
+                    ops::BitXorAssign::bitxor_assign,
                 ));
             }
             InstAssignOp::BitOr => {
                 vm_try!(self.internal_infallible_bitwise_assign(
                     target,
                     Protocol::BIT_OR_ASSIGN,
+                    ops::BitOrAssign::bitor_assign,
+                    ops::BitOrAssign::bitor_assign,
                     ops::BitOrAssign::bitor_assign,
                 ));
             }
@@ -1980,13 +1993,16 @@ impl Vm {
                     Protocol::SHL_ASSIGN,
                     || VmErrorKind::Overflow,
                     |a, b| a.checked_shl(u32::try_from(b).ok()?),
+                    |a, b| a.checked_shl(u32::try_from(b).ok()?),
                 ));
             }
             InstAssignOp::Shr => {
-                vm_try!(self.internal_infallible_bitwise_assign(
+                vm_try!(self.internal_bitwise_assign(
                     target,
                     Protocol::SHR_ASSIGN,
-                    ops::ShrAssign::shr_assign,
+                    || VmErrorKind::Underflow,
+                    |a, b| a.checked_shr(u32::try_from(b).ok()?),
+                    |a, b| a.checked_shr(u32::try_from(b).ok()?),
                 ));
             }
         }

--- a/crates/rune/src/tests/attribute.rs
+++ b/crates/rune/src/tests/attribute.rs
@@ -4,7 +4,7 @@ use ErrorKind::*;
 
 #[test]
 fn basic_use() {
-    let _: () = rune! {
+    rune! {
         mod private {
             #[test]
             fn test_case() {

--- a/crates/rune/src/tests/bug_454.rs
+++ b/crates/rune/src/tests/bug_454.rs
@@ -3,7 +3,7 @@ prelude!();
 /// See https://github.com/rune-rs/rune/issues/454
 #[test]
 pub fn test_bug_454() {
-    let (): () = rune! {
+    rune! {
         struct Test;
 
         fn call(a, b) {

--- a/crates/rune/src/tests/bugfixes.rs
+++ b/crates/rune/src/tests/bugfixes.rs
@@ -28,7 +28,7 @@ fn test_pattern_binding_bug() {
 /// inside of an inst fn call.
 #[test]
 fn test_string_pattern_in_instance_fn_bug() {
-    let _: () = rune! {
+    rune! {
         enum Inst { A, Unknown }
 
         pub fn works() {

--- a/crates/rune/src/tests/collections.rs
+++ b/crates/rune/src/tests/collections.rs
@@ -2,7 +2,7 @@ prelude!();
 
 #[test]
 fn test_hash_map_tile() {
-    let _: () = rune! {
+    rune! {
         pub fn main() {
             use std::collections::HashMap;
 
@@ -24,7 +24,7 @@ fn test_hash_map_tile() {
 
 #[test]
 fn test_hash_set_tuple() {
-    let _: () = rune! {
+    rune! {
         pub fn main() {
             use std::collections::HashSet;
 

--- a/crates/rune/src/tests/compiler_visibility.rs
+++ b/crates/rune/src/tests/compiler_visibility.rs
@@ -96,7 +96,7 @@ fn test_indirect_access() {
 // Test borrowed from: https://doc.rust-lang.org/reference/visibility-and-privacy.html
 #[test]
 fn test_rust_example() {
-    let _: () = rune! {
+    rune! {
         mod crate_helper_module {
             pub fn crate_helper() {}
 

--- a/crates/rune/src/tests/continue_.rs
+++ b/crates/rune/src/tests/continue_.rs
@@ -4,7 +4,7 @@ use ErrorKind::*;
 
 #[test]
 fn test_continue_label() {
-    let _: () = rune! {
+    rune! {
         pub fn main() {
             let n = 0;
             let not_used = true;
@@ -32,7 +32,7 @@ fn test_continue_label() {
 
 #[test]
 fn while_continue() {
-    let _: () = rune! {
+    rune! {
         pub fn main() {
             let n = 0;
             let condition = true;
@@ -56,7 +56,7 @@ fn while_continue() {
 
 #[test]
 fn loop_continue() {
-    let _: () = rune! {
+    rune! {
         pub fn main() {
             let n = 0;
             let condition = true;
@@ -85,7 +85,7 @@ fn loop_continue() {
 
 #[test]
 fn for_continue() {
-    let _: () = rune! {
+    rune! {
         pub fn main() {
             let n = 0;
             let condition = true;

--- a/crates/rune/src/tests/core_macros.rs
+++ b/crates/rune/src/tests/core_macros.rs
@@ -9,12 +9,12 @@ macro_rules! test_case {
 
 #[test]
 fn test_asserts() {
-    let _: () = rune!(
+    rune!(
         pub fn main() {
             assert!(true)
         }
     );
-    let _: () = rune!(
+    rune!(
         pub fn main() {
             assert_eq!(1 + 1, 2)
         }

--- a/crates/rune/src/tests/instance.rs
+++ b/crates/rune/src/tests/instance.rs
@@ -2,7 +2,7 @@ prelude!();
 
 #[test]
 fn test_basic_self() {
-    let _: () = rune! {
+    rune! {
         struct Foo {
             value,
         }
@@ -24,7 +24,7 @@ fn test_basic_self() {
 
 #[test]
 fn test_chaining() {
-    let _: () = rune! {
+    rune! {
         struct Foo {
             value,
         }

--- a/crates/rune/src/tests/iterator.rs
+++ b/crates/rune/src/tests/iterator.rs
@@ -42,7 +42,7 @@ fn test_rev() {
 
 #[test]
 fn test_next_back() {
-    let _: () = rune! {
+    rune! {
         const SOURCE = [1, 2, 3, "foo"];
 
         pub fn main() {

--- a/crates/rune/src/tests/patterns.rs
+++ b/crates/rune/src/tests/patterns.rs
@@ -112,7 +112,7 @@ fn test_vec_patterns() {
     );
     assert_eq!(out, true);
 
-    let _: () = rune!(
+    rune!(
         pub fn main() {
             match [] {
                 [a, b] => a + 1 == b,

--- a/crates/rune/src/tests/range.rs
+++ b/crates/rune/src/tests/range.rs
@@ -5,7 +5,7 @@ use VmErrorKind::*;
 
 #[test]
 fn range_accessors() {
-    let _: () = rune! {
+    rune! {
         pub fn main() {
             assert_eq!((1..10).start, 1);
             assert_eq!((1..10).end, 10);
@@ -21,7 +21,7 @@ fn range_accessors() {
 
 #[test]
 fn range_iter() {
-    let _: () = rune! {
+    rune! {
         pub fn main() {
             assert_eq!((1..4).iter().collect::<Vec>(), [1, 2, 3]);
             assert_eq!((1..4).iter().rev().collect::<Vec>(), [3, 2, 1]);
@@ -38,7 +38,7 @@ fn range_iter() {
 
 #[test]
 fn range_match() {
-    let _: () = rune! {
+    rune! {
         pub fn main() {
             use std::ops::{RangeFrom, RangeFull, RangeInclusive, RangeToInclusive, RangeTo, Range};
 
@@ -60,13 +60,13 @@ fn range_match() {
 
 #[test]
 fn test_non_numeric_ranges() {
-    let _: () = rune! {
+    rune! {
         pub fn main() {
             assert_eq!((#{}..=10).start, #{});
         }
     };
 
-    let _: () = rune! {
+    rune! {
         pub fn main() {
             let a = ..=(1, 2, 3);
             assert_eq!(a.end, (1, 2, 3));
@@ -76,7 +76,7 @@ fn test_non_numeric_ranges() {
 
 #[test]
 fn test_range_into_iter() {
-    let _: () = rune! {
+    rune! {
         pub fn main() {
             let d = [];
 
@@ -88,7 +88,7 @@ fn test_range_into_iter() {
         }
     };
 
-    let _: () = rune! {
+    rune! {
         pub fn main() {
             fn end() {
                 4

--- a/crates/rune/src/tests/variants.rs
+++ b/crates/rune/src/tests/variants.rs
@@ -4,7 +4,7 @@ prelude!();
 /// See: https://github.com/rune-rs/rune/pull/215
 #[test]
 fn assert_variant_comparisons() {
-    let _: () = rune! {
+    rune! {
         enum Foo { A, B }
 
         pub fn main() {
@@ -13,7 +13,7 @@ fn assert_variant_comparisons() {
         }
     };
 
-    let _: () = rune! {
+    rune! {
         enum Foo { A(a), B }
 
         pub fn main() {
@@ -22,7 +22,7 @@ fn assert_variant_comparisons() {
         }
     };
 
-    let _: () = rune! {
+    rune! {
         enum Foo { A { a }, B }
 
         pub fn main() {

--- a/crates/rune/src/tests/vm_arithmetic.rs
+++ b/crates/rune/src/tests/vm_arithmetic.rs
@@ -130,6 +130,44 @@ fn test_rem() {
 }
 
 #[test]
+fn test_byte_ops() {
+    let out: u8 = rune!(
+        pub fn main() {
+            12u8 & 6u8
+        }
+    );
+    assert_eq!(out, 4u8);
+
+    let out: u8 = rune!(
+        pub fn main() {
+            12u8 ^ 6u8
+        }
+    );
+    assert_eq!(out, 10u8);
+
+    let out: u8 = rune!(
+        pub fn main() {
+            12u8 | 6u8
+        }
+    );
+    assert_eq!(out, 14u8);
+
+    let out: u8 = rune!(
+        pub fn main() {
+            12u8 << 2
+        }
+    );
+    assert_eq!(out, 48u8);
+
+    let out: u8 = rune!(
+        pub fn main() {
+            12u8 >> 2
+        }
+    );
+    assert_eq!(out, 3u8);
+}
+
+#[test]
 fn test_bit_ops() {
     op_tests!(0b1100 & 0b0110 = 0b1100 & 0b0110);
     op_tests!(0b1100 ^ 0b0110 = 0b1100 ^ 0b0110);

--- a/crates/rune/src/tests/vm_arithmetic.rs
+++ b/crates/rune/src/tests/vm_arithmetic.rs
@@ -3,61 +3,61 @@ prelude!();
 use VmErrorKind::*;
 
 macro_rules! op_tests {
-    ($lhs:literal $op:tt $rhs:literal = $out:expr) => {
-        let out: i64 = rune!(pub fn main() { let a = $lhs; let b = $rhs; a $op b});
+    ($ty:ty, $lhs:literal $op:tt $rhs:literal = $out:expr) => {
+        let out: $ty = rune!(pub fn main() { let a = $lhs; let b = $rhs; a $op b});
         assert_eq!(out, $out);
 
-        let out: i64 = rune_s!(&format!(
+        let out: $ty = rune_s!(&format!(
             r#"pub fn main() {{ let a = {lhs}; let b = {rhs}; a {op}= b; a }}"#,
-            lhs = $lhs, rhs = $rhs, op = stringify!($op),
+            lhs = stringify!($lhs), rhs = stringify!($rhs), op = stringify!($op),
         ));
         assert_eq!(out, $out);
 
-        let out: i64 = rune_s!(&format!(
+        let out: $ty = rune_s!(&format!(
             r#"struct Foo {{ padding, field }}; pub fn main() {{ let a = Foo{{ padding: 0, field: {lhs} }}; let b = {rhs}; a.field {op}= b; a.field }}"#,
-            lhs = $lhs, rhs = $rhs, op = stringify!($op),
+            lhs = stringify!($lhs), rhs = stringify!($rhs), op = stringify!($op),
         ));
         assert_eq!(out, $out);
 
-        let out: i64 = rune_s!(&format!(
+        let out: $ty = rune_s!(&format!(
             r#"enum Enum {{ Foo {{ padding, field }} }}; pub fn main() {{ let a = Enum::Foo {{ padding: 0, field: {lhs} }}; let b = {rhs}; a.field {op}= b; a.field }}"#,
-            lhs = $lhs, rhs = $rhs, op = stringify!($op),
+            lhs = stringify!($lhs), rhs = stringify!($rhs), op = stringify!($op),
         ));
         assert_eq!(out, $out);
 
-        let out: i64 = rune_s!(&format!(
+        let out: $ty = rune_s!(&format!(
             r#"pub fn main() {{ let a = #{{ padding: 0, field: {lhs} }}; let b = {rhs}; a.field {op}= b; a.field }}"#,
-            lhs = $lhs, rhs = $rhs, op = stringify!($op),
+            lhs = stringify!($lhs), rhs = stringify!($rhs), op = stringify!($op),
         ));
         assert_eq!(out, $out);
 
-        let out: i64 = rune_s!(&format!(
+        let out: $ty = rune_s!(&format!(
             r#"pub fn main() {{ let a = (0, {lhs}); let b = {rhs}; a.1 {op}= b; a.1 }}"#,
-            lhs = $lhs, rhs = $rhs, op = stringify!($op),
+            lhs = stringify!($lhs), rhs = stringify!($rhs), op = stringify!($op),
         ));
         assert_eq!(out, $out);
 
-        let out: i64 = rune_s!(&format!(
+        let out: $ty = rune_s!(&format!(
             r#"struct Foo(padding, a); pub fn main() {{ let a = Foo(0, {lhs}); let b = {rhs}; a.1 {op}= b; a.1 }}"#,
-            lhs = $lhs, rhs = $rhs, op = stringify!($op),
+            lhs = stringify!($lhs), rhs = stringify!($rhs), op = stringify!($op),
         ));
         assert_eq!(out, $out);
 
-        let out: i64 = rune_s!(&format!(
+        let out: $ty = rune_s!(&format!(
             r#"enum Enum {{ Foo(padding, a) }}; pub fn main() {{ let a = Enum::Foo(0, {lhs}); let b = {rhs}; a.1 {op}= b; a.1 }}"#,
-            lhs = $lhs, rhs = $rhs, op = stringify!($op),
+            lhs = stringify!($lhs), rhs = stringify!($rhs), op = stringify!($op),
         ));
         assert_eq!(out, $out);
 
-        let out: i64 = rune_s!(&format!(
+        let out: $ty = rune_s!(&format!(
             r#"pub fn main() {{ let a = Ok({lhs}); let b = {rhs}; a.0 {op}= b; a.0 }}"#,
-            lhs = $lhs, rhs = $rhs, op = stringify!($op),
+            lhs = stringify!($lhs), rhs = stringify!($rhs), op = stringify!($op),
         ));
         assert_eq!(out, $out);
 
-        let out: i64 = rune_s!(&format!(
+        let out: $ty = rune_s!(&format!(
             r#"pub fn main() {{ let a = Some({lhs}); let b = {rhs}; a.0 {op}= b; a.0 }}"#,
-            lhs = $lhs, rhs = $rhs, op = stringify!($op),
+            lhs = stringify!($lhs), rhs = stringify!($rhs), op = stringify!($op),
         ));
         assert_eq!(out, $out);
     }
@@ -68,7 +68,7 @@ macro_rules! error_test {
         assert_vm_error!(
             &format!(
                 r#"pub fn main() {{ let a = {lhs}; let b = {rhs}; a {op} b; }}"#,
-                lhs = $lhs, rhs = $rhs, op = stringify!($op),
+                lhs = stringify!($lhs), rhs = stringify!($rhs), op = stringify!($op),
             ),
             $error => {}
         );
@@ -76,7 +76,7 @@ macro_rules! error_test {
         assert_vm_error!(
             &format!(
                 r#"pub fn main() {{ let a = {lhs}; let b = {rhs}; a {op}= b; }}"#,
-                lhs = $lhs, rhs = $rhs, op = stringify!($op),
+                lhs = stringify!($lhs), rhs = stringify!($rhs), op = stringify!($op),
             ),
             $error => {}
         );
@@ -84,7 +84,7 @@ macro_rules! error_test {
         assert_vm_error!(
             &format!(
                 r#"pub fn main() {{ let a = #{{ padding: 0, field: {lhs} }}; let b = {rhs}; a.field {op}= b; }}"#,
-                lhs = $lhs, rhs = $rhs, op = stringify!($op),
+                lhs = stringify!($lhs), rhs = stringify!($rhs), op = stringify!($op),
             ),
             $error => {}
         );
@@ -92,7 +92,7 @@ macro_rules! error_test {
         assert_vm_error!(
             &format!(
                 r#"pub fn main() {{ let a = (0, {lhs}); let b = {rhs}; a.1 {op}= b; }}"#,
-                lhs = $lhs, rhs = $rhs, op = stringify!($op),
+                lhs = stringify!($lhs), rhs = stringify!($rhs), op = stringify!($op),
             ),
             $error => {}
         );
@@ -101,86 +101,73 @@ macro_rules! error_test {
 
 #[test]
 fn test_add() {
-    op_tests!(10 + 2 = 12);
+    op_tests!(i64, 10 + 2 = 12);
     error_test!(9223372036854775807i64 + 2 = Overflow);
 }
 
 #[test]
 fn test_sub() {
-    op_tests!(10 - 2 = 8);
+    op_tests!(i64, 10 - 2 = 8);
     error_test!(-9223372036854775808i64 - 2 = Underflow);
 }
 
 #[test]
 fn test_mul() {
-    op_tests!(10 * 2 = 20);
+    op_tests!(i64, 10 * 2 = 20);
     error_test!(9223372036854775807i64 * 2 = Overflow);
 }
 
 #[test]
 fn test_div() {
-    op_tests!(10 / 2 = 5);
+    op_tests!(i64, 10 / 2 = 5);
     error_test!(10 / 0 = DivideByZero);
 }
 
 #[test]
 fn test_rem() {
-    op_tests!(10 % 3 = 1);
+    op_tests!(i64, 10 % 3 = 1);
     error_test!(10 % 0 = DivideByZero);
 }
 
 #[test]
-fn test_byte_ops() {
-    let out: u8 = rune!(
-        pub fn main() {
-            12u8 & 6u8
-        }
-    );
-    assert_eq!(out, 4u8);
-
-    let out: u8 = rune!(
-        pub fn main() {
-            12u8 ^ 6u8
-        }
-    );
-    assert_eq!(out, 10u8);
-
-    let out: u8 = rune!(
-        pub fn main() {
-            12u8 | 6u8
-        }
-    );
-    assert_eq!(out, 14u8);
-
-    let out: u8 = rune!(
-        pub fn main() {
-            12u8 << 2
-        }
-    );
-    assert_eq!(out, 48u8);
-
-    let out: u8 = rune!(
-        pub fn main() {
-            12u8 >> 2
-        }
-    );
-    assert_eq!(out, 3u8);
-}
-
-#[test]
-fn test_bit_ops() {
-    op_tests!(0b1100 & 0b0110 = 0b1100 & 0b0110);
-    op_tests!(0b1100 ^ 0b0110 = 0b1100 ^ 0b0110);
-    op_tests!(0b1100 | 0b0110 = 0b1100 | 0b0110);
-    op_tests!(0b1100 << 2 = 0b1100 << 2);
-    op_tests!(0b1100 >> 2 = 0b1100 >> 2);
+fn test_bit_ops_i64() {
+    op_tests!(i64, 0b1100 & 0b0110 = 0b1100 & 0b0110);
+    op_tests!(i64, 0b1100 ^ 0b0110 = 0b1100 ^ 0b0110);
+    op_tests!(i64, 0b1100 | 0b0110 = 0b1100 | 0b0110);
+    op_tests!(i64, 0b1100 << 2 = 0b1100 << 2);
+    op_tests!(i64, 0b1100 >> 2 = 0b1100 >> 2);
     error_test!(0b1 << 64 = Overflow);
 }
 
 #[test]
-fn test_bitwise_not() {
-    let out: i64 = rune! {
-        pub fn main() { let a = 0b10100; !a }
-    };
+fn test_bit_ops_u8() {
+    op_tests!(u8, 0b1100u8 & 0b0110u8 = 0b1100u8 & 0b0110u8);
+    op_tests!(u8, 0b1100u8 ^ 0b0110u8 = 0b1100u8 ^ 0b0110u8);
+    op_tests!(u8, 0b1100u8 | 0b0110u8 = 0b1100u8 | 0b0110u8);
+    op_tests!(u8, 0b1100u8 << 2 = 0b1100u8 << 2);
+    op_tests!(u8, 0b1100u8 >> 2 = 0b1100u8 >> 2);
+    error_test!(0b1u8 << 8 = Overflow);
+    error_test!(0b1u8 >> 8 = Underflow);
+}
+
+#[test]
+fn test_bitwise_not_i64() {
+    let out: i64 = rune!(
+        pub fn main() {
+            let a = 0b10100;
+            !a
+        }
+    );
     assert_eq!(out, !0b10100);
+}
+
+#[test]
+fn test_bitwise_not_u8() {
+    let out: u8 = rune!(
+        pub fn main() {
+            let a = 0b10100u8;
+            !a
+        }
+    );
+    assert_eq!(out, !0b10100u8);
 }

--- a/crates/rune/src/tests/vm_arithmetic.rs
+++ b/crates/rune/src/tests/vm_arithmetic.rs
@@ -137,6 +137,7 @@ fn test_bit_ops_i64() {
     op_tests!(i64, 0b1100 << 2 = 0b1100 << 2);
     op_tests!(i64, 0b1100 >> 2 = 0b1100 >> 2);
     error_test!(0b1 << 64 = Overflow);
+    error_test!(0b1 >> 64 = Underflow);
 }
 
 #[test]

--- a/crates/rune/src/tests/vm_general.rs
+++ b/crates/rune/src/tests/vm_general.rs
@@ -10,7 +10,7 @@ fn test_small_programs() {
         }
     );
     assert_eq!(out, 42u64);
-    let _: () = rune!(
+    rune!(
         pub fn main() {}
     );
 
@@ -146,7 +146,7 @@ fn test_shadowing() {
 
 #[test]
 fn test_vectors() {
-    let _: () = rune!(
+    rune!(
         pub fn main() {
             let v = [1, 2, 3, 4, 5];
         }

--- a/crates/rune/src/tests/vm_not_used.rs
+++ b/crates/rune/src/tests/vm_not_used.rs
@@ -2,7 +2,7 @@ prelude!();
 
 #[test]
 fn test_not_used() {
-    let _: () = rune! {
+    rune! {
         pub fn main() {
             0;
             4.1;

--- a/crates/rune/src/workspace/emit.rs
+++ b/crates/rune/src/workspace/emit.rs
@@ -6,7 +6,6 @@ use std::io;
 use codespan_reporting::diagnostic as d;
 use codespan_reporting::term;
 use codespan_reporting::term::termcolor::WriteColor;
-pub use codespan_reporting::term::termcolor;
 
 use crate::alloc::prelude::*;
 use crate::alloc;


### PR DESCRIPTION
Currently rune doesn't allow these bitwise operators on the `Byte` type:
* BitAnd (u8 & u8)
* BitAndAssign (u8 &= u8)
* BitXor (u8 ^ u8)
* BitXorAssign (u8 ^= u8)
* BitOr (u8 | u8)
* BitOrAssign (u8 |= u8)
* Shl (u8 << u8)
* ShlAssign (u8 <<= u8)
* Shr (u8 >> u8)
* ShrAssign (u8 >>= u8)

Also, rune doesn't allow these bitwise operators on the `Bool` type:
* BitAndAssign (bool &= bool)
* BitXorAssign (bool ^= bool)
* BitOrAssign (bool |= bool)

The following commit adds all these bitwise operators.

Then, following rune script can be run as expected:

```
pub fn main() {

    // byte ops
    let byte = 128u8;

    println!("byte & 1u8 {}", byte & 1u8);
    byte &= 1u8;
    println!("{}", byte);

    println!("byte ^ 1u8: {}", byte ^ 1u8);
    byte ^= 1u8;
    println!("{}", byte);

    println!("byte | 1u8: {}", byte | 1u8 );
    byte |= 1u8;
    println!("{}", byte);

    println!("byte << 1u8: {}", byte << 1u8);
    byte <<= 1u8;
    println!("{}", byte);

    println!("byte >> 1u8: {}", byte >> 1u8);
    byte >>= 1u8;
    println!("{}", byte);


    // bool ops
    let mybool = true;

    mybool &= true;
    println!("{}", mybool);

    mybool ^= true;
    println!("{}", mybool);

    mybool |= true;
    println!("{}", mybool);
}
```

