### PR TITLE
vm: Change operations to free temporaries

### DIFF
--- a/crates/rune/src/compile/v1/linear.rs
+++ b/crates/rune/src/compile/v1/linear.rs
@@ -69,6 +69,15 @@ impl<'a, 'hir> Linear<'a, 'hir> {
     }
 
     #[inline]
+    pub(super) fn free_non_dangling(self) -> compile::Result<()> {
+        for addr in self.into_iter().rev() {
+            addr.free_non_dangling()?;
+        }
+
+        Ok(())
+    }
+
+    #[inline]
     pub(super) fn forget(self) -> compile::Result<()> {
         for var in self {
             var.forget()?;

--- a/crates/rune/src/compile/v1/needs.rs
+++ b/crates/rune/src/compile/v1/needs.rs
@@ -290,15 +290,25 @@ impl<'a, 'hir> Address<'a, 'hir> {
         Ok(())
     }
 
+    pub(super) fn free(self) -> compile::Result<()> {
+        self.free_inner(true)
+    }
+
+    pub(super) fn free_non_dangling(self) -> compile::Result<()> {
+        self.free_inner(false)
+    }
+
     /// Free the current address.
-    pub(super) fn free(mut self) -> compile::Result<()> {
+    fn free_inner(mut self, dangling: bool) -> compile::Result<()> {
         match replace(&mut self.kind, AddressKind::Freed) {
             AddressKind::Local | AddressKind::Dangling => {
-                self.scopes.free_addr(self.span, self.address, self.name)?;
+                self.scopes
+                    .free_addr(self.span, self.address, self.name, dangling)?;
             }
             AddressKind::Scope(scope) => {
                 if self.scopes.top_id() == scope {
-                    self.scopes.free_addr(self.span, self.address, self.name)?;
+                    self.scopes
+                        .free_addr(self.span, self.address, self.name, dangling)?;
                 }
             }
             AddressKind::Freed => {

--- a/crates/rune/src/compile/v1/scopes.rs
+++ b/crates/rune/src/compile/v1/scopes.rs
@@ -421,6 +421,7 @@ impl<'hir> Scopes<'hir> {
         span: &dyn Spanned,
         addr: InstAddress,
         name: Option<&'static str>,
+        dangling: bool,
     ) -> compile::Result<()> {
         let mut scopes = self.scopes.borrow_mut();
 
@@ -447,7 +448,9 @@ impl<'hir> Scopes<'hir> {
             ));
         }
 
-        self.dangling.borrow_mut().insert(addr).with_span(span)?;
+        if dangling {
+            self.dangling.borrow_mut().insert(addr).with_span(span)?;
+        }
 
         let mut slots = self.slots.borrow_mut();
 

--- a/crates/rune/src/runtime/value.rs
+++ b/crates/rune/src/runtime/value.rs
@@ -607,7 +607,7 @@ impl Value {
     }
 
     /// Construct an empty value.
-    pub(crate) const fn empty() -> Self {
+    pub const fn empty() -> Self {
         Self {
             repr: ValueRepr::Empty,
         }

--- a/crates/rune/src/shared/mod.rs
+++ b/crates/rune/src/shared/mod.rs
@@ -35,6 +35,7 @@ macro_rules! _rune_diagnose {
 #[doc(inline)]
 pub(crate) use _rune_diagnose as rune_diagnose;
 
+#[cfg(debug_assertions)]
 pub(crate) enum RuneAssert {
     /// Assert should panic.
     Panic,
@@ -42,6 +43,7 @@ pub(crate) enum RuneAssert {
     Error,
 }
 
+#[cfg(debug_assertions)]
 impl RuneAssert {
     /// Test if the assert is a panic.
     pub(crate) fn is_panic(&self) -> bool {
@@ -49,7 +51,7 @@ impl RuneAssert {
     }
 }
 
-#[cfg(not(feature = "std"))]
+#[cfg(all(debug_assertions, not(feature = "std")))]
 mod r#impl {
     use core::fmt;
 
@@ -77,7 +79,7 @@ mod r#impl {
 }
 
 /// Test whether current assertions model should panic.
-#[cfg(feature = "std")]
+#[cfg(all(debug_assertions, feature = "std"))]
 mod r#impl {
     use core::sync::atomic::{AtomicU8, Ordering};
 
@@ -111,4 +113,5 @@ mod r#impl {
     }
 }
 
+#[cfg(debug_assertions)]
 pub(crate) use self::r#impl::*;


### PR DESCRIPTION
This significantly reduces the number of internal cloning and dropping we need to do for temporaries.

The idea is that for linear allocations, today we allocate the linear values and then just leave them in-memory after they've been used in an operation just to then drop them one-by-one.

Instead, we modify such operations to take values from memory as part oft he operation, replacing a clone with a memory swap and avoid having to drop the values.