### PR TITLE
Closure environments

### DIFF
--- a/crates/rune/src/compile/unit_builder.rs
+++ b/crates/rune/src/compile/unit_builder.rs
@@ -663,6 +663,7 @@ impl UnitBuilder {
         item: &Item,
         instance: Option<(Hash, &str)>,
         args: usize,
+        captures: Option<usize>,
         assembly: Assembly,
         call: Call,
         debug_args: Box<[Box<str>]>,
@@ -672,7 +673,12 @@ impl UnitBuilder {
 
         let offset = unit_storage.offset();
 
-        let info = UnitFn::Offset { offset, call, args };
+        let info = UnitFn::Offset {
+            offset,
+            call,
+            args,
+            captures,
+        };
         let signature = DebugSignature::new(item.try_to_owned()?, DebugArgs::Named(debug_args));
 
         if let Some((type_hash, name)) = instance {

--- a/crates/rune/src/compile/v1/assemble.rs
+++ b/crates/rune/src/compile/v1/assemble.rs
@@ -311,7 +311,12 @@ pub(crate) fn expr_closure_secondary<'hir>(
     }
 
     if !hir.captures.is_empty() {
-        cx.asm.push(Inst::PushTuple, span)?;
+        cx.asm.push(
+            Inst::PushEnvironment {
+                count: hir.captures.len(),
+            },
+            span,
+        )?;
 
         for capture in hir.captures.iter().copied() {
             cx.scopes.define(capture, span)?;

--- a/crates/rune/src/runtime/args.rs
+++ b/crates/rune/src/runtime/args.rs
@@ -34,6 +34,7 @@ macro_rules! impl_into_args {
                 VmResult::Ok(vec)
             }
 
+            #[inline]
             fn count(&self) -> usize {
                 $count
             }

--- a/crates/rune/src/runtime/inst.rs
+++ b/crates/rune/src/runtime/inst.rs
@@ -641,8 +641,8 @@ pub enum Inst {
     /// Take the tuple that is on top of the stack and push its content onto the
     /// stack.
     ///
-    /// Note: this is used by closures to "unpack" their environment into local
-    /// variables.
+    /// This is used to unpack an environment for closures - if the closure has
+    /// an environment.
     ///
     /// # Operation
     ///
@@ -650,7 +650,10 @@ pub enum Inst {
     /// <tuple>
     /// => <value...>
     /// ```
-    PushTuple,
+    PushEnvironment {
+        /// The expected size of the tuple.
+        count: usize,
+    },
     /// Construct a push an object onto the stack. The number of elements
     /// in the object are determined the slot of the object keys `slot` and are
     /// popped from the stack.

--- a/crates/rune/src/runtime/protocol_caller.rs
+++ b/crates/rune/src/runtime/protocol_caller.rs
@@ -51,6 +51,7 @@ impl ProtocolCaller for EnvProtocolCaller {
                 offset,
                 args: expected,
                 call,
+                ..
             }) = unit.function(hash)
             {
                 vm_try!(check_args(count, expected));

--- a/crates/rune/src/runtime/unit.rs
+++ b/crates/rune/src/runtime/unit.rs
@@ -244,6 +244,9 @@ pub(crate) enum UnitFn {
         call: Call,
         /// The number of arguments the function takes.
         args: usize,
+        /// If the offset is a closure, this indicates the number of captures in
+        /// the first argument.
+        captures: Option<usize>,
     },
     /// An empty constructor of the type identified by the given hash.
     EmptyStruct {
@@ -281,20 +284,28 @@ impl TryClone for UnitFn {
 impl fmt::Display for UnitFn {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Offset { offset, call, args } => {
-                write!(f, "offset {}, {}, {}", offset, call, args)?;
+            Self::Offset {
+                offset,
+                call,
+                args,
+                captures,
+            } => {
+                write!(
+                    f,
+                    "offset offset={offset}, call={call}, args={args}, captures={captures:?}"
+                )?;
             }
             Self::EmptyStruct { hash } => {
-                write!(f, "unit {}", hash)?;
+                write!(f, "unit hash={hash}")?;
             }
             Self::TupleStruct { hash, args } => {
-                write!(f, "tuple {}, {}", hash, args)?;
+                write!(f, "tuple hash={hash}, args={args}")?;
             }
             Self::UnitVariant { hash } => {
-                write!(f, "empty-variant {}", hash)?;
+                write!(f, "empty-variant hash={hash}")?;
             }
             Self::TupleVariant { hash, args } => {
-                write!(f, "tuple-variant {}, {}", hash, args)?;
+                write!(f, "tuple-variant hash={hash}, args={args}")?;
             }
         }
 

--- a/crates/rune/src/runtime/vm_error.rs
+++ b/crates/rune/src/runtime/vm_error.rs
@@ -625,6 +625,10 @@ pub(crate) enum VmErrorKind {
         actual: usize,
         expected: usize,
     },
+    BadEnvironmentCount {
+        actual: usize,
+        expected: usize,
+    },
     BadArgument {
         arg: usize,
     },
@@ -827,6 +831,10 @@ impl fmt::Display for VmErrorKind {
             VmErrorKind::BadArgumentCount { actual, expected } => write!(
                 f,
                 "Wrong number of arguments `{actual}`, expected `{expected}`",
+            ),
+            VmErrorKind::BadEnvironmentCount { actual, expected } => write!(
+                f,
+                "Wrong environment size `{actual}`, expected `{expected}`",
             ),
             VmErrorKind::BadArgument { arg } => write!(f, "Bad argument #{arg}"),
             VmErrorKind::UnsupportedIndexSet {

--- a/crates/rune/src/tests.rs
+++ b/crates/rune/src/tests.rs
@@ -408,6 +408,7 @@ mod bug_417;
 mod bug_422;
 mod bug_428;
 mod bug_454;
+mod bug_700;
 mod bugfixes;
 mod builtin_macros;
 mod capture;

--- a/crates/rune/src/tests/bug_700.rs
+++ b/crates/rune/src/tests/bug_700.rs
@@ -1,0 +1,53 @@
+use crate::runtime::static_type;
+
+prelude!();
+
+/// See https://github.com/rune-rs/rune/issues/700
+#[test]
+pub fn test_bug_700() -> Result<()> {
+    let context = Context::new();
+
+    let mut sources = sources! {
+        entry => {
+            pub fn main(argument) {
+                || argument
+            }
+        }
+    };
+
+    let unit = prepare(&mut sources).with_context(&context).build()?;
+    let mut vm = Vm::new(Arc::new(context.runtime()?), Arc::new(unit));
+
+    let value = vm.call(["main"], (42,))?;
+    let function = from_value::<Function>(value)?;
+
+    let output: i64 = function.call(()).into_result()?;
+    assert_eq!(output, 42);
+
+    // This should error, because the function is missing the environment variable.
+    let error = vm.call(function.type_hash(), ()).unwrap_err();
+
+    assert_eq!(
+        error.into_kind(),
+        VmErrorKind::BadArgumentCount {
+            actual: 0,
+            expected: 1
+        }
+    );
+
+    // We call with an argument, but it's not a tuple, which is required for the environment.
+    let error = vm.call(function.type_hash(), (0,)).unwrap_err();
+
+    assert_eq!(
+        error.into_kind(),
+        VmErrorKind::Expected {
+            expected: TypeInfo::StaticType(static_type::TUPLE_TYPE),
+            actual: TypeInfo::StaticType(static_type::INTEGER_TYPE)
+        }
+    );
+
+    let value = vm.call(function.type_hash(), ((84,),)).unwrap();
+    let output: i64 = from_value::<i64>(value)?;
+    assert_eq!(output, 84);
+    Ok(())
+}


### PR DESCRIPTION
This adds metadata about the closures related to environments, and ensures that we are explicitly testing for their size, rather than maybe incidentally erroring in case the wrong number of environment variables is passed in.

We also now correctly records the number of arguments for closures, which used to be buggy. The environment is an implicit argument, making the signature of closures capturing environments one larger.

Fixes #700