### PR TITLE
Use less generics in protocols dispatch

### DIFF
--- a/crates/rune/src/hashbrown/table.rs
+++ b/crates/rune/src/hashbrown/table.rs
@@ -54,55 +54,55 @@ impl<V> Table<V> {
     }
 
     #[inline(always)]
-    pub(crate) fn insert_with<P>(
+    pub(crate) fn insert_with(
         &mut self,
         key: Value,
         value: V,
-        caller: &mut P,
-    ) -> VmResult<Option<V>>
-    where
-        P: ?Sized + ProtocolCaller,
-    {
+        caller: &mut dyn ProtocolCaller,
+    ) -> VmResult<Option<V>> {
         let hash = vm_try!(hash(&self.state, &key, caller));
 
-        let existing =
-            match self
-                .table
-                .find_or_find_insert_slot(caller, hash, eq(&key), hasher(&self.state))
-            {
-                Ok(bucket) => Some(mem::replace(unsafe { &mut bucket.as_mut().1 }, value)),
-                Err(ErrorOrInsertSlot::InsertSlot(slot)) => {
-                    unsafe {
-                        self.table.insert_in_slot(hash, slot, (key, value));
-                    }
-                    None
+        let existing = match self.table.find_or_find_insert_slot(
+            caller,
+            hash,
+            KeyEq::new(&key),
+            StateHasher::new(&self.state),
+        ) {
+            Ok(bucket) => Some(mem::replace(unsafe { &mut bucket.as_mut().1 }, value)),
+            Err(ErrorOrInsertSlot::InsertSlot(slot)) => {
+                unsafe {
+                    self.table.insert_in_slot(hash, slot, (key, value));
                 }
-                Err(ErrorOrInsertSlot::Error(error)) => return VmResult::err(error),
-            };
+                None
+            }
+            Err(ErrorOrInsertSlot::Error(error)) => return VmResult::err(error),
+        };
 
         VmResult::Ok(existing)
     }
 
-    pub(crate) fn get<P>(&self, key: &Value, caller: &mut P) -> VmResult<Option<&(Value, V)>>
-    where
-        P: ?Sized + ProtocolCaller,
-    {
+    pub(crate) fn get(
+        &self,
+        key: &Value,
+        caller: &mut dyn ProtocolCaller,
+    ) -> VmResult<Option<&(Value, V)>> {
         if self.table.is_empty() {
             return VmResult::Ok(None);
         }
 
         let hash = vm_try!(hash(&self.state, key, caller));
-        VmResult::Ok(vm_try!(self.table.get(caller, hash, eq(key))))
+        VmResult::Ok(vm_try!(self.table.get(caller, hash, KeyEq::new(key))))
     }
 
     #[inline(always)]
-    pub(crate) fn remove_with<P>(&mut self, key: &Value, caller: &mut P) -> VmResult<Option<V>>
-    where
-        P: ?Sized + ProtocolCaller,
-    {
+    pub(crate) fn remove_with(
+        &mut self,
+        key: &Value,
+        caller: &mut dyn ProtocolCaller,
+    ) -> VmResult<Option<V>> {
         let hash = vm_try!(hash(&self.state, key, caller));
 
-        match self.table.remove_entry(caller, hash, eq(key)) {
+        match self.table.remove_entry(caller, hash, KeyEq::new(key)) {
             Ok(value) => VmResult::Ok(value.map(|(_, value)| value)),
             Err(error) => VmResult::Err(error),
         }
@@ -260,7 +260,7 @@ where
 }
 
 /// Convenience function to hash a value.
-fn hash<S>(state: &S, value: &Value, caller: &mut impl ProtocolCaller) -> VmResult<u64>
+fn hash<S>(state: &S, value: &Value, caller: &mut dyn ProtocolCaller) -> VmResult<u64>
 where
     S: BuildHasher<Hasher = hash_map::Hasher>,
 {
@@ -269,22 +269,40 @@ where
     VmResult::Ok(hasher.finish())
 }
 
-/// Construct a hasher for a value in the table.
-fn hasher<P, V, S>(state: &S) -> impl Fn(&mut P, &(Value, V)) -> Result<u64, VmError> + '_
-where
-    P: ?Sized + ProtocolCaller,
-    S: BuildHasher<Hasher = hash_map::Hasher>,
-{
-    move |caller, (key, _): &(Value, V)| hash(state, key, caller).into_result()
+struct StateHasher<'a> {
+    state: &'a hash_map::RandomState,
+}
+
+impl<'a> StateHasher<'a> {
+    #[inline]
+    fn new(state: &'a hash_map::RandomState) -> Self {
+        Self { state }
+    }
+}
+
+impl<V> alloc::hashbrown::HasherFn<dyn ProtocolCaller, (Value, V), VmError> for StateHasher<'_> {
+    #[inline]
+    fn hash(&self, cx: &mut dyn ProtocolCaller, (key, _): &(Value, V)) -> Result<u64, VmError> {
+        hash(self.state, key, cx).into_result()
+    }
 }
 
 /// Construct an equality function for a value in the table that will compare an
 /// entry with the current key.
-fn eq<P, V>(key: &Value) -> impl Fn(&mut P, &(Value, V)) -> Result<bool, VmError> + '_
-where
-    P: ?Sized + ProtocolCaller,
-{
-    move |caller: &mut P, (other, _): &(Value, V)| -> Result<bool, VmError> {
-        key.eq_with(other, caller).into_result()
+struct KeyEq<'a> {
+    key: &'a Value,
+}
+
+impl<'a> KeyEq<'a> {
+    #[inline]
+    fn new(key: &'a Value) -> Self {
+        Self { key }
+    }
+}
+
+impl<V> alloc::hashbrown::EqFn<dyn ProtocolCaller, (Value, V), VmError> for KeyEq<'_> {
+    #[inline]
+    fn eq(&self, cx: &mut dyn ProtocolCaller, (other, _): &(Value, V)) -> Result<bool, VmError> {
+        self.key.eq_with(other, cx).into_result()
     }
 }

--- a/crates/rune/src/modules/collections/hash_map.rs
+++ b/crates/rune/src/modules/collections/hash_map.rs
@@ -377,10 +377,7 @@ impl HashMap {
         })
     }
 
-    pub(crate) fn from_iter<P>(mut it: Iterator, caller: &mut P) -> VmResult<Self>
-    where
-        P: ?Sized + ProtocolCaller,
-    {
+    pub(crate) fn from_iter(mut it: Iterator, caller: &mut dyn ProtocolCaller) -> VmResult<Self> {
         let mut map = Self::new();
 
         while let Some(value) = vm_try!(it.next()) {
@@ -472,7 +469,7 @@ impl HashMap {
     pub(crate) fn string_debug_with(
         &self,
         f: &mut Formatter,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<()> {
         vm_write!(f, "{{");
 
@@ -523,7 +520,7 @@ impl HashMap {
         self.partial_eq_with(other, &mut EnvProtocolCaller)
     }
 
-    fn partial_eq_with(&self, other: &Self, caller: &mut impl ProtocolCaller) -> VmResult<bool> {
+    fn partial_eq_with(&self, other: &Self, caller: &mut dyn ProtocolCaller) -> VmResult<bool> {
         if self.table.len() != other.table.len() {
             return VmResult::Ok(false);
         }

--- a/crates/rune/src/modules/collections/hash_set.rs
+++ b/crates/rune/src/modules/collections/hash_set.rs
@@ -403,7 +403,7 @@ impl HashSet {
         self.string_debug_with(f, &mut EnvProtocolCaller)
     }
 
-    fn string_debug_with(&self, f: &mut Formatter, _: &mut impl ProtocolCaller) -> VmResult<()> {
+    fn string_debug_with(&self, f: &mut Formatter, _: &mut dyn ProtocolCaller) -> VmResult<()> {
         vm_write!(f, "{{");
 
         let mut it = self.table.iter().peekable();
@@ -420,10 +420,7 @@ impl HashSet {
         VmResult::Ok(())
     }
 
-    pub(crate) fn from_iter<P>(mut it: Iterator, caller: &mut P) -> VmResult<Self>
-    where
-        P: ?Sized + ProtocolCaller,
-    {
+    pub(crate) fn from_iter(mut it: Iterator, caller: &mut dyn ProtocolCaller) -> VmResult<Self> {
         let mut set = vm_try!(Table::try_with_capacity(it.size_hint().0));
 
         while let Some(key) = vm_try!(it.next()) {

--- a/crates/rune/src/modules/collections/vec_deque.rs
+++ b/crates/rune/src/modules/collections/vec_deque.rs
@@ -558,7 +558,7 @@ impl VecDeque {
     fn string_debug_with(
         &self,
         f: &mut Formatter,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<()> {
         let mut it = self.inner.iter().peekable();
 
@@ -597,7 +597,7 @@ impl VecDeque {
         self.partial_eq_with(b, &mut EnvProtocolCaller)
     }
 
-    fn partial_eq_with(&self, b: Value, caller: &mut impl ProtocolCaller) -> VmResult<bool> {
+    fn partial_eq_with(&self, b: Value, caller: &mut dyn ProtocolCaller) -> VmResult<bool> {
         let mut b = vm_try!(b.into_iter_with(caller));
 
         for a in &self.inner {
@@ -635,7 +635,7 @@ impl VecDeque {
         self.eq_with(b, &mut EnvProtocolCaller)
     }
 
-    fn eq_with(&self, b: &VecDeque, caller: &mut impl ProtocolCaller) -> VmResult<bool> {
+    fn eq_with(&self, b: &VecDeque, caller: &mut dyn ProtocolCaller) -> VmResult<bool> {
         let mut b = b.inner.iter();
 
         for a in &self.inner {
@@ -675,7 +675,7 @@ impl VecDeque {
     fn partial_cmp_with(
         &self,
         b: &VecDeque,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<Option<Ordering>> {
         let mut b = b.inner.iter();
 
@@ -716,7 +716,7 @@ impl VecDeque {
         self.cmp_with(b, &mut EnvProtocolCaller)
     }
 
-    fn cmp_with(&self, other: &VecDeque, caller: &mut impl ProtocolCaller) -> VmResult<Ordering> {
+    fn cmp_with(&self, other: &VecDeque, caller: &mut dyn ProtocolCaller) -> VmResult<Ordering> {
         let mut b = other.inner.iter();
 
         for a in self.inner.iter() {

--- a/crates/rune/src/runtime.rs
+++ b/crates/rune/src/runtime.rs
@@ -12,6 +12,7 @@ pub use self::any_obj::{AnyObj, AnyObjError, AnyObjVtable};
 
 mod args;
 pub use self::args::Args;
+pub(crate) use self::args::{DynArgs, DynArgsUsed, DynGuardedArgs};
 
 mod awaited;
 pub(crate) use self::awaited::Awaited;

--- a/crates/rune/src/runtime/control_flow.rs
+++ b/crates/rune/src/runtime/control_flow.rs
@@ -37,7 +37,7 @@ impl ControlFlow {
     pub(crate) fn string_debug_with(
         &self,
         f: &mut Formatter,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<()> {
         match self {
             ControlFlow::Continue(value) => {
@@ -58,7 +58,7 @@ impl ControlFlow {
     pub(crate) fn partial_eq_with(
         &self,
         other: &Self,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<bool> {
         match (self, other) {
             (ControlFlow::Continue(a), ControlFlow::Continue(b)) => {
@@ -72,7 +72,7 @@ impl ControlFlow {
     pub(crate) fn eq_with(
         &self,
         other: &ControlFlow,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<bool> {
         match (self, other) {
             (ControlFlow::Continue(a), ControlFlow::Continue(b)) => Value::eq_with(a, b, caller),

--- a/crates/rune/src/runtime/format.rs
+++ b/crates/rune/src/runtime/format.rs
@@ -206,7 +206,7 @@ impl FormatSpec {
         &self,
         value: &Value,
         f: &mut Formatter,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<()> {
         match *vm_try!(value.borrow_kind_ref()) {
             ValueKind::Char(c) => {
@@ -239,7 +239,7 @@ impl FormatSpec {
         &self,
         value: &Value,
         f: &mut Formatter,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<()> {
         match *vm_try!(value.borrow_kind_ref()) {
             ValueKind::String(ref s) => {
@@ -329,7 +329,7 @@ impl FormatSpec {
         &self,
         value: &Value,
         f: &mut Formatter,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<()> {
         f.buf_mut().clear();
 

--- a/crates/rune/src/runtime/generator_state.rs
+++ b/crates/rune/src/runtime/generator_state.rs
@@ -72,7 +72,7 @@ impl GeneratorState {
     pub(crate) fn partial_eq_with(
         &self,
         other: &Self,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<bool> {
         match (self, other) {
             (GeneratorState::Yielded(a), GeneratorState::Yielded(b)) => {
@@ -85,7 +85,7 @@ impl GeneratorState {
         }
     }
 
-    pub(crate) fn eq_with(&self, other: &Self, caller: &mut impl ProtocolCaller) -> VmResult<bool> {
+    pub(crate) fn eq_with(&self, other: &Self, caller: &mut dyn ProtocolCaller) -> VmResult<bool> {
         match (self, other) {
             (GeneratorState::Yielded(a), GeneratorState::Yielded(b)) => {
                 Value::eq_with(a, b, caller)

--- a/crates/rune/src/runtime/object.rs
+++ b/crates/rune/src/runtime/object.rs
@@ -344,7 +344,7 @@ impl Object {
     pub(crate) fn partial_eq_with(
         a: &Self,
         b: Value,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<bool> {
         let mut b = vm_try!(b.into_iter());
 
@@ -371,15 +371,12 @@ impl Object {
         VmResult::Ok(true)
     }
 
-    pub(crate) fn eq_with<P>(
+    pub(crate) fn eq_with(
         a: &Self,
         b: &Self,
-        eq: fn(&Value, &Value, &mut P) -> VmResult<bool>,
-        caller: &mut P,
-    ) -> VmResult<bool>
-    where
-        P: ProtocolCaller,
-    {
+        eq: fn(&Value, &Value, &mut dyn ProtocolCaller) -> VmResult<bool>,
+        caller: &mut dyn ProtocolCaller,
+    ) -> VmResult<bool> {
         if a.inner.len() != b.inner.len() {
             return VmResult::Ok(false);
         }
@@ -400,7 +397,7 @@ impl Object {
     pub(crate) fn partial_cmp_with(
         a: &Self,
         b: &Self,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<Option<Ordering>> {
         let mut b = b.inner.iter();
 
@@ -430,7 +427,7 @@ impl Object {
     pub(crate) fn cmp_with(
         a: &Self,
         b: &Self,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<Ordering> {
         let mut b = b.inner.iter();
 

--- a/crates/rune/src/runtime/range.rs
+++ b/crates/rune/src/runtime/range.rs
@@ -166,7 +166,7 @@ impl Range {
     pub(crate) fn partial_eq_with(
         &self,
         b: &Self,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<bool> {
         if !vm_try!(Value::partial_eq_with(&self.start, &b.start, caller)) {
             return VmResult::Ok(false);
@@ -191,7 +191,7 @@ impl Range {
         self.eq_with(other, &mut EnvProtocolCaller)
     }
 
-    pub(crate) fn eq_with(&self, b: &Self, caller: &mut impl ProtocolCaller) -> VmResult<bool> {
+    pub(crate) fn eq_with(&self, b: &Self, caller: &mut dyn ProtocolCaller) -> VmResult<bool> {
         if !vm_try!(Value::eq_with(&self.start, &b.start, caller)) {
             return VmResult::Ok(false);
         }
@@ -217,7 +217,7 @@ impl Range {
     pub(crate) fn partial_cmp_with(
         &self,
         b: &Self,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<Option<Ordering>> {
         match vm_try!(Value::partial_cmp_with(&self.start, &b.start, caller)) {
             Some(Ordering::Equal) => (),
@@ -243,11 +243,7 @@ impl Range {
         self.cmp_with(other, &mut EnvProtocolCaller)
     }
 
-    pub(crate) fn cmp_with(
-        &self,
-        b: &Self,
-        caller: &mut impl ProtocolCaller,
-    ) -> VmResult<Ordering> {
+    pub(crate) fn cmp_with(&self, b: &Self, caller: &mut dyn ProtocolCaller) -> VmResult<Ordering> {
         match vm_try!(Value::cmp_with(&self.start, &b.start, caller)) {
             Ordering::Equal => (),
             other => return VmResult::Ok(other),
@@ -280,7 +276,7 @@ impl Range {
     pub(crate) fn contains_with(
         &self,
         value: Value,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<bool> {
         match vm_try!(Value::partial_cmp_with(&self.start, &value, caller)) {
             Some(Ordering::Less | Ordering::Equal) => {}

--- a/crates/rune/src/runtime/range_from.rs
+++ b/crates/rune/src/runtime/range_from.rs
@@ -156,7 +156,7 @@ impl RangeFrom {
     pub(crate) fn partial_eq_with(
         &self,
         b: &Self,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<bool> {
         Value::partial_eq_with(&self.start, &b.start, caller)
     }
@@ -177,7 +177,7 @@ impl RangeFrom {
         self.eq_with(other, &mut EnvProtocolCaller)
     }
 
-    pub(crate) fn eq_with(&self, b: &Self, caller: &mut impl ProtocolCaller) -> VmResult<bool> {
+    pub(crate) fn eq_with(&self, b: &Self, caller: &mut dyn ProtocolCaller) -> VmResult<bool> {
         Value::eq_with(&self.start, &b.start, caller)
     }
 
@@ -199,7 +199,7 @@ impl RangeFrom {
     pub(crate) fn partial_cmp_with(
         &self,
         b: &Self,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<Option<Ordering>> {
         Value::partial_cmp_with(&self.start, &b.start, caller)
     }
@@ -220,11 +220,7 @@ impl RangeFrom {
         self.cmp_with(other, &mut EnvProtocolCaller)
     }
 
-    pub(crate) fn cmp_with(
-        &self,
-        b: &Self,
-        caller: &mut impl ProtocolCaller,
-    ) -> VmResult<Ordering> {
+    pub(crate) fn cmp_with(&self, b: &Self, caller: &mut dyn ProtocolCaller) -> VmResult<Ordering> {
         Value::cmp_with(&self.start, &b.start, caller)
     }
 
@@ -252,7 +248,7 @@ impl RangeFrom {
     pub(crate) fn contains_with(
         &self,
         value: Value,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<bool> {
         VmResult::Ok(matches!(
             vm_try!(Value::partial_cmp_with(&self.start, &value, caller)),

--- a/crates/rune/src/runtime/range_full.rs
+++ b/crates/rune/src/runtime/range_full.rs
@@ -45,24 +45,24 @@ impl RangeFull {
     pub(crate) fn partial_eq_with(
         _: &Self,
         _: &Self,
-        _: &mut impl ProtocolCaller,
+        _: &mut dyn ProtocolCaller,
     ) -> VmResult<bool> {
         VmResult::Ok(true)
     }
 
-    pub(crate) fn eq_with(_: &Self, _: &Self, _: &mut impl ProtocolCaller) -> VmResult<bool> {
+    pub(crate) fn eq_with(_: &Self, _: &Self, _: &mut dyn ProtocolCaller) -> VmResult<bool> {
         VmResult::Ok(true)
     }
 
     pub(crate) fn partial_cmp_with(
         _: &Self,
         _: &Self,
-        _: &mut impl ProtocolCaller,
+        _: &mut dyn ProtocolCaller,
     ) -> VmResult<Option<Ordering>> {
         VmResult::Ok(Some(Ordering::Equal))
     }
 
-    pub(crate) fn cmp_with(_: &Self, _: &Self, _: &mut impl ProtocolCaller) -> VmResult<Ordering> {
+    pub(crate) fn cmp_with(_: &Self, _: &Self, _: &mut dyn ProtocolCaller) -> VmResult<Ordering> {
         VmResult::Ok(Ordering::Equal)
     }
 

--- a/crates/rune/src/runtime/range_inclusive.rs
+++ b/crates/rune/src/runtime/range_inclusive.rs
@@ -167,7 +167,7 @@ impl RangeInclusive {
     pub(crate) fn partial_eq_with(
         &self,
         b: &Self,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<bool> {
         if !vm_try!(Value::partial_eq_with(&self.start, &b.start, caller)) {
             return VmResult::Ok(false);
@@ -192,7 +192,7 @@ impl RangeInclusive {
         self.eq_with(other, &mut EnvProtocolCaller)
     }
 
-    pub(crate) fn eq_with(&self, b: &Self, caller: &mut impl ProtocolCaller) -> VmResult<bool> {
+    pub(crate) fn eq_with(&self, b: &Self, caller: &mut dyn ProtocolCaller) -> VmResult<bool> {
         if !vm_try!(Value::eq_with(&self.start, &b.start, caller)) {
             return VmResult::Ok(false);
         }
@@ -218,7 +218,7 @@ impl RangeInclusive {
     pub(crate) fn partial_cmp_with(
         &self,
         b: &Self,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<Option<Ordering>> {
         match vm_try!(Value::partial_cmp_with(&self.start, &b.start, caller)) {
             Some(Ordering::Equal) => (),
@@ -244,11 +244,7 @@ impl RangeInclusive {
         self.cmp_with(other, &mut EnvProtocolCaller)
     }
 
-    pub(crate) fn cmp_with(
-        &self,
-        b: &Self,
-        caller: &mut impl ProtocolCaller,
-    ) -> VmResult<Ordering> {
+    pub(crate) fn cmp_with(&self, b: &Self, caller: &mut dyn ProtocolCaller) -> VmResult<Ordering> {
         match vm_try!(Value::cmp_with(&self.start, &b.start, caller)) {
             Ordering::Equal => (),
             other => return VmResult::Ok(other),
@@ -281,7 +277,7 @@ impl RangeInclusive {
     pub(crate) fn contains_with(
         &self,
         value: Value,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<bool> {
         match vm_try!(Value::partial_cmp_with(&self.start, &value, caller)) {
             Some(Ordering::Less | Ordering::Equal) => {}

--- a/crates/rune/src/runtime/range_to.rs
+++ b/crates/rune/src/runtime/range_to.rs
@@ -78,7 +78,7 @@ impl RangeTo {
     pub(crate) fn partial_eq_with(
         &self,
         b: &Self,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<bool> {
         Value::partial_eq_with(&self.end, &b.end, caller)
     }
@@ -99,7 +99,7 @@ impl RangeTo {
         self.eq_with(other, &mut EnvProtocolCaller)
     }
 
-    pub(crate) fn eq_with(&self, b: &Self, caller: &mut impl ProtocolCaller) -> VmResult<bool> {
+    pub(crate) fn eq_with(&self, b: &Self, caller: &mut dyn ProtocolCaller) -> VmResult<bool> {
         Value::eq_with(&self.end, &b.end, caller)
     }
 
@@ -121,7 +121,7 @@ impl RangeTo {
     pub(crate) fn partial_cmp_with(
         &self,
         b: &Self,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<Option<Ordering>> {
         Value::partial_cmp_with(&self.end, &b.end, caller)
     }
@@ -142,11 +142,7 @@ impl RangeTo {
         self.cmp_with(other, &mut EnvProtocolCaller)
     }
 
-    pub(crate) fn cmp_with(
-        &self,
-        b: &Self,
-        caller: &mut impl ProtocolCaller,
-    ) -> VmResult<Ordering> {
+    pub(crate) fn cmp_with(&self, b: &Self, caller: &mut dyn ProtocolCaller) -> VmResult<Ordering> {
         Value::cmp_with(&self.end, &b.end, caller)
     }
 
@@ -174,7 +170,7 @@ impl RangeTo {
     pub(crate) fn contains_with(
         &self,
         value: Value,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<bool> {
         VmResult::Ok(matches!(
             vm_try!(Value::partial_cmp_with(&self.end, &value, caller)),

--- a/crates/rune/src/runtime/range_to_inclusive.rs
+++ b/crates/rune/src/runtime/range_to_inclusive.rs
@@ -76,7 +76,7 @@ impl RangeToInclusive {
     pub(crate) fn partial_eq_with(
         &self,
         b: &Self,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<bool> {
         Value::partial_eq_with(&self.end, &b.end, caller)
     }
@@ -97,7 +97,7 @@ impl RangeToInclusive {
         self.eq_with(other, &mut EnvProtocolCaller)
     }
 
-    pub(crate) fn eq_with(&self, b: &Self, caller: &mut impl ProtocolCaller) -> VmResult<bool> {
+    pub(crate) fn eq_with(&self, b: &Self, caller: &mut dyn ProtocolCaller) -> VmResult<bool> {
         Value::eq_with(&self.end, &b.end, caller)
     }
 
@@ -119,7 +119,7 @@ impl RangeToInclusive {
     pub(crate) fn partial_cmp_with(
         &self,
         b: &Self,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<Option<Ordering>> {
         Value::partial_cmp_with(&self.end, &b.end, caller)
     }
@@ -140,11 +140,7 @@ impl RangeToInclusive {
         self.cmp_with(other, &mut EnvProtocolCaller)
     }
 
-    pub(crate) fn cmp_with(
-        &self,
-        b: &Self,
-        caller: &mut impl ProtocolCaller,
-    ) -> VmResult<Ordering> {
+    pub(crate) fn cmp_with(&self, b: &Self, caller: &mut dyn ProtocolCaller) -> VmResult<Ordering> {
         Value::cmp_with(&self.end, &b.end, caller)
     }
 
@@ -172,7 +168,7 @@ impl RangeToInclusive {
     pub(crate) fn contains_with(
         &self,
         value: Value,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<bool> {
         VmResult::Ok(matches!(
             vm_try!(Value::partial_cmp_with(&self.end, &value, caller)),

--- a/crates/rune/src/runtime/tuple.rs
+++ b/crates/rune/src/runtime/tuple.rs
@@ -50,7 +50,7 @@ impl Tuple {
     pub(crate) fn hash_with(
         &self,
         hasher: &mut Hasher,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<()> {
         for value in self.values.iter() {
             vm_try!(value.hash_with(hasher, caller));

--- a/crates/rune/src/runtime/variant.rs
+++ b/crates/rune/src/runtime/variant.rs
@@ -64,7 +64,7 @@ impl Variant {
     pub(crate) fn partial_eq_with(
         a: &Self,
         b: &Self,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<bool> {
         debug_assert_eq!(
             a.rtti.enum_hash, b.rtti.enum_hash,
@@ -87,7 +87,7 @@ impl Variant {
         }
     }
 
-    pub(crate) fn eq_with(a: &Self, b: &Self, caller: &mut impl ProtocolCaller) -> VmResult<bool> {
+    pub(crate) fn eq_with(a: &Self, b: &Self, caller: &mut dyn ProtocolCaller) -> VmResult<bool> {
         debug_assert_eq!(
             a.rtti.enum_hash, b.rtti.enum_hash,
             "comparison only makes sense if enum hashes match"
@@ -112,7 +112,7 @@ impl Variant {
     pub(crate) fn partial_cmp_with(
         a: &Self,
         b: &Self,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<Option<Ordering>> {
         debug_assert_eq!(
             a.rtti.enum_hash, b.rtti.enum_hash,
@@ -137,7 +137,7 @@ impl Variant {
     pub(crate) fn cmp_with(
         a: &Self,
         b: &Self,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<Ordering> {
         debug_assert_eq!(
             a.rtti.enum_hash, b.rtti.enum_hash,

--- a/crates/rune/src/runtime/vec.rs
+++ b/crates/rune/src/runtime/vec.rs
@@ -220,7 +220,7 @@ impl Vec {
     pub(crate) fn string_debug_with(
         this: &[Value],
         f: &mut Formatter,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<()> {
         let mut it = this.iter().peekable();
         vm_write!(f, "[");
@@ -240,7 +240,7 @@ impl Vec {
     pub(crate) fn partial_eq_with(
         a: &[Value],
         b: Value,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<bool> {
         let mut b = vm_try!(b.into_iter_with(caller));
 
@@ -261,15 +261,12 @@ impl Vec {
         VmResult::Ok(true)
     }
 
-    pub(crate) fn eq_with<P>(
+    pub(crate) fn eq_with(
         a: &[Value],
         b: &[Value],
-        eq: fn(&Value, &Value, &mut P) -> VmResult<bool>,
-        caller: &mut P,
-    ) -> VmResult<bool>
-    where
-        P: ProtocolCaller,
-    {
+        eq: fn(&Value, &Value, &mut dyn ProtocolCaller) -> VmResult<bool>,
+        caller: &mut dyn ProtocolCaller,
+    ) -> VmResult<bool> {
         if a.len() != b.len() {
             return VmResult::Ok(false);
         }
@@ -286,7 +283,7 @@ impl Vec {
     pub(crate) fn partial_cmp_with(
         a: &[Value],
         b: &[Value],
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<Option<Ordering>> {
         let mut b = b.iter();
 
@@ -311,7 +308,7 @@ impl Vec {
     pub(crate) fn cmp_with(
         a: &[Value],
         b: &[Value],
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<Ordering> {
         let mut b = b.iter();
 
@@ -385,7 +382,7 @@ impl Vec {
     pub(crate) fn hash_with(
         &self,
         hasher: &mut Hasher,
-        caller: &mut impl ProtocolCaller,
+        caller: &mut dyn ProtocolCaller,
     ) -> VmResult<()> {
         for value in self.inner.iter() {
             vm_try!(value.hash_with(hasher, caller));

--- a/crates/rune/src/runtime/vm_error.rs
+++ b/crates/rune/src/runtime/vm_error.rs
@@ -11,8 +11,8 @@ use crate::compile::ItemBuf;
 use crate::hash::Hash;
 use crate::runtime::unit::{BadInstruction, BadJump};
 use crate::runtime::{
-    AccessError, AccessErrorKind, BoxedPanic, CallFrame, ExecutionState, FullTypeOf, MaybeTypeOf,
-    Panic, Protocol, SliceError, StackError, TypeInfo, TypeOf, Unit, Vm, VmHaltInfo,
+    AccessError, AccessErrorKind, BoxedPanic, CallFrame, DynArgsUsed, ExecutionState, FullTypeOf,
+    MaybeTypeOf, Panic, Protocol, SliceError, StackError, TypeInfo, TypeOf, Unit, Vm, VmHaltInfo,
 };
 
 /// A virtual machine error which includes tracing information.
@@ -542,6 +542,9 @@ pub(crate) enum VmErrorKind {
     BadJump {
         error: BadJump,
     },
+    DynArgsUsed {
+        error: DynArgsUsed,
+    },
     Panic {
         reason: Panic,
     },
@@ -752,6 +755,7 @@ impl fmt::Display for VmErrorKind {
             VmErrorKind::SliceError { error } => error.fmt(f),
             VmErrorKind::BadInstruction { error } => error.fmt(f),
             VmErrorKind::BadJump { error } => error.fmt(f),
+            VmErrorKind::DynArgsUsed { error } => error.fmt(f),
             VmErrorKind::Panic { reason } => write!(f, "Panicked: {reason}"),
             VmErrorKind::NoRunningVm {} => write!(f, "No running virtual machines"),
             VmErrorKind::Halted { halt } => write!(f, "Halted for unexpected reason `{halt}`"),
@@ -999,6 +1003,13 @@ impl From<BadJump> for VmErrorKind {
     #[inline]
     fn from(error: BadJump) -> Self {
         VmErrorKind::BadJump { error }
+    }
+}
+
+impl From<DynArgsUsed> for VmErrorKind {
+    #[inline]
+    fn from(error: DynArgsUsed) -> Self {
+        VmErrorKind::DynArgsUsed { error }
     }
 }
 


### PR DESCRIPTION
This improves compile times and reduces binary duplication.