### PR TITLE
Add WarningDiagnostic::emit

### DIFF
--- a/crates/rune/src/diagnostics/emit.rs
+++ b/crates/rune/src/diagnostics/emit.rs
@@ -286,6 +286,24 @@ impl FatalDiagnostic {
     }
 }
 
+impl WarningDiagnostic {
+    /// Generate formatted diagnostics capable of referencing source lines and
+    /// hints.
+    ///
+    /// See [prepare][crate::prepare] for how to use.
+    pub fn emit<O>(
+        &self,
+        out: &mut O,
+        sources: &Sources,
+    ) -> Result<(), EmitError>
+    where
+        O: WriteColor,
+    {
+        let config = term::Config::default();
+        warning_diagnostics_emit(self, out, sources, &config)
+    }
+}
+
 impl Unit {
     /// Dump instructions in a human readable manner.
     pub fn emit_instructions<O>(

--- a/crates/rune/src/diagnostics/emit.rs
+++ b/crates/rune/src/diagnostics/emit.rs
@@ -291,11 +291,7 @@ impl WarningDiagnostic {
     /// hints.
     ///
     /// See [prepare][crate::prepare] for how to use.
-    pub fn emit<O>(
-        &self,
-        out: &mut O,
-        sources: &Sources,
-    ) -> Result<(), EmitError>
+    pub fn emit<O>(&self, out: &mut O, sources: &Sources) -> Result<(), EmitError>
     where
         O: WriteColor,
     {


### PR DESCRIPTION
I think this may have just been an oversight since it was already implemented for `FatalDiagnostic` 🙂