### PR TITLE
Make equality symmetric for user defined types.

### DIFF
--- a/crates/rune/src/runtime/value.rs
+++ b/crates/rune/src/runtime/value.rs
@@ -1591,8 +1591,13 @@ impl Value {
             }
         }
 
-        if let CallResult::Ok(value) =
-            vm_try!(caller.try_call_protocol_fn(Protocol::PARTIAL_EQ, self.clone(), (b.clone(),)))
+        let mut result = vm_try!(caller.try_call_protocol_fn(Protocol::PARTIAL_EQ, self.clone(), (b.clone(),)));
+        if let CallResult::Unsupported(_) = result {
+            // If we cannot resolve a == b, we try b == a.
+            result = vm_try!(caller.try_call_protocol_fn(Protocol::PARTIAL_EQ, b.clone(), (self.clone(),)));
+        }
+
+        if let CallResult::Ok(value) = result
         {
             return <_>::from_value(value);
         }
@@ -1775,8 +1780,13 @@ impl Value {
             _ => {}
         }
 
-        if let CallResult::Ok(value) =
-            vm_try!(caller.try_call_protocol_fn(Protocol::EQ, self.clone(), (b.clone(),)))
+        let mut result = vm_try!(caller.try_call_protocol_fn(Protocol::EQ, self.clone(), (b.clone(),)));
+        if let CallResult::Unsupported(_) = result {
+            // If we cannot resolve a == b, we try b == a.
+            result = vm_try!(caller.try_call_protocol_fn(Protocol::EQ, b.clone(), (self.clone(),)));
+        }
+
+        if let CallResult::Ok(value) = result
         {
             return <_>::from_value(value);
         }


### PR DESCRIPTION
As a user of Rune, I'd like equality to be symmetric, so that the order of the equality does not matter. This means that ``a == b`` implicitly also means that ``b == a``. 

Currently this is not the case when defining an associated method for a type, where the other type is not the same as the instance type. An example of the use case for this is a user defined string wrapper, where we want to implement equality with a Rune string, and want it to work both ways. In the current implementation, if we implement equality from type a to type b, we can do a == b, but when doing b == a we get an error that the function does not exist, as it's only implemented on type a.

This pull request aims to fix that.

To do so the following changes were made:
- The protocol callers were changed to have their implementation inside of ``try_call_protocol_fn``, instead of ``call_protocol_fn``. ``try_call_protocol_fn`` already existed, but due to its implementation could never return a CallResult that was not ``CallResult::Ok``. After this change, it's now possible to receive a ``CallResult::Unsupported`` from ``try_call_protocol_fn``. 
- The  ``call_protocol_fn`` now calls ``try_call_protocol_fn``, and returns a ``VmErrorKind::MissingProtocolFunction`` error if it receives a ``CallResult::Unsupported``. Note that this is different from the previous error, which was ``VmErrorKind::MissingFunction``. The ``MissingProtocolFunction`` error felt like a far clearer error here.
- The ``partial_eq_with`` and ``eq_with`` functions of ``Value`` now try to resolve ``b == a``  if they're unable to resolve ``a == b``. 


As a side effect, due to the above changes where ``try_call_protocol_fn`` can now return values other than ``CallResult::Ok`` or VmError, it's now possible to reach several errors that were unreachable before. For cmp, eq, partial_eq, and hash, you'll now receive the already existing UnsupportedBinaryOperation or UnsupportedUnaryOperation errors when the protocol is not implemented.