### PR TITLE
Minor LSP fixups

### DIFF
--- a/crates/rune/src/languageserver/completion.rs
+++ b/crates/rune/src/languageserver/completion.rs
@@ -122,7 +122,7 @@ pub(super) fn complete_native_instance_data(
             let docs = meta.docs.lines().join("\n");
             let args = meta.docs.args().unwrap_or_default().join(", ");
 
-            let detail = return_type.map(|r| format!("({args} -> {r}"));
+            let detail = return_type.map(|r| format!("({args}) -> {r}"));
 
             results.try_push(CompletionItem {
                 label: n.try_to_string()?.into_std(),
@@ -146,7 +146,7 @@ pub(super) fn complete_native_instance_data(
                     detail: None,
                     description: Some(prefix.try_to_string()?.into_std()),
                 }),
-                data: Some(serde_json::to_value(meta.hash).unwrap()),
+                data: Some(serde_json::to_value(meta.hash.into_inner() as i64).unwrap()),
                 ..Default::default()
             })?;
         }
@@ -201,7 +201,7 @@ pub(super) fn complete_native_loose_data(
                     },
                     new_text: func_name.into_std(),
                 })),
-                data: Some(serde_json::to_value(meta.hash).unwrap()),
+                data: Some(serde_json::to_value(meta.hash.into_inner() as i64).unwrap()),
                 ..Default::default()
             })?;
         }

--- a/crates/rune/src/languageserver/state.rs
+++ b/crates/rune/src/languageserver/state.rs
@@ -708,7 +708,7 @@ impl Source {
 
         // The set of tokens that delimit symbols.
         let x: &[_] = &[
-            ',', ';', '(', '.', '=', '+', '-', '*', '/', '}', '{', ']', '[', ')', ':',
+            ',', ';', '(', '.', '=', '+', '-', '*', '/', '}', '{', ']', '[', ')',
         ];
 
         let end_search = (offset - start_byte + 1).min(chunk.len());


### PR DESCRIPTION
* A formatting error in a detail
* I started writing a rune mode for emacs (again...), and noticed that returning a u64 as the data is out of spec -- only u32/i32 are legal. This causes emacs to barf because the JSON parser there assumes `i64` as the integer value. This data doesn't seem to be used, but at least this transform is reversible if we want it.
* I noticed that completing `json::` didn't include `json::` as the prefix, leading to very odd results. I think the symbol-heuristic is a bit too naive still, but this is a tiny bit better. For example, completing the example would lead to `json::json::from_string`, whereas now it'll correctly only have `json::to_string`