### PR TITLE
Remove JumpIfBranch instruction

### DIFF
--- a/crates/rune/src/compile/assembly.rs
+++ b/crates/rune/src/compile/assembly.rs
@@ -24,11 +24,6 @@ pub(crate) enum AssemblyInst {
         addr: InstAddress,
         label: Label,
     },
-    JumpIfBranch {
-        addr: InstAddress,
-        branch: i64,
-        label: Label,
-    },
     IterNext {
         addr: InstAddress,
         label: Label,
@@ -135,26 +130,6 @@ impl Assembly {
         self.inner_push(
             AssemblyInst::JumpIfNot {
                 addr,
-                label: label.try_clone()?,
-            },
-            span,
-        )?;
-
-        Ok(())
-    }
-
-    /// Add a conditional jump-if-branch instruction.
-    pub(crate) fn jump_if_branch(
-        &mut self,
-        addr: InstAddress,
-        branch: i64,
-        label: &Label,
-        span: &dyn Spanned,
-    ) -> compile::Result<()> {
-        self.inner_push(
-            AssemblyInst::JumpIfBranch {
-                addr,
-                branch,
                 label: label.try_clone()?,
             },
             span,

--- a/crates/rune/src/compile/unit_builder.rs
+++ b/crates/rune/src/compile/unit_builder.rs
@@ -857,29 +857,6 @@ impl UnitBuilder {
                         .encode(Inst::JumpIfNot { cond: addr, jump })
                         .with_span(span)?;
                 }
-                AssemblyInst::JumpIfBranch {
-                    addr,
-                    branch,
-                    label,
-                } => {
-                    let jump = label
-                        .jump()
-                        .ok_or(ErrorKind::MissingLabelLocation {
-                            name: label.name,
-                            index: label.index,
-                        })
-                        .with_span(span)?;
-
-                    write!(comment, "label:{}", label)?;
-
-                    storage
-                        .encode(Inst::JumpIfBranch {
-                            branch: addr,
-                            value: branch,
-                            jump,
-                        })
-                        .with_span(span)?;
-                }
                 AssemblyInst::IterNext { addr, label, out } => {
                     let jump = label
                         .jump()

--- a/crates/rune/src/runtime/awaited.rs
+++ b/crates/rune/src/runtime/awaited.rs
@@ -6,7 +6,7 @@ pub(crate) enum Awaited {
     /// A future to be awaited.
     Future(Future, Output),
     /// A select to be awaited.
-    Select(Select, Output, Output),
+    Select(Select, Output),
 }
 
 impl Awaited {
@@ -17,9 +17,9 @@ impl Awaited {
                 let value = vm_try!(future.await.with_vm(vm));
                 vm_try!(out.store(vm.stack_mut(), value));
             }
-            Self::Select(select, branch_addr, value_addr) => {
-                let (branch, value) = vm_try!(select.await.with_vm(vm));
-                vm_try!(branch_addr.store(vm.stack_mut(), || branch));
+            Self::Select(select, value_addr) => {
+                let (ip, value) = vm_try!(select.await.with_vm(vm));
+                vm.set_ip(ip);
                 vm_try!(value_addr.store(vm.stack_mut(), || value));
             }
         }

--- a/crates/rune/src/runtime/inst.rs
+++ b/crates/rune/src/runtime/inst.rs
@@ -364,27 +364,20 @@ pub enum Inst {
         /// Whether the produced value from the await should be kept or not.
         out: Output,
     },
-    /// Select over `len` futures on the stack. Sets the `branch` register to
-    /// the index of the branch that completed. And pushes its value on the
-    /// stack.
+    /// Select over `len` futures stored at address `addr`.
     ///
-    /// This operation will block the VM until at least one of the underlying
-    /// futures complete.
+    /// Once a branch has been matched, will store the branch that matched in
+    /// the branch register and perform a jump by the index of the branch that
+    /// matched.
     ///
-    /// # Operation
-    ///
-    /// ```text
-    /// <future...>
-    /// => <value>
-    /// ```
+    /// Will also store the output if the future into `value`. If no branch
+    /// matched, the empty value will be stored.
     #[musli(packed)]
     Select {
         /// The base address of futures being waited on.
         addr: InstAddress,
         /// The number of futures to poll.
         len: usize,
-        /// Where to store the branch value.
-        branch: Output,
         /// Where to store the value produced by the future that completed.
         value: Output,
     },
@@ -515,24 +508,6 @@ pub enum Inst {
         /// The address of the condition for the jump.
         cond: InstAddress,
         /// The offset to jump if the condition is true.
-        jump: usize,
-    },
-    /// Compares the `branch` register with the top of the stack, and if they
-    /// match pops the top of the stack and performs the jump to offset.
-    ///
-    /// # Operation
-    ///
-    /// ```text
-    /// <integer>
-    /// => *nothing*
-    /// ```
-    #[musli(packed)]
-    JumpIfBranch {
-        /// Where the branch value is stored.
-        branch: InstAddress,
-        /// The branch value to compare against.
-        value: i64,
-        /// The offset to jump.
         jump: usize,
     },
     /// Construct a push a vector value onto the stack. The number of elements

--- a/crates/rune/src/runtime/select.rs
+++ b/crates/rune/src/runtime/select.rs
@@ -11,18 +11,18 @@ use crate::runtime::{Future, Mut, Value, VmResult};
 /// A stored select.
 #[derive(Debug)]
 pub struct Select {
-    futures: FuturesUnordered<SelectFuture<i64, Mut<Future>>>,
+    futures: FuturesUnordered<SelectFuture<usize, Mut<Future>>>,
 }
 
 impl Select {
     /// Construct a new stored select.
-    pub(crate) fn new(futures: FuturesUnordered<SelectFuture<i64, Mut<Future>>>) -> Self {
+    pub(crate) fn new(futures: FuturesUnordered<SelectFuture<usize, Mut<Future>>>) -> Self {
         Self { futures }
     }
 }
 
 impl future::Future for Select {
-    type Output = VmResult<(i64, Value)>;
+    type Output = VmResult<(usize, Value)>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let poll = Pin::new(&mut self.futures).poll_next(cx);


### PR DESCRIPTION
If we turn `Select` into an internally jumping instruction instead, we don't need to have additional logic to jump by branch.