### PR TITLE
cli: Improve test running and commandline arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,27 +68,23 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - run: cargo build
 
-  miri_rune:
+  miri:
     runs-on: ubuntu-latest
     needs: basics
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - crate: rune
+            target: "runtime:: hir::arena:: --skip runtime::vm:: --skip runtime::vm_execution::"
+          - crate: rune-alloc
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly
       with:
         components: miri
     - uses: Swatinem/rust-cache@v2
-    - run: cargo miri test -p rune --all-features -- runtime hir::arena
-
-  miri_rune_alloc:
-    runs-on: ubuntu-latest
-    needs: basics
-    steps:
-    - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@nightly
-      with:
-        components: miri
-    - uses: Swatinem/rust-cache@v2
-    - run: cargo miri test -p rune-alloc --all-features
+    - run: cargo miri test -p ${{matrix.crate}} --all-features -- ${{matrix.target}}
 
   nightly:
     runs-on: ubuntu-latest
@@ -152,7 +148,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    needs: [no_default_features, build_feature, docs, msrv, miri_rune, miri_rune_alloc, no_std, wasm]
+    needs: [no_default_features, build_feature, docs, msrv, miri, no_std, wasm]
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@stable

--- a/crates/rune/src/cli/benches.rs
+++ b/crates/rune/src/cli/benches.rs
@@ -1,9 +1,8 @@
 use std::fmt;
 use std::io::Write;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
-
-use clap::Parser;
 
 use crate::alloc::Vec;
 use crate::cli::{AssetKind, CommandBase, Config, ExitCode, Io, SharedFlags};
@@ -14,16 +13,27 @@ use crate::runtime::{Function, Unit, Value};
 use crate::support::Result;
 use crate::{Context, Hash, Sources, Vm};
 
-#[derive(Parser, Debug)]
-pub(super) struct Flags {
-    /// Rounds of warmup to perform
-    #[arg(long, default_value = "100")]
-    warmup: u32,
+mod cli {
+    use std::path::PathBuf;
+    use std::vec::Vec;
 
-    /// Iterations to run of the benchmark
-    #[arg(long, default_value = "100")]
-    iterations: u32,
+    use clap::Parser;
+
+    #[derive(Parser, Debug)]
+    #[command(rename_all = "kebab-case")]
+    pub(crate) struct Flags {
+        /// Rounds of warmup to perform
+        #[arg(long, default_value = "100")]
+        pub(super) warmup: u32,
+        /// Iterations to run of the benchmark
+        #[arg(long, default_value = "100")]
+        pub(super) iterations: u32,
+        /// Explicit paths to benchmark.
+        pub(super) bench_path: Vec<PathBuf>,
+    }
 }
+
+pub(super) use cli::Flags;
 
 impl CommandBase for Flags {
     #[inline]
@@ -39,6 +49,11 @@ impl CommandBase for Flags {
     #[inline]
     fn propagate(&mut self, c: &mut Config, _: &mut SharedFlags) {
         c.test = true;
+    }
+
+    #[inline]
+    fn paths(&self) -> &[PathBuf] {
+        &self.bench_path
     }
 }
 

--- a/crates/rune/src/cli/check.rs
+++ b/crates/rune/src/cli/check.rs
@@ -1,19 +1,31 @@
 use std::io::Write;
 use std::path::Path;
+use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use clap::Parser;
 
 use crate::cli::{visitor, AssetKind, CommandBase, Config, Entry, ExitCode, Io, SharedFlags};
 use crate::compile::FileSourceLoader;
 use crate::{Diagnostics, Options, Source, Sources};
 
-#[derive(Parser, Debug)]
-pub(super) struct Flags {
-    /// Exit with a non-zero exit-code even for warnings
-    #[arg(long)]
-    warnings_are_errors: bool,
+mod cli {
+    use std::path::PathBuf;
+    use std::vec::Vec;
+
+    use clap::Parser;
+
+    #[derive(Parser, Debug)]
+    #[command(rename_all = "kebab-case")]
+    pub(crate) struct Flags {
+        /// Exit with a non-zero exit-code even for warnings
+        #[arg(long)]
+        pub(super) warnings_are_errors: bool,
+        /// Explicit paths to check.
+        pub(super) check_path: Vec<PathBuf>,
+    }
 }
+
+pub(super) use cli::Flags;
 
 impl CommandBase for Flags {
     #[inline]
@@ -29,6 +41,11 @@ impl CommandBase for Flags {
     #[inline]
     fn describe(&self) -> &str {
         "Checking"
+    }
+
+    #[inline]
+    fn paths(&self) -> &[PathBuf] {
+        &self.check_path
     }
 }
 

--- a/crates/rune/src/cli/format.rs
+++ b/crates/rune/src/cli/format.rs
@@ -1,8 +1,7 @@
-use core::fmt;
-
+use std::fmt;
 use std::io::Write;
+use std::path::PathBuf;
 
-use clap::Parser;
 use similar::{ChangeTag, TextDiff};
 
 use crate::alloc::prelude::*;
@@ -12,16 +11,28 @@ use crate::support::{Context, Result};
 use crate::termcolor::{Color, ColorSpec, WriteColor};
 use crate::{Diagnostics, Options, Source, Sources};
 
-#[derive(Parser, Debug)]
-pub(super) struct Flags {
-    /// Exit with a non-zero exit-code even for warnings
-    #[arg(long)]
-    warnings_are_errors: bool,
-    /// Perform format checking. If there's any files which needs to be changed
-    /// returns a non-successful exitcode.
-    #[arg(long)]
-    check: bool,
+mod cli {
+    use std::path::PathBuf;
+    use std::vec::Vec;
+
+    use clap::Parser;
+
+    #[derive(Parser, Debug)]
+    #[command(rename_all = "kebab-case")]
+    pub(crate) struct Flags {
+        /// Exit with a non-zero exit-code even for warnings
+        #[arg(long)]
+        pub(super) warnings_are_errors: bool,
+        /// Perform format checking. If there's any files which needs to be changed
+        /// returns a non-successful exitcode.
+        #[arg(long)]
+        pub(super) check: bool,
+        /// Explicit paths to format.
+        pub(super) fmt_path: Vec<PathBuf>,
+    }
 }
+
+pub(super) use cli::Flags;
 
 impl CommandBase for Flags {
     #[inline]
@@ -32,6 +43,12 @@ impl CommandBase for Flags {
     #[inline]
     fn describe(&self) -> &str {
         "Formatting"
+    }
+
+    /// Extra paths to run.
+    #[inline]
+    fn paths(&self) -> &[PathBuf] {
+        &self.fmt_path
     }
 }
 

--- a/crates/rune/src/compile/meta.rs
+++ b/crates/rune/src/compile/meta.rs
@@ -383,6 +383,11 @@ pub struct DocType {
 }
 
 impl DocType {
+    /// Construct an empty type documentation.
+    pub(crate) fn empty() -> Self {
+        Self::new(Hash::EMPTY)
+    }
+
     /// Construct type documentation.
     #[cfg_attr(not(feature = "doc"), allow(unused_variables))]
     pub fn with_generics<const N: usize>(
@@ -397,18 +402,12 @@ impl DocType {
         })
     }
 
-    #[cfg(feature = "doc")]
+    /// Construct type with the specified base type.
+    #[cfg_attr(not(feature = "doc"), allow(unused_variables))]
     pub(crate) fn new(base: Hash) -> Self {
         Self {
-            base,
-            generics: Box::default(),
-        }
-    }
-
-    pub(crate) fn empty() -> Self {
-        Self {
             #[cfg(feature = "doc")]
-            base: Hash::EMPTY,
+            base,
             #[cfg(feature = "doc")]
             generics: Box::default(),
         }

--- a/crates/rune/src/doc/build.rs
+++ b/crates/rune/src/doc/build.rs
@@ -73,7 +73,7 @@ mod embed {
 pub(crate) fn build(
     name: &str,
     artifacts: &mut Artifacts,
-    context: &crate::Context,
+    context: Option<&crate::Context>,
     visitors: &[Visitor],
 ) -> Result<()> {
     let context = Context::new(context, visitors);

--- a/crates/rune/src/runtime/shared.rs
+++ b/crates/rune/src/runtime/shared.rs
@@ -138,8 +138,8 @@ impl<T> Shared<T> {
         unsafe {
             let guard = self.inner.as_ref().access.exclusive()?.into_raw();
 
-            // NB: we need to prevent the Drop impl for Shared from being called,
-            // since we are deconstructing its internals.
+            // NB: we need to prevent the Drop impl for Shared from being
+            // called, since we are deconstructing its internals.
             let this = ManuallyDrop::new(self);
 
             Ok(Mut {
@@ -150,17 +150,17 @@ impl<T> Shared<T> {
         }
     }
 
-    /// Deconstruct the shader value into a guard and shared box.
+    /// Deconstruct the shared value into a guard and shared box.
     ///
     /// # Safety
     ///
     /// The content of the shared value will be forcibly destructed once the
-    /// returned guard is dropped, use of the shared value after this point will
-    /// lead to undefined behavior.
+    /// returned guard is dropped, unchecked use of the shared value after this
+    /// point will lead to undefined behavior.
     pub(crate) unsafe fn into_drop_guard(self) -> (Self, SharedPointerGuard) {
-        // Increment the reference count by one, to prevent it from every being
-        // dropped.
-        SharedBox::inc(self.inner.as_ptr());
+        // Increment the reference count by one to account for the guard holding
+        // onto it.
+        SharedBox::inc(self.inner);
 
         let guard = SharedPointerGuard {
             _inner: RawDrop::take_shared_box(self.inner),
@@ -222,7 +222,7 @@ impl<T: ?Sized> TryClone for Shared<T> {
 impl<T: ?Sized> Clone for Shared<T> {
     fn clone(&self) -> Self {
         unsafe {
-            SharedBox::inc(self.inner.as_ptr());
+            SharedBox::inc(self.inner);
         }
 
         Self { inner: self.inner }
@@ -232,7 +232,7 @@ impl<T: ?Sized> Clone for Shared<T> {
 impl<T: ?Sized> Drop for Shared<T> {
     fn drop(&mut self) {
         unsafe {
-            SharedBox::dec(self.inner.as_ptr());
+            SharedBox::dec(self.inner);
         }
     }
 }
@@ -270,14 +270,15 @@ struct SharedBox<T: ?Sized> {
 
 impl<T: ?Sized> SharedBox<T> {
     /// Increment the reference count of the inner value.
-    unsafe fn inc(this: *const Self) {
-        let count = (*this).count.get();
+    unsafe fn inc(this: ptr::NonNull<Self>) {
+        let count_ref = &*ptr::addr_of!((*this.as_ptr()).count);
+        let count = count_ref.get();
 
         if count == 0 || count == usize::MAX {
             crate::alloc::abort();
         }
 
-        (*this).count.set(count + 1);
+        count_ref.set(count + 1);
     }
 
     /// Decrement the reference count in inner, and free the underlying data if
@@ -286,31 +287,30 @@ impl<T: ?Sized> SharedBox<T> {
     /// # Safety
     ///
     /// ProtocolCaller needs to ensure that `this` is a valid pointer.
-    unsafe fn dec(this: *mut Self) -> bool {
-        let count = (*this).count.get();
+    unsafe fn dec(this: ptr::NonNull<Self>) -> bool {
+        let count_ref = &*ptr::addr_of!((*this.as_ptr()).count);
+        let count = count_ref.get();
 
         if count == 0 {
             crate::alloc::abort();
         }
 
         let count = count - 1;
-        (*this).count.set(count);
+        count_ref.set(count);
 
         if count != 0 {
             return false;
         }
 
-        let this = Box::from_raw_in(this, rune_alloc::alloc::Global);
+        let this = Box::from_raw_in(this.as_ptr(), rune_alloc::alloc::Global);
 
         if this.access.is_taken() {
             // NB: This prevents the inner `T` from being dropped in case it
             // has already been taken (as indicated by `is_taken`).
             //
             // If it has been taken, the shared box contains invalid memory.
-            drop(transmute::<
-                Box<SharedBox<T>>,
-                Box<SharedBox<ManuallyDrop<T>>>,
-            >(this));
+            let this = transmute::<Box<SharedBox<T>>, Box<SharedBox<ManuallyDrop<T>>>>(this);
+            drop(this);
         } else {
             // NB: At the point of the final drop, no on else should be using
             // this.
@@ -325,20 +325,20 @@ impl<T: ?Sized> SharedBox<T> {
     }
 }
 
-type DropFn = unsafe fn(*const ());
+type DropFn = unsafe fn(ptr::NonNull<()>);
 
 struct RawDrop {
-    data: *const (),
+    data: ptr::NonNull<()>,
     drop_fn: DropFn,
 }
 
 impl RawDrop {
     /// Construct an empty raw drop function.
     const fn empty() -> Self {
-        fn drop_fn(_: *const ()) {}
+        fn drop_fn(_: ptr::NonNull<()>) {}
 
         Self {
-            data: ptr::null(),
+            data: ptr::NonNull::dangling(),
             drop_fn,
         }
     }
@@ -347,13 +347,13 @@ impl RawDrop {
     ///
     /// The argument must have been produced using `Arc::into_raw`.
     #[cfg(feature = "alloc")]
-    unsafe fn from_rc<T>(data: *const T) -> Self {
-        unsafe fn drop_fn<T>(data: *const ()) {
-            let _ = Rc::from_raw(data as *const T);
+    unsafe fn from_rc<T>(data: ptr::NonNull<T>) -> Self {
+        unsafe fn drop_fn<T>(data: ptr::NonNull<()>) {
+            let _ = Rc::from_raw(data.cast::<T>().as_ptr().cast_const());
         }
 
         Self {
-            data: data as *const (),
+            data: data.cast(),
             drop_fn: drop_fn::<T>,
         }
     }
@@ -362,13 +362,13 @@ impl RawDrop {
     ///
     /// The argument must have been produced using `Arc::into_raw`.
     #[cfg(feature = "alloc")]
-    unsafe fn from_arc<T>(data: *const T) -> Self {
-        unsafe fn drop_fn<T>(data: *const ()) {
-            let _ = Arc::from_raw(data as *const T);
+    unsafe fn from_arc<T>(data: ptr::NonNull<T>) -> Self {
+        unsafe fn drop_fn<T>(data: ptr::NonNull<()>) {
+            let _ = Arc::from_raw(data.cast::<T>().as_ptr().cast_const());
         }
 
         Self {
-            data: data as *const (),
+            data: data.cast(),
             drop_fn: drop_fn::<T>,
         }
     }
@@ -378,14 +378,13 @@ impl RawDrop {
     /// # Safety
     ///
     /// Should only be constructed over a pointer that is lively owned.
-    fn decrement_shared_box<T>(inner: ptr::NonNull<SharedBox<T>>) -> Self {
-        unsafe fn drop_fn_impl<T>(data: *const ()) {
-            let shared = data as *mut () as *mut SharedBox<T>;
-            SharedBox::dec(shared);
+    fn decrement_shared_box<T>(data: ptr::NonNull<SharedBox<T>>) -> Self {
+        unsafe fn drop_fn_impl<T>(data: ptr::NonNull<()>) {
+            SharedBox::dec(data.cast::<SharedBox<T>>());
         }
 
         Self {
-            data: inner.as_ptr() as *const (),
+            data: data.cast(),
             drop_fn: drop_fn_impl::<T>,
         }
     }
@@ -396,27 +395,25 @@ impl RawDrop {
     /// # Safety
     ///
     /// Should only be constructed over a pointer that is lively owned.
-    fn take_shared_box<T>(inner: ptr::NonNull<SharedBox<T>>) -> Self {
-        unsafe fn drop_fn_impl<T>(data: *const ()) {
-            let shared = data as *mut () as *mut SharedBox<T>;
+    fn take_shared_box<T>(data: ptr::NonNull<SharedBox<T>>) -> Self {
+        unsafe fn drop_fn_impl<T>(data: ptr::NonNull<()>) {
+            let shared = data.cast::<SharedBox<T>>();
 
             // Mark the shared box for exclusive access.
             let _ = ManuallyDrop::new(
-                (*shared)
-                    .access
+                (*ptr::addr_of!((*shared.as_ptr()).access))
                     .take()
                     .expect("raw pointers must not be shared"),
             );
 
             // Free the inner `Any` structure, and since we have marked the
             // Shared as taken, this will prevent anyone else from doing it.
-            drop(ptr::read((*shared).data.get()));
-
+            drop(ptr::read((*ptr::addr_of!((*shared.as_ptr()).data)).get()));
             SharedBox::dec(shared);
         }
 
         Self {
-            data: inner.as_ptr() as *const (),
+            data: data.cast(),
             drop_fn: drop_fn_impl::<T>,
         }
     }
@@ -459,9 +456,10 @@ impl<T> From<Rc<T>> for Ref<T> {
     /// ```
     fn from(value: Rc<T>) -> Ref<T> {
         let data = Rc::into_raw(value);
+        let data = unsafe { ptr::NonNull::new_unchecked(data as *mut _) };
 
         Ref {
-            data: unsafe { ptr::NonNull::new_unchecked(data as *mut _) },
+            data,
             guard: None,
             inner: unsafe { RawDrop::from_rc(data) },
         }
@@ -483,9 +481,10 @@ impl<T> From<Arc<T>> for Ref<T> {
     /// ```
     fn from(value: Arc<T>) -> Ref<T> {
         let data = Arc::into_raw(value);
+        let data = unsafe { ptr::NonNull::new_unchecked(data as *mut _) };
 
         Ref {
-            data: unsafe { ptr::NonNull::new_unchecked(data as *mut _) },
+            data,
             guard: None,
             inner: unsafe { RawDrop::from_arc(data) },
         }

--- a/crates/rune/src/workspace/manifest.rs
+++ b/crates/rune/src/workspace/manifest.rs
@@ -12,6 +12,7 @@ use serde::de::IntoDeserializer;
 use serde::Deserialize;
 use serde_hashkey as key;
 
+use crate as rune;
 use crate::alloc::prelude::*;
 use crate::alloc::{self, String, Vec};
 use crate::ast::{Span, Spanned};
@@ -65,10 +66,11 @@ impl fmt::Display for FoundKind {
 }
 
 /// A found item in the workspace.
-#[derive(Debug)]
+#[derive(Debug, TryClone)]
 #[non_exhaustive]
 pub struct Found {
     /// The kind found.
+    #[try_clone(copy)]
     pub kind: FoundKind,
     /// A found path that can be built.
     pub path: PathBuf,
@@ -77,7 +79,7 @@ pub struct Found {
 }
 
 /// A found item in the workspace associated with a package.
-#[derive(Debug)]
+#[derive(Debug, TryClone)]
 #[non_exhaustive]
 pub struct FoundPackage<'a> {
     /// A found path that can be built.


### PR DESCRIPTION
Command output has been improved to indicate where tests are found.

As an added capability, we can now filter tests by specifying filter arguments the same way Rust supports it.

![image](https://github.com/user-attachments/assets/0f395894-0989-4cd0-89d8-e8a2d2db0289)


