### PR TITLE
cli: Run direct arguments with `-O function-body=true`

### DIFF
--- a/crates/rune-core/src/hash.rs
+++ b/crates/rune-core/src/hash.rs
@@ -91,10 +91,7 @@ impl Hash {
     }
 
     /// Get the hash of a type.
-    pub fn type_hash<I>(path: I) -> Self
-    where
-        I: ToTypeHash,
-    {
+    pub fn type_hash(path: impl ToTypeHash) -> Self {
         path.to_type_hash()
     }
 

--- a/crates/rune-core/src/hash/to_type_hash.rs
+++ b/crates/rune-core/src/hash/to_type_hash.rs
@@ -29,8 +29,7 @@ pub trait ToTypeHash {
 
 impl<I> ToTypeHash for I
 where
-    I: Copy + IntoIterator,
-    I::Item: IntoComponent,
+    I: Copy + IntoIterator<Item: IntoComponent>,
 {
     #[inline]
     fn to_type_hash(&self) -> Hash {

--- a/crates/rune/src/cli/doc.rs
+++ b/crates/rune/src/cli/doc.rs
@@ -94,6 +94,12 @@ where
     let mut naming = Naming::default();
 
     for e in entries {
+        let mut options = options.clone();
+
+        if e.is_argument() {
+            options.function_body = true;
+        }
+
         let item = naming.item(&e)?;
 
         let mut visitor = crate::doc::Visitor::new(&item)?;
@@ -117,7 +123,7 @@ where
         let _ = crate::prepare(&mut sources)
             .with_context(&context)
             .with_diagnostics(&mut diagnostics)
-            .with_options(options)
+            .with_options(&options)
             .with_visitor(&mut visitor)?
             .with_source_loader(&mut source_loader)
             .build();

--- a/crates/rune/src/cli/naming.rs
+++ b/crates/rune/src/cli/naming.rs
@@ -16,7 +16,7 @@ impl Naming {
     /// Construct a unique crate name for the given entrypoint.
     pub(crate) fn item(&mut self, e: &EntryPoint<'_>) -> alloc::Result<ItemBuf> {
         let mut item = match &e {
-            EntryPoint::Path(path) => match path.file_stem().and_then(OsStr::to_str) {
+            EntryPoint::Path(path, _) => match path.file_stem().and_then(OsStr::to_str) {
                 Some(name) => ItemBuf::with_crate(name)?,
                 None => ItemBuf::with_crate("entry")?,
             },

--- a/crates/rune/src/cli/run.rs
+++ b/crates/rune/src/cli/run.rs
@@ -7,7 +7,7 @@ use anyhow::{anyhow, Result};
 
 use crate::cli::{AssetKind, CommandBase, Config, ExitCode, Io, SharedFlags};
 use crate::runtime::{UnitStorage, VmError, VmExecution, VmResult};
-use crate::{Context, Sources, Unit, Value, Vm};
+use crate::{Context, Hash, Sources, Unit, Value, Vm};
 
 mod cli {
     use std::path::PathBuf;
@@ -146,6 +146,7 @@ pub(super) async fn run(
     context: &Context,
     unit: Arc<Unit>,
     sources: &Sources,
+    entry: Hash,
 ) -> Result<ExitCode> {
     if args.dump_native_functions {
         writeln!(io.stdout, "# functions")?;
@@ -225,7 +226,7 @@ pub(super) async fn run(
     let last = Instant::now();
 
     let mut vm = Vm::new(runtime, unit);
-    let mut execution: VmExecution<_> = vm.execute(["main"], ())?;
+    let mut execution: VmExecution<_> = vm.execute(entry, ())?;
 
     let result = if args.trace {
         match do_trace(

--- a/crates/rune/src/compile/options.rs
+++ b/crates/rune/src/compile/options.rs
@@ -38,6 +38,9 @@ pub struct Options {
     /// Use the second version of the compiler in parallel.
     pub(crate) v2: bool,
     /// Build sources as function bodies.
+    ///
+    /// The function to run will be located at `$0`, which can be constructed
+    /// with `Hash::type_hash([ComponentRef::Id(0)])`.
     pub(crate) function_body: bool,
     /// When running tests, include std tests.
     pub(crate) test_std: bool,


### PR DESCRIPTION
This enabled `-O function-body=true` for arguments which have been directly specified.

That means sources like this:

```rust
let it = [1, 2].iter().rev().chain([3, 4].iter()).enumerate();
assert_eq!(it.next_back(), Some((3, 4)));
it.collect::<Vec>();
foo()
```

Without having to specify a `main` entrypoint can be run directly by passing them as arguments to `rune run <path>`.

For the old behavior, `rune run --path <path>` can be used which should be seen more as loading the specified path as part of the root module.

Note that when `function_body` is specified as an option, the entrypoint can be found at `$0` which can be constructed with the following code:

```rust
use rune::item::ComponentRef;
use rune::Hash;

let entry = let entry = if is_function_body {
    Hash::type_hash([ComponentRef::Id(0)])
} else {
    Hash::type_hash(["main"])
};
```

You can also pass `[ComponentRef::Id(0)]` directly to any relevant vm functions such as `Vm::call`.