### PR TITLE
Fix formatting panic for 0.13.x

### DIFF
--- a/crates/rune/src/runtime/value.rs
+++ b/crates/rune/src/runtime/value.rs
@@ -2035,7 +2035,15 @@ impl fmt::Debug for Value {
                 let mut o = Formatter::new();
 
                 if value.string_debug(&mut o).is_err() {
-                    return Err(fmt::Error);
+                    match value.type_info() {
+                        VmResult::Ok(type_info) => {
+                            write!(f, "<{} object at {:p}>", type_info, value)?;
+                        }
+                        VmResult::Err(e) => {
+                            write!(f, "<unknown object at {:p}: {}>", value, e)?;
+                        }
+                    }
+                    return Ok(());
                 }
 
                 f.write_str(o.as_str())?;

--- a/crates/rune/src/runtime/vm.rs
+++ b/crates/rune/src/runtime/vm.rs
@@ -2058,7 +2058,7 @@ impl Vm {
     }
 
     #[inline]
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self, return_value))]
     fn op_return_internal(
         &mut self,
         return_value: Value,


### PR DESCRIPTION
Two commits are needed to fix this on 0.13:

* Do not trace return value (causes panic on `Result:Err`). This is a cherry pick from main
* Backport changes to `Value::string_debug_with`. This is manual backport of the way the code is now done in main and fixes the observed crash.

(fixes #747)