### PR TITLE
rune: Allow empty values to be const constructed

### DIFF
--- a/crates/rune/src/compile/ir/compiler.rs
+++ b/crates/rune/src/compile/ir/compiler.rs
@@ -239,7 +239,7 @@ fn lit(c: &mut Ctxt<'_, '_>, span: Span, hir: hir::Lit<'_>) -> compile::Result<i
 #[instrument(span = span)]
 fn expr_tuple(c: &mut Ctxt<'_, '_>, span: Span, hir: &hir::ExprSeq<'_>) -> compile::Result<ir::Ir> {
     if hir.items.is_empty() {
-        let value = Value::empty().with_span(span)?;
+        let value = Value::unit().with_span(span)?;
         return Ok(ir::Ir::new(span, value));
     }
 

--- a/crates/rune/src/compile/ir/eval.rs
+++ b/crates/rune/src/compile/ir/eval.rs
@@ -50,7 +50,7 @@ fn eval_ir_assign(
         .scopes
         .mut_target(&ir.target, move |t| ir.op.assign(ir, t, value))?;
 
-    Ok(Value::empty().with_span(ir)?)
+    Ok(Value::unit().with_span(ir)?)
 }
 
 fn eval_ir_binary(
@@ -170,7 +170,7 @@ fn eval_ir_branches(
         return eval_ir_scope(branch, interp, used);
     }
 
-    Ok(Value::empty().with_span(ir)?)
+    Ok(Value::unit().with_span(ir)?)
 }
 
 fn eval_ir_call(
@@ -214,7 +214,7 @@ fn eval_ir_decl(
     interp.budget.take(ir)?;
     let value = eval_ir(&ir.value, interp, used)?;
     interp.scopes.decl(&ir.name, value).with_span(ir)?;
-    Ok(Value::empty().with_span(ir)?)
+    Ok(Value::unit().with_span(ir)?)
 }
 
 fn eval_ir_loop(
@@ -265,7 +265,7 @@ fn eval_ir_loop(
 
         Ok(value)
     } else {
-        Ok(Value::empty().with_span(ir)?)
+        Ok(Value::unit().with_span(ir)?)
     }
 }
 
@@ -299,7 +299,7 @@ fn eval_ir_scope(
     let value = if let Some(last) = &ir.last {
         eval_ir(last, interp, used)?
     } else {
-        Value::empty().with_span(ir)?
+        Value::unit().with_span(ir)?
     };
 
     interp.scopes.pop(guard).with_span(ir)?;
@@ -314,7 +314,7 @@ fn eval_ir_set(
     interp.budget.take(ir)?;
     let value = eval_ir(&ir.value, interp, used)?;
     interp.scopes.set_target(&ir.target, value)?;
-    Ok(Value::empty().with_span(ir)?)
+    Ok(Value::unit().with_span(ir)?)
 }
 
 fn eval_ir_template(

--- a/crates/rune/src/compile/v1/assemble.rs
+++ b/crates/rune/src/compile/v1/assemble.rs
@@ -1691,6 +1691,8 @@ fn expr_break<'a, 'hir>(
 
         converge!(expr(cx, hir, &mut needs)?, free(needs));
         needs.free()?;
+    } else if let Some(out) = output {
+        cx.asm.push(Inst::unit(out), span)?;
     }
 
     // Drop loop temporaries.
@@ -2980,8 +2982,8 @@ fn expr_loop<'a, 'hir>(
         cx.asm.push(Inst::unit(out), span)?;
     }
 
-    // NB: breaks produce their own value / perform their own cleanup.
     cx.asm.label(&break_label)?;
+
     linear.free()?;
     cx.breaks.pop();
     Ok(Asm::new(span, ()))

--- a/crates/rune/src/modules/capture_io.rs
+++ b/crates/rune/src/modules/capture_io.rs
@@ -117,6 +117,6 @@ fn dbg_impl(
         vm_try!(writeln!(o, "{:?}", value).map_err(VmError::panic));
     }
 
-    vm_try!(out.store(stack, Value::empty));
+    vm_try!(out.store(stack, Value::unit));
     VmResult::Ok(())
 }

--- a/crates/rune/src/modules/future.rs
+++ b/crates/rune/src/modules/future.rs
@@ -43,7 +43,7 @@ where
         };
 
         futures.push(SelectFuture::new(index, future));
-        vm_try!(results.try_push(vm_try!(Value::empty())));
+        vm_try!(results.try_push(Value::empty()));
     }
 
     while !futures.is_empty() {
@@ -85,7 +85,7 @@ where
 #[rune::function]
 async fn join(value: Value) -> VmResult<Value> {
     match &*vm_try!(value.borrow_kind_ref()) {
-        ValueKind::EmptyTuple => VmResult::Ok(vm_try!(Value::empty())),
+        ValueKind::EmptyTuple => VmResult::Ok(vm_try!(Value::unit())),
         ValueKind::Tuple(tuple) => VmResult::Ok(vm_try!(
             try_join_impl(tuple.iter(), tuple.len(), |vec| VmResult::Ok(vm_try!(
                 Value::tuple(vec)

--- a/crates/rune/src/runtime/access.rs
+++ b/crates/rune/src/runtime/access.rs
@@ -27,6 +27,13 @@ pub struct AccessError {
 
 impl AccessError {
     #[inline]
+    pub(crate) const fn empty() -> Self {
+        Self {
+            kind: AccessErrorKind::Empty,
+        }
+    }
+
+    #[inline]
     pub(crate) fn new(kind: AccessErrorKind) -> Self {
         Self { kind }
     }
@@ -35,6 +42,7 @@ impl AccessError {
 impl fmt::Display for AccessError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self.kind {
+            AccessErrorKind::Empty => write!(f, "Empty value"),
             AccessErrorKind::UnexpectedType { expected, actual } => write!(
                 f,
                 "Expected data of type `{expected}`, but found `{actual}`",
@@ -98,6 +106,7 @@ impl From<AccessErrorKind> for AccessError {
 
 #[derive(Debug, PartialEq)]
 pub(crate) enum AccessErrorKind {
+    Empty,
     UnexpectedType { expected: RawStr, actual: RawStr },
     NotAccessibleRef { error: NotAccessibleRef },
     NotAccessibleMut { error: NotAccessibleMut },

--- a/crates/rune/src/runtime/const_value.rs
+++ b/crates/rune/src/runtime/const_value.rs
@@ -44,7 +44,7 @@ impl ConstValue {
     /// otherwise.
     pub fn as_value(&self) -> alloc::Result<Value> {
         Ok(match self {
-            Self::EmptyTuple => Value::empty()?,
+            Self::EmptyTuple => Value::unit()?,
             Self::Byte(b) => Value::try_from(*b)?,
             Self::Char(c) => Value::try_from(*c)?,
             Self::Bool(b) => Value::try_from(*b)?,

--- a/crates/rune/src/runtime/generator.rs
+++ b/crates/rune/src/runtime/generator.rs
@@ -59,7 +59,7 @@ where
         };
 
         let state = if execution.is_resumed() {
-            vm_try!(execution.resume_with(vm_try!(Value::empty())))
+            vm_try!(execution.resume_with(Value::empty()))
         } else {
             vm_try!(execution.resume())
         };

--- a/crates/rune/src/runtime/inst.rs
+++ b/crates/rune/src/runtime/inst.rs
@@ -1742,7 +1742,7 @@ impl InstValue {
     /// Convert into a value that can be pushed onto the stack.
     pub fn into_value(self) -> alloc::Result<Value> {
         match self {
-            Self::EmptyTuple => Value::empty(),
+            Self::EmptyTuple => Value::unit(),
             Self::Bool(v) => Value::try_from(v),
             Self::Byte(v) => Value::try_from(v),
             Self::Char(v) => Value::try_from(v),

--- a/crates/rune/src/runtime/shared.rs
+++ b/crates/rune/src/runtime/shared.rs
@@ -17,6 +17,7 @@ use crate::alloc::{self, Box};
 use crate::runtime::{Access, AccessError, BorrowMut, BorrowRef, RawAccessGuard, Snapshot};
 
 /// A shared value.
+#[repr(transparent)]
 pub(crate) struct Shared<T: ?Sized> {
     inner: ptr::NonNull<SharedBox<T>>,
 }

--- a/crates/rune/src/runtime/stack.rs
+++ b/crates/rune/src/runtime/stack.rs
@@ -190,8 +190,7 @@ impl Stack {
             return Ok(());
         }
 
-        let empty = Value::empty()?;
-        self.stack.try_resize(self.top + size, empty)?;
+        self.stack.try_resize_with(self.top + size, Value::empty)?;
         Ok(())
     }
 

--- a/crates/rune/src/runtime/stream.rs
+++ b/crates/rune/src/runtime/stream.rs
@@ -41,7 +41,7 @@ where
         };
 
         let state = if execution.is_resumed() {
-            vm_try!(execution.async_resume_with(vm_try!(Value::empty())).await)
+            vm_try!(execution.async_resume_with(Value::empty()).await)
         } else {
             vm_try!(execution.async_resume().await)
         };

--- a/crates/rune/src/runtime/tuple.rs
+++ b/crates/rune/src/runtime/tuple.rs
@@ -299,7 +299,7 @@ macro_rules! impl_tuple {
 
         impl ToValue for () {
             fn to_value(self) -> VmResult<Value> {
-                VmResult::Ok(vm_try!(Value::empty()))
+                VmResult::Ok(vm_try!(Value::unit()))
             }
         }
     };

--- a/crates/rune/src/runtime/value/serde.rs
+++ b/crates/rune/src/runtime/value/serde.rs
@@ -276,7 +276,7 @@ impl<'de> de::Visitor<'de> for VmVisitor {
     where
         E: de::Error,
     {
-        Value::empty().map_err(E::custom)
+        Value::unit().map_err(E::custom)
     }
 
     #[inline]

--- a/crates/rune/src/runtime/vm.rs
+++ b/crates/rune/src/runtime/vm.rs
@@ -1721,7 +1721,7 @@ impl Vm {
 
     #[cfg_attr(feature = "bench", inline(never))]
     fn op_drop(&mut self, addr: InstAddress) -> VmResult<()> {
-        *vm_try!(self.stack.at_mut(addr)) = vm_try!(Value::empty());
+        *vm_try!(self.stack.at_mut(addr)) = Value::empty();
         VmResult::Ok(())
     }
 
@@ -2685,7 +2685,7 @@ impl Vm {
     #[cfg_attr(feature = "bench", inline(never))]
     fn op_is_unit(&mut self, addr: InstAddress, out: Output) -> VmResult<()> {
         let value = vm_try!(self.stack.at(addr));
-        let is_unit = vm_try!(value.is_empty());
+        let is_unit = matches!(&*vm_try!(value.borrow_kind_ref()), ValueKind::EmptyTuple);
         vm_try!(out.store(&mut self.stack, is_unit));
         VmResult::Ok(())
     }

--- a/crates/rune/src/runtime/vm_execution.rs
+++ b/crates/rune/src/runtime/vm_execution.rs
@@ -207,7 +207,7 @@ where
             return VmResult::err(VmErrorKind::ExpectedExecutionState { actual: state });
         };
 
-        vm_try!(out.store(self.head.as_mut().stack_mut(), || VmResult::Ok(value)));
+        vm_try!(out.store(self.head.as_mut().stack_mut(), value));
         self.inner_async_resume(None).await
     }
 
@@ -228,7 +228,7 @@ where
         diagnostics: Option<&mut dyn VmDiagnostics>,
     ) -> VmResult<GeneratorState> {
         if let ExecutionState::Resumed(out) = self.state {
-            vm_try!(out.store(self.head.as_mut().stack_mut(), Value::empty));
+            vm_try!(out.store(self.head.as_mut().stack_mut(), Value::unit));
         }
 
         self.inner_async_resume(diagnostics).await
@@ -262,7 +262,7 @@ where
                 VmHalt::Yielded(addr, out) => {
                     let value = match addr {
                         Some(addr) => vm_try!(vm.stack().at(addr)).clone(),
-                        None => vm_try!(Value::empty()),
+                        None => vm_try!(Value::unit()),
                     };
 
                     self.state = ExecutionState::Resumed(out);
@@ -294,7 +294,7 @@ where
             return VmResult::err(VmErrorKind::ExpectedExecutionState { actual: state });
         };
 
-        vm_try!(out.store(self.head.as_mut().stack_mut(), || VmResult::Ok(value)));
+        vm_try!(out.store(self.head.as_mut().stack_mut(), value));
         self.inner_resume(None)
     }
 
@@ -320,7 +320,7 @@ where
         diagnostics: Option<&mut dyn VmDiagnostics>,
     ) -> VmResult<GeneratorState> {
         if let ExecutionState::Resumed(out) = replace(&mut self.state, ExecutionState::Suspended) {
-            vm_try!(out.store(self.head.as_mut().stack_mut(), Value::empty()));
+            vm_try!(out.store(self.head.as_mut().stack_mut(), Value::unit()));
         }
 
         self.inner_resume(diagnostics)
@@ -351,7 +351,7 @@ where
                 VmHalt::Yielded(addr, out) => {
                     let value = match addr {
                         Some(addr) => vm_try!(vm.stack().at(addr)).clone(),
-                        None => vm_try!(Value::empty()),
+                        None => vm_try!(Value::unit()),
                     };
 
                     self.state = ExecutionState::Resumed(out);
@@ -448,7 +448,7 @@ where
 
         let value = match addr {
             Some(addr) => vm_try!(self.head.as_ref().stack().at(addr)).clone(),
-            None => vm_try!(Value::empty()),
+            None => vm_try!(Value::unit()),
         };
 
         debug_assert!(self.states.is_empty(), "Execution states should be empty");


### PR DESCRIPTION
This change improves performance across most of our benchmarks by around 10%.

The idea here is that we want `Value` to have a cheap, non-allocating empty implementation. When slots are initializing they are filled with these empty values and previously they would all have to be allocated.

This also means that dropping values does not require you to allocate a new value to replace it.

This change means that there is an empty value representation which is cheap to initialize and clone.