### PR TITLE
Support autocomplete for Ace editor

### DIFF
--- a/crates/rune/src/cli/ace.rs
+++ b/crates/rune/src/cli/ace.rs
@@ -10,7 +10,7 @@ use crate::alloc::prelude::*;
 use crate::alloc::Vec;
 use crate::cli::naming::Naming;
 use crate::cli::{AssetKind, CommandBase, Config, Entry, EntryPoint, ExitCode, Io, SharedFlags};
-use crate::compile::{FileSourceLoader, ItemBuf};
+use crate::compile::FileSourceLoader;
 use crate::{Diagnostics, Options, Source, Sources};
 
 #[derive(Parser, Debug)]
@@ -79,9 +79,8 @@ where
     let mut naming = Naming::default();
 
     for e in entries {
-        let name = naming.name(&e)?;
+        let item = naming.item(&e)?;
 
-        let item = ItemBuf::with_crate(&name)?;
         let mut visitor = crate::doc::Visitor::new(&item)?;
         let mut sources = Sources::new();
 

--- a/crates/rune/src/cli/ace.rs
+++ b/crates/rune/src/cli/ace.rs
@@ -1,0 +1,128 @@
+use std::io::Write;
+use std::path::PathBuf;
+
+use crate::doc::Artifacts;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+
+use crate::alloc::prelude::*;
+use crate::alloc::Vec;
+use crate::cli::naming::Naming;
+use crate::cli::{AssetKind, CommandBase, Config, Entry, EntryPoint, ExitCode, Io, SharedFlags};
+use crate::compile::{FileSourceLoader, ItemBuf};
+use crate::{Diagnostics, Options, Source, Sources};
+
+#[derive(Parser, Debug)]
+pub(super) struct Flags {
+    /// Exit with a non-zero exit-code even for warnings
+    #[arg(long)]
+    warnings_are_errors: bool,
+    /// Output directory to write documentation to.
+    #[arg(long)]
+    output: Option<PathBuf>,
+    /// Generate .await and ? extension for functions.
+    #[arg(long)]
+    extensions: bool,
+}
+
+impl CommandBase for Flags {
+    #[inline]
+    fn is_workspace(&self, _: AssetKind) -> bool {
+        true
+    }
+
+    #[inline]
+    fn describe(&self) -> &str {
+        "Documenting"
+    }
+}
+
+pub(super) fn run<'p, I>(
+    io: &mut Io<'_>,
+    entry: &mut Entry<'_>,
+    c: &Config,
+    flags: &Flags,
+    shared: &SharedFlags,
+    options: &Options,
+    entries: I,
+) -> Result<ExitCode>
+where
+    I: IntoIterator<Item = EntryPoint<'p>>,
+{
+    let root = match &flags.output {
+        Some(root) => root.clone(),
+        None => match &c.manifest_root {
+            Some(path) => path.join("target").join("rune-ace"),
+            None => match std::env::var_os("CARGO_TARGET_DIR") {
+                Some(target) => {
+                    let mut target = PathBuf::from(target);
+                    target.push("rune-ace");
+                    target
+                }
+                None => {
+                    let mut target = PathBuf::new();
+                    target.push("target");
+                    target.push("rune-ace");
+                    target
+                }
+            },
+        },
+    };
+
+    writeln!(io.stdout, "Building ace autocompletion: {}", root.display())?;
+
+    let context = shared.context(entry, c, None)?;
+
+    let mut visitors = Vec::new();
+
+    let mut naming = Naming::default();
+
+    for e in entries {
+        let name = naming.name(&e)?;
+
+        let item = ItemBuf::with_crate(&name)?;
+        let mut visitor = crate::doc::Visitor::new(&item)?;
+        let mut sources = Sources::new();
+
+        let source = match Source::from_path(e.path()) {
+            Ok(source) => source,
+            Err(error) => return Err(error).context(e.path().display().try_to_string()?),
+        };
+
+        sources.insert(source)?;
+
+        let mut diagnostics = if shared.warnings || flags.warnings_are_errors {
+            Diagnostics::new()
+        } else {
+            Diagnostics::without_warnings()
+        };
+
+        let mut source_loader = FileSourceLoader::new();
+
+        let _ = crate::prepare(&mut sources)
+            .with_context(&context)
+            .with_diagnostics(&mut diagnostics)
+            .with_options(options)
+            .with_visitor(&mut visitor)?
+            .with_source_loader(&mut source_loader)
+            .build();
+
+        diagnostics.emit(&mut io.stdout.lock(), &sources)?;
+
+        if diagnostics.has_error() || flags.warnings_are_errors && diagnostics.has_warning() {
+            return Ok(ExitCode::Failure);
+        }
+
+        visitors.try_push(visitor)?;
+    }
+
+    let mut artifacts = Artifacts::new();
+    crate::doc::build_autocomplete(&mut artifacts, &context, &visitors, flags.extensions)?;
+
+    for asset in artifacts.assets() {
+        asset.build(&root)?;
+    }
+
+    Ok(ExitCode::Success)
+}

--- a/crates/rune/src/cli/mod.rs
+++ b/crates/rune/src/cli/mod.rs
@@ -6,6 +6,7 @@
 //! * Build a language server, which is aware of things only available in your
 //!   context.
 
+mod ace;
 mod benches;
 mod check;
 mod doc;
@@ -431,6 +432,8 @@ enum Command {
     Check(CommandShared<check::Flags>),
     /// Build documentation.
     Doc(CommandShared<doc::Flags>),
+    /// Build ace autocompletion.
+    Ace(CommandShared<ace::Flags>),
     /// Run all tests but do not execute
     Test(CommandShared<tests::Flags>),
     /// Run the given program as a benchmark
@@ -446,9 +449,10 @@ enum Command {
 }
 
 impl Command {
-    const ALL: [&'static str; 8] = [
+    const ALL: [&'static str; 9] = [
         "check",
         "doc",
+        "ace",
         "test",
         "bench",
         "run",
@@ -461,6 +465,7 @@ impl Command {
         let (shared, command): (_, &mut dyn CommandBase) = match self {
             Command::Check(shared) => (&mut shared.shared, &mut shared.command),
             Command::Doc(shared) => (&mut shared.shared, &mut shared.command),
+            Command::Ace(shared) => (&mut shared.shared, &mut shared.command),
             Command::Test(shared) => (&mut shared.shared, &mut shared.command),
             Command::Bench(shared) => (&mut shared.shared, &mut shared.command),
             Command::Run(shared) => (&mut shared.shared, &mut shared.command),
@@ -476,6 +481,7 @@ impl Command {
         let (shared, command): (_, &dyn CommandBase) = match self {
             Command::Check(shared) => (&shared.shared, &shared.command),
             Command::Doc(shared) => (&shared.shared, &shared.command),
+            Command::Ace(shared) => (&shared.shared, &shared.command),
             Command::Test(shared) => (&shared.shared, &shared.command),
             Command::Bench(shared) => (&shared.shared, &shared.command),
             Command::Run(shared) => (&shared.shared, &shared.command),
@@ -910,6 +916,10 @@ where
         Command::Doc(f) => {
             let options = f.options()?;
             return doc::run(io, entry, c, &f.command, &f.shared, &options, entries);
+        }
+        Command::Ace(f) => {
+            let options = f.options()?;
+            return ace::run(io, entry, c, &f.command, &f.shared, &options, entries);
         }
         Command::Fmt(f) => {
             let options = f.options()?;

--- a/crates/rune/src/compile/prelude.rs
+++ b/crates/rune/src/compile/prelude.rs
@@ -1,3 +1,5 @@
+use core::ops::Deref;
+
 use crate::alloc::{self, Box, HashMap};
 use crate::item::{IntoComponent, Item, ItemBuf};
 
@@ -52,6 +54,15 @@ impl Prelude {
     /// Access a value from the prelude.
     pub(crate) fn get<'a>(&'a self, name: &str) -> Option<&'a Item> {
         Some(self.prelude.get(name)?)
+    }
+
+    /// Return the local name of an item
+    #[allow(dead_code)]
+    pub(crate) fn get_local<'a>(&'a self, item: &ItemBuf) -> Option<&'a str> {
+        self.prelude
+            .iter()
+            .find(|(_, i)| i == &item)
+            .map(|(s, _)| s.deref())
     }
 
     /// Define a prelude item.

--- a/crates/rune/src/doc/autocomplete.rs
+++ b/crates/rune/src/doc/autocomplete.rs
@@ -178,6 +178,20 @@ impl<'a> AutoCompleteCtx<'a> {
 
     fn get_fn_param(f: &Function) -> Result<String> {
         let mut param = String::try_from("(")?;
+
+        // add arguments when no argument names are provided
+        if let Some(args) = f.args {
+            if args != 0 && f.args != f.arg_names.map(|a| a.len()) {
+                for i in 0..args {
+                    if i != 0 {
+                        param.try_push_str(", ")?;
+                    }
+                    param.try_push_str("value")?;
+                }
+            }
+        }
+
+        // add argument names
         for a in f.arg_names.into_iter().flatten() {
             if param.len() != 1 {
                 param.try_push_str(", ")?;

--- a/crates/rune/src/doc/autocomplete.rs
+++ b/crates/rune/src/doc/autocomplete.rs
@@ -1,0 +1,394 @@
+use core::fmt::Display;
+
+use crate::doc::{Artifacts, Context, Visitor};
+
+use anyhow::{Context as _, Result};
+use pulldown_cmark::{Options, Parser};
+use rune_alloc::{fmt::TryWrite, HashMap, String};
+use rune_core::{Hash, ItemBuf};
+use syntect::parsing::SyntaxSet;
+
+use super::{
+    build::markdown,
+    context::{Function, Kind, Meta},
+};
+
+use crate::alloc::prelude::*;
+
+pub(crate) fn build(
+    artifacts: &mut Artifacts,
+    context: &crate::Context,
+    visitors: &[Visitor],
+    extensions: bool,
+) -> Result<()> {
+    let context = Context::new(context, visitors);
+
+    let mut acx = AutoCompleteCtx::new(&context, extensions);
+    for item in context.iter_modules() {
+        let item = item?;
+        acx.collect_meta(&item)?;
+    }
+    acx.build(artifacts)?;
+
+    Ok(())
+}
+
+struct AutoCompleteCtx<'a> {
+    ctx: &'a Context<'a>,
+    extensions: bool,
+    syntax_set: SyntaxSet,
+    fixed: HashMap<ItemBuf, Meta<'a>>,
+    instance: HashMap<ItemBuf, Meta<'a>>,
+}
+
+impl<'a> AutoCompleteCtx<'a> {
+    fn new(ctx: &'a Context, extensions: bool) -> AutoCompleteCtx<'a> {
+        AutoCompleteCtx {
+            ctx,
+            extensions,
+            syntax_set: SyntaxSet::load_defaults_newlines(),
+            fixed: HashMap::new(),
+            instance: HashMap::new(),
+        }
+    }
+
+    fn collect_meta(&mut self, item: &ItemBuf) -> Result<()> {
+        for meta in self.ctx.meta(item)?.into_iter() {
+            match meta.kind {
+                Kind::Unsupported => {}
+                Kind::Type => {
+                    self.fixed.try_insert(item.try_clone()?, meta)?;
+                }
+                Kind::Struct => {
+                    for (_, name) in self.ctx.iter_components(item)?.into_iter() {
+                        let item = item.join([name])?;
+                        self.collect_meta(&item)?;
+                    }
+                    self.fixed.try_insert(item.try_clone()?, meta)?;
+                }
+                Kind::Variant => {
+                    self.fixed.try_insert(item.try_clone()?, meta)?;
+                }
+                Kind::Enum => {
+                    for (_, name) in self.ctx.iter_components(item)?.into_iter() {
+                        let item = item.join([name])?;
+                        self.collect_meta(&item)?;
+                    }
+                    self.fixed.try_insert(item.try_clone()?, meta)?;
+                }
+                Kind::Macro => {
+                    self.fixed.try_insert(item.try_clone()?, meta)?;
+                }
+                Kind::Function(f) => {
+                    if f.arg_names.into_iter().flatten().next().map(|s| s.as_str()) == Some("self")
+                    {
+                        self.instance.try_insert(item.try_clone()?, meta)?;
+                    } else {
+                        self.fixed.try_insert(item.try_clone()?, meta)?;
+                    }
+                }
+                Kind::Const(_) => {
+                    self.fixed.try_insert(item.try_clone()?, meta)?;
+                }
+                Kind::Module => {
+                    for (_, name) in self.ctx.iter_components(item)?.into_iter() {
+                        let item = item.join([name])?;
+                        self.collect_meta(&item)?;
+                    }
+                    self.fixed.try_insert(item.try_clone()?, meta)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn build(&mut self, artifacts: &mut Artifacts) -> Result<()> {
+        let mut content = std::string::String::new();
+        self.write(&mut content)?;
+
+        artifacts.asset(false, "autocomplete.js", || {
+            let string = String::try_from(content)?;
+            Ok(string.into_bytes().into())
+        })?;
+
+        Ok(())
+    }
+
+    fn doc_to_html(&self, meta: &Meta) -> Result<Option<String>> {
+        let mut input = String::new();
+
+        for line in meta.docs {
+            let line = line.strip_prefix(' ').unwrap_or(line);
+            input.try_push_str(line)?;
+            input.try_push('\n')?;
+        }
+
+        let mut o = String::new();
+        write!(o, "<div class=\"docs\">")?;
+        let mut options = Options::empty();
+        options.insert(Options::ENABLE_STRIKETHROUGH);
+
+        let iter = Parser::new_ext(&input, options);
+
+        markdown::push_html(&self.syntax_set, &mut o, iter, None)?;
+
+        write!(o, "</div>")?;
+        let o = String::try_from(o.replace("`", "\\`"))?;
+
+        Ok(Some(o))
+    }
+
+    fn get_name(item: &ItemBuf) -> Result<String> {
+        let mut name = item.try_to_string()?;
+
+        if name.starts_with("::std::io::print!()") {
+            name.try_replace_range(..12, "")?;
+        }
+        if name.starts_with("::std::io::println!()") {
+            name.try_replace_range(..12, "")?;
+        }
+        if name.starts_with("::std::io::dbg!()") {
+            name.try_replace_range(..12, "")?;
+        }
+        if name.starts_with("::std::vec::") {
+            name.try_replace_range(..12, "")?;
+        }
+        if name.starts_with("::") {
+            name.try_replace_range(..2, "")?;
+        }
+        Ok(name)
+    }
+
+    fn get_fn_ext(f: &Function) -> Result<String> {
+        let mut ext = String::new();
+        // automatic .await for async functions
+        if f.is_async {
+            ext.try_push_str(".await")?;
+        }
+
+        // automatic questionmark for result and option
+        if f.return_type == Some(Hash::new(0x1978eae6b50a98ef))
+            || f.return_type == Some(Hash::new(0xc0958f246e193e78))
+        {
+            ext.try_push_str("?")?;
+        }
+        Ok(ext)
+    }
+
+    fn get_fn_param(f: &Function) -> Result<String> {
+        let mut param = String::try_from("(")?;
+        for a in f.arg_names.into_iter().flatten() {
+            if param.len() != 1 {
+                param.try_push_str(", ")?;
+            }
+            if param.len() == 1 && a == "self" {
+                continue;
+            }
+            param.try_push_str(a)?;
+        }
+        param.try_push(')')?;
+        Ok(param)
+    }
+
+    fn get_fn_ret_typ(&self, f: &Function) -> Result<String> {
+        let mut param = String::new();
+        if !self.extensions {
+            return Ok(param);
+        }
+
+        if let Some(item) = f
+            .return_type
+            .and_then(|h| self.ctx.meta_by_hash(h).ok())
+            .and_then(|v| v.into_iter().next())
+            .and_then(|m| m.item)
+            .and_then(|i| i.last())
+        {
+            param.try_push_str(" -> ")?;
+            param.try_push_str(&item.try_to_string()?)?;
+        }
+
+        Ok(param)
+    }
+
+    fn write_hint(
+        &self,
+        f: &mut dyn core::fmt::Write,
+        value: &str,
+        meta: &str,
+        score: usize,
+        caption: Option<&str>,
+        doc: Option<&str>,
+    ) -> Result<()> {
+        write!(f, r#"{{"#)?;
+        write!(f, r#"value: "{value}""#)?;
+        if let Some(caption) = caption {
+            write!(f, r#", caption: "{caption}""#)?;
+        }
+        write!(f, r#", meta: "{meta}""#)?;
+        write!(f, r#", score: {score}"#)?;
+        if let Some(doc) = doc {
+            write!(f, r#", docHTML: `{}`"#, doc)?;
+        }
+        write!(f, "}}\n")?;
+        Ok(())
+    }
+
+    fn write_instances(&self, f: &mut dyn core::fmt::Write) -> Result<()> {
+        write!(f, r#"var instance = ["#)?;
+
+        let mut no_comma = true;
+        for (item, meta) in self.instance.iter() {
+            let Kind::Function(fnc) = meta.kind else {
+                continue;
+            };
+            if no_comma {
+                no_comma = false;
+            } else {
+                write!(f, r#","#)?;
+            }
+
+            let mut iter = item.iter().rev();
+            let mut value = iter
+                .next()
+                .context("No function name found for instance function")?
+                .try_to_string()?;
+            value.try_push_str(&Self::get_fn_param(&fnc)?)?;
+
+            let mut typ = String::new();
+            typ.try_push_str(&value)?;
+            typ.try_push_str(&self.get_fn_ret_typ(&fnc)?)?;
+            value.try_push_str(&Self::get_fn_ext(&fnc)?)?;
+            if let Some(pre) = iter.next().and_then(|t| t.try_to_string().ok()) {
+                typ.try_push_str(" [")?;
+                typ.try_push_str(&pre)?;
+                typ.try_push(']')?;
+            }
+
+            let doc = self.doc_to_html(meta).ok().flatten();
+
+            let info = if fnc.is_async {
+                "async Instance"
+            } else {
+                "Instance"
+            };
+
+            self.write_hint(f, &value, info, 0, Some(&typ), doc.as_deref())?;
+        }
+        write!(f, "];")?;
+
+        Ok(())
+    }
+
+    fn write_fixed(&self, f: &mut dyn core::fmt::Write) -> Result<()> {
+        write!(f, r#"var fixed = ["#)?;
+
+        let mut no_comma = true;
+        for (item, meta) in self.fixed.iter() {
+            if no_comma {
+                no_comma = false;
+            } else {
+                write!(f, r#","#)?;
+            }
+
+            match meta.kind {
+                Kind::Unsupported => {
+                    no_comma = true;
+                }
+                Kind::Type => {
+                    let name = Self::get_name(item)?;
+                    let doc = self.doc_to_html(meta).ok().flatten();
+                    self.write_hint(f, &name, "Type", 0, None, doc.as_deref())?;
+                }
+                Kind::Struct => {
+                    let name = Self::get_name(item)?;
+                    let doc = self.doc_to_html(meta).ok().flatten();
+                    self.write_hint(f, &name, "Struct", 0, None, doc.as_deref())?;
+                }
+                Kind::Variant => {
+                    let name = Self::get_name(item)?;
+                    let doc = self.doc_to_html(meta).ok().flatten();
+                    self.write_hint(f, &name, "Variant", 0, None, doc.as_deref())?;
+                }
+                Kind::Enum => {
+                    let name = Self::get_name(item)?;
+                    let doc = self.doc_to_html(meta).ok().flatten();
+                    self.write_hint(f, &name, "Enum", 0, None, doc.as_deref())?;
+                }
+                Kind::Macro => {
+                    let mut name = Self::get_name(item)?;
+                    name.try_push_str("!()")?;
+                    let doc = self.doc_to_html(meta).ok().flatten();
+                    self.write_hint(f, &name, "Type", 0, None, doc.as_deref())?;
+                }
+                Kind::Function(fnc) => {
+                    let mut value = Self::get_name(item)?;
+                    value.try_push_str(&Self::get_fn_param(&fnc)?)?;
+                    let mut caption = value.try_clone()?;
+                    caption.try_push_str(&self.get_fn_ret_typ(&fnc)?)?;
+                    value.try_push_str(&Self::get_fn_ext(&fnc)?)?;
+                    let doc = self.doc_to_html(meta).ok().flatten();
+                    let info = if fnc.is_async {
+                        "async Function"
+                    } else {
+                        "Function"
+                    };
+                    self.write_hint(f, &value, info, 0, Some(&caption), doc.as_deref())?;
+                }
+                Kind::Const(_) => {
+                    let name = Self::get_name(item)?;
+                    let doc = self.doc_to_html(meta).ok().flatten();
+                    self.write_hint(f, &name, "Const", 10, None, doc.as_deref())?;
+                }
+                Kind::Module => {
+                    let name = Self::get_name(item)?;
+                    let doc = self.doc_to_html(meta).ok().flatten();
+                    self.write_hint(f, &name, "Module", 9, None, doc.as_deref())?;
+                }
+            }
+        }
+        write!(f, "];")?;
+
+        Ok(())
+    }
+
+    fn write(&self, f: &mut dyn core::fmt::Write) -> Result<()> {
+        write!(f, "{COMPLETER}\n\n")?;
+        self.write_fixed(f)?;
+        write!(f, "\n\n")?;
+        self.write_instances(f)?;
+        Ok(())
+    }
+}
+
+impl<'a> Display for AutoCompleteCtx<'a> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.write(f).map_err(|_| core::fmt::Error)
+    }
+}
+
+static COMPLETER: &'static str = r#"
+const runeCompleter = {
+  getCompletions: (editor, session, pos, prefix, callback) => {
+    if (prefix.length === 0) {
+      callback(null, []);
+      return
+    }
+
+    if (prefix.includes(".")) {
+      callback(null, []);
+      return
+    }
+
+    var token = session.getTokenAt(pos.row, pos.column).value;
+
+    if (token.includes(".")) {
+      callback(null, instance);
+    }
+    else {
+      callback(null, fixed);
+    }
+  }
+};
+export default runeCompleter;
+"#;

--- a/crates/rune/src/doc/autocomplete.rs
+++ b/crates/rune/src/doc/autocomplete.rs
@@ -60,7 +60,7 @@ impl<'a> AutoCompleteCtx<'a> {
                     self.fixed.try_insert(item.try_clone()?, meta)?;
                 }
                 Kind::Struct => {
-                    for (_, name) in self.ctx.iter_components(item)?.into_iter() {
+                    for (_, name) in self.ctx.iter_components(item)? {
                         let item = item.join([name])?;
                         self.collect_meta(&item)?;
                     }
@@ -70,7 +70,7 @@ impl<'a> AutoCompleteCtx<'a> {
                     self.fixed.try_insert(item.try_clone()?, meta)?;
                 }
                 Kind::Enum => {
-                    for (_, name) in self.ctx.iter_components(item)?.into_iter() {
+                    for (_, name) in self.ctx.iter_components(item)? {
                         let item = item.join([name])?;
                         self.collect_meta(&item)?;
                     }
@@ -91,7 +91,7 @@ impl<'a> AutoCompleteCtx<'a> {
                     self.fixed.try_insert(item.try_clone()?, meta)?;
                 }
                 Kind::Module => {
-                    for (_, name) in self.ctx.iter_components(item)?.into_iter() {
+                    for (_, name) in self.ctx.iter_components(item)? {
                         let item = item.join([name])?;
                         self.collect_meta(&item)?;
                     }
@@ -134,7 +134,7 @@ impl<'a> AutoCompleteCtx<'a> {
         markdown::push_html(&self.syntax_set, &mut o, iter, None)?;
 
         write!(o, "</div>")?;
-        let o = String::try_from(o.replace("`", "\\`"))?;
+        let o = String::try_from(o.replace('`', "\\`"))?;
 
         Ok(Some(o))
     }
@@ -230,7 +230,7 @@ impl<'a> AutoCompleteCtx<'a> {
         if let Some(doc) = doc {
             write!(f, r#", docHTML: `{}`"#, doc)?;
         }
-        write!(f, "}}\n")?;
+        writeln!(f, "}}")?;
         Ok(())
     }
 
@@ -367,7 +367,7 @@ impl<'a> Display for AutoCompleteCtx<'a> {
     }
 }
 
-static COMPLETER: &'static str = r#"
+static COMPLETER: &str = r#"
 const runeCompleter = {
   getCompletions: (editor, session, pos, prefix, callback) => {
     if (prefix.length === 0) {

--- a/crates/rune/src/doc/autocomplete.rs
+++ b/crates/rune/src/doc/autocomplete.rs
@@ -372,23 +372,17 @@ const runeCompleter = {
   getCompletions: (editor, session, pos, prefix, callback) => {
     if (prefix.length === 0) {
       callback(null, []);
-      return
+      return;
     }
 
-    if (prefix.includes(".")) {
-      callback(null, []);
-      return
-    }
-
-    var token = session.getTokenAt(pos.row, pos.column).value;
+    var token = session.getTokenAt(pos.row, pos.column - 1).value;
 
     if (token.includes(".")) {
       callback(null, instance);
-    }
-    else {
+    } else {
       callback(null, fixed);
     }
-  }
+  },
 };
 export default runeCompleter;
 "#;

--- a/crates/rune/src/doc/build.rs
+++ b/crates/rune/src/doc/build.rs
@@ -1,5 +1,5 @@
 mod js;
-mod markdown;
+pub(crate) mod markdown;
 mod type_;
 
 use core::fmt;

--- a/crates/rune/src/doc/build/markdown.rs
+++ b/crates/rune/src/doc/build/markdown.rs
@@ -420,7 +420,7 @@ where
 }
 
 /// Process markdown html and captures tests.
-pub(super) fn push_html<'a, I>(
+pub(crate) fn push_html<'a, I>(
     syntax_set: &'a SyntaxSet,
     string: &'a mut String,
     iter: I,

--- a/crates/rune/src/doc/mod.rs
+++ b/crates/rune/src/doc/mod.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "cli")]
 mod context;
 #[cfg(feature = "cli")]
-use self::context::Context;
+pub(crate) use self::context::Context;
 
 #[cfg(feature = "cli")]
 mod artifacts;
@@ -22,3 +22,6 @@ pub(crate) use self::build::build;
 mod visitor;
 #[cfg(any(feature = "languageserver", feature = "cli"))]
 pub(crate) use self::visitor::{Visitor, VisitorData};
+
+mod autocomplete;
+pub(crate) use self::autocomplete::build as build_autocomplete;

--- a/crates/rune/src/doc/mod.rs
+++ b/crates/rune/src/doc/mod.rs
@@ -23,5 +23,7 @@ mod visitor;
 #[cfg(any(feature = "languageserver", feature = "cli"))]
 pub(crate) use self::visitor::{Visitor, VisitorData};
 
+#[cfg(feature = "cli")]
 mod autocomplete;
+#[cfg(feature = "cli")]
 pub(crate) use self::autocomplete::build as build_autocomplete;

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,6 @@
+# rune examples
+
+See:
+
+* [examples] - wide range of rust code examples.
+* [ace] - ace editor integration.

--- a/examples/ace/.gitignore
+++ b/examples/ace/.gitignore
@@ -1,0 +1,1 @@
+autocomplete.js

--- a/examples/ace/README.md
+++ b/examples/ace/README.md
@@ -1,0 +1,10 @@
+# ace editor example
+
+Steps to run and build this example:
+
+```sh
+cargo run -p rune-cli -- ace --output .
+python -m http.server
+```
+
+Then you can navigate to http://localhost:8000

--- a/examples/ace/index.html
+++ b/examples/ace/index.html
@@ -1,0 +1,41 @@
+<html>
+    <head>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.35.4/ace.js" integrity="sha512-ADBQV64rzhFIJkiHBan+9UeZRq3DZrP6/S2+FS2EX5icsYw/IQgmFaSmt6UTqZpWXkpCKluztsTpOtxx5GkD2A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.35.4/ext-language_tools.min.js" integrity="sha512-4l33zsqrqf1PBA3iEZ399Jl9on7It0HngOkI3TG2c6W0wUyTiXRxd9Eh8zFBXNy8fMlgda/u4u1metnbEf5Hzg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+
+        <style>
+            #editor {
+                position: absolute;
+                top: 0;
+                right: 0;
+                bottom: 0;
+                left: 0;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="editor">
+println!("Hello World!");
+        </div>
+        <script>
+            let init = async () => {
+                let runeCompleter = (await import("./autocomplete.js")).default;
+
+                var editor = ace.edit("editor");
+                editor.setTheme("ace/theme/monokai");
+                editor.getSession().setMode("ace/mode/rust");
+
+                editor.setOptions({
+                    enableBasicAutocompletion: true,
+                    //enableSnippets: true,
+                    enableLiveAutocompletion: true
+                });
+
+                let langTools = ace.require("ace/ext/language_tools");
+                langTools.addCompleter(runeCompleter);
+            };
+
+            init();
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
This PR adds the support for generating autocomplete instructions for the ace editor.
Refers to this feature request: https://github.com/rune-rs/rune/issues/640

One topic is to detect `std` imports, which are available globally, like `std::vec::Vec` towards `Vec`.

Generate the autocomplete with the following rune cli command:
```bash
rune ace --output your/location/folder --extensions
```
The optional output parameter defines a different folder where the autocomplete.js file will be created.
The extensions flag will add a `?` to all Option/Result returning functions and a `.await` to all async functions.

How to use this within your ace setup:
```js
// ensure to register this ace file as dependency
//<script src="../build/src-noconflict/ext-language_tools.js"></script>

// import the generated autocomplete.js
import runeCompleter from "rune-ace/autocomplete";

// setup your ace editor as normal
var editor = ace.edit("editor");
editor.setTheme("ace/theme/tomorrow");
editor.session.setMode("ace/mode/html");

// enable autocompletion and optional snippets
editor.setOptions({
  enableBasicAutocompletion: true,
  //enableSnippets: true,
  enableLiveAutocompletion: true
});

// register the rune autocomplete
let langTools = ace.require("ace/ext/language_tools");
langTools.addCompleter(runeCompleter);
```
