### PR TITLE
Fix how the virtual machine perform internal calls

### DIFF
--- a/crates/rune/src/cli/tests.rs
+++ b/crates/rune/src/cli/tests.rs
@@ -13,7 +13,7 @@ use crate::cli::{
 use crate::compile::{FileSourceLoader, ItemBuf};
 use crate::doc::TestParams;
 use crate::modules::capture_io::CaptureIo;
-use crate::runtime::{UnitFn, Value, Vm, VmError, VmResult, ValueKind};
+use crate::runtime::{UnitFn, Value, ValueKind, Vm, VmError, VmResult};
 use crate::termcolor::{Color, ColorSpec, WriteColor};
 use crate::{Diagnostics, Hash, Source, Sources, Unit};
 

--- a/crates/rune/src/compile/assembly.rs
+++ b/crates/rune/src/compile/assembly.rs
@@ -171,15 +171,14 @@ impl Assembly {
         span: &dyn Spanned,
         comment: &dyn fmt::Display,
     ) -> compile::Result<()> {
-        let pos = self.instructions.len();
-
-        let c = self.comments.entry(pos).or_try_default()?;
+        let index = self.instructions.len();
+        let c = self.comments.entry(index).or_try_default()?;
 
         if !c.is_empty() {
             c.try_push_str("; ")?;
         }
 
-        write!(c, "{}", comment)?;
+        write!(c, "{comment}")?;
         self.push(raw, span)?;
         Ok(())
     }

--- a/crates/rune/src/internal_macros.rs
+++ b/crates/rune/src/internal_macros.rs
@@ -71,46 +71,6 @@ macro_rules! repeat_macro {
     };
 }
 
-macro_rules! cfg_emit {
-    ($($item:item)*) => {
-        $(
-            #[cfg(feature = "emit")]
-            #[cfg_attr(rune_docsrs, doc(cfg(feature = "emit")))]
-            $item
-        )*
-    }
-}
-
-macro_rules! cfg_workspace {
-    ($($item:item)*) => {
-        $(
-            #[cfg(feature = "workspace")]
-            #[cfg_attr(rune_docsrs, doc(cfg(feature = "workspace")))]
-            $item
-        )*
-    }
-}
-
-macro_rules! cfg_cli {
-    ($($item:item)*) => {
-        $(
-            #[cfg(feature = "cli")]
-            #[cfg_attr(rune_docsrs, doc(cfg(feature = "cli")))]
-            $item
-        )*
-    }
-}
-
-macro_rules! cfg_doc {
-    ($($item:item)*) => {
-        $(
-            #[cfg(feature = "doc")]
-            #[cfg_attr(rune_docsrs, doc(cfg(feature = "doc")))]
-            $item
-        )*
-    }
-}
-
 macro_rules! cfg_std {
     ($($item:item)*) => {
         $(

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -200,10 +200,10 @@ pub mod ast;
 #[cfg(feature = "fmt")]
 pub mod fmt;
 
-cfg_emit! {
-    #[doc(inline)]
-    pub use ::codespan_reporting::term::termcolor;
-}
+#[cfg(feature = "emit")]
+#[cfg_attr(rune_docsrs, doc(cfg(feature = "emit")))]
+#[doc(inline)]
+pub use ::codespan_reporting::term::termcolor;
 
 mod any;
 pub use self::any::Any;
@@ -264,9 +264,9 @@ mod worker;
 #[doc(hidden)]
 pub mod support;
 
-cfg_workspace! {
-    pub mod workspace;
-}
+#[cfg(feature = "workspace")]
+#[cfg_attr(rune_docsrs, doc(cfg(feature = "workspace")))]
+pub mod workspace;
 
 // Macros used internally and re-exported.
 pub(crate) use rune_macros::__internal_impl_any;
@@ -604,16 +604,16 @@ pub use rune_macros::hash;
 
 pub use rune_macros::item;
 
-cfg_cli! {
-    pub mod cli;
-}
+#[cfg(feature = "cli")]
+#[cfg_attr(rune_docsrs, doc(cfg(feature = "cli")))]
+pub mod cli;
 
 #[cfg(feature = "languageserver")]
 pub mod languageserver;
 
-cfg_doc! {
-    pub mod doc;
-}
+#[cfg(feature = "doc")]
+#[cfg_attr(rune_docsrs, doc(cfg(feature = "doc")))]
+pub mod doc;
 
 /// Privately exported details.
 #[doc(hidden)]

--- a/crates/rune/src/runtime.rs
+++ b/crates/rune/src/runtime.rs
@@ -158,7 +158,7 @@ mod vec_tuple;
 pub use self::vec_tuple::VecTuple;
 
 mod vm;
-pub use self::vm::{CallFrame, Vm};
+pub use self::vm::{CallFrame, Isolated, Vm};
 
 mod vm_call;
 pub(crate) use self::vm_call::VmCall;

--- a/crates/rune/src/runtime/function.rs
+++ b/crates/rune/src/runtime/function.rs
@@ -7,6 +7,7 @@ use crate as rune;
 use crate::alloc::prelude::*;
 use crate::alloc::{self, Box, Vec};
 use crate::module;
+use crate::runtime::vm::Isolated;
 use crate::runtime::{
     Args, Call, ConstValue, FromValue, FunctionHandler, InstAddress, Output, OwnedTuple, Rtti,
     RuntimeContext, Stack, Unit, Value, ValueKind, VariantRtti, Vm, VmCall, VmErrorKind, VmHalt,
@@ -931,7 +932,7 @@ impl FnOffset {
         let same_context =
             matches!(self.call, Call::Immediate if vm.is_same_context(&self.context));
 
-        vm_try!(vm.push_call_frame(self.offset, addr, args, !same_context, out));
+        vm_try!(vm.push_call_frame(self.offset, addr, args, Isolated::new(!same_context), out));
         vm_try!(extra.into_stack(vm.stack_mut()));
 
         // Fast path, just allocate a call frame and keep running.

--- a/crates/rune/src/runtime/protocol_caller.rs
+++ b/crates/rune/src/runtime/protocol_caller.rs
@@ -1,20 +1,26 @@
-use crate::runtime::vm::CallResult;
+use crate::runtime::vm::{CallResult, CallResultOnly, Isolated};
 use crate::runtime::{
-    GuardedArgs, Output, Protocol, Stack, UnitFn, Value, Vm, VmError, VmErrorKind, VmResult,
+    GuardedArgs, Protocol, Stack, UnitFn, Value, Vm, VmError, VmErrorKind, VmExecution, VmResult,
 };
 use crate::Hash;
 
 /// Trait used for integrating an instance function call.
 pub(crate) trait ProtocolCaller: Sized {
     /// Call the given protocol function.
-    fn call_protocol_fn<A>(
-        &mut self,
-        protocol: Protocol,
-        target: Value,
-        args: A,
-    ) -> VmResult<Value>
+    fn call_protocol_fn<A>(&mut self, protocol: Protocol, target: Value, args: A) -> VmResult<Value>
     where
-        A: GuardedArgs;
+        A: GuardedArgs,
+    {
+        match vm_try!(self.try_call_protocol_fn(protocol, target, args)) {
+            CallResultOnly::Ok(value) => VmResult::Ok(value),
+            CallResultOnly::Unsupported(value) => {
+                VmResult::err(VmErrorKind::MissingProtocolFunction {
+                    protocol,
+                    instance: vm_try!(value.type_info()),
+                })
+            }
+        }
+    }
 
     /// Call the given protocol function.
     fn try_call_protocol_fn<A>(
@@ -22,15 +28,10 @@ pub(crate) trait ProtocolCaller: Sized {
         protocol: Protocol,
         target: Value,
         args: A,
-    ) -> VmResult<CallResult<Value>>
+    ) -> VmResult<CallResultOnly<Value>>
     where
         A: GuardedArgs,
-        Self: Sized,
-    {
-        VmResult::Ok(CallResult::Ok(vm_try!(
-            self.call_protocol_fn(protocol, target, args)
-        )))
-    }
+        Self: Sized;
 }
 
 /// Use the global environment caller.
@@ -39,11 +40,28 @@ pub(crate) trait ProtocolCaller: Sized {
 pub(crate) struct EnvProtocolCaller;
 
 impl ProtocolCaller for EnvProtocolCaller {
-    fn call_protocol_fn<A>(&mut self, protocol: Protocol, target: Value, args: A) -> VmResult<Value>
+    fn try_call_protocol_fn<A>(
+        &mut self,
+        protocol: Protocol,
+        target: Value,
+        args: A,
+    ) -> VmResult<CallResultOnly<Value>>
     where
         A: GuardedArgs,
     {
-        return crate::runtime::env::shared(|context, unit| {
+        /// Check that arguments matches expected or raise the appropriate error.
+        fn check_args(args: usize, expected: usize) -> Result<(), VmError> {
+            if args != expected {
+                return Err(VmError::from(VmErrorKind::BadArgumentCount {
+                    actual: args,
+                    expected,
+                }));
+            }
+
+            Ok(())
+        }
+
+        crate::runtime::env::shared(|context, unit| {
             let count = args.count() + 1;
             let hash = Hash::associated_function(vm_try!(target.type_hash()), protocol.hash);
 
@@ -64,54 +82,58 @@ impl ProtocolCaller for EnvProtocolCaller {
 
                 let mut vm = Vm::with_stack(context.clone(), unit.clone(), stack);
                 vm.set_ip(offset);
-                return call.call_with_vm(vm);
+                return VmResult::Ok(CallResultOnly::Ok(vm_try!(call.call_with_vm(vm))));
             }
 
-            let Some(handler) = context.function(hash) else {
-                return VmResult::err(VmErrorKind::MissingProtocolFunction {
-                    protocol,
-                    instance: vm_try!(target.type_info()),
-                });
-            };
-
-            let mut stack = vm_try!(Stack::with_capacity(count));
-            let addr = stack.addr();
-            vm_try!(stack.push(target));
-            // Safety: We hold onto the guard until the vm has completed.
-            let _guard = unsafe { vm_try!(args.unsafe_into_stack(&mut stack)) };
-            vm_try!(handler(&mut stack, addr, count, Output::keep(0)));
-            VmResult::Ok(vm_try!(stack.at(addr)).clone())
-        });
-
-        /// Check that arguments matches expected or raise the appropriate error.
-        fn check_args(args: usize, expected: usize) -> Result<(), VmError> {
-            if args != expected {
-                return Err(VmError::from(VmErrorKind::BadArgumentCount {
-                    actual: args,
-                    expected,
-                }));
+            if let Some(handler) = context.function(hash) {
+                let mut stack = vm_try!(Stack::with_capacity(count));
+                let addr = stack.addr();
+                vm_try!(stack.push(target));
+                // Safety: We hold onto the guard until the vm has completed.
+                let _guard = unsafe { vm_try!(args.unsafe_into_stack(&mut stack)) };
+                vm_try!(handler(&mut stack, addr, count, addr.output()));
+                let value = vm_try!(stack.at(addr)).clone();
+                stack.truncate(addr);
+                return VmResult::Ok(CallResultOnly::Ok(value));
             }
 
-            Ok(())
-        }
+            VmResult::Ok(CallResultOnly::Unsupported(target))
+        })
     }
 }
 
 impl ProtocolCaller for Vm {
-    fn call_protocol_fn<A>(&mut self, protocol: Protocol, target: Value, args: A) -> VmResult<Value>
+    fn try_call_protocol_fn<A>(
+        &mut self,
+        protocol: Protocol,
+        target: Value,
+        args: A,
+    ) -> VmResult<CallResultOnly<Value>>
     where
         A: GuardedArgs,
     {
         let addr = self.stack().addr();
+        vm_try!(self.stack_mut().push(()));
 
-        if let CallResult::Unsupported(..) =
-            vm_try!(self.call_instance_fn(target, protocol, args, addr.output()))
-        {
-            return VmResult::err(VmErrorKind::MissingFunction {
-                hash: protocol.hash,
-            });
+        match vm_try!(self.call_instance_fn(
+            Isolated::Isolated,
+            target,
+            protocol,
+            args,
+            addr.output()
+        )) {
+            CallResult::Unsupported(value) => VmResult::Ok(CallResultOnly::Unsupported(value)),
+            CallResult::Ok(()) => {
+                let value = vm_try!(self.stack().at(addr)).clone();
+                self.stack_mut().truncate(addr);
+                VmResult::Ok(CallResultOnly::Ok(value))
+            }
+            CallResult::Frame => {
+                let mut execution = VmExecution::new(self);
+                let value = vm_try!(execution.complete());
+                execution.vm_mut().stack_mut().truncate(addr);
+                VmResult::Ok(CallResultOnly::Ok(value))
+            }
         }
-
-        VmResult::Ok(vm_try!(self.stack().at(addr)).clone())
     }
 }

--- a/crates/rune/src/runtime/stack.rs
+++ b/crates/rune/src/runtime/stack.rs
@@ -156,8 +156,8 @@ impl Stack {
     ///
     /// fn sum(stack: &mut Stack, addr: InstAddress, args: usize, out: Output) -> VmResult<()> {
     ///     for value in vm_try!(stack.slice_at_mut(addr, args)) {
-    ///         let number = value.as_integer();
-    ///         *value = vm_try!(Value::try_from(number + 1));
+    ///         let number = vm_try!(value.as_integer());
+    ///         *value = vm_try!(rune::to_value(number + 1));
     ///     }
     ///
     ///     out.store(stack, ());
@@ -251,12 +251,6 @@ impl Stack {
     pub(crate) fn clear(&mut self) {
         self.stack.clear();
         self.top = 0;
-    }
-
-    /// Iterate over the stack.
-    #[cfg(feature = "cli")]
-    pub(crate) fn iter(&self) -> impl Iterator<Item = &Value> + '_ {
-        self.stack.iter()
     }
 
     /// Get the offset that corresponds to the bottom of the stack right now.

--- a/crates/rune/src/runtime/value.rs
+++ b/crates/rune/src/runtime/value.rs
@@ -13,7 +13,7 @@ use crate::alloc::fmt::TryWrite;
 use crate::alloc::prelude::*;
 use crate::alloc::{self, String};
 use crate::compile::ItemBuf;
-use crate::runtime::vm::CallResult;
+use crate::runtime::vm::CallResultOnly;
 use crate::runtime::{
     AccessError, AccessErrorKind, AnyObj, AnyObjError, BorrowMut, BorrowRef, Bytes, ConstValue,
     ControlFlow, EnvProtocolCaller, Format, Formatter, FromValue, FullTypeOf, Function, Future,
@@ -1590,7 +1590,7 @@ impl Value {
             }
         }
 
-        if let CallResult::Ok(value) =
+        if let CallResultOnly::Ok(value) =
             vm_try!(caller.try_call_protocol_fn(Protocol::PARTIAL_EQ, self.clone(), (b.clone(),)))
         {
             return <_>::from_value(value);
@@ -1653,7 +1653,7 @@ impl Value {
             _ => {}
         }
 
-        if let CallResult::Ok(value) =
+        if let CallResultOnly::Ok(value) =
             vm_try!(caller.try_call_protocol_fn(Protocol::HASH, self.clone(), (hasher,)))
         {
             return <_>::from_value(value);
@@ -1774,7 +1774,7 @@ impl Value {
             _ => {}
         }
 
-        if let CallResult::Ok(value) =
+        if let CallResultOnly::Ok(value) =
             vm_try!(caller.try_call_protocol_fn(Protocol::EQ, self.clone(), (b.clone(),)))
         {
             return <_>::from_value(value);
@@ -1897,7 +1897,7 @@ impl Value {
             _ => {}
         }
 
-        if let CallResult::Ok(value) =
+        if let CallResultOnly::Ok(value) =
             vm_try!(caller.try_call_protocol_fn(Protocol::PARTIAL_CMP, self.clone(), (b.clone(),)))
         {
             return <_>::from_value(value);
@@ -2022,7 +2022,7 @@ impl Value {
             _ => {}
         }
 
-        if let CallResult::Ok(value) =
+        if let CallResultOnly::Ok(value) =
             vm_try!(caller.try_call_protocol_fn(Protocol::CMP, self.clone(), (b.clone(),)))
         {
             return <_>::from_value(value);

--- a/crates/rune/src/runtime/vm.rs
+++ b/crates/rune/src/runtime/vm.rs
@@ -1,4 +1,5 @@
 use core::cmp::Ordering;
+use core::fmt;
 use core::mem::replace;
 use core::ops;
 use core::ptr::NonNull;
@@ -10,7 +11,6 @@ use crate::alloc::prelude::*;
 use crate::alloc::{self, String};
 use crate::hash::{Hash, IntoHash, ToTypeHash};
 use crate::modules::{option, result};
-use crate::runtime::budget;
 use crate::runtime::future::SelectFuture;
 use crate::runtime::unit::{UnitFn, UnitStorage};
 use crate::runtime::{
@@ -22,8 +22,47 @@ use crate::runtime::{
     Value, ValueKind, Variant, VariantData, Vec, VmError, VmErrorKind, VmExecution, VmHalt,
     VmIntegerRepr, VmResult, VmSendExecution,
 };
+use crate::runtime::{budget, ProtocolCaller};
 
 use super::{VmDiagnostics, VmDiagnosticsObj};
+
+/// Indicating the kind of isolation that is present for a frame.
+#[derive(Debug, Clone, Copy)]
+pub enum Isolated {
+    /// The frame is isolated, once pop it will cause the execution to complete.
+    Isolated,
+    /// No isolation is present, the vm will continue executing.
+    None,
+}
+
+impl Isolated {
+    #[inline]
+    pub(crate) fn new(value: bool) -> Self {
+        if value {
+            Self::Isolated
+        } else {
+            Self::None
+        }
+    }
+
+    #[inline]
+    pub(crate) fn then_some<T>(self, value: T) -> Option<T> {
+        match self {
+            Self::Isolated => Some(value),
+            Self::None => None,
+        }
+    }
+}
+
+impl fmt::Display for Isolated {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Isolated => write!(f, "isolated"),
+            Self::None => write!(f, "none"),
+        }
+    }
+}
 
 /// Small helper function to build errors.
 fn err<T, E>(error: E) -> VmResult<T>
@@ -36,9 +75,23 @@ where
 /// The result from a dynamic call. Indicates if the attempted operation is
 /// supported.
 #[derive(Debug)]
+pub(crate) enum CallResultOnly<T> {
+    /// Call successful. Return value is on the stack.
+    Ok(T),
+    /// Call failed because function was missing so the method is unsupported.
+    /// Contains target value.
+    Unsupported(Value),
+}
+
+/// The result from a dynamic call. Indicates if the attempted operation is
+/// supported.
+#[derive(Debug)]
 pub(crate) enum CallResult<T> {
     /// Call successful. Return value is on the stack.
     Ok(T),
+    /// A call frame was pushed onto the virtual machine, which needs to be
+    /// advanced to produce the result.
+    Frame,
     /// Call failed because function was missing so the method is unsupported.
     /// Contains target value.
     Unsupported(Value),
@@ -568,6 +621,7 @@ impl Vm {
     #[inline(always)]
     pub(crate) fn call_instance_fn<H, A>(
         &mut self,
+        isolated: Isolated,
         target: Value,
         hash: H,
         args: A,
@@ -588,13 +642,18 @@ impl Vm {
             ..
         }) = self.unit.function(hash)
         {
+            vm_try!(self.called_function_hook(hash));
             let addr = self.stack.addr();
             vm_try!(self.stack.push(target));
             // Safety: We hold onto the guard for the duration of this call.
             let _guard = unsafe { vm_try!(args.unsafe_into_stack(&mut self.stack)) };
             vm_try!(check_args(count, expected));
-            vm_try!(self.call_offset_fn(offset, call, addr, count, out));
-            return VmResult::Ok(CallResult::Ok(()));
+
+            if vm_try!(self.call_offset_fn(offset, call, addr, count, isolated, out)) {
+                return VmResult::Ok(CallResult::Frame);
+            } else {
+                return VmResult::Ok(CallResult::Ok(()));
+            }
         }
 
         if let Some(handler) = self.context.function(hash) {
@@ -604,6 +663,7 @@ impl Vm {
             // Safety: We hold onto the guard for the duration of this call.
             let _guard = unsafe { vm_try!(args.unsafe_into_stack(&mut self.stack)) };
             vm_try!(handler(&mut self.stack, addr, count, out));
+            self.stack.truncate(addr);
             return VmResult::Ok(CallResult::Ok(()));
         }
 
@@ -641,8 +701,10 @@ impl Vm {
             let addr = self.stack.addr();
             vm_try!(self.called_function_hook(hash));
             vm_try!(self.stack.push(target));
+            // Safety: We hold onto the guard for the duration of this call.
             let _guard = unsafe { vm_try!(args.unsafe_into_stack(&mut self.stack)) };
             vm_try!(handler(&mut self.stack, addr, count, out));
+            self.stack.truncate(addr);
             return VmResult::Ok(CallResult::Ok(()));
         }
 
@@ -667,9 +729,12 @@ impl Vm {
 
         if let Some(handler) = self.context.function(hash) {
             let addr = self.stack.addr();
+            vm_try!(self.called_function_hook(hash));
             vm_try!(self.stack.push(target));
+            // Safety: We hold onto the guard for the duration of this call.
             let _guard = unsafe { vm_try!(args.unsafe_into_stack(&mut self.stack)) };
             vm_try!(handler(&mut self.stack, addr, count, out));
+            self.stack.truncate(addr);
             return VmResult::Ok(CallResult::Ok(()));
         }
 
@@ -705,7 +770,7 @@ impl Vm {
         ip: usize,
         addr: InstAddress,
         args: usize,
-        isolated: bool,
+        isolated: Isolated,
         out: Output,
     ) -> Result<(), VmErrorKind> {
         tracing::trace!("pushing call frame");
@@ -742,12 +807,12 @@ impl Vm {
 
     /// Pop a call frame and return it.
     #[tracing::instrument(skip(self), fields(call_frames = self.call_frames.len(), top = self.stack.top(), stack = self.stack.len(), self.ip))]
-    pub(crate) fn pop_call_frame(&mut self) -> Result<(bool, Option<Output>), VmErrorKind> {
+    pub(crate) fn pop_call_frame(&mut self) -> Result<(Isolated, Option<Output>), VmErrorKind> {
         tracing::trace!("popping call frame");
 
         let Some(frame) = self.call_frames.pop() else {
             self.stack.pop_stack_top(0)?;
-            return Ok((true, None));
+            return Ok((Isolated::Isolated, None));
         };
 
         tracing::trace!(?frame);
@@ -1021,12 +1086,9 @@ impl Vm {
 
         let hash = index.hash();
 
-        VmResult::Ok(
-            match vm_try!(self.call_field_fn(Protocol::GET, target, hash, (), out)) {
-                CallResult::Ok(()) => CallResult::Ok(()),
-                CallResult::Unsupported(target) => CallResult::Unsupported(target),
-            },
-        )
+        let result = vm_try!(self.call_field_fn(Protocol::GET, target, hash, (), out));
+
+        VmResult::Ok(result)
     }
 
     fn try_object_slot_index_set(
@@ -1071,11 +1133,9 @@ impl Vm {
         }
 
         let hash = field.hash();
-
-        let value =
+        let result =
             vm_try!(self.call_field_fn(Protocol::SET, target, hash, (value,), Output::discard()));
-
-        VmResult::Ok(value)
+        VmResult::Ok(result)
     }
 
     fn on_tuple<F, O>(&self, ty: TypeCheck, value: &Value, f: F) -> VmResult<Option<O>>
@@ -1270,6 +1330,7 @@ impl Vm {
         call: Call,
         addr: InstAddress,
         args: usize,
+        isolated: Isolated,
         out: Output,
     ) -> Result<bool, VmErrorKind> {
         let moved = match call {
@@ -1278,7 +1339,7 @@ impl Vm {
                 false
             }
             Call::Immediate => {
-                self.push_call_frame(offset, addr, args, false, out)?;
+                self.push_call_frame(offset, addr, args, isolated, out)?;
                 true
             }
             Call::Stream => {
@@ -1341,9 +1402,13 @@ impl Vm {
     ) -> VmResult<()> {
         match fallback {
             TargetFallback::Value(lhs, rhs) => {
-                if let CallResult::Unsupported(lhs) =
-                    vm_try!(self.call_instance_fn(lhs, protocol, (&rhs,), Output::discard()))
-                {
+                if let CallResult::Unsupported(lhs) = vm_try!(self.call_instance_fn(
+                    Isolated::None,
+                    lhs,
+                    protocol,
+                    (&rhs,),
+                    Output::discard()
+                )) {
                     return err(VmErrorKind::UnsupportedBinaryOperation {
                         op: protocol.name,
                         lhs: vm_try!(lhs.type_info()),
@@ -1421,7 +1486,7 @@ impl Vm {
         let rhs = rhs.clone();
 
         if let CallResult::Unsupported(lhs) =
-            vm_try!(self.call_instance_fn(lhs, protocol, (&rhs,), out))
+            vm_try!(self.call_instance_fn(Isolated::None, lhs, protocol, (&rhs,), out))
         {
             return err(VmErrorKind::UnsupportedBinaryOperation {
                 op: protocol.name,
@@ -1467,7 +1532,7 @@ impl Vm {
         };
 
         if let CallResult::Unsupported(lhs) =
-            vm_try!(self.call_instance_fn(lhs, protocol, (&rhs,), out))
+            vm_try!(self.call_instance_fn(Isolated::None, lhs, protocol, (&rhs,), out))
         {
             return err(VmErrorKind::UnsupportedBinaryOperation {
                 op: protocol.name,
@@ -1551,7 +1616,7 @@ impl Vm {
         }
 
         if let CallResult::Unsupported(lhs) =
-            vm_try!(self.call_instance_fn(lhs, protocol, (&rhs,), out))
+            vm_try!(self.call_instance_fn(Isolated::None, lhs, protocol, (&rhs,), out))
         {
             return err(VmErrorKind::UnsupportedBinaryOperation {
                 op: protocol.name,
@@ -2161,6 +2226,7 @@ impl Vm {
         let value = value.clone();
 
         if let CallResult::Unsupported(target) = vm_try!(self.call_instance_fn(
+            Isolated::None,
             target,
             Protocol::INDEX_SET,
             (&index, &value),
@@ -2320,9 +2386,13 @@ impl Vm {
             let target = target.clone();
             let index = index.clone();
 
-            if let CallResult::Unsupported(target) =
-                vm_try!(self.call_instance_fn(target, Protocol::INDEX_GET, (&index,), out))
-            {
+            if let CallResult::Unsupported(target) = vm_try!(self.call_instance_fn(
+                Isolated::None,
+                target,
+                Protocol::INDEX_GET,
+                (&index,),
+                out
+            )) {
                 return err(VmErrorKind::UnsupportedIndexGet {
                     target: vm_try!(target.type_info()),
                     index: vm_try!(index.type_info()),
@@ -2417,12 +2487,15 @@ impl Vm {
     ) -> VmResult<()> {
         let target = vm_try!(self.stack.at(addr)).clone();
 
-        match vm_try!(self.try_object_slot_index_get(target, slot, out)) {
-            CallResult::Ok(()) => VmResult::Ok(()),
-            CallResult::Unsupported(target) => err(VmErrorKind::UnsupportedObjectSlotIndexGet {
+        if let CallResult::Unsupported(target) =
+            vm_try!(self.try_object_slot_index_get(target, slot, out))
+        {
+            return err(VmErrorKind::UnsupportedObjectSlotIndexGet {
                 target: vm_try!(target.type_info()),
-            }),
+            });
         }
+
+        VmResult::Ok(())
     }
 
     /// Operation to allocate an object.
@@ -2624,27 +2697,27 @@ impl Vm {
     /// Perform the try operation on the given stack location.
     #[cfg_attr(feature = "bench", inline(never))]
     fn op_try(&mut self, addr: InstAddress, out: Output) -> VmResult<Option<Output>> {
-        let value = vm_try!(self.stack.at(addr)).clone();
-
         let result = 'out: {
-            match &*vm_try!(value.borrow_kind_ref()) {
-                ValueKind::Result(result) => break 'out vm_try!(result::result_try(result)),
-                ValueKind::Option(option) => break 'out vm_try!(option::option_try(option)),
-                _ => {}
+            let value = {
+                let value = vm_try!(self.stack.at(addr));
+
+                match &*vm_try!(value.borrow_kind_ref()) {
+                    ValueKind::Result(result) => break 'out vm_try!(result::result_try(result)),
+                    ValueKind::Option(option) => break 'out vm_try!(option::option_try(option)),
+                    _ => {}
+                }
+
+                value.clone()
+            };
+
+            match vm_try!(self.try_call_protocol_fn(Protocol::TRY, value, ())) {
+                CallResultOnly::Ok(value) => vm_try!(ControlFlow::from_value(value)),
+                CallResultOnly::Unsupported(target) => {
+                    return err(VmErrorKind::UnsupportedTryOperand {
+                        actual: vm_try!(target.type_info()),
+                    })
+                }
             }
-
-            let addr = self.stack.addr();
-
-            if let CallResult::Unsupported(target) =
-                vm_try!(self.call_instance_fn(value, Protocol::TRY, (), addr.output()))
-            {
-                return err(VmErrorKind::UnsupportedTryOperand {
-                    actual: vm_try!(target.type_info()),
-                });
-            }
-
-            let value = vm_try!(self.stack.at(addr)).clone();
-            vm_try!(ControlFlow::from_value(value))
         };
 
         match result {
@@ -2803,13 +2876,10 @@ impl Vm {
 
             let value = value.clone();
 
-            let CallResult::Ok(()) =
-                vm_try!(self.call_instance_fn(value, Protocol::IS_VARIANT, (index,), out))
-            else {
-                break 'out false;
-            };
-
-            return VmResult::Ok(());
+            match vm_try!(self.try_call_protocol_fn(Protocol::IS_VARIANT, value, (index,))) {
+                CallResultOnly::Ok(value) => vm_try!(bool::from_value(value)),
+                CallResultOnly::Unsupported(..) => false,
+            }
         };
 
         vm_try!(out.store(&mut self.stack, is_match));
@@ -3002,7 +3072,7 @@ impl Vm {
                 ..
             } => {
                 vm_try!(check_args(args, expected));
-                vm_try!(self.call_offset_fn(offset, call, addr, args, out));
+                vm_try!(self.call_offset_fn(offset, call, addr, args, Isolated::None, out));
             }
             UnitFn::EmptyStruct { hash } => {
                 vm_try!(check_args(args, 0));
@@ -3076,7 +3146,7 @@ impl Vm {
         args: usize,
         out: Output,
     ) -> VmResult<()> {
-        vm_try!(self.call_offset_fn(offset, call, addr, args, out));
+        vm_try!(self.call_offset_fn(offset, call, addr, args, Isolated::None, out));
         VmResult::Ok(())
     }
 
@@ -3099,8 +3169,9 @@ impl Vm {
             ..
         }) = self.unit.function(hash)
         {
+            vm_try!(self.called_function_hook(hash));
             vm_try!(check_args(args, expected));
-            vm_try!(self.call_offset_fn(offset, call, addr, args, out));
+            vm_try!(self.call_offset_fn(offset, call, addr, args, Isolated::None, out));
             return VmResult::Ok(());
         }
 
@@ -3579,7 +3650,7 @@ pub struct CallFrame {
     pub top: usize,
     /// Indicates that the call frame is isolated and should force an exit into
     /// the vm execution context.
-    pub isolated: bool,
+    pub isolated: Isolated,
     /// Keep the value produced from the call frame.
     pub out: Output,
 }

--- a/crates/rune/src/runtime/vm_error.rs
+++ b/crates/rune/src/runtime/vm_error.rs
@@ -759,22 +759,22 @@ impl fmt::Display for VmErrorKind {
             VmErrorKind::Underflow {} => write!(f, "Numerical underflow"),
             VmErrorKind::DivideByZero {} => write!(f, "Division by zero"),
             VmErrorKind::MissingEntry { item, hash } => {
-                write!(f, "Missing entry `{item}` with hash `{hash}`",)
+                write!(f, "Missing entry `{item}` with hash `{hash}`")
             }
             VmErrorKind::MissingEntryHash { hash } => {
-                write!(f, "Missing entry with hash `{hash}`",)
+                write!(f, "Missing entry with hash `{hash}`")
             }
             VmErrorKind::MissingFunction { hash } => {
-                write!(f, "Missing function with hash `{hash}`",)
+                write!(f, "Missing function with hash `{hash}`")
             }
             VmErrorKind::MissingContextFunction { hash } => {
-                write!(f, "Missing context function with hash `{hash}`",)
+                write!(f, "Missing context function with hash `{hash}`")
             }
             VmErrorKind::MissingProtocolFunction { protocol, instance } => {
-                write!(f, "Missing protocol function `{protocol}` for `{instance}`",)
+                write!(f, "Missing protocol function `{protocol}` for `{instance}`")
             }
             VmErrorKind::MissingInstanceFunction { hash, instance } => {
-                write!(f, "Missing instance function `{hash}` for `{instance}`",)
+                write!(f, "Missing instance function `{hash}` for `{instance}`")
             }
             VmErrorKind::IpOutOfBounds { ip, length } => write!(
                 f,
@@ -787,20 +787,20 @@ impl fmt::Display for VmErrorKind {
                 )
             }
             VmErrorKind::UnsupportedUnaryOperation { op, operand } => {
-                write!(f, "Unsupported unary operation `{op}` on {operand}",)
+                write!(f, "Unsupported unary operation `{op}` on {operand}")
             }
             VmErrorKind::MissingStaticString { slot } => {
-                write!(f, "Static string slot `{slot}` does not exist",)
+                write!(f, "Static string slot `{slot}` does not exist")
             }
             VmErrorKind::MissingStaticObjectKeys { slot } => {
-                write!(f, "Static object keys slot `{slot}` does not exist",)
+                write!(f, "Static object keys slot `{slot}` does not exist")
             }
             VmErrorKind::MissingVariantRtti { hash } => write!(
                 f,
                 "Missing runtime information for variant with hash `{hash}`",
             ),
             VmErrorKind::MissingRtti { hash } => {
-                write!(f, "Missing runtime information for type with hash `{hash}`",)
+                write!(f, "Missing runtime information for type with hash `{hash}`")
             }
             VmErrorKind::BadArgumentCount { actual, expected } => write!(
                 f,
@@ -832,40 +832,40 @@ impl fmt::Display for VmErrorKind {
                 "The tuple index set operation is not supported on `{target}`",
             ),
             VmErrorKind::UnsupportedObjectSlotIndexGet { target } => {
-                write!(f, "Field not available to get on `{target}`",)
+                write!(f, "Field not available to get on `{target}`")
             }
             VmErrorKind::UnsupportedObjectSlotIndexSet { target } => {
-                write!(f, "Field not available to set on `{target}`",)
+                write!(f, "Field not available to set on `{target}`")
             }
             VmErrorKind::UnsupportedIs { value, test_type } => {
-                write!(f, "Operation `{value} is {test_type}` is not supported",)
+                write!(f, "Operation `{value} is {test_type}` is not supported")
             }
             VmErrorKind::UnsupportedAs { value, type_hash } => {
-                write!(f, "Operation `{value} as {type_hash}` is not supported",)
+                write!(f, "Operation `{value} as {type_hash}` is not supported")
             }
             VmErrorKind::UnsupportedCallFn { actual } => write!(
                 f,
                 "Type `{actual}` cannot be called since it's not a function",
             ),
             VmErrorKind::ObjectIndexMissing { slot } => {
-                write!(f, "Missing index by static string slot `{slot}`",)
+                write!(f, "Missing index by static string slot `{slot}`")
             }
             VmErrorKind::MissingIndex { target } => {
-                write!(f, "Type `{target}` missing index",)
+                write!(f, "Type `{target}` missing index")
             }
             VmErrorKind::MissingIndexInteger { target, index } => {
-                write!(f, "Type `{target}` missing integer index `{index}`",)
+                write!(f, "Type `{target}` missing integer index `{index}`")
             }
             #[cfg(feature = "alloc")]
             VmErrorKind::MissingIndexKey { target } => {
-                write!(f, "Type `{target}` missing index",)
+                write!(f, "Type `{target}` missing index")
             }
             VmErrorKind::OutOfRange { index, length } => write!(
                 f,
                 "Index out of bounds, the length is `{length}` but the index is `{index}`",
             ),
             VmErrorKind::UnsupportedTryOperand { actual } => {
-                write!(f, "Type `{actual}` is not supported as try operand",)
+                write!(f, "Type `{actual}` is not supported as try operand")
             }
             VmErrorKind::UnsupportedIterRangeInclusive { start, end } => {
                 write!(f, "Cannot build an iterator out of {start}..={end}")
@@ -877,26 +877,26 @@ impl fmt::Display for VmErrorKind {
                 write!(f, "Cannot build an iterator out of {start}..{end}")
             }
             VmErrorKind::UnsupportedIterNextOperand { actual } => {
-                write!(f, "Type `{actual}` is not supported as iter-next operand",)
+                write!(f, "Type `{actual}` is not supported as iter-next operand")
             }
             VmErrorKind::Expected { expected, actual } => {
-                write!(f, "Expected type `{expected}` but found `{actual}`",)
+                write!(f, "Expected type `{expected}` but found `{actual}`")
             }
             VmErrorKind::ExpectedAny { actual } => {
-                write!(f, "Expected `Any` type, but found `{actual}`",)
+                write!(f, "Expected `Any` type, but found `{actual}`")
             }
             VmErrorKind::ValueToIntegerCoercionError { from, to } => {
-                write!(f, "Failed to convert value `{from}` to integer `{to}`",)
+                write!(f, "Failed to convert value `{from}` to integer `{to}`")
             }
             VmErrorKind::IntegerToValueCoercionError { from, to } => {
-                write!(f, "Failed to convert integer `{from}` to value `{to}`",)
+                write!(f, "Failed to convert integer `{from}` to value `{to}`")
             }
             VmErrorKind::ExpectedTupleLength { actual, expected } => write!(
                 f,
                 "Expected a tuple of length `{expected}`, but found one with length `{actual}`",
             ),
             VmErrorKind::ConstNotSupported { actual } => {
-                write!(f, "Type `{actual}` can't be converted to a constant value",)
+                write!(f, "Type `{actual}` can't be converted to a constant value")
             }
             VmErrorKind::MissingInterfaceEnvironment {} => {
                 write!(f, "Missing interface environment")
@@ -913,7 +913,7 @@ impl fmt::Display for VmErrorKind {
             VmErrorKind::FutureCompleted {} => write!(f, "Future already completed"),
             VmErrorKind::MissingVariant { name } => write!(f, "No variant matching `{name}`"),
             VmErrorKind::MissingField { target, field } => {
-                write!(f, "Missing field `{field}` on `{target}`",)
+                write!(f, "Missing field `{field}` on `{target}`")
             }
             VmErrorKind::MissingVariantName {} => {
                 write!(f, "missing variant name in runtime information")
@@ -927,7 +927,7 @@ impl fmt::Display for VmErrorKind {
                 "missing dynamic index #{index} in tuple struct `{target}`",
             ),
             VmErrorKind::ExpectedVariant { actual } => {
-                write!(f, "Expected an enum variant, but got `{actual}`",)
+                write!(f, "Expected an enum variant, but got `{actual}`")
             }
             VmErrorKind::UnsupportedObjectFieldGet { target } => write!(
                 f,
@@ -941,7 +941,7 @@ impl fmt::Display for VmErrorKind {
             }
             #[cfg(feature = "alloc")]
             VmErrorKind::IllegalFloatOperation { value } => {
-                write!(f, "Cannot perform operation on float `{value}`",)
+                write!(f, "Cannot perform operation on float `{value}`")
             }
             VmErrorKind::MissingCallFrame => {
                 write!(f, "Missing call frame for internal vm call")

--- a/crates/rune/src/workspace.rs
+++ b/crates/rune/src/workspace.rs
@@ -10,11 +10,13 @@ mod spanned_value;
 mod build;
 pub use self::build::{prepare, Build, BuildError};
 
-cfg_emit! {
-    mod emit;
-    #[doc(inline)]
-    pub use self::emit::EmitError;
-}
+#[cfg(feature = "emit")]
+#[cfg_attr(rune_docsrs, doc(cfg(feature = "emit")))]
+mod emit;
+#[cfg(feature = "emit")]
+#[cfg_attr(rune_docsrs, doc(cfg(feature = "emit")))]
+#[doc(inline)]
+pub use self::emit::EmitError;
 
 mod error;
 pub use self::error::WorkspaceError;


### PR DESCRIPTION
Some internal calls had buggy implementations, like calling protocol functions which are associated with the unit. This did not cause any issues, because there's *currently* no way to add such implementations.

We should also add tests for these.