### PR TITLE
Create a public function for source formatting

### DIFF
--- a/crates/rune/src/fmt.rs
+++ b/crates/rune/src/fmt.rs
@@ -9,6 +9,7 @@ mod indent_writer;
 mod printer;
 mod whitespace;
 
+use crate::alloc::String;
 use crate::alloc::Vec;
 use crate::ast;
 use crate::parse::{Parse, Parser};

--- a/crates/rune/src/fmt.rs
+++ b/crates/rune/src/fmt.rs
@@ -29,8 +29,7 @@ pub(crate) fn layout_source(source: &str) -> Result<Vec<u8>, FormattingError> {
 }
 
 /// Format the given source.
-#[cfg(feature = "anyhow")]
-pub fn format_source(source: &str) -> anyhow::Result<String> {
+pub fn format_source(source: &str) -> Result<String, impl std::error::Error> {
     let formatted = layout_source(source)?;
     Ok(String::from_utf8(formatted).unwrap())
 }

--- a/crates/rune/src/fmt.rs
+++ b/crates/rune/src/fmt.rs
@@ -26,3 +26,10 @@ pub(crate) fn layout_source(source: &str) -> Result<Vec<u8>, FormattingError> {
     printer.visit_file(&ast)?;
     printer.commit()
 }
+
+/// Format the given source.
+#[cfg(feature = "anyhow")]
+pub fn format_source(source: &str) -> anyhow::Result<String> {
+    let formatted = layout_source(source)?;
+    Ok(String::from_utf8(formatted).unwrap())
+}

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -197,7 +197,7 @@ mod exported_macros;
 pub mod ast;
 
 #[cfg(feature = "fmt")]
-pub(crate) mod fmt;
+pub mod fmt;
 
 cfg_emit! {
     pub use ::codespan_reporting::term::termcolor;


### PR DESCRIPTION
Alternative solution for #652.

In most cases, users don't need FormattingError enum itself, and just serializing the error message makes things easier in later code chagnes I believe.