### PR TITLE
Add support for captured arguments from macros

### DIFF
--- a/book/src/hot_reloading.md
+++ b/book/src/hot_reloading.md
@@ -11,7 +11,7 @@ A typical way to accomplish this is to watch a scripts directory using the
 to the directory are detected. See the [`hot_reloading` example] and in
 particular the [`PathReloader`] type.
 
-```
+```rust
 {{#include ../../examples/examples/hot_reloading.rs}}
 ```
 

--- a/crates/rune/src/compile/context.rs
+++ b/crates/rune/src/compile/context.rs
@@ -152,7 +152,6 @@ impl Context {
         this.install(crate::modules::fmt::module()?)?;
         this.install(crate::modules::future::module()?)?;
         this.install(crate::modules::i64::module()?)?;
-        #[cfg(feature = "std")]
         this.install(crate::modules::io::module(stdio)?)?;
         this.install(crate::modules::iter::module()?)?;
         this.install(crate::modules::macros::module()?)?;

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -29,18 +29,17 @@
 //! * Runs a compact representation of the language on top of an efficient
 //!   [stack-based virtual machine][support-virtual-machine].
 //! * Clean [Rust integration 💻][support-rust-integration].
+//! * [Multithreaded 📖][support-multithreading] execution.
+//! * [Hot reloading 📖][support-hot-reloading].
 //! * Memory safe through [reference counting 📖][support-reference-counted].
-//! * [Awesome macros 📖][support-macros].
-//! * [Template literals 📖][support-templates].
-//! * [Try operators 📖][support-try].
-//! * [Pattern matching 📖][support-patterns].
+//! * [Awesome macros 📖][support-macros] and [Template literals 📖][support-templates].
+//! * [Try operators 📖][support-try] and [Pattern matching 📖][support-patterns].
 //! * [Structs and enums 📖][support-structs] with associated data and
 //!   functions.
-//! * Dynamic [vectors 📖][support-dynamic-vectors], [objects
-//!   📖][support-anon-objects], and [tuples 📖][support-anon-tuples] with
+//! * Dynamic containers like [vectors 📖][support-dynamic-vectors], [objects
+//!   📖][support-anon-objects], and [tuples 📖][support-anon-tuples] all with
 //!   out-of-the-box [serde support 💻][support-serde].
-//! * First-class [async support 📖][support-async].
-//! * [Generators 📖][support-generators].
+//! * First-class [async support 📖][support-async] with [Generators 📖][support-generators].
 //! * Dynamic [instance functions 📖][support-instance-functions].
 //! * [Stack isolation 📖][support-stack-isolation] between function calls.
 //!
@@ -114,8 +113,10 @@
 //! [support-async]: https://rune-rs.github.io/book/async.html
 //! [support-dynamic-vectors]: https://rune-rs.github.io/book/vectors.html
 //! [support-generators]: https://rune-rs.github.io/book/generators.html
+//! [support-hot-reloading]: https://rune-rs.github.io/book/hot_reloading.html
 //! [support-instance-functions]: https://rune-rs.github.io/book/instance_functions.html
 //! [support-macros]: https://rune-rs.github.io/book/macros.html
+//! [support-multithreading]: https://rune-rs.github.io/book/multithreading.html
 //! [support-patterns]: https://rune-rs.github.io/book/pattern_matching.html
 //! [support-reference-counted]: https://rune-rs.github.io/book/variables.html
 //! [support-rust-integration]: https://github.com/rune-rs/rune/tree/main/crates/rune-modules

--- a/crates/rune/src/macros/token_stream.rs
+++ b/crates/rune/src/macros/token_stream.rs
@@ -125,7 +125,7 @@ pub trait ToTokens {
     /// Turn the current item into tokens.
     fn to_tokens(
         &self,
-        context: &mut MacroContext<'_, '_, '_>,
+        cx: &mut MacroContext<'_, '_, '_>,
         stream: &mut TokenStream,
     ) -> alloc::Result<()>;
 }

--- a/crates/rune/src/modules.rs
+++ b/crates/rune/src/modules.rs
@@ -21,7 +21,6 @@ pub mod future;
 pub mod generator;
 pub mod hash;
 pub mod i64;
-#[cfg(feature = "std")]
 pub mod io;
 pub mod iter;
 pub mod macros;

--- a/crates/rune/src/tests.rs
+++ b/crates/rune/src/tests.rs
@@ -409,6 +409,7 @@ mod bug_422;
 mod bug_428;
 mod bug_454;
 mod bugfixes;
+mod builtin_macros;
 mod capture;
 mod char;
 mod collections;

--- a/crates/rune/src/tests/builtin_macros.rs
+++ b/crates/rune/src/tests/builtin_macros.rs
@@ -1,0 +1,73 @@
+prelude!();
+
+use crate::termcolor::{ColorChoice, StandardStream};
+
+macro_rules! capture {
+    ($($tt:tt)*) => {{
+        let capture = crate::modules::capture_io::CaptureIo::new();
+        let module = crate::modules::capture_io::module(&capture).context("building capture module")?;
+
+        let mut context = Context::with_config(false).context("building context")?;
+        context.install(module).context("installing module")?;
+
+        let source = Source::memory(concat!("pub fn main() { ", stringify!($($tt)*), " }")).context("building source")?;
+
+        let mut sources = Sources::new();
+        sources.insert(source).context("inserting source")?;
+
+        let mut diagnostics = Diagnostics::new();
+
+        let unit = prepare(&mut sources).with_context(&context).with_diagnostics(&mut diagnostics).build();
+
+        if !diagnostics.is_empty() {
+            let mut writer = StandardStream::stderr(ColorChoice::Always);
+            diagnostics.emit(&mut writer, &sources)?;
+        }
+
+        let unit = Arc::new(unit.context("building unit")?);
+
+        let context = context.runtime().context("constructing runtime context")?;
+        let context = Arc::new(context);
+
+        let mut vm = Vm::new(context, unit);
+        vm.call(["main"], ()).context("calling main")?;
+        capture.drain_utf8().context("draining utf-8 capture")?
+    }};
+}
+
+macro_rules! test_case {
+    ($expected:expr, {$($prefix:tt)*}, $($format:tt)*) => {{
+        let string = capture!($($prefix)* println!($($format)*));
+        assert_eq!(string, concat!($expected, "\n"), "Expecting println!");
+
+        let string = capture!($($prefix)* print!($($format)*));
+        assert_eq!(string, $expected, "Expecting print!");
+
+        let string: String = rune!(pub fn main() { $($prefix)* format!($($format)*) });
+        assert_eq!(string, $expected, "Expecting format!");
+    }}
+}
+
+#[test]
+fn format_macros() -> Result<()> {
+    test_case!("Hello World!", {}, "Hello World!");
+    test_case!("Hello World!", {}, "Hello {}!", "World");
+    test_case!(
+        "Hello World!",
+        {
+            let pos = "Hello";
+        },
+        "{pos} {}!",
+        "World"
+    );
+    test_case!(
+        "Hello World!",
+        {
+            let pos = "Not Hello";
+        },
+        "{pos} {}!",
+        "World",
+        pos = "Hello"
+    );
+    Ok(())
+}


### PR DESCRIPTION
This adds support for capturing named variables from inside of a macro, like this:

```rust
let var = "World";
println!("Hello {var}");
```