### PR TITLE
docs: Add missing docs for module(keep)

### DIFF
--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -581,7 +581,7 @@ pub(crate) use rune_macros::__internal_impl_any;
 ///
 /// By default, the name of the function is mangled and the metadata is given
 /// the original name. This means you can't easily call the function from both
-/// Rune and Rust. This behaviour can be changed by using the `keep` option, in
+/// Rune and Rust. This behaviour can be changed by using the `keep` attribute, in
 /// which case you must refer to the meta object by a mangled name
 /// (specifically the function name with `__meta` appended):
 ///

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -577,6 +577,34 @@ pub(crate) use rune_macros::__internal_impl_any;
 /// }
 /// ```
 ///
+/// # Using `keep` to keep the name
+///
+/// By default, the name of the function is mangled and the metadata is given
+/// the original name. This means you can't easily call the function from both
+/// Rune and Rust. This behaviour can be changed by using the `keep` option, in
+/// which case you must  refer to the meta object by a managled name
+/// (specifically the function name with `__meta` appended).:
+///
+/// ```
+/// use rune::{Module, ContextError};
+///
+/// /// Don't mangle the name of the function
+/// #[rune::function(keep)]
+/// fn to_uppercase(string: &str) -> String {
+///     string.to_uppercase()
+/// }
+///
+/// fn module() -> Result<Module, ContextError> {
+///     let mut m = Module::new();
+///     m.function_meta(to_uppercase__meta)?;
+///     Ok(m)
+/// }
+///
+/// fn call_from_rust() {
+///    assert_eq!(to_uppercase("hello"), "HELLO");
+/// }
+/// ```
+///
 /// [`VmResult`]: crate::runtime::VmResult
 /// [`vm_try!`]: crate::vm_try!
 pub use rune_macros::function;

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -583,7 +583,7 @@ pub(crate) use rune_macros::__internal_impl_any;
 /// the original name. This means you can't easily call the function from both
 /// Rune and Rust. This behaviour can be changed by using the `keep` option, in
 /// which case you must refer to the meta object by a mangled name
-/// (specifically the function name with `__meta` appended).:
+/// (specifically the function name with `__meta` appended):
 ///
 /// ```
 /// use rune::{Module, ContextError};

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -582,7 +582,7 @@ pub(crate) use rune_macros::__internal_impl_any;
 /// By default, the name of the function is mangled and the metadata is given
 /// the original name. This means you can't easily call the function from both
 /// Rune and Rust. This behaviour can be changed by using the `keep` option, in
-/// which case you must  refer to the meta object by a managled name
+/// which case you must refer to the meta object by a mangled name
 /// (specifically the function name with `__meta` appended).:
 ///
 /// ```


### PR DESCRIPTION
Fixes #754

I have not made any fix for 0.13. Don't know if we want to backport it (should be very simple if so)