### PR TITLE
doc: Render the `any` type explicitly

### DIFF
--- a/crates/rune/src/doc/static/runedoc.css.hbs
+++ b/crates/rune/src/doc/static/runedoc.css.hbs
@@ -5,6 +5,7 @@
     --link-color: #d2991d;
     --headings-border-bottom-color: #d2d2d2;
     --type-link-color: #2dbfb8;
+    --any-color: #c03bca;
     --fn-link-color: #2bab63;
     --method-link-color: #2bab63;
     --macro-link-color: #09bd00;
@@ -283,6 +284,10 @@ a {
 
 .protocol {
     color: var(--fn-link-color);
+}
+
+.any {
+    color: var(--any-color);
 }
 
 .item-title {

--- a/crates/rune/src/modules/char.rs
+++ b/crates/rune/src/modules/char.rs
@@ -58,8 +58,8 @@ fn from_i64(value: i64) -> VmResult<Option<Value>> {
 /// assert_eq!(c.to_i64(), 80);
 /// ```
 #[rune::function(instance)]
-fn to_i64(value: char) -> VmResult<Value> {
-    VmResult::Ok(vm_try!(Value::try_from(value as i64)))
+fn to_i64(value: char) -> VmResult<i64> {
+    VmResult::Ok(value as i64)
 }
 
 /// Returns `true` if this `char` has the `Alphabetic` property.


### PR DESCRIPTION
Relates #757

This ensures that if any dynamic type is supported by a method, it will be indicated using the new `any` placeholder.

![image](https://github.com/user-attachments/assets/a579d09c-5315-409c-b332-648633363e3d)

This solves an ambiguity in documentation so we can differentiate between methods which return `()` (empty tuple) and any value like `clone` above.

Eventually with gradual typing this is expected to become a proper `any` type that can be used which essentially disables type checking.

Once it is a proper type it should also be documented.