### PR TITLE
rune: Collect generics for static types (relates #757)

### DIFF
--- a/crates/rune-macros/src/any.rs
+++ b/crates/rune-macros/src/any.rs
@@ -606,6 +606,15 @@ where
                     fn maybe_type_of() -> Option<#full_type_of> {
                         Some(<Self as #type_of>::type_of())
                     }
+
+                    #[inline]
+                    fn maybe_visit_generics<F, E>(f: &mut F) -> Result<(), E>
+                    where
+                        F: FnMut(Option<#full_type_of>) -> Result<(), E>
+                    {
+                        #(f(<#generic_names as #maybe_type_of>::maybe_type_of())?;)*
+                        Ok(())
+                    }
                 }
             })
         } else if let Some(ty) = attr.static_type {
@@ -628,6 +637,15 @@ where
                     #[inline]
                     fn maybe_type_of() -> Option<#full_type_of> {
                         Some(<Self as #type_of>::type_of())
+                    }
+
+                    #[inline]
+                    fn maybe_visit_generics<F, E>(f: &mut F) -> Result<(), E>
+                    where
+                        F: FnMut(Option<#full_type_of>) -> Result<(), E>
+                    {
+                        #(f(<#generic_names as #maybe_type_of>::maybe_type_of())?;)*
+                        Ok(())
                     }
                 }
             })

--- a/crates/rune/src/doc/build.rs
+++ b/crates/rune/src/doc/build.rs
@@ -646,11 +646,19 @@ impl<'m> Ctxt<'_, 'm> {
         let mut it = arguments.iter().peekable();
 
         while let Some(arg) = it.next() {
-            write!(string, "{}", arg.name)?;
+            if matches!(sig, Signature::Instance) && arg.name.is_self() {
+                if let Some(hash) = arg.base {
+                    self.write_link(&mut string, hash, Some("self"), &[])?;
+                } else {
+                    write!(string, "self")?;
+                }
+            } else {
+                write!(string, "{}", arg.name)?;
 
-            if let Some(hash) = arg.base {
-                string.try_push_str(": ")?;
-                self.write_link(&mut string, hash, None, &arg.generics)?;
+                if let Some(hash) = arg.base {
+                    string.try_push_str(": ")?;
+                    self.write_link(&mut string, hash, None, &arg.generics)?;
+                }
             }
 
             if it.peek().is_some() {

--- a/crates/rune/src/module/function_meta.rs
+++ b/crates/rune/src/module/function_meta.rs
@@ -57,9 +57,9 @@ pub struct FunctionData {
     #[cfg(feature = "doc")]
     pub(crate) args: Option<usize>,
     #[cfg(feature = "doc")]
-    pub(crate) return_type: Option<FullTypeOf>,
+    pub(crate) argument_types: Box<[meta::DocType]>,
     #[cfg(feature = "doc")]
-    pub(crate) argument_types: Box<[Option<FullTypeOf>]>,
+    pub(crate) return_type: meta::DocType,
 }
 
 impl FunctionData {
@@ -72,9 +72,9 @@ impl FunctionData {
             #[cfg(feature = "doc")]
             args: None,
             #[cfg(feature = "doc")]
-            return_type: None,
-            #[cfg(feature = "doc")]
             argument_types: Box::default(),
+            #[cfg(feature = "doc")]
+            return_type: meta::DocType::empty(),
         }
     }
 
@@ -97,9 +97,9 @@ impl FunctionData {
             #[cfg(feature = "doc")]
             args: Some(F::args()),
             #[cfg(feature = "doc")]
-            return_type: F::Return::maybe_type_of(),
-            #[cfg(feature = "doc")]
             argument_types: A::into_box()?,
+            #[cfg(feature = "doc")]
+            return_type: meta::DocType::from_maybe_type_of::<F::Return>()?,
         })
     }
 }
@@ -268,9 +268,9 @@ pub struct AssociatedFunctionData {
     #[cfg(feature = "doc")]
     pub(crate) args: Option<usize>,
     #[cfg(feature = "doc")]
-    pub(crate) return_type: Option<FullTypeOf>,
+    pub(crate) argument_types: Box<[meta::DocType]>,
     #[cfg(feature = "doc")]
-    pub(crate) argument_types: Box<[Option<FullTypeOf>]>,
+    pub(crate) return_type: meta::DocType,
 }
 
 impl AssociatedFunctionData {
@@ -283,9 +283,9 @@ impl AssociatedFunctionData {
             #[cfg(feature = "doc")]
             args: None,
             #[cfg(feature = "doc")]
-            return_type: None,
-            #[cfg(feature = "doc")]
             argument_types: Box::default(),
+            #[cfg(feature = "doc")]
+            return_type: meta::DocType::empty(),
         }
     }
 
@@ -307,9 +307,9 @@ impl AssociatedFunctionData {
             #[cfg(feature = "doc")]
             args: Some(F::args()),
             #[cfg(feature = "doc")]
-            return_type: F::Return::maybe_type_of(),
-            #[cfg(feature = "doc")]
             argument_types: A::into_box()?,
+            #[cfg(feature = "doc")]
+            return_type: meta::DocType::from_maybe_type_of::<F::Return>()?,
         })
     }
 
@@ -331,9 +331,9 @@ impl AssociatedFunctionData {
             #[cfg(feature = "doc")]
             args: Some(F::args()),
             #[cfg(feature = "doc")]
-            return_type: F::Return::maybe_type_of(),
-            #[cfg(feature = "doc")]
             argument_types: A::into_box()?,
+            #[cfg(feature = "doc")]
+            return_type: meta::DocType::from_maybe_type_of::<F::Return>()?,
         })
     }
 }
@@ -529,7 +529,7 @@ pub struct FunctionMetaData {
 #[doc(hidden)]
 pub trait FunctionArgs {
     #[doc(hidden)]
-    fn into_box() -> alloc::Result<Box<[Option<FullTypeOf>]>>;
+    fn into_box() -> alloc::Result<Box<[meta::DocType]>>;
 }
 
 macro_rules! iter_function_args {
@@ -540,8 +540,8 @@ macro_rules! iter_function_args {
         {
             #[inline]
             #[doc(hidden)]
-            fn into_box() -> alloc::Result<Box<[Option<FullTypeOf>]>> {
-                try_vec![$(<$ty>::maybe_type_of()),*].try_into_boxed_slice()
+            fn into_box() -> alloc::Result<Box<[meta::DocType]>> {
+                try_vec![$(meta::DocType::from_maybe_type_of::<$ty>()?),*].try_into_boxed_slice()
             }
         }
     }

--- a/crates/rune/src/module/function_traits.rs
+++ b/crates/rune/src/module/function_traits.rs
@@ -144,6 +144,14 @@ where
     fn maybe_type_of() -> Option<FullTypeOf> {
         T::maybe_type_of()
     }
+
+    #[inline]
+    fn maybe_visit_generics<F, E>(f: &mut F) -> Result<(), E>
+    where
+        F: FnMut(Option<FullTypeOf>) -> Result<(), E>,
+    {
+        T::maybe_visit_generics(f)
+    }
 }
 
 impl<T> TypeOf for Ref<T>
@@ -181,6 +189,14 @@ where
     #[inline]
     fn maybe_type_of() -> Option<FullTypeOf> {
         T::maybe_type_of()
+    }
+
+    #[inline]
+    fn maybe_visit_generics<F, E>(f: &mut F) -> Result<(), E>
+    where
+        F: FnMut(Option<FullTypeOf>) -> Result<(), E>,
+    {
+        T::maybe_visit_generics(f)
     }
 }
 

--- a/crates/rune/src/runtime/any_obj.rs
+++ b/crates/rune/src/runtime/any_obj.rs
@@ -514,8 +514,17 @@ impl AnyObj {
 }
 
 impl MaybeTypeOf for AnyObj {
+    #[inline]
     fn maybe_type_of() -> Option<FullTypeOf> {
         None
+    }
+
+    #[inline]
+    fn maybe_visit_generics<F, E>(_f: &mut F) -> Result<(), E>
+    where
+        F: FnMut(Option<FullTypeOf>) -> Result<(), E>,
+    {
+        Ok(())
     }
 }
 

--- a/crates/rune/src/runtime/type_of.rs
+++ b/crates/rune/src/runtime/type_of.rs
@@ -29,6 +29,11 @@ pub trait TypeOf {
 pub trait MaybeTypeOf {
     /// Type information for the given type.
     fn maybe_type_of() -> Option<FullTypeOf>;
+
+    /// Visit generic parameters.
+    fn maybe_visit_generics<F, E>(f: &mut F) -> Result<(), E>
+    where
+        F: FnMut(Option<FullTypeOf>) -> Result<(), E>;
 }
 
 impl<T> MaybeTypeOf for &T
@@ -38,6 +43,14 @@ where
     #[inline]
     fn maybe_type_of() -> Option<FullTypeOf> {
         T::maybe_type_of()
+    }
+
+    #[inline]
+    fn maybe_visit_generics<F, E>(f: &mut F) -> Result<(), E>
+    where
+        F: FnMut(Option<FullTypeOf>) -> Result<(), E>,
+    {
+        T::maybe_visit_generics(f)
     }
 }
 
@@ -49,6 +62,14 @@ where
     fn maybe_type_of() -> Option<FullTypeOf> {
         T::maybe_type_of()
     }
+
+    #[inline]
+    fn maybe_visit_generics<F, E>(f: &mut F) -> Result<(), E>
+    where
+        F: FnMut(Option<FullTypeOf>) -> Result<(), E>,
+    {
+        T::maybe_visit_generics(f)
+    }
 }
 
 impl<T> MaybeTypeOf for Ref<T>
@@ -58,6 +79,14 @@ where
     #[inline]
     fn maybe_type_of() -> Option<FullTypeOf> {
         T::maybe_type_of()
+    }
+
+    #[inline]
+    fn maybe_visit_generics<F, E>(f: &mut F) -> Result<(), E>
+    where
+        F: FnMut(Option<FullTypeOf>) -> Result<(), E>,
+    {
+        T::maybe_visit_generics(f)
     }
 }
 
@@ -69,6 +98,14 @@ where
     fn maybe_type_of() -> Option<FullTypeOf> {
         T::maybe_type_of()
     }
+
+    #[inline]
+    fn maybe_visit_generics<F, E>(f: &mut F) -> Result<(), E>
+    where
+        F: FnMut(Option<FullTypeOf>) -> Result<(), E>,
+    {
+        T::maybe_visit_generics(f)
+    }
 }
 
 impl<T> MaybeTypeOf for Shared<T>
@@ -78,6 +115,14 @@ where
     #[inline]
     fn maybe_type_of() -> Option<FullTypeOf> {
         T::maybe_type_of()
+    }
+
+    #[inline]
+    fn maybe_visit_generics<F, E>(f: &mut F) -> Result<(), E>
+    where
+        F: FnMut(Option<FullTypeOf>) -> Result<(), E>,
+    {
+        T::maybe_visit_generics(f)
     }
 }
 

--- a/crates/rune/src/runtime/value.rs
+++ b/crates/rune/src/runtime/value.rs
@@ -2320,6 +2320,14 @@ impl MaybeTypeOf for Value {
     fn maybe_type_of() -> Option<FullTypeOf> {
         None
     }
+
+    #[inline]
+    fn maybe_visit_generics<F, E>(_: &mut F) -> Result<(), E>
+    where
+        F: FnMut(Option<FullTypeOf>) -> Result<(), E>,
+    {
+        Ok(())
+    }
 }
 
 impl TryClone for Value {

--- a/crates/rune/src/runtime/vm_error.rs
+++ b/crates/rune/src/runtime/vm_error.rs
@@ -373,6 +373,14 @@ where
     fn maybe_type_of() -> Option<FullTypeOf> {
         T::maybe_type_of()
     }
+
+    #[inline]
+    fn maybe_visit_generics<F, E>(f: &mut F) -> Result<(), E>
+    where
+        F: FnMut(Option<FullTypeOf>) -> Result<(), E>,
+    {
+        T::maybe_visit_generics(f)
+    }
 }
 
 cfg_std! {

--- a/crates/rune/src/tests/bug_344.rs
+++ b/crates/rune/src/tests/bug_344.rs
@@ -198,6 +198,14 @@ impl MaybeTypeOf for GuardCheck {
     fn maybe_type_of() -> Option<FullTypeOf> {
         Some(Self::type_of())
     }
+
+    #[inline]
+    fn maybe_visit_generics<F, E>(_: &mut F) -> Result<(), E>
+    where
+        F: FnMut(Option<FullTypeOf>) -> Result<(), E>,
+    {
+        Ok(())
+    }
 }
 
 impl InstallWith for GuardCheck {}


### PR DESCRIPTION
Relates: #757

This picks up one level of static generics (deeper levels should be fixed):

![image](https://github.com/user-attachments/assets/e23e8d3a-2ed9-4ec9-83a0-9292ed05b5ab)

However, we don't have a way to render tuples, especially the empty tuple could use some love:

![image](https://github.com/user-attachments/assets/535d222d-5d7e-45cc-bd34-1b657c568d1b)
