### PR TITLE
feat: add impl-level exporting QoL macro

### DIFF
--- a/crates/rune-macros/Cargo.toml
+++ b/crates/rune-macros/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["parser-implementations"]
 
 [dependencies]
 rune-core = { version = "=0.14.0", path = "../rune-core", features = ["std"] }
-syn = { version = "2.0.16", features = ["full"] }
+syn = { version = "2.0.16", features = ["full", "extra-traits"] }
 quote = "1.0.27"
 proc-macro2 = "1.0.56"
 

--- a/crates/rune-macros/src/function.rs
+++ b/crates/rune-macros/src/function.rs
@@ -116,13 +116,13 @@ impl FunctionAttrs {
 }
 
 pub(crate) struct Function {
-    attributes: Vec<syn::Attribute>,
-    vis: syn::Visibility,
-    sig: syn::Signature,
-    remainder: TokenStream,
-    docs: syn::ExprArray,
-    arguments: syn::ExprArray,
-    takes_self: bool,
+    pub attributes: Vec<syn::Attribute>,
+    pub vis: syn::Visibility,
+    pub sig: syn::Signature,
+    pub remainder: TokenStream,
+    pub docs: syn::ExprArray,
+    pub arguments: syn::ExprArray,
+    pub takes_self: bool,
 }
 
 impl Function {

--- a/crates/rune-macros/src/item_impl.rs
+++ b/crates/rune-macros/src/item_impl.rs
@@ -1,0 +1,92 @@
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+use syn::parse::ParseStream;
+use syn::punctuated::Punctuated;
+
+pub(crate) struct ItemImplAttrs {
+    /// Name of the exporter function
+    name: syn::Ident,
+}
+
+impl ItemImplAttrs {
+    pub(crate) fn parse(input: ParseStream) -> syn::Result<Self> {
+        let name = input
+            .parse::<syn::Ident>()
+            .unwrap_or_else(|_| syn::Ident::new("export_rune_methods", input.span()));
+        Ok(Self { name })
+    }
+}
+
+pub(crate) struct ItemImpl(pub syn::ItemImpl);
+
+impl ItemImpl {
+    pub(crate) fn expand(self, attrs: ItemImplAttrs) -> syn::Result<TokenStream> {
+        let Self(mut block) = self;
+
+        let mut export_list = Vec::new();
+        let export_attr: syn::Attribute = syn::parse_quote!(#[export]);
+
+        for item in block.items.iter_mut() {
+            if let syn::ImplItem::Fn(method) = item {
+                let attr_index = method
+                    .attrs
+                    .iter()
+                    .enumerate()
+                    .find_map(|(index, attr)| (*attr == export_attr).then_some(index));
+
+                if let Some(index) = attr_index {
+                    method.attrs.remove(index);
+
+                    let reparsed = syn::parse::Parser::parse2(
+                        crate::function::Function::parse,
+                        method.to_token_stream(),
+                    )?;
+
+                    let name = method.sig.ident.clone();
+                    let name_string = syn::LitStr::new(
+                        &reparsed.sig.ident.to_string(),
+                        reparsed.sig.ident.span(),
+                    );
+                    let path = syn::Path {
+                        leading_colon: None,
+                        segments: Punctuated::from_iter(
+                            [
+                                syn::PathSegment::from(<syn::Token![Self]>::default()),
+                                syn::PathSegment::from(name.clone()),
+                            ]
+                            .into_iter(),
+                        ),
+                    };
+
+                    let docs = reparsed.docs;
+                    let arguments = reparsed.arguments;
+
+                    let meta = quote! {
+                        rune::__private::FunctionMetaData {
+                            kind: rune::__private::FunctionMetaKind::instance(#name_string, #path)?,
+                            name: #name_string,
+                            deprecated: None,
+                            docs: &#docs[..],
+                            arguments: &#arguments[..],
+                        }
+                    };
+
+                    export_list.push(meta);
+                }
+            }
+        }
+
+        let name = attrs.name;
+
+        let export_count = export_list.len();
+        let exporter = quote! {
+            fn #name() -> rune::alloc::Result<[rune::__private::FunctionMetaData; #export_count]> {
+                Ok([ #(#export_list),* ])
+            }
+        };
+
+        block.items.push(syn::parse2(exporter).unwrap());
+
+        Ok(block.to_token_stream().into())
+    }
+}

--- a/crates/rune-macros/src/lib.rs
+++ b/crates/rune-macros/src/lib.rs
@@ -37,6 +37,7 @@ mod hash;
 mod inst_display;
 mod instrument;
 mod internals;
+mod item_impl;
 mod macro_;
 mod module;
 mod opaque;
@@ -70,6 +71,22 @@ pub fn function(
     let function = syn::parse_macro_input!(item with crate::function::Function::parse);
 
     let output = match function.expand(attrs) {
+        Ok(output) => output,
+        Err(e) => return proc_macro::TokenStream::from(e.to_compile_error()),
+    };
+
+    output.into()
+}
+
+#[proc_macro_attribute]
+pub fn impl_item(
+    attrs: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let attrs = syn::parse_macro_input!(attrs with crate::item_impl::ItemImplAttrs::parse);
+    let item = crate::item_impl::ItemImpl(syn::parse_macro_input!(item as syn::ItemImpl));
+
+    let output = match item.expand(attrs) {
         Ok(output) => output,
         Err(e) => return proc_macro::TokenStream::from(e.to_compile_error()),
     };

--- a/crates/rune-macros/tests/derive.rs
+++ b/crates/rune-macros/tests/derive.rs
@@ -17,3 +17,27 @@ fn generic_derive() {
         value: T,
     }
 }
+
+#[test]
+fn export_impl() {
+    #[derive(crate::Any)]
+    struct MyStruct(usize);
+
+    #[crate::impl_item]
+    impl MyStruct {
+        #[export]
+        pub fn foo(&self) -> usize {
+            self.0
+        }
+    }
+
+    #[crate::impl_item(export_rune_api_extension)]
+    impl MyStruct {
+        #[export]
+        pub fn bar(&self) -> usize {
+            self.0 + 1
+        }
+    }
+
+    assert!(MyStruct(2).foo() + 1 == MyStruct(2).bar());
+}

--- a/crates/rune-macros/tests/derive.rs
+++ b/crates/rune-macros/tests/derive.rs
@@ -37,6 +37,18 @@ fn export_impl() {
         pub fn bar(&self) -> usize {
             self.0 + 1
         }
+
+        pub fn rune_export(
+            mut module: rune::Module,
+        ) -> rune::alloc::Result<Result<rune::Module, rune::ContextError>> {
+            for func in Self::export_rune_api_extension()? {
+                if let Err(e) = module.function_from_meta(func) {
+                    return Ok(Err(e));
+                }
+            }
+
+            Ok(Ok(module))
+        }
     }
 
     assert!(MyStruct(2).foo() + 1 == MyStruct(2).bar());

--- a/crates/rune/src/module/module.rs
+++ b/crates/rune/src/module/module.rs
@@ -25,6 +25,8 @@ use crate::runtime::{
 };
 use crate::Hash;
 
+use super::FunctionMetaData;
+
 /// Function builder as returned by [`Module::function`].
 ///
 /// This allows for building a function regularly with
@@ -1242,7 +1244,14 @@ impl Module {
     #[inline]
     pub fn function_meta(&mut self, meta: FunctionMeta) -> Result<ItemFnMut<'_>, ContextError> {
         let meta = meta()?;
+        self.function_from_meta(meta)
+    }
 
+    /// Register a function handler through its metadata.
+    pub fn function_from_meta(
+        &mut self,
+        meta: FunctionMetaData,
+    ) -> Result<ItemFnMut<'_>, ContextError> {
         match meta.kind {
             FunctionMetaKind::Function(data) => {
                 let mut docs = Docs::EMPTY;


### PR DESCRIPTION
This adds a new macro that allows for more concise exporting of a lot of functions.
Currently in a sort of PoC state, a lot can and will be improved.

### Why ?
Having to edit multiple places when making simple changes to an API is tedious and a source of error.

### How ?
```rust
#[derive(rune::Any)]
struct MyStruct(#[rune::get] usize);

// Creates a function that returns an array of all the function metadata
#[rune::item_impl]
impl MyStruct {
    #[export]
    pub fn succ(&self) -> Self {
        Self(self.0 + 1)
    }
}
```

### What's missing
- [ ] Proper documentation
- [ ] Non-instance function handling

I had to add the `extra-traits` syn feature, if you know of a way to do the comparison on `crates/rune-macros/src/item_impl.rs:35` without it that'd be pretty cool.