### PR TITLE
doc: Fix rendering of custom links

### DIFF
--- a/crates/rune/src/doc/build.rs
+++ b/crates/rune/src/doc/build.rs
@@ -420,7 +420,7 @@ impl<'m> Ctxt<'_, 'm> {
         match *ty {
             meta::DocType {
                 base, ref generics, ..
-            } if base == static_type::TUPLE_TYPE.hash && generics.is_empty() => Ok(None),
+            } if static_type::TUPLE == base && generics.is_empty() => Ok(None),
             meta::DocType {
                 base, ref generics, ..
             } => Ok(Some(self.link(base, None, generics)?)),
@@ -591,7 +591,7 @@ impl<'m> Ctxt<'_, 'm> {
             return Ok(());
         };
 
-        if hash == static_type::TUPLE_TYPE.hash && text.is_none() {
+        if static_type::TUPLE == hash && text.is_none() {
             write!(o, "(")?;
             self.write_generics(o, generics)?;
             write!(o, ")")?;

--- a/crates/rune/src/module/module.rs
+++ b/crates/rune/src/module/module.rs
@@ -716,7 +716,7 @@ impl Module {
     {
         let mut enum_ = InternalEnum::new(
             "GeneratorState",
-            crate::runtime::static_type::GENERATOR_STATE_TYPE,
+            crate::runtime::static_type::GENERATOR_STATE,
         );
 
         // Note: these numeric variants are magic, and must simply match up with
@@ -756,7 +756,7 @@ impl Module {
     where
         N: IntoComponent,
     {
-        let mut enum_ = InternalEnum::new("Option", crate::runtime::static_type::OPTION_TYPE);
+        let mut enum_ = InternalEnum::new("Option", crate::runtime::static_type::OPTION);
 
         // Note: these numeric variants are magic, and must simply match up with
         // what's being used in the virtual machine implementation for these
@@ -790,7 +790,7 @@ impl Module {
     where
         N: IntoComponent,
     {
-        let mut enum_ = InternalEnum::new("Result", crate::runtime::static_type::RESULT_TYPE);
+        let mut enum_ = InternalEnum::new("Result", crate::runtime::static_type::RESULT);
 
         // Note: these numeric variants are magic, and must simply match up with
         // what's being used in the virtual machine implementation for these

--- a/crates/rune/src/runtime/bytes.rs
+++ b/crates/rune/src/runtime/bytes.rs
@@ -17,7 +17,7 @@ use crate::Any;
 
 /// A vector of bytes.
 #[derive(Default, Any, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[rune(builtin, static_type = BYTES_TYPE)]
+#[rune(builtin, static_type = BYTES)]
 pub struct Bytes {
     pub(crate) bytes: Vec<u8>,
 }

--- a/crates/rune/src/runtime/const_value.rs
+++ b/crates/rune/src/runtime/const_value.rs
@@ -98,18 +98,18 @@ impl ConstValue {
     /// Get the type information of the value.
     pub fn type_info(&self) -> TypeInfo {
         match self {
-            Self::EmptyTuple => TypeInfo::StaticType(crate::runtime::static_type::TUPLE_TYPE),
-            Self::Byte(..) => TypeInfo::StaticType(crate::runtime::static_type::BYTE_TYPE),
-            Self::Char(..) => TypeInfo::StaticType(crate::runtime::static_type::CHAR_TYPE),
-            Self::Bool(..) => TypeInfo::StaticType(crate::runtime::static_type::BOOL_TYPE),
-            Self::String(..) => TypeInfo::StaticType(crate::runtime::static_type::STRING_TYPE),
-            Self::Bytes(..) => TypeInfo::StaticType(crate::runtime::static_type::BYTES_TYPE),
-            Self::Integer(..) => TypeInfo::StaticType(crate::runtime::static_type::INTEGER_TYPE),
-            Self::Float(..) => TypeInfo::StaticType(crate::runtime::static_type::FLOAT_TYPE),
-            Self::Vec(..) => TypeInfo::StaticType(crate::runtime::static_type::VEC_TYPE),
-            Self::Tuple(..) => TypeInfo::StaticType(crate::runtime::static_type::TUPLE_TYPE),
-            Self::Object(..) => TypeInfo::StaticType(crate::runtime::static_type::OBJECT_TYPE),
-            Self::Option(..) => TypeInfo::StaticType(crate::runtime::static_type::OPTION_TYPE),
+            Self::EmptyTuple => TypeInfo::StaticType(crate::runtime::static_type::TUPLE),
+            Self::Byte(..) => TypeInfo::StaticType(crate::runtime::static_type::BYTE),
+            Self::Char(..) => TypeInfo::StaticType(crate::runtime::static_type::CHAR),
+            Self::Bool(..) => TypeInfo::StaticType(crate::runtime::static_type::BOOL),
+            Self::String(..) => TypeInfo::StaticType(crate::runtime::static_type::STRING),
+            Self::Bytes(..) => TypeInfo::StaticType(crate::runtime::static_type::BYTES),
+            Self::Integer(..) => TypeInfo::StaticType(crate::runtime::static_type::INTEGER),
+            Self::Float(..) => TypeInfo::StaticType(crate::runtime::static_type::FLOAT),
+            Self::Vec(..) => TypeInfo::StaticType(crate::runtime::static_type::VEC),
+            Self::Tuple(..) => TypeInfo::StaticType(crate::runtime::static_type::TUPLE),
+            Self::Object(..) => TypeInfo::StaticType(crate::runtime::static_type::OBJECT),
+            Self::Option(..) => TypeInfo::StaticType(crate::runtime::static_type::OPTION),
         }
     }
 }

--- a/crates/rune/src/runtime/control_flow.rs
+++ b/crates/rune/src/runtime/control_flow.rs
@@ -23,7 +23,7 @@ use crate::Any;
 #[derive(Debug, Clone, TryClone, Any)]
 #[rune(crate)]
 #[try_clone(crate)]
-#[rune(builtin, static_type = CONTROL_FLOW_TYPE)]
+#[rune(builtin, static_type = CONTROL_FLOW)]
 pub enum ControlFlow {
     /// Move on to the next phase of the operation as normal.
     #[rune(constructor)]

--- a/crates/rune/src/runtime/format.rs
+++ b/crates/rune/src/runtime/format.rs
@@ -41,7 +41,7 @@ impl fmt::Display for AlignmentFromStrError {
 
 /// A format specification, wrapping an inner value.
 #[derive(Any, Debug, Clone, TryClone)]
-#[rune(builtin, static_type = FORMAT_TYPE)]
+#[rune(builtin, static_type = FORMAT)]
 pub struct Format {
     /// The value being formatted.
     pub(crate) value: Value,

--- a/crates/rune/src/runtime/function.rs
+++ b/crates/rune/src/runtime/function.rs
@@ -44,7 +44,7 @@ use crate::Hash;
 /// ```
 #[derive(Any, TryClone)]
 #[repr(transparent)]
-#[rune(builtin, static_type = FUNCTION_TYPE)]
+#[rune(builtin, static_type = FUNCTION)]
 pub struct Function(FunctionImpl<Value>);
 
 impl Function {

--- a/crates/rune/src/runtime/future.rs
+++ b/crates/rune/src/runtime/future.rs
@@ -16,7 +16,7 @@ type DynFuture = dyn future::Future<Output = VmResult<Value>> + 'static;
 /// the virtual machine that created it.
 #[derive(Any)]
 #[rune(crate)]
-#[rune(builtin, static_type = FUTURE_TYPE)]
+#[rune(builtin, static_type = FUTURE)]
 #[rune(from_value = Value::into_future)]
 pub struct Future {
     future: Option<Pin<Box<DynFuture>>>,

--- a/crates/rune/src/runtime/generator.rs
+++ b/crates/rune/src/runtime/generator.rs
@@ -24,7 +24,7 @@ use crate::Any;
 /// ```
 #[derive(Any)]
 #[rune(crate)]
-#[rune(builtin, static_type = GENERATOR_TYPE, from_value_params = [Vm])]
+#[rune(builtin, static_type = GENERATOR, from_value_params = [Vm])]
 #[rune(from_value = Value::into_generator, from_value_ref = Value::into_generator_ref, from_value_mut = Value::into_generator_mut)]
 pub struct Generator<T>
 where

--- a/crates/rune/src/runtime/generator_state.rs
+++ b/crates/rune/src/runtime/generator_state.rs
@@ -50,7 +50,7 @@ use crate::Any;
 /// # Ok::<_, rune::support::Error>(())
 /// ```
 #[derive(Any, Debug, TryClone)]
-#[rune(builtin, static_type = GENERATOR_STATE_TYPE)]
+#[rune(builtin, static_type = GENERATOR_STATE)]
 pub enum GeneratorState {
     /// The generator yielded.
     Yielded(Value),

--- a/crates/rune/src/runtime/iterator.rs
+++ b/crates/rune/src/runtime/iterator.rs
@@ -74,7 +74,7 @@ macro_rules! maybe {
 
 /// An owning iterator.
 #[derive(Any)]
-#[rune(builtin, static_type = ITERATOR_TYPE)]
+#[rune(builtin, static_type = ITERATOR)]
 #[rune(from_value = Value::into_iterator, from_value_ref = Value::into_iterator_ref, from_value_mut = Value::into_iterator_mut)]
 pub struct Iterator {
     iter: IterRepr,

--- a/crates/rune/src/runtime/object.rs
+++ b/crates/rune/src/runtime/object.rs
@@ -81,7 +81,7 @@ pub type Values<'a> = hash_map::Values<'a, String, Value>;
 /// ```
 #[derive(Any, Default)]
 #[repr(transparent)]
-#[rune(builtin, static_type = OBJECT_TYPE)]
+#[rune(builtin, static_type = OBJECT)]
 pub struct Object {
     inner: HashMap<String, Value>,
 }

--- a/crates/rune/src/runtime/range.rs
+++ b/crates/rune/src/runtime/range.rs
@@ -55,7 +55,7 @@ use crate::Any;
 /// ```
 #[derive(Any, Clone, TryClone)]
 #[try_clone(crate)]
-#[rune(builtin, constructor, static_type = RANGE_TYPE)]
+#[rune(builtin, constructor, static_type = RANGE)]
 #[rune(from_value = Value::into_range, from_value_ref = Value::into_range_ref, from_value_mut = Value::into_range_mut)]
 pub struct Range {
     /// The start value of the range.

--- a/crates/rune/src/runtime/range_from.rs
+++ b/crates/rune/src/runtime/range_from.rs
@@ -52,7 +52,7 @@ use crate::Any;
 /// ```
 #[derive(Any, Clone, TryClone)]
 #[try_clone(crate)]
-#[rune(builtin, constructor, static_type = RANGE_FROM_TYPE)]
+#[rune(builtin, constructor, static_type = RANGE_FROM)]
 #[rune(from_value = Value::into_range_from, from_value_ref = Value::into_range_from_ref, from_value_mut = Value::into_range_from_mut)]
 pub struct RangeFrom {
     /// The start value of the range.

--- a/crates/rune/src/runtime/range_full.rs
+++ b/crates/rune/src/runtime/range_full.rs
@@ -32,7 +32,7 @@ use crate::Any;
 /// ```
 #[derive(Any, Default, Clone, TryClone)]
 #[try_clone(crate)]
-#[rune(builtin, constructor, static_type = RANGE_FULL_TYPE)]
+#[rune(builtin, constructor, static_type = RANGE_FULL)]
 #[rune(from_value = Value::into_range_full, from_value_ref = Value::into_range_full_ref, from_value_mut = Value::into_range_full_mut)]
 pub struct RangeFull;
 

--- a/crates/rune/src/runtime/range_inclusive.rs
+++ b/crates/rune/src/runtime/range_inclusive.rs
@@ -56,7 +56,7 @@ use crate::Any;
 /// ```
 #[derive(Any, Clone, TryClone)]
 #[try_clone(crate)]
-#[rune(builtin, constructor, static_type = RANGE_INCLUSIVE_TYPE)]
+#[rune(builtin, constructor, static_type = RANGE_INCLUSIVE)]
 #[rune(from_value = Value::into_range_inclusive, from_value_ref = Value::into_range_inclusive_ref, from_value_mut = Value::into_range_inclusive_mut)]
 pub struct RangeInclusive {
     /// The start value of the range.

--- a/crates/rune/src/runtime/range_to.rs
+++ b/crates/rune/src/runtime/range_to.rs
@@ -42,7 +42,7 @@ use crate::Any;
 #[derive(Any, Clone, TryClone)]
 #[try_clone(crate)]
 #[rune(crate)]
-#[rune(builtin, constructor, static_type = RANGE_TO_TYPE)]
+#[rune(builtin, constructor, static_type = RANGE_TO)]
 #[rune(from_value = Value::into_range_to, from_value_ref = Value::into_range_to_ref, from_value_mut = Value::into_range_to_mut)]
 pub struct RangeTo {
     /// The end value of the range.

--- a/crates/rune/src/runtime/range_to_inclusive.rs
+++ b/crates/rune/src/runtime/range_to_inclusive.rs
@@ -40,7 +40,7 @@ use crate::Any;
 /// # Ok::<_, rune::support::Error>(())
 /// ```
 #[derive(Any, Clone, TryClone)]
-#[rune(builtin, constructor, static_type = RANGE_TO_INCLUSIVE_TYPE)]
+#[rune(builtin, constructor, static_type = RANGE_TO_INCLUSIVE)]
 #[rune(from_value = Value::into_range_to_inclusive, from_value_ref = Value::into_range_to_inclusive_ref, from_value_mut = Value::into_range_to_inclusive_mut)]
 pub struct RangeToInclusive {
     /// The end value of the range.

--- a/crates/rune/src/runtime/static_type.rs
+++ b/crates/rune/src/runtime/static_type.rs
@@ -34,6 +34,12 @@ impl PartialEq for &'static StaticType {
 
 impl Eq for &'static StaticType {}
 
+impl PartialEq<Hash> for &'static StaticType {
+    fn eq(&self, other: &Hash) -> bool {
+        self.hash == *other
+    }
+}
+
 impl hash::Hash for &'static StaticType {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         self.hash.hash(state)
@@ -41,206 +47,206 @@ impl hash::Hash for &'static StaticType {
 }
 
 /// Hash for `::std::u8`.
-pub(crate) const BYTE_TYPE_HASH: Hash = ::rune_macros::hash!(::std::u8);
+pub(crate) const BYTE_HASH: Hash = ::rune_macros::hash!(::std::u8);
 
 /// The specialized type information for a byte type.
-pub(crate) static BYTE_TYPE: &StaticType = &StaticType {
+pub(crate) static BYTE: &StaticType = &StaticType {
     name: RawStr::from_str("u8"),
-    hash: BYTE_TYPE_HASH,
+    hash: BYTE_HASH,
 };
 
-impl_static_type!(u8 => BYTE_TYPE);
+impl_static_type!(u8 => BYTE);
 
 /// The specialized type information for a bool type.
-pub(crate) static BOOL_TYPE: &StaticType = &StaticType {
+pub(crate) static BOOL: &StaticType = &StaticType {
     name: RawStr::from_str("bool"),
     hash: ::rune_macros::hash!(::std::bool),
 };
 
-impl_static_type!(bool => BOOL_TYPE);
+impl_static_type!(bool => BOOL);
 
 /// The specialized type information for a char type.
-pub(crate) static CHAR_TYPE: &StaticType = &StaticType {
+pub(crate) static CHAR: &StaticType = &StaticType {
     name: RawStr::from_str("char"),
     hash: ::rune_macros::hash!(::std::char),
 };
 
-impl_static_type!(char => CHAR_TYPE);
+impl_static_type!(char => CHAR);
 
 /// Hash for `::std::i64`.
-pub(crate) const INTEGER_TYPE_HASH: Hash = ::rune_macros::hash!(::std::i64);
+pub(crate) const INTEGER_HASH: Hash = ::rune_macros::hash!(::std::i64);
 
 /// The specialized type information for a integer type.
-pub(crate) static INTEGER_TYPE: &StaticType = &StaticType {
+pub(crate) static INTEGER: &StaticType = &StaticType {
     name: RawStr::from_str("i64"),
-    hash: INTEGER_TYPE_HASH,
+    hash: INTEGER_HASH,
 };
 
-impl_static_type!(i8 => INTEGER_TYPE);
-// NB: u8 is its own BYTE_TYPE
-impl_static_type!(u16 => INTEGER_TYPE);
-impl_static_type!(i16 => INTEGER_TYPE);
-impl_static_type!(u32 => INTEGER_TYPE);
-impl_static_type!(i32 => INTEGER_TYPE);
-impl_static_type!(u64 => INTEGER_TYPE);
-impl_static_type!(i64 => INTEGER_TYPE);
-impl_static_type!(u128 => INTEGER_TYPE);
-impl_static_type!(i128 => INTEGER_TYPE);
-impl_static_type!(usize => INTEGER_TYPE);
-impl_static_type!(isize => INTEGER_TYPE);
+impl_static_type!(i8 => INTEGER);
+// NB: u8 is its own type BYTE.
+impl_static_type!(u16 => INTEGER);
+impl_static_type!(i16 => INTEGER);
+impl_static_type!(u32 => INTEGER);
+impl_static_type!(i32 => INTEGER);
+impl_static_type!(u64 => INTEGER);
+impl_static_type!(i64 => INTEGER);
+impl_static_type!(u128 => INTEGER);
+impl_static_type!(i128 => INTEGER);
+impl_static_type!(usize => INTEGER);
+impl_static_type!(isize => INTEGER);
 
 /// Hash for `::std::f64`.
-pub(crate) const FLOAT_TYPE_HASH: Hash = ::rune_macros::hash!(::std::f64);
+pub(crate) const FLOAT_HASH: Hash = ::rune_macros::hash!(::std::f64);
 
-pub(crate) static FLOAT_TYPE: &StaticType = &StaticType {
+pub(crate) static FLOAT: &StaticType = &StaticType {
     name: RawStr::from_str("f64"),
-    hash: FLOAT_TYPE_HASH,
+    hash: FLOAT_HASH,
 };
 
-impl_static_type!(f32 => FLOAT_TYPE);
-impl_static_type!(f64 => FLOAT_TYPE);
+impl_static_type!(f32 => FLOAT);
+impl_static_type!(f64 => FLOAT);
 
-pub(crate) static STRING_TYPE: &StaticType = &StaticType {
+pub(crate) static STRING: &StaticType = &StaticType {
     name: RawStr::from_str("String"),
     hash: ::rune_macros::hash!(::std::string::String),
 };
 
 #[cfg(feature = "alloc")]
-impl_static_type!(::rust_alloc::string::String => STRING_TYPE);
-impl_static_type!(alloc::String => STRING_TYPE);
-impl_static_type!(str => STRING_TYPE);
+impl_static_type!(::rust_alloc::string::String => STRING);
+impl_static_type!(alloc::String => STRING);
+impl_static_type!(str => STRING);
 
-pub(crate) static BYTES_TYPE: &StaticType = &StaticType {
+pub(crate) static BYTES: &StaticType = &StaticType {
     name: RawStr::from_str("Bytes"),
     hash: ::rune_macros::hash!(::std::bytes::Bytes),
 };
 
-impl_static_type!([u8] => BYTES_TYPE);
+impl_static_type!([u8] => BYTES);
 
-pub(crate) static VEC_TYPE: &StaticType = &StaticType {
+pub(crate) static VEC: &StaticType = &StaticType {
     name: RawStr::from_str("Vec"),
     hash: ::rune_macros::hash!(::std::vec::Vec),
 };
 
-impl_static_type!([rt::Value] => VEC_TYPE);
+impl_static_type!([rt::Value] => VEC);
 #[cfg(feature = "alloc")]
-impl_static_type!(impl<T> ::rust_alloc::vec::Vec<T> => VEC_TYPE);
-impl_static_type!(impl<T> alloc::Vec<T> => VEC_TYPE);
-impl_static_type!(impl<T> rt::VecTuple<T> => VEC_TYPE);
+impl_static_type!(impl<T> ::rust_alloc::vec::Vec<T> => VEC);
+impl_static_type!(impl<T> alloc::Vec<T> => VEC);
+impl_static_type!(impl<T> rt::VecTuple<T> => VEC);
 
-pub(crate) static TUPLE_TYPE: &StaticType = &StaticType {
+pub(crate) static TUPLE: &StaticType = &StaticType {
     name: RawStr::from_str("Tuple"),
     hash: ::rune_macros::hash!(::std::tuple::Tuple),
 };
 
-impl_static_type!(rt::OwnedTuple => TUPLE_TYPE);
+impl_static_type!(rt::OwnedTuple => TUPLE);
 
-pub(crate) static OBJECT_TYPE: &StaticType = &StaticType {
+pub(crate) static OBJECT: &StaticType = &StaticType {
     name: RawStr::from_str("Object"),
     hash: ::rune_macros::hash!(::std::object::Object),
 };
 
-impl_static_type!(rt::Struct => OBJECT_TYPE);
-impl_static_type!(impl<T> HashMap<::rust_alloc::string::String, T> => OBJECT_TYPE);
-impl_static_type!(impl<T> HashMap<alloc::String, T> => OBJECT_TYPE);
+impl_static_type!(rt::Struct => OBJECT);
+impl_static_type!(impl<T> HashMap<::rust_alloc::string::String, T> => OBJECT);
+impl_static_type!(impl<T> HashMap<alloc::String, T> => OBJECT);
 
 cfg_std! {
-    impl_static_type!(impl<T> ::std::collections::HashMap<::rust_alloc::string::String, T> => OBJECT_TYPE);
-    impl_static_type!(impl<T> ::std::collections::HashMap<alloc::String, T> => OBJECT_TYPE);
+    impl_static_type!(impl<T> ::std::collections::HashMap<::rust_alloc::string::String, T> => OBJECT);
+    impl_static_type!(impl<T> ::std::collections::HashMap<alloc::String, T> => OBJECT);
 }
 
-pub(crate) static RANGE_FROM_TYPE: &StaticType = &StaticType {
+pub(crate) static RANGE_FROM: &StaticType = &StaticType {
     name: RawStr::from_str("RangeFrom"),
     hash: ::rune_macros::hash!(::std::ops::RangeFrom),
 };
 
-pub(crate) static RANGE_FULL_TYPE: &StaticType = &StaticType {
+pub(crate) static RANGE_FULL: &StaticType = &StaticType {
     name: RawStr::from_str("RangeFull"),
     hash: ::rune_macros::hash!(::std::ops::RangeFull),
 };
 
-pub(crate) static RANGE_INCLUSIVE_TYPE: &StaticType = &StaticType {
+pub(crate) static RANGE_INCLUSIVE: &StaticType = &StaticType {
     name: RawStr::from_str("RangeInclusive"),
     hash: ::rune_macros::hash!(::std::ops::RangeInclusive),
 };
 
-pub(crate) static RANGE_TO_INCLUSIVE_TYPE: &StaticType = &StaticType {
+pub(crate) static RANGE_TO_INCLUSIVE: &StaticType = &StaticType {
     name: RawStr::from_str("RangeToInclusive"),
     hash: ::rune_macros::hash!(::std::ops::RangeToInclusive),
 };
 
-pub(crate) static RANGE_TO_TYPE: &StaticType = &StaticType {
+pub(crate) static RANGE_TO: &StaticType = &StaticType {
     name: RawStr::from_str("RangeTo"),
     hash: ::rune_macros::hash!(::std::ops::RangeTo),
 };
 
-pub(crate) static RANGE_TYPE: &StaticType = &StaticType {
+pub(crate) static RANGE: &StaticType = &StaticType {
     name: RawStr::from_str("Range"),
     hash: ::rune_macros::hash!(::std::ops::Range),
 };
 
-pub(crate) static CONTROL_FLOW_TYPE: &StaticType = &StaticType {
+pub(crate) static CONTROL_FLOW: &StaticType = &StaticType {
     name: RawStr::from_str("ControlFlow"),
     hash: ::rune_macros::hash!(::std::ops::ControlFlow),
 };
 
-impl_static_type!(impl<C, B> ControlFlow<C, B> => CONTROL_FLOW_TYPE);
+impl_static_type!(impl<C, B> ControlFlow<C, B> => CONTROL_FLOW);
 
-pub(crate) static FUTURE_TYPE: &StaticType = &StaticType {
+pub(crate) static FUTURE: &StaticType = &StaticType {
     name: RawStr::from_str("Future"),
     hash: ::rune_macros::hash!(::std::future::Future),
 };
 
-pub(crate) static GENERATOR_TYPE: &StaticType = &StaticType {
+pub(crate) static GENERATOR: &StaticType = &StaticType {
     name: RawStr::from_str("Generator"),
     hash: ::rune_macros::hash!(::std::ops::Generator),
 };
 
-pub(crate) static GENERATOR_STATE_TYPE: &StaticType = &StaticType {
+pub(crate) static GENERATOR_STATE: &StaticType = &StaticType {
     name: RawStr::from_str("GeneratorState"),
     hash: ::rune_macros::hash!(::std::ops::GeneratorState),
 };
 
-pub(crate) static STREAM_TYPE: &StaticType = &StaticType {
+pub(crate) static STREAM: &StaticType = &StaticType {
     name: RawStr::from_str("Stream"),
     hash: ::rune_macros::hash!(::std::stream::Stream),
 };
 
-pub(crate) static RESULT_TYPE: &StaticType = &StaticType {
+pub(crate) static RESULT: &StaticType = &StaticType {
     name: RawStr::from_str("Result"),
     hash: ::rune_macros::hash!(::std::result::Result),
 };
 
-impl_static_type!(impl<T, E> Result<T, E> => RESULT_TYPE);
+impl_static_type!(impl<T, E> Result<T, E> => RESULT);
 
-pub(crate) static OPTION_TYPE: &StaticType = &StaticType {
+pub(crate) static OPTION: &StaticType = &StaticType {
     name: RawStr::from_str("Option"),
     hash: ::rune_macros::hash!(::std::option::Option),
 };
 
-impl_static_type!(impl<T> Option<T> => OPTION_TYPE);
+impl_static_type!(impl<T> Option<T> => OPTION);
 
-pub(crate) static FUNCTION_TYPE: &StaticType = &StaticType {
+pub(crate) static FUNCTION: &StaticType = &StaticType {
     name: RawStr::from_str("Function"),
     hash: ::rune_macros::hash!(::std::ops::Function),
 };
 
-pub(crate) static FORMAT_TYPE: &StaticType = &StaticType {
+pub(crate) static FORMAT: &StaticType = &StaticType {
     name: RawStr::from_str("Format"),
     hash: ::rune_macros::hash!(::std::fmt::Format),
 };
 
-pub(crate) static ITERATOR_TYPE: &StaticType = &StaticType {
+pub(crate) static ITERATOR: &StaticType = &StaticType {
     name: RawStr::from_str("Iterator"),
     hash: ::rune_macros::hash!(::std::iter::Iterator),
 };
 
-pub(crate) static ORDERING_TYPE: &StaticType = &StaticType {
+pub(crate) static ORDERING: &StaticType = &StaticType {
     name: RawStr::from_str("Ordering"),
     hash: ::rune_macros::hash!(::std::cmp::Ordering),
 };
 
-impl_static_type!(Ordering => ORDERING_TYPE);
+impl_static_type!(Ordering => ORDERING);
 
 pub(crate) static TYPE: &StaticType = &StaticType {
     name: RawStr::from_str("Type"),

--- a/crates/rune/src/runtime/stream.rs
+++ b/crates/rune/src/runtime/stream.rs
@@ -7,7 +7,7 @@ use crate::Any;
 /// A stream with a stored virtual machine.
 #[derive(Any)]
 #[rune(crate)]
-#[rune(builtin, static_type = STREAM_TYPE, from_value_params = [Vm])]
+#[rune(builtin, static_type = STREAM, from_value_params = [Vm])]
 #[rune(from_value = Value::into_stream, from_value_ref = Value::into_stream_ref, from_value_mut = Value::into_stream_mut)]
 pub struct Stream<T>
 where

--- a/crates/rune/src/runtime/tuple.rs
+++ b/crates/rune/src/runtime/tuple.rs
@@ -15,7 +15,7 @@ use crate::Any;
 
 /// The type of a tuple slice.
 #[derive(Any)]
-#[rune(builtin, static_type = TUPLE_TYPE)]
+#[rune(builtin, static_type = TUPLE)]
 #[repr(transparent)]
 pub struct Tuple {
     values: [Value],
@@ -289,7 +289,7 @@ impl FromValue for OwnedTuple {
 macro_rules! impl_tuple {
     // Skip conflicting implementation with `()`.
     (0) => {
-        impl_static_type!(() => crate::runtime::static_type::TUPLE_TYPE);
+        impl_static_type!(() => crate::runtime::static_type::TUPLE);
 
         impl FromValue for () {
             fn from_value(value: Value) -> VmResult<Self> {
@@ -305,7 +305,7 @@ macro_rules! impl_tuple {
     };
 
     ($count:expr $(, $ty:ident $var:ident $ignore_count:expr)*) => {
-        impl_static_type!(impl <$($ty),*> ($($ty,)*) => crate::runtime::static_type::TUPLE_TYPE);
+        impl_static_type!(impl <$($ty),*> ($($ty,)*) => crate::runtime::static_type::TUPLE);
 
         impl <$($ty,)*> FromValue for ($($ty,)*)
         where

--- a/crates/rune/src/runtime/value.rs
+++ b/crates/rune/src/runtime/value.rs
@@ -2361,9 +2361,9 @@ impl TypeValue {
     #[doc(hidden)]
     pub fn type_info(&self) -> TypeInfo {
         match self {
-            TypeValue::EmptyTuple => TypeInfo::StaticType(crate::runtime::static_type::TUPLE_TYPE),
-            TypeValue::Tuple(..) => TypeInfo::StaticType(crate::runtime::static_type::TUPLE_TYPE),
-            TypeValue::Object(..) => TypeInfo::StaticType(crate::runtime::static_type::OBJECT_TYPE),
+            TypeValue::EmptyTuple => TypeInfo::StaticType(crate::runtime::static_type::TUPLE),
+            TypeValue::Tuple(..) => TypeInfo::StaticType(crate::runtime::static_type::TUPLE),
+            TypeValue::Object(..) => TypeInfo::StaticType(crate::runtime::static_type::OBJECT),
             TypeValue::EmptyStruct(empty) => empty.type_info(),
             TypeValue::TupleStruct(tuple) => tuple.type_info(),
             TypeValue::Struct(object) => object.type_info(),
@@ -2449,59 +2449,49 @@ pub(crate) enum ValueKind {
 impl ValueKind {
     pub(crate) fn type_info(&self) -> TypeInfo {
         match self {
-            ValueKind::Bool(..) => TypeInfo::StaticType(crate::runtime::static_type::BOOL_TYPE),
-            ValueKind::Byte(..) => TypeInfo::StaticType(crate::runtime::static_type::BYTE_TYPE),
-            ValueKind::Char(..) => TypeInfo::StaticType(crate::runtime::static_type::CHAR_TYPE),
-            ValueKind::Integer(..) => {
-                TypeInfo::StaticType(crate::runtime::static_type::INTEGER_TYPE)
-            }
-            ValueKind::Float(..) => TypeInfo::StaticType(crate::runtime::static_type::FLOAT_TYPE),
+            ValueKind::Bool(..) => TypeInfo::StaticType(crate::runtime::static_type::BOOL),
+            ValueKind::Byte(..) => TypeInfo::StaticType(crate::runtime::static_type::BYTE),
+            ValueKind::Char(..) => TypeInfo::StaticType(crate::runtime::static_type::CHAR),
+            ValueKind::Integer(..) => TypeInfo::StaticType(crate::runtime::static_type::INTEGER),
+            ValueKind::Float(..) => TypeInfo::StaticType(crate::runtime::static_type::FLOAT),
             ValueKind::Type(..) => TypeInfo::StaticType(crate::runtime::static_type::TYPE),
-            ValueKind::Ordering(..) => {
-                TypeInfo::StaticType(crate::runtime::static_type::ORDERING_TYPE)
-            }
-            ValueKind::String(..) => TypeInfo::StaticType(crate::runtime::static_type::STRING_TYPE),
-            ValueKind::Bytes(..) => TypeInfo::StaticType(crate::runtime::static_type::BYTES_TYPE),
-            ValueKind::Vec(..) => TypeInfo::StaticType(crate::runtime::static_type::VEC_TYPE),
-            ValueKind::EmptyTuple => TypeInfo::StaticType(crate::runtime::static_type::TUPLE_TYPE),
-            ValueKind::Tuple(..) => TypeInfo::StaticType(crate::runtime::static_type::TUPLE_TYPE),
-            ValueKind::Object(..) => TypeInfo::StaticType(crate::runtime::static_type::OBJECT_TYPE),
+            ValueKind::Ordering(..) => TypeInfo::StaticType(crate::runtime::static_type::ORDERING),
+            ValueKind::String(..) => TypeInfo::StaticType(crate::runtime::static_type::STRING),
+            ValueKind::Bytes(..) => TypeInfo::StaticType(crate::runtime::static_type::BYTES),
+            ValueKind::Vec(..) => TypeInfo::StaticType(crate::runtime::static_type::VEC),
+            ValueKind::EmptyTuple => TypeInfo::StaticType(crate::runtime::static_type::TUPLE),
+            ValueKind::Tuple(..) => TypeInfo::StaticType(crate::runtime::static_type::TUPLE),
+            ValueKind::Object(..) => TypeInfo::StaticType(crate::runtime::static_type::OBJECT),
             ValueKind::RangeFrom(..) => {
-                TypeInfo::StaticType(crate::runtime::static_type::RANGE_FROM_TYPE)
+                TypeInfo::StaticType(crate::runtime::static_type::RANGE_FROM)
             }
             ValueKind::RangeFull(..) => {
-                TypeInfo::StaticType(crate::runtime::static_type::RANGE_FULL_TYPE)
+                TypeInfo::StaticType(crate::runtime::static_type::RANGE_FULL)
             }
             ValueKind::RangeInclusive(..) => {
-                TypeInfo::StaticType(crate::runtime::static_type::RANGE_INCLUSIVE_TYPE)
+                TypeInfo::StaticType(crate::runtime::static_type::RANGE_INCLUSIVE)
             }
             ValueKind::RangeToInclusive(..) => {
-                TypeInfo::StaticType(crate::runtime::static_type::RANGE_TO_INCLUSIVE_TYPE)
+                TypeInfo::StaticType(crate::runtime::static_type::RANGE_TO_INCLUSIVE)
             }
-            ValueKind::RangeTo(..) => {
-                TypeInfo::StaticType(crate::runtime::static_type::RANGE_TO_TYPE)
-            }
-            ValueKind::Range(..) => TypeInfo::StaticType(crate::runtime::static_type::RANGE_TYPE),
+            ValueKind::RangeTo(..) => TypeInfo::StaticType(crate::runtime::static_type::RANGE_TO),
+            ValueKind::Range(..) => TypeInfo::StaticType(crate::runtime::static_type::RANGE),
             ValueKind::ControlFlow(..) => {
-                TypeInfo::StaticType(crate::runtime::static_type::CONTROL_FLOW_TYPE)
+                TypeInfo::StaticType(crate::runtime::static_type::CONTROL_FLOW)
             }
-            ValueKind::Future(..) => TypeInfo::StaticType(crate::runtime::static_type::FUTURE_TYPE),
-            ValueKind::Stream(..) => TypeInfo::StaticType(crate::runtime::static_type::STREAM_TYPE),
+            ValueKind::Future(..) => TypeInfo::StaticType(crate::runtime::static_type::FUTURE),
+            ValueKind::Stream(..) => TypeInfo::StaticType(crate::runtime::static_type::STREAM),
             ValueKind::Generator(..) => {
-                TypeInfo::StaticType(crate::runtime::static_type::GENERATOR_TYPE)
+                TypeInfo::StaticType(crate::runtime::static_type::GENERATOR)
             }
             ValueKind::GeneratorState(..) => {
-                TypeInfo::StaticType(crate::runtime::static_type::GENERATOR_STATE_TYPE)
+                TypeInfo::StaticType(crate::runtime::static_type::GENERATOR_STATE)
             }
-            ValueKind::Option(..) => TypeInfo::StaticType(crate::runtime::static_type::OPTION_TYPE),
-            ValueKind::Result(..) => TypeInfo::StaticType(crate::runtime::static_type::RESULT_TYPE),
-            ValueKind::Function(..) => {
-                TypeInfo::StaticType(crate::runtime::static_type::FUNCTION_TYPE)
-            }
-            ValueKind::Format(..) => TypeInfo::StaticType(crate::runtime::static_type::FORMAT_TYPE),
-            ValueKind::Iterator(..) => {
-                TypeInfo::StaticType(crate::runtime::static_type::ITERATOR_TYPE)
-            }
+            ValueKind::Option(..) => TypeInfo::StaticType(crate::runtime::static_type::OPTION),
+            ValueKind::Result(..) => TypeInfo::StaticType(crate::runtime::static_type::RESULT),
+            ValueKind::Function(..) => TypeInfo::StaticType(crate::runtime::static_type::FUNCTION),
+            ValueKind::Format(..) => TypeInfo::StaticType(crate::runtime::static_type::FORMAT),
+            ValueKind::Iterator(..) => TypeInfo::StaticType(crate::runtime::static_type::ITERATOR),
             ValueKind::EmptyStruct(empty) => empty.type_info(),
             ValueKind::TupleStruct(tuple) => tuple.type_info(),
             ValueKind::Struct(object) => object.type_info(),
@@ -2516,37 +2506,35 @@ impl ValueKind {
     /// *enum*, and not the type hash of the variant itself.
     pub(crate) fn type_hash(&self) -> Hash {
         match self {
-            ValueKind::Bool(..) => crate::runtime::static_type::BOOL_TYPE.hash,
-            ValueKind::Byte(..) => crate::runtime::static_type::BYTE_TYPE.hash,
-            ValueKind::Char(..) => crate::runtime::static_type::CHAR_TYPE.hash,
-            ValueKind::Integer(..) => crate::runtime::static_type::INTEGER_TYPE.hash,
-            ValueKind::Float(..) => crate::runtime::static_type::FLOAT_TYPE.hash,
+            ValueKind::Bool(..) => crate::runtime::static_type::BOOL.hash,
+            ValueKind::Byte(..) => crate::runtime::static_type::BYTE.hash,
+            ValueKind::Char(..) => crate::runtime::static_type::CHAR.hash,
+            ValueKind::Integer(..) => crate::runtime::static_type::INTEGER.hash,
+            ValueKind::Float(..) => crate::runtime::static_type::FLOAT.hash,
             ValueKind::Type(..) => crate::runtime::static_type::TYPE.hash,
-            ValueKind::Ordering(..) => crate::runtime::static_type::ORDERING_TYPE.hash,
-            ValueKind::String(..) => crate::runtime::static_type::STRING_TYPE.hash,
-            ValueKind::Bytes(..) => crate::runtime::static_type::BYTES_TYPE.hash,
-            ValueKind::Vec(..) => crate::runtime::static_type::VEC_TYPE.hash,
-            ValueKind::EmptyTuple => crate::runtime::static_type::TUPLE_TYPE.hash,
-            ValueKind::Tuple(..) => crate::runtime::static_type::TUPLE_TYPE.hash,
-            ValueKind::Object(..) => crate::runtime::static_type::OBJECT_TYPE.hash,
-            ValueKind::RangeFrom(..) => crate::runtime::static_type::RANGE_FROM_TYPE.hash,
-            ValueKind::RangeFull(..) => crate::runtime::static_type::RANGE_FULL_TYPE.hash,
-            ValueKind::RangeInclusive(..) => crate::runtime::static_type::RANGE_INCLUSIVE_TYPE.hash,
-            ValueKind::RangeToInclusive(..) => {
-                crate::runtime::static_type::RANGE_TO_INCLUSIVE_TYPE.hash
-            }
-            ValueKind::RangeTo(..) => crate::runtime::static_type::RANGE_TO_TYPE.hash,
-            ValueKind::Range(..) => crate::runtime::static_type::RANGE_TYPE.hash,
-            ValueKind::ControlFlow(..) => crate::runtime::static_type::CONTROL_FLOW_TYPE.hash,
-            ValueKind::Future(..) => crate::runtime::static_type::FUTURE_TYPE.hash,
-            ValueKind::Stream(..) => crate::runtime::static_type::STREAM_TYPE.hash,
-            ValueKind::Generator(..) => crate::runtime::static_type::GENERATOR_TYPE.hash,
-            ValueKind::GeneratorState(..) => crate::runtime::static_type::GENERATOR_STATE_TYPE.hash,
-            ValueKind::Result(..) => crate::runtime::static_type::RESULT_TYPE.hash,
-            ValueKind::Option(..) => crate::runtime::static_type::OPTION_TYPE.hash,
-            ValueKind::Function(..) => crate::runtime::static_type::FUNCTION_TYPE.hash,
-            ValueKind::Format(..) => crate::runtime::static_type::FORMAT_TYPE.hash,
-            ValueKind::Iterator(..) => crate::runtime::static_type::ITERATOR_TYPE.hash,
+            ValueKind::Ordering(..) => crate::runtime::static_type::ORDERING.hash,
+            ValueKind::String(..) => crate::runtime::static_type::STRING.hash,
+            ValueKind::Bytes(..) => crate::runtime::static_type::BYTES.hash,
+            ValueKind::Vec(..) => crate::runtime::static_type::VEC.hash,
+            ValueKind::EmptyTuple => crate::runtime::static_type::TUPLE.hash,
+            ValueKind::Tuple(..) => crate::runtime::static_type::TUPLE.hash,
+            ValueKind::Object(..) => crate::runtime::static_type::OBJECT.hash,
+            ValueKind::RangeFrom(..) => crate::runtime::static_type::RANGE_FROM.hash,
+            ValueKind::RangeFull(..) => crate::runtime::static_type::RANGE_FULL.hash,
+            ValueKind::RangeInclusive(..) => crate::runtime::static_type::RANGE_INCLUSIVE.hash,
+            ValueKind::RangeToInclusive(..) => crate::runtime::static_type::RANGE_TO_INCLUSIVE.hash,
+            ValueKind::RangeTo(..) => crate::runtime::static_type::RANGE_TO.hash,
+            ValueKind::Range(..) => crate::runtime::static_type::RANGE.hash,
+            ValueKind::ControlFlow(..) => crate::runtime::static_type::CONTROL_FLOW.hash,
+            ValueKind::Future(..) => crate::runtime::static_type::FUTURE.hash,
+            ValueKind::Stream(..) => crate::runtime::static_type::STREAM.hash,
+            ValueKind::Generator(..) => crate::runtime::static_type::GENERATOR.hash,
+            ValueKind::GeneratorState(..) => crate::runtime::static_type::GENERATOR_STATE.hash,
+            ValueKind::Result(..) => crate::runtime::static_type::RESULT.hash,
+            ValueKind::Option(..) => crate::runtime::static_type::OPTION.hash,
+            ValueKind::Function(..) => crate::runtime::static_type::FUNCTION.hash,
+            ValueKind::Format(..) => crate::runtime::static_type::FORMAT.hash,
+            ValueKind::Iterator(..) => crate::runtime::static_type::ITERATOR.hash,
             ValueKind::EmptyStruct(empty) => empty.rtti.hash,
             ValueKind::TupleStruct(tuple) => tuple.rtti.hash,
             ValueKind::Struct(object) => object.rtti.hash,

--- a/crates/rune/src/runtime/vec.rs
+++ b/crates/rune/src/runtime/vec.rs
@@ -40,7 +40,7 @@ use self::iter::Iter;
 /// ```
 #[derive(Default, Any)]
 #[repr(transparent)]
-#[rune(builtin, static_type = VEC_TYPE)]
+#[rune(builtin, static_type = VEC)]
 #[rune(from_value = Value::into_vec, from_value_ref = Value::into_vec_ref, from_value_mut = Value::into_vec_mut)]
 pub struct Vec {
     inner: alloc::Vec<Value>,

--- a/crates/rune/src/runtime/vm.rs
+++ b/crates/rune/src/runtime/vm.rs
@@ -1162,11 +1162,11 @@ impl Vm {
         macro_rules! convert {
             ($from:ty, $value:expr, $ty:expr) => {
                 match $ty.into_hash() {
-                    runtime::static_type::FLOAT_TYPE_HASH => {
+                    runtime::static_type::FLOAT_HASH => {
                         vm_try!(Value::try_from($value as f64))
                     }
-                    runtime::static_type::BYTE_TYPE_HASH => vm_try!(Value::try_from($value as u8)),
-                    runtime::static_type::INTEGER_TYPE_HASH => {
+                    runtime::static_type::BYTE_HASH => vm_try!(Value::try_from($value as u8)),
+                    runtime::static_type::INTEGER_HASH => {
                         vm_try!(Value::try_from($value as i64))
                     }
                     ty => {

--- a/crates/rune/src/tests/bug_700.rs
+++ b/crates/rune/src/tests/bug_700.rs
@@ -41,8 +41,8 @@ pub fn test_bug_700() -> Result<()> {
     assert_eq!(
         error.into_kind(),
         VmErrorKind::Expected {
-            expected: TypeInfo::StaticType(static_type::TUPLE_TYPE),
-            actual: TypeInfo::StaticType(static_type::INTEGER_TYPE)
+            expected: TypeInfo::StaticType(static_type::TUPLE),
+            actual: TypeInfo::StaticType(static_type::INTEGER)
         }
     );
 


### PR DESCRIPTION
This fixes an issue where custom text for self links like for `Tuple` is correctly rendered.

Instead of `fn is_empty(self)` they were rendered as `fn is_empty(())`.