### PR TITLE
Make types in rune tests less ambiguous

### DIFF
--- a/crates/rune/src/tests/attribute.rs
+++ b/crates/rune/src/tests/attribute.rs
@@ -4,7 +4,7 @@ use ErrorKind::*;
 
 #[test]
 fn basic_use() {
-    rune! {
+    let _: () = rune! {
         mod private {
             #[test]
             fn test_case() {

--- a/crates/rune/src/tests/bug_454.rs
+++ b/crates/rune/src/tests/bug_454.rs
@@ -3,7 +3,7 @@ prelude!();
 /// See https://github.com/rune-rs/rune/issues/454
 #[test]
 pub fn test_bug_454() {
-    rune! {
+    let _: () = rune! {
         struct Test;
 
         fn call(a, b) {

--- a/crates/rune/src/tests/bugfixes.rs
+++ b/crates/rune/src/tests/bugfixes.rs
@@ -28,7 +28,7 @@ fn test_pattern_binding_bug() {
 /// inside of an inst fn call.
 #[test]
 fn test_string_pattern_in_instance_fn_bug() {
-    rune! {
+    let _: () = rune! {
         enum Inst { A, Unknown }
 
         pub fn works() {

--- a/crates/rune/src/tests/collections.rs
+++ b/crates/rune/src/tests/collections.rs
@@ -2,7 +2,7 @@ prelude!();
 
 #[test]
 fn test_hash_map_tile() {
-    rune! {
+    let _: () = rune! {
         pub fn main() {
             use std::collections::HashMap;
 
@@ -24,7 +24,7 @@ fn test_hash_map_tile() {
 
 #[test]
 fn test_hash_set_tuple() {
-    rune! {
+    let _: () = rune! {
         pub fn main() {
             use std::collections::HashSet;
 

--- a/crates/rune/src/tests/compiler_visibility.rs
+++ b/crates/rune/src/tests/compiler_visibility.rs
@@ -96,7 +96,7 @@ fn test_indirect_access() {
 // Test borrowed from: https://doc.rust-lang.org/reference/visibility-and-privacy.html
 #[test]
 fn test_rust_example() {
-    rune! {
+    let _: () = rune! {
         mod crate_helper_module {
             pub fn crate_helper() {}
 

--- a/crates/rune/src/tests/continue_.rs
+++ b/crates/rune/src/tests/continue_.rs
@@ -4,7 +4,7 @@ use ErrorKind::*;
 
 #[test]
 fn test_continue_label() {
-    rune! {
+    let _: () = rune! {
         pub fn main() {
             let n = 0;
             let not_used = true;
@@ -32,7 +32,7 @@ fn test_continue_label() {
 
 #[test]
 fn while_continue() {
-    rune! {
+    let _: () = rune! {
         pub fn main() {
             let n = 0;
             let condition = true;
@@ -56,7 +56,7 @@ fn while_continue() {
 
 #[test]
 fn loop_continue() {
-    rune! {
+    let _: () = rune! {
         pub fn main() {
             let n = 0;
             let condition = true;
@@ -85,7 +85,7 @@ fn loop_continue() {
 
 #[test]
 fn for_continue() {
-    rune! {
+    let _: () = rune! {
         pub fn main() {
             let n = 0;
             let condition = true;

--- a/crates/rune/src/tests/core_macros.rs
+++ b/crates/rune/src/tests/core_macros.rs
@@ -9,12 +9,13 @@ macro_rules! test_case {
 
 #[test]
 fn test_asserts() {
-    rune!(
+    let _: () = rune!(
         pub fn main() {
             assert!(true)
         }
     );
-    rune!(
+
+    let _: () = rune!(
         pub fn main() {
             assert_eq!(1 + 1, 2)
         }

--- a/crates/rune/src/tests/instance.rs
+++ b/crates/rune/src/tests/instance.rs
@@ -2,7 +2,7 @@ prelude!();
 
 #[test]
 fn test_basic_self() {
-    rune! {
+    let _: () = rune! {
         struct Foo {
             value,
         }
@@ -24,7 +24,7 @@ fn test_basic_self() {
 
 #[test]
 fn test_chaining() {
-    rune! {
+    let _: () = rune! {
         struct Foo {
             value,
         }

--- a/crates/rune/src/tests/iterator.rs
+++ b/crates/rune/src/tests/iterator.rs
@@ -42,7 +42,7 @@ fn test_rev() {
 
 #[test]
 fn test_next_back() {
-    rune! {
+    let _: () = rune! {
         const SOURCE = [1, 2, 3, "foo"];
 
         pub fn main() {

--- a/crates/rune/src/tests/patterns.rs
+++ b/crates/rune/src/tests/patterns.rs
@@ -113,7 +113,7 @@ fn test_vec_patterns() {
     );
     assert_eq!(out, true);
 
-    rune!(
+    let _: () = rune!(
         pub fn main() {
             match [] {
                 [a, b] => a + 1 == b,
@@ -290,7 +290,7 @@ fn test_const_in_pattern() {
                 pat2 = $pat2,
             };
 
-            let tuple: (i64, i64, i64, i64) = rune_s!(string.as_str());
+            let tuple: (i64, i64, i64, i64) = eval(string);
             assert_eq!(tuple, (1, 6, 7, 4));
         };
     }

--- a/crates/rune/src/tests/range.rs
+++ b/crates/rune/src/tests/range.rs
@@ -5,7 +5,7 @@ use VmErrorKind::*;
 
 #[test]
 fn range_accessors() {
-    rune! {
+    let _: () = rune! {
         pub fn main() {
             assert_eq!((1..10).start, 1);
             assert_eq!((1..10).end, 10);
@@ -21,7 +21,7 @@ fn range_accessors() {
 
 #[test]
 fn range_iter() {
-    rune! {
+    let _: () = rune! {
         pub fn main() {
             assert_eq!((1..4).iter().collect::<Vec>(), [1, 2, 3]);
             assert_eq!((1..4).iter().rev().collect::<Vec>(), [3, 2, 1]);
@@ -38,7 +38,7 @@ fn range_iter() {
 
 #[test]
 fn range_match() {
-    rune! {
+    let _: () = rune! {
         pub fn main() {
             use std::ops::{RangeFrom, RangeFull, RangeInclusive, RangeToInclusive, RangeTo, Range};
 
@@ -60,13 +60,13 @@ fn range_match() {
 
 #[test]
 fn test_non_numeric_ranges() {
-    rune! {
+    let _: () = rune! {
         pub fn main() {
             assert_eq!((#{}..=10).start, #{});
         }
     };
 
-    rune! {
+    let _: () = rune! {
         pub fn main() {
             let a = ..=(1, 2, 3);
             assert_eq!(a.end, (1, 2, 3));
@@ -76,7 +76,7 @@ fn test_non_numeric_ranges() {
 
 #[test]
 fn test_range_into_iter() {
-    rune! {
+    let _: () = rune! {
         pub fn main() {
             let d = [];
 
@@ -88,7 +88,7 @@ fn test_range_into_iter() {
         }
     };
 
-    rune! {
+    let _: () = rune! {
         pub fn main() {
             fn end() {
                 4

--- a/crates/rune/src/tests/variants.rs
+++ b/crates/rune/src/tests/variants.rs
@@ -4,7 +4,7 @@ prelude!();
 /// See: https://github.com/rune-rs/rune/pull/215
 #[test]
 fn assert_variant_comparisons() {
-    rune! {
+    let _: () = rune! {
         enum Foo { A, B }
 
         pub fn main() {
@@ -13,7 +13,7 @@ fn assert_variant_comparisons() {
         }
     };
 
-    rune! {
+    let _: () = rune! {
         enum Foo { A(a), B }
 
         pub fn main() {
@@ -22,7 +22,7 @@ fn assert_variant_comparisons() {
         }
     };
 
-    rune! {
+    let _: () = rune! {
         enum Foo { A { a }, B }
 
         pub fn main() {

--- a/crates/rune/src/tests/vm_arithmetic.rs
+++ b/crates/rune/src/tests/vm_arithmetic.rs
@@ -7,55 +7,55 @@ macro_rules! op_tests {
         let out: $ty = rune!(pub fn main() { let a = $lhs; let b = $rhs; a $op b});
         assert_eq!(out, $out);
 
-        let out: $ty = rune_s!(&format!(
+        let out: $ty = eval(&format!(
             r#"pub fn main() {{ let a = {lhs}; let b = {rhs}; a {op}= b; a }}"#,
             lhs = stringify!($lhs), rhs = stringify!($rhs), op = stringify!($op),
         ));
         assert_eq!(out, $out);
 
-        let out: $ty = rune_s!(&format!(
+        let out: $ty = eval(&format!(
             r#"struct Foo {{ padding, field }}; pub fn main() {{ let a = Foo{{ padding: 0, field: {lhs} }}; let b = {rhs}; a.field {op}= b; a.field }}"#,
             lhs = stringify!($lhs), rhs = stringify!($rhs), op = stringify!($op),
         ));
         assert_eq!(out, $out);
 
-        let out: $ty = rune_s!(&format!(
+        let out: $ty = eval(&format!(
             r#"enum Enum {{ Foo {{ padding, field }} }}; pub fn main() {{ let a = Enum::Foo {{ padding: 0, field: {lhs} }}; let b = {rhs}; a.field {op}= b; a.field }}"#,
             lhs = stringify!($lhs), rhs = stringify!($rhs), op = stringify!($op),
         ));
         assert_eq!(out, $out);
 
-        let out: $ty = rune_s!(&format!(
+        let out: $ty = eval(&format!(
             r#"pub fn main() {{ let a = #{{ padding: 0, field: {lhs} }}; let b = {rhs}; a.field {op}= b; a.field }}"#,
             lhs = stringify!($lhs), rhs = stringify!($rhs), op = stringify!($op),
         ));
         assert_eq!(out, $out);
 
-        let out: $ty = rune_s!(&format!(
+        let out: $ty = eval(&format!(
             r#"pub fn main() {{ let a = (0, {lhs}); let b = {rhs}; a.1 {op}= b; a.1 }}"#,
             lhs = stringify!($lhs), rhs = stringify!($rhs), op = stringify!($op),
         ));
         assert_eq!(out, $out);
 
-        let out: $ty = rune_s!(&format!(
+        let out: $ty = eval(&format!(
             r#"struct Foo(padding, a); pub fn main() {{ let a = Foo(0, {lhs}); let b = {rhs}; a.1 {op}= b; a.1 }}"#,
             lhs = stringify!($lhs), rhs = stringify!($rhs), op = stringify!($op),
         ));
         assert_eq!(out, $out);
 
-        let out: $ty = rune_s!(&format!(
+        let out: $ty = eval(&format!(
             r#"enum Enum {{ Foo(padding, a) }}; pub fn main() {{ let a = Enum::Foo(0, {lhs}); let b = {rhs}; a.1 {op}= b; a.1 }}"#,
             lhs = stringify!($lhs), rhs = stringify!($rhs), op = stringify!($op),
         ));
         assert_eq!(out, $out);
 
-        let out: $ty = rune_s!(&format!(
+        let out: $ty = eval(&format!(
             r#"pub fn main() {{ let a = Ok({lhs}); let b = {rhs}; a.0 {op}= b; a.0 }}"#,
             lhs = stringify!($lhs), rhs = stringify!($rhs), op = stringify!($op),
         ));
         assert_eq!(out, $out);
 
-        let out: $ty = rune_s!(&format!(
+        let out: $ty = eval(&format!(
             r#"pub fn main() {{ let a = Some({lhs}); let b = {rhs}; a.0 {op}= b; a.0 }}"#,
             lhs = stringify!($lhs), rhs = stringify!($rhs), op = stringify!($op),
         ));

--- a/crates/rune/src/tests/vm_assign_exprs.rs
+++ b/crates/rune/src/tests/vm_assign_exprs.rs
@@ -79,7 +79,7 @@ fn test_assign_tuple() {
 
 #[test]
 fn test_assign_assign_exprs() {
-    let out: (i64, (), ()) = rune_s! {
+    let out: (i64, (), ()) = eval(
         r#"
         pub fn main() {
             let a = #{b: #{c: #{d: 1}}};
@@ -89,7 +89,7 @@ fn test_assign_assign_exprs() {
             c = b = a.b.c = 4;
             (a.b.c, b, c)
         }
-        "#
-    };
+        "#,
+    );
     assert_eq!(out, (4, (), ()));
 }

--- a/crates/rune/src/tests/vm_closures.rs
+++ b/crates/rune/src/tests/vm_closures.rs
@@ -181,9 +181,8 @@ fn test_nested_async_closure() {
 
 #[test]
 fn test_closure_in_lit_vec() -> VmResult<()> {
-    let ret: VecTuple<(i64, Function, Function, i64)> = rune_s! {
-        r#"pub fn main() { let a = 4; [0, || 2, || 4, 3] }"#
-    };
+    let ret: VecTuple<(i64, Function, Function, i64)> =
+        eval(r#"pub fn main() { let a = 4; [0, || 2, || 4, 3] }"#);
 
     let (start, first, second, end) = ret.0;
     assert_eq!(0, start);
@@ -195,9 +194,8 @@ fn test_closure_in_lit_vec() -> VmResult<()> {
 
 #[test]
 fn test_closure_in_lit_tuple() -> VmResult<()> {
-    let ret: (i64, Function, Function, i64) = rune_s! {
-        r#"pub fn main() { let a = 4; (0, || 2, || a, 3) }"#
-    };
+    let ret: (i64, Function, Function, i64) =
+        eval(r#"pub fn main() { let a = 4; (0, || 2, || a, 3) }"#);
 
     let (start, first, second, end) = ret;
     assert_eq!(0, start);
@@ -217,9 +215,7 @@ fn test_closure_in_lit_object() -> Result<()> {
         d: i64,
     }
 
-    let proxy: Proxy = rune_s! {
-        r#"pub fn main() { let a = 4; #{a: 0, b: || 2, c: || a, d: 3} }"#
-    };
+    let proxy: Proxy = eval("pub fn main() { let a = 4; #{a: 0, b: || 2, c: || a, d: 3} }");
 
     assert_eq!(0, proxy.a);
     assert_eq!(2, proxy.b.call::<i64>(()).into_result()?);

--- a/crates/rune/src/tests/vm_const_exprs.rs
+++ b/crates/rune/src/tests/vm_const_exprs.rs
@@ -7,7 +7,8 @@ macro_rules! test_op {
             lhs = $lhs, rhs = $rhs, op = stringify!($op),
         );
 
-        let out: $ty = rune_s!(&program);
+        let out: $ty = eval(&program);
+
         assert_eq!(
             out,
             $result,
@@ -25,7 +26,7 @@ fn test_const_values() {
     let out: String = rune!(const VALUE = "Hello World"; pub fn main() { VALUE });
     assert_eq!(out, "Hello World");
 
-    let out: String = rune_s!(
+    let out: String = eval(
         r#"
         const VALUE = `Hello ${WORLD} ${A} ${B} ${C}`;
         const WORLD = "World";
@@ -33,7 +34,7 @@ fn test_const_values() {
         const B = 1.0;
         const C = true;
         pub fn main() { VALUE }
-    "#
+    "#,
     );
     assert_eq!(out, "Hello World 1 1.0 true");
 }
@@ -63,7 +64,8 @@ macro_rules! test_float_op {
             lhs = $lhs, rhs = $rhs, op = stringify!($op),
         );
 
-        let out: $ty = rune_s!(&program);
+        let out: $ty = eval(&program);
+
         assert_eq!(
             out,
             $result,
@@ -170,7 +172,8 @@ fn test_const_fn() {
 
     assert_eq!(result, 6);
 
-    let result: String = rune_s! { r#"
+    let result: String = eval(
+        r#"
     const VALUE = "baz";
 
     const fn foo(n) {
@@ -180,11 +183,13 @@ fn test_const_fn() {
     pub fn main() {
         foo(`bar ${VALUE}`)
     }
-    "#};
+    "#,
+    );
 
     assert_eq!(result, "foo bar baz");
 
-    let result: String = rune_s! { r#"
+    let result: String = eval(
+        r#"
         const VALUE = foo("bar", "baz");
 
         const fn foo(a, b) {
@@ -198,7 +203,8 @@ fn test_const_fn() {
         pub fn main() {
             VALUE
         }
-    "#};
+    "#,
+    );
 
     assert_eq!(result, "foo bar baz biz");
 }

--- a/crates/rune/src/tests/vm_general.rs
+++ b/crates/rune/src/tests/vm_general.rs
@@ -10,7 +10,8 @@ fn test_small_programs() {
         }
     );
     assert_eq!(out, 42u64);
-    rune!(
+
+    let _: () = rune!(
         pub fn main() {}
     );
 
@@ -146,7 +147,7 @@ fn test_shadowing() {
 
 #[test]
 fn test_vectors() {
-    rune!(
+    let _: () = rune!(
         pub fn main() {
             let v = [1, 2, 3, 4, 5];
         }
@@ -442,18 +443,21 @@ fn test_string_concat() {
 
 #[test]
 fn test_template_string() {
-    let out: String = rune_s! { r#"
+    let out: String = eval(
+        r#"
         pub fn main() {
             let name = "John Doe";
             `Hello ${name}, I am ${1 - 10} years old!`
         }
-    "# };
+    "#,
+    );
     assert_eq!(out, "Hello John Doe, I am -9 years old!");
 
     // Contrived expression with an arbitrary sub-expression.
     // This tests that the temporary variables used during calculations do not
     // accidentally clobber the scope.
-    let out: String = rune_s! { r#"
+    let out: String = eval(
+        r#"
         pub fn main() {
             let name = "John Doe";
 
@@ -463,7 +467,8 @@ fn test_template_string() {
                 a
             }} years old!`
         }
-    "# };
+    "#,
+    );
     assert_eq!(out, "Hello John Doe, I am 22 years old!");
 }
 
@@ -541,7 +546,8 @@ fn test_async_fn() {
 
 #[test]
 fn test_complex_field_access() {
-    let out: Option<i64> = rune_s! { r#"
+    let out: Option<i64> = eval(
+        r#"
         fn foo() {
             #{hello: #{world: 42}}
         }
@@ -549,7 +555,8 @@ fn test_complex_field_access() {
         pub fn main() {
             Some((foo()).hello["world"])
         }
-    "# };
+    "#,
+    );
     assert_eq!(out, Some(42));
 }
 

--- a/crates/rune/src/tests/vm_not_used.rs
+++ b/crates/rune/src/tests/vm_not_used.rs
@@ -2,7 +2,7 @@ prelude!();
 
 #[test]
 fn test_not_used() {
-    rune! {
+    let _: () = rune! {
         pub fn main() {
             0;
             4.1;

--- a/crates/rune/src/tests/vm_test_imports.rs
+++ b/crates/rune/src/tests/vm_test_imports.rs
@@ -49,7 +49,7 @@ fn test_reexport() {
 
 #[test]
 fn test_access() {
-    assert!(rune! {
+    rune_assert! {
         mod a { pub struct Foo; }
 
         mod b {
@@ -59,7 +59,7 @@ fn test_access() {
         }
 
         pub fn main() { b::test() }
-    });
+    };
 
     assert_errors! {
         r#"

--- a/crates/rune/src/tests/vm_tuples.rs
+++ b/crates/rune/src/tests/vm_tuples.rs
@@ -2,13 +2,15 @@ prelude!();
 
 #[test]
 fn test_mutate_tuples() {
-    let out: String = rune_s! { r#"
+    let out: String = eval(
+        r#"
         pub fn main() {
             let m = ("Now", "You", "See", "Me");
             m.2 = "Don't";
             m.3 = "!";
             `${m.0} ${m.1} ${m.2} ${m.3}`
         }
-    "# };
+    "#,
+    );
     assert_eq!(out, "Now You Don't !");
 }

--- a/crates/rune/src/tests/wildcard_imports.rs
+++ b/crates/rune/src/tests/wildcard_imports.rs
@@ -2,37 +2,37 @@ prelude!();
 
 #[test]
 fn test_wildcard_precedence() {
-    assert!(rune! {
+    rune_assert! {
         mod a { pub struct Foo; }
         mod b { pub struct Foo; }
         use {a::*, b::*};
         use b::Foo;
         pub fn main() { Foo is b::Foo }
-    });
+    };
 
-    assert!(rune! {
+    rune_assert! {
         mod a { pub struct Foo; }
         mod b { pub struct Foo; }
         use {b::*, a::*};
         use a::Foo;
         pub fn main() { Foo is a::Foo }
-    });
+    };
 
-    assert!(rune! {
+    rune_assert! {
         mod a { pub struct Foo; }
         mod b { pub struct Foo; }
         use a::*;
         use b::*;
         use a::Foo;
         pub fn main() { Foo is a::Foo }
-    });
+    };
 
-    assert!(rune! {
+    rune_assert! {
         mod a { pub struct Foo; }
         mod b { pub struct Foo; }
         use a::Foo;
         use a::*;
         use b::*;
         pub fn main() { Foo is a::Foo }
-    });
+    };
 }


### PR DESCRIPTION
Relates https://github.com/rust-lang/rust/issues/123748

Some cleanups we can benefit from regardless. Avoids tripping proposed never-type heuristics.