### PR TITLE
rune: Do not trace return value (causes panic on Result:Err)

### DIFF
--- a/crates/rune/src/runtime/vm.rs
+++ b/crates/rune/src/runtime/vm.rs
@@ -2239,7 +2239,7 @@ impl Vm {
     }
 
     #[inline]
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self, return_value))]
     fn op_return_internal(&mut self, return_value: Value) -> VmResult<Option<Output>> {
         let (exit, out) = vm_try!(self.pop_call_frame());
 


### PR DESCRIPTION
This is the fix for  #747 on the main branch (removal of instrumenting the return value). I left the instrument itself in, though this could be removed instead if it isn't useful to keep that around.