### PR TITLE
Wrap arguments metadata for documentation in more complex types (relates #757)

### DIFF
--- a/crates/rune-alloc/src/fmt/mod.rs
+++ b/crates/rune-alloc/src/fmt/mod.rs
@@ -72,16 +72,19 @@ pub trait TryWrite {
 
     #[inline]
     #[doc(hidden)]
-    fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> Result<(), Error>
-    where
-        Self: Sized,
-    {
-        struct Writer<'a> {
-            target: &'a mut dyn TryWrite,
+    fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> Result<(), Error> {
+        struct Writer<'a, T>
+        where
+            T: ?Sized,
+        {
+            target: &'a mut T,
             error: Option<Error>,
         }
 
-        impl fmt::Write for Writer<'_> {
+        impl<T> fmt::Write for Writer<'_, T>
+        where
+            T: ?Sized + TryWrite,
+        {
             #[inline]
             fn write_str(&mut self, s: &str) -> fmt::Result {
                 if let Err(error) = (*self.target).try_write_str(s) {

--- a/crates/rune/src/compile/docs.rs
+++ b/crates/rune/src/compile/docs.rs
@@ -27,8 +27,8 @@ impl Docs {
 
     /// Get arguments associated with documentation.
     #[cfg(feature = "doc")]
-    pub(crate) fn args(&self) -> Option<&[String]> {
-        self.arguments.as_deref()
+    pub(crate) fn args(&self) -> &[String] {
+        self.arguments.as_deref().unwrap_or_default()
     }
 
     /// Get lines of documentation.

--- a/crates/rune/src/compile/meta.rs
+++ b/crates/rune/src/compile/meta.rs
@@ -320,15 +320,72 @@ pub struct Signature {
     /// An asynchronous function.
     #[cfg(feature = "doc")]
     pub(crate) is_async: bool,
-    /// Arguments.
+    /// Arguments to the function.
     #[cfg(feature = "doc")]
-    pub(crate) args: Option<usize>,
+    pub(crate) arguments: Option<Box<[DocArgument]>>,
     /// Return type of the function.
     #[cfg(feature = "doc")]
-    pub(crate) return_type: Option<Hash>,
-    /// Argument types to the function.
-    #[cfg(feature = "doc")]
-    pub(crate) argument_types: Box<[Option<Hash>]>,
+    pub(crate) return_type: DocType,
+}
+
+/// A name inside of a document.
+#[derive(Debug, TryClone)]
+#[cfg(feature = "doc")]
+pub(crate) enum DocName {
+    /// A string name.
+    Name(Box<str>),
+    /// A numbered name.
+    Index(#[try_clone(copy)] usize),
+}
+
+#[cfg(feature = "doc")]
+impl fmt::Display for DocName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DocName::Name(name) => write!(f, "{name}"),
+            DocName::Index(index) if *index == 0 => write!(f, "value"),
+            DocName::Index(index) => write!(f, "value{index}"),
+        }
+    }
+}
+
+/// A description of a type.
+#[derive(Debug, TryClone)]
+#[cfg(feature = "doc")]
+pub(crate) struct DocArgument {
+    /// The name of an argument.
+    pub(crate) name: DocName,
+    /// The base type.
+    pub(crate) base: Option<Hash>,
+    /// Generic parameters.
+    pub(crate) generics: Box<[DocType]>,
+}
+
+/// A description of a type.
+#[derive(Debug, TryClone)]
+#[cfg(feature = "doc")]
+pub(crate) struct DocType {
+    /// The base type.
+    pub(crate) base: Option<Hash>,
+    /// Generic parameters.
+    pub(crate) generics: Box<[DocType]>,
+}
+
+#[cfg(feature = "doc")]
+impl DocType {
+    pub(crate) fn new(base: Option<Hash>) -> Self {
+        Self {
+            base,
+            generics: Box::default(),
+        }
+    }
+
+    pub(crate) fn empty() -> Self {
+        Self {
+            base: None,
+            generics: Box::default(),
+        }
+    }
 }
 
 /// The kind of an associated function.

--- a/crates/rune/src/indexing.rs
+++ b/crates/rune/src/indexing.rs
@@ -67,11 +67,13 @@ pub(crate) enum FunctionAst {
 impl FunctionAst {
     /// Get the number of arguments for the function ast.
     #[cfg(feature = "doc")]
-    pub(crate) fn args(&self) -> usize {
-        match self {
-            FunctionAst::Empty(..) => 0,
-            FunctionAst::Item(ast) => ast.args.len(),
-        }
+    pub(crate) fn args(&self) -> impl ExactSizeIterator<Item = &dyn Spanned> {
+        let args = match self {
+            FunctionAst::Item(ast) => ast.args.as_slice(),
+            FunctionAst::Empty(..) => &[],
+        };
+
+        args.iter().map(|(arg, _)| -> &dyn Spanned { arg })
     }
 }
 

--- a/crates/rune/src/languageserver/completion.rs
+++ b/crates/rune/src/languageserver/completion.rs
@@ -116,11 +116,12 @@ pub(super) fn complete_native_instance_data(
         if n.starts_with(symbol) {
             let return_type = signature
                 .return_type
+                .base
                 .and_then(|hash| context.lookup_meta_by_hash(hash).next())
                 .and_then(|r| r.item.as_deref());
 
             let docs = meta.docs.lines().join("\n");
-            let args = meta.docs.args().unwrap_or_default().join(", ");
+            let args = meta.docs.args().join(", ");
 
             let detail = return_type.map(|r| format!("({args}) -> {r}"));
 
@@ -175,11 +176,12 @@ pub(super) fn complete_native_loose_data(
         if func_name.starts_with(symbol) {
             let return_type = signature
                 .return_type
+                .base
                 .and_then(|hash| context.lookup_meta_by_hash(hash).next())
                 .and_then(|r| r.item.as_deref());
 
             let docs = meta.docs.lines().join("\n");
-            let args = meta.docs.args().unwrap_or_default().join(", ");
+            let args = meta.docs.args().join(", ");
 
             let detail = return_type.map(|r| format!("({args}) -> {r}"));
 


### PR DESCRIPTION
This is a tricky bit that should clarify what is needed to implement #757.

Instead of having metadata spread over disparate fields, they're now unified in a handful of concise types that needs to be implemented and used when generating documentation.