### PR TITLE
Start work on pattern optimizations

### DIFF
--- a/crates/rune/src/compile/options.rs
+++ b/crates/rune/src/compile/options.rs
@@ -44,6 +44,8 @@ pub struct Options {
     pub(crate) function_body: bool,
     /// When running tests, include std tests.
     pub(crate) test_std: bool,
+    /// Enable lowering optimizations.
+    pub(crate) lowering: u8,
 }
 
 impl Options {
@@ -87,6 +89,17 @@ impl Options {
             }
             "test-std" => {
                 self.test_std = tail.map_or(true, |s| s == "true");
+            }
+            "lowering" => {
+                self.lowering = match tail {
+                    Some("0") | None => 0,
+                    Some("1") => 1,
+                    _ => {
+                        return Err(ParseOptionError {
+                            option: option.into(),
+                        })
+                    }
+                };
             }
             _ => {
                 return Err(ParseOptionError {
@@ -143,6 +156,7 @@ impl Default for Options {
             v2: false,
             function_body: false,
             test_std: false,
+            lowering: 0,
         }
     }
 }

--- a/crates/rune/src/diagnostics/emit.rs
+++ b/crates/rune/src/diagnostics/emit.rs
@@ -396,6 +396,18 @@ impl Unit {
                 writeln!(out, "fn {} ({}):", signature, hash)?;
             }
 
+            for label in debug.map(|d| d.labels.as_slice()).unwrap_or_default() {
+                writeln!(out, "{}:", label)?;
+            }
+
+            write!(out, "  {n:04} = {inst}")?;
+
+            if let Some(comment) = debug.and_then(|d| d.comment.as_ref()) {
+                write!(out, " // {}", comment)?;
+            }
+
+            writeln!(out)?;
+
             if !without_source {
                 if let Some((source, span)) =
                     debug.and_then(|d| sources.get(d.source_id).map(|s| (s, d.span)))
@@ -407,18 +419,6 @@ impl Unit {
                     }
                 }
             }
-
-            for label in debug.map(|d| d.labels.as_slice()).unwrap_or_default() {
-                writeln!(out, "{}:", label)?;
-            }
-
-            write!(out, "  {:04} = {}", n, inst)?;
-
-            if let Some(comment) = debug.and_then(|d| d.comment.as_ref()) {
-                write!(out, " // {}", comment)?;
-            }
-
-            writeln!(out)?;
         }
 
         Ok(())

--- a/crates/rune/tests/assign.rn
+++ b/crates/rune/tests/assign.rn
@@ -1,0 +1,7 @@
+#[test]
+fn inline_assign() {
+    let a = 10;
+    let b = 20;
+    let (a, b) = (b, a);
+    assert_eq!(a + b, 30);
+}

--- a/crates/rune/tests/closures.rn
+++ b/crates/rune/tests/closures.rn
@@ -8,3 +8,10 @@ fn test_basic_closure() {
     assert_eq!(work(|a, b| n + a + b), 4);
     assert_eq!(work(|a, b| n + a * b), 3);
 }
+
+#[test]
+fn test_lowering() {
+    let c = 5;
+    let c = |a| |b| || a + b + c;
+    assert_eq!(c(1)(2)(), 8);
+}


### PR DESCRIPTION
This is the first stab at demangling patterns like these:

```rust
let (a, b) = (c, d);
```

Directly into a sequence of assignments instead:

```rust
let a = c;
let b = d;
```

Note that we probably need to introduce generated variable slots, since currently expressions like these will be broken:

```rust
let (a, b) = (b, a);
```

Since naively they would be desugared to this, which is wrong:

```rust
let a = b;
let b = a; // woops, sees the value of `a` instead of `b`.
```