### PR TITLE
doc: Render tuples correctly

### DIFF
--- a/crates/rune/src/doc/build/type_.rs
+++ b/crates/rune/src/doc/build/type_.rs
@@ -5,7 +5,7 @@ use crate::alloc::borrow::Cow;
 use crate::alloc::fmt::TryWrite;
 use crate::alloc::prelude::*;
 use crate::alloc::{String, Vec};
-use crate::compile::{meta, ComponentRef, Item};
+use crate::compile::{ComponentRef, Item};
 use crate::doc::build::{Builder, Ctxt, IndexEntry, IndexKind};
 use crate::doc::context::{Assoc, AssocFnKind, Meta};
 
@@ -110,12 +110,7 @@ pub(super) fn build_assoc_fns<'m>(
                             name,
                             args: cx.args_to_string(sig, assoc.arguments)?,
                             parameters,
-                            return_type: match assoc.return_type {
-                                meta::DocType { base, generics, .. } if !base.is_empty() => {
-                                    Some(cx.link(*base, None, generics)?)
-                                }
-                                _ => None,
-                            },
+                            return_type: cx.return_type(assoc.return_type)?,
                             line_doc,
                             doc,
                         })?;
@@ -140,12 +135,7 @@ pub(super) fn build_assoc_fns<'m>(
                     name: protocol.name,
                     field,
                     repr,
-                    return_type: match assoc.return_type {
-                        meta::DocType { base, generics, .. } if !base.is_empty() => {
-                            Some(cx.link(*base, None, generics)?)
-                        }
-                        _ => None,
-                    },
+                    return_type: cx.return_type(assoc.return_type)?,
                     doc,
                     deprecated: assoc.deprecated,
                 })?;


### PR DESCRIPTION
Fixes #757 since this is basically all I think we can do now.

This ensures that tuples are rendered as we'd expect them to be rendered:
![image](https://github.com/user-attachments/assets/f0f02981-bc5c-4d9b-b15b-97ddf24879f5)

Empty tuples as return values are rendered like this:
![image](https://github.com/user-attachments/assets/e43bc17b-055d-4b62-b51e-277bee7568dd)

I also added `String::split_once` since it's a method which uses a combination of Option + tuple types to render the documentation.