### PR TITLE
doc: Clean up how documentation works

### DIFF
--- a/crates/rune/Cargo.toml
+++ b/crates/rune/Cargo.toml
@@ -51,7 +51,7 @@ anyhow = { version = "1.0.71", default-features = false, optional = true }
 bincode = { version = "1.3.3", optional = true }
 clap = { version = "4.2.7", features = ["derive"], optional = true }
 codespan-reporting = { version = "0.11.1", optional = true }
-handlebars = { version = "5.1.0", optional = true }
+handlebars = { version = "6.0.0", optional = true }
 pulldown-cmark = { version = "0.9.2", optional = true }
 relative-path = { version = "1.8.0", optional = true, features = ["serde"] }
 rust-embed = { version = "6.6.1", optional = true }

--- a/crates/rune/src/cli/doc.rs
+++ b/crates/rune/src/cli/doc.rs
@@ -9,7 +9,7 @@ use crate::alloc::prelude::*;
 use crate::cli::naming::Naming;
 use crate::cli::{AssetKind, CommandBase, Config, Entry, EntryPoint, ExitCode, Io, SharedFlags};
 use crate::compile::FileSourceLoader;
-use crate::{Diagnostics, ItemBuf, Options, Source, Sources};
+use crate::{Diagnostics, Options, Source, Sources};
 
 mod cli {
     use std::path::PathBuf;
@@ -94,9 +94,8 @@ where
     let mut naming = Naming::default();
 
     for e in entries {
-        let name = naming.name(&e)?;
+        let item = naming.item(&e)?;
 
-        let item = ItemBuf::with_crate(&name)?;
         let mut visitor = crate::doc::Visitor::new(&item)?;
         let mut sources = Sources::new();
 

--- a/crates/rune/src/cli/naming.rs
+++ b/crates/rune/src/cli/naming.rs
@@ -1,49 +1,39 @@
-use core::mem::replace;
-
 use std::ffi::OsStr;
 
 use crate::alloc::prelude::*;
-use crate::alloc::{self, try_format, HashSet, String};
+use crate::alloc::{self, HashMap};
 use crate::cli::EntryPoint;
-use crate::workspace;
+use crate::item::ComponentRef;
+use crate::ItemBuf;
 
 /// Helper to perform non-conflicting crate naming.
 #[derive(Default)]
 pub(crate) struct Naming {
-    names: HashSet<String>,
-    count: usize,
+    names: HashMap<ItemBuf, usize>,
 }
 
 impl Naming {
     /// Construct a unique crate name for the given entrypoint.
-    pub(crate) fn name(&mut self, e: &EntryPoint<'_>) -> alloc::Result<String> {
-        let name = match &e {
+    pub(crate) fn item(&mut self, e: &EntryPoint<'_>) -> alloc::Result<ItemBuf> {
+        let mut item = match &e {
             EntryPoint::Path(path) => match path.file_stem().and_then(OsStr::to_str) {
-                Some(name) => String::try_from(name)?,
-                None => String::try_from("entry")?,
+                Some(name) => ItemBuf::with_crate(name)?,
+                None => ItemBuf::with_crate("entry")?,
             },
             EntryPoint::Package(p) => {
                 let name = p.found.name.as_str();
-
-                let ext = match &p.found.kind {
-                    workspace::FoundKind::Binary => "bin",
-                    workspace::FoundKind::Test => "test",
-                    workspace::FoundKind::Example => "example",
-                    workspace::FoundKind::Bench => "bench",
-                };
-
-                try_format!("{}-{name}-{ext}", p.package.name)
+                ItemBuf::with_crate_item(&p.package.name, [name])?
             }
         };
 
-        // TODO: make it so that we can communicate different entrypoints in the
-        // visitors context instead of this hackery.
-        Ok(if !self.names.try_insert(name.try_clone()?)? {
-            let next = self.count.wrapping_add(1);
-            let index = replace(&mut self.count, next);
-            try_format!("{name}{index}")
-        } else {
-            name
-        })
+        let values = self.names.entry(item.try_clone()?).or_try_default()?;
+
+        if *values > 0 {
+            let name = try_format!("{}", *values - 1);
+            item.push(ComponentRef::Str(&name))?;
+        }
+
+        *values += 1;
+        Ok(item)
     }
 }

--- a/crates/rune/src/cli/tests.rs
+++ b/crates/rune/src/cli/tests.rs
@@ -134,8 +134,7 @@ where
     };
 
     for entry in entries {
-        let name = naming.name(&entry)?;
-        let item = ItemBuf::with_crate(&name)?;
+        let item = naming.item(&entry)?;
 
         let mut sources = Sources::new();
 

--- a/crates/rune/src/compile/context.rs
+++ b/crates/rune/src/compile/context.rs
@@ -902,6 +902,7 @@ impl Context {
             .entry(i.hash)
             .or_try_default()?
             .try_push(i.trait_hash)?;
+
         Ok(())
     }
 

--- a/crates/rune/src/doc/static/function.html.hbs
+++ b/crates/rune/src/doc/static/function.html.hbs
@@ -1,9 +1,15 @@
 {{#> layout}}
 <body>
-<div class="title-wrapper"><h3 class="title">Function {{literal module}}::<span class="fn">{{name}}</span></h3><a class="overview" href="{{literal root_index}}">Overview</a></div>
+<div class="title-wrapper">
+<h3 class="title">Function {{literal module}}::<span class="fn">{{name}}</span></h3><a class="overview" href="{{literal root_index}}">Overview</a></div>
 <div class="signature">
-{{#if is_async}}<span class="keyword async">async</span> {{/if}} <span class="keyword fn">fn</span> <span class="fn">{{name}}</span>({{literal args}}){{#if this.return_type}} -&gt; {{literal this.return_type}}{{/if}}</h3>
+    {{#if is_test}}<div class="keyword attribute">#[test]</div>{{/if}}
+    {{#if is_bench}}<div class="keyword attribute">#[bench]</div>{{/if}}
+    {{#if is_async}}<span class="keyword async">async</span> {{/if}}
+    <span class="keyword fn">fn</span>
+    <span class="fn">{{name}}</span>({{literal args}}){{#if this.return_type}} -&gt; {{literal this.return_type}}{{/if}}
 </div>
+</h3>
 {{#if deprecated}}<div class="deprecated"><span class="heading">Deprecated:</span><span class="content">{{deprecated}}</span></div>{{/if}}
 {{#if doc}}{{literal doc}}{{/if}}
 {{/layout}}

--- a/crates/rune/src/doc/static/runedoc.css.hbs
+++ b/crates/rune/src/doc/static/runedoc.css.hbs
@@ -306,3 +306,7 @@ a {
     font-size: 1.2rem;
     color: var(--link-color);
 }
+
+.attribute {
+    color: var(--text-color);
+}

--- a/crates/rune/src/doc/static/type.html.hbs
+++ b/crates/rune/src/doc/static/type.html.hbs
@@ -34,28 +34,14 @@
 {{/each}}
 {{/if}}
 
-{{#if protocols}}
-<h4 class="section-title">Protocols</h4>
-
-{{#each protocols}}
-    <div class="item item-fn">
-        <div id="protocol.{{this.name}}" class="item-title">
-        protocol <a href="#protocol.{{this.name}}" class="protocol">{{this.name}}</a> {{field}}
-        {{#if this.deprecated}}<div class="deprecated"><span class="heading">Deprecated:</span><span class="content">{{this.deprecated}}</span></div>{{/if}}
-        </div>
-        {{#if this.repr}}{{literal this.repr}}{{/if}}
-        {{#if this.doc}}{{literal this.doc}}{{/if}}
-    </div>
-{{/each}}
-{{/if}}
-
 {{#if traits}}
-<h4 class="section-title">Traits implemented</h4>
+<h4 class="section-title">Trait Implementations</h4>
 
 {{#each traits}}
     <div class="item item-trait">
         <div id="trait.{{this.item}}" class="item-title">
             impl {{literal this.module}}::<a href="{{this.url}}" class="trait">{{this.name}}</a>
+            for <span class="{{../what_class}}">{{../name}}</span>
         </div>
     </div>
 
@@ -79,6 +65,21 @@
             {{#if this.doc}}{{literal this.doc}}{{/if}}
         </div>
     {{/each}}
+{{/each}}
+{{/if}}
+
+{{#if protocols}}
+<h4 class="section-title">Protocols</h4>
+
+{{#each protocols}}
+    <div class="item item-fn">
+        <div id="protocol.{{this.name}}" class="item-title">
+        protocol <a href="#protocol.{{this.name}}" class="protocol">{{this.name}}</a> {{field}}
+        {{#if this.deprecated}}<div class="deprecated"><span class="heading">Deprecated:</span><span class="content">{{this.deprecated}}</span></div>{{/if}}
+        </div>
+        {{#if this.repr}}{{literal this.repr}}{{/if}}
+        {{#if this.doc}}{{literal this.doc}}{{/if}}
+    </div>
 {{/each}}
 {{/if}}
 

--- a/crates/rune/src/indexing/index.rs
+++ b/crates/rune/src/indexing/index.rs
@@ -505,13 +505,15 @@ pub(crate) fn file(idx: &mut Indexer<'_, '_>, ast: &mut ast::File) -> compile::R
     for doc in p.parse_all::<attrs::Doc>(resolve_context!(idx.q), &ast.attributes)? {
         let (span, doc) = doc?;
 
+        let doc_string = doc.doc_string.resolve(resolve_context!(idx.q))?;
+
         idx.q
             .visitor
             .visit_doc_comment(
                 &DynLocation::new(idx.source_id, &span),
                 idx.q.pool.module_item(idx.item.module),
                 idx.q.pool.module_item_hash(idx.item.module),
-                &doc.doc_string.resolve(resolve_context!(idx.q))?,
+                &doc_string,
             )
             .with_span(span)?;
     }

--- a/crates/rune/tests/streams.rn
+++ b/crates/rune/tests/streams.rn
@@ -1,9 +1,13 @@
+//! Test that async streams work.
+
 async fn foo(n) {
     yield n;
     yield n + 1;
     yield n + 2;
 }
 
+/// Select over two async streams and ensure that the expected numerical value
+//matches.
 #[test]
 async fn select_streams() {
     let count = 0;


### PR DESCRIPTION
Previously documentation for rune modules and doc comments wasn't properly picked up.

This also simplifies the model used in documentation contexts in ensuring that item doesn't have to be checked everywhere.

Item is only unavailable for protocol, index, and field functions. And these are iterated over explicitly as associated items. So we avoid paying for that complexity now.