### PR TITLE
ace: built rune-mode and change how autocompleter is configured

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        feature: [capture-io, "cli,doc", "cli,fmt", cli, workspace, languageserver, byte-code, emit]
+        feature: [cli, "cli,doc", "cli,fmt", doc, workspace, languageserver, byte-code, capture-io, emit]
     env:
       RUSTFLAGS: -D warnings
     steps:

--- a/crates/rune/src/ace/mod.rs
+++ b/crates/rune/src/ace/mod.rs
@@ -1,0 +1,31 @@
+mod autocomplete;
+pub(crate) use self::autocomplete::build as build_autocomplete;
+
+use anyhow::{anyhow, Context as _, Result};
+
+use crate::alloc::borrow::Cow;
+use crate::doc::Artifacts;
+
+mod embed {
+    #[cfg(debug_assertions)]
+    use rust_alloc::boxed::Box;
+    #[cfg(debug_assertions)]
+    use rust_alloc::string::String;
+
+    use rust_embed::RustEmbed;
+
+    #[derive(RustEmbed)]
+    #[folder = "src/ace/static"]
+    pub(super) struct Assets;
+}
+
+pub(crate) fn theme(artifacts: &mut Artifacts) -> Result<()> {
+    for name in ["rune-mode.js", "rune-highlight-rules.js"] {
+        artifacts.asset(false, name, || {
+            let file = embed::Assets::get(name).with_context(|| anyhow!("missing {name}"))?;
+            Ok(Cow::try_from(file.data)?)
+        })?;
+    }
+
+    Ok(())
+}

--- a/crates/rune/src/ace/static/rune-completer.js
+++ b/crates/rune/src/ace/static/rune-completer.js
@@ -1,0 +1,21 @@
+ace.define('ace/autocomplete/rune',
+    ["require", "exports", "module"],
+    function (require, exports, module) {
+        exports.Completer = {
+            getCompletions: (editor, session, pos, prefix, callback) => {
+                if (prefix.length === 0) {
+                    callback(null, []);
+                    return;
+                }
+
+                var token = session.getTokenAt(pos.row, pos.column - 1).value;
+
+                if (token.includes(".")) {
+                    callback(null, instance);
+                } else {
+                    callback(null, fixed);
+                }
+            },
+        };
+    }
+);

--- a/crates/rune/src/ace/static/rune-highlight-rules.js
+++ b/crates/rune/src/ace/static/rune-highlight-rules.js
@@ -1,0 +1,175 @@
+ace.define('ace/mode/rune-highlight-rules',
+    ["require", "exports", "module", "ace/lib/oop", "ace/mode/text_highlight_rules"],
+    function (require, exports, module) {
+        "use strict";
+
+        const TextHighlightRules = require("ace/mode/text_highlight_rules").TextHighlightRules;
+        const oop = require("ace/lib/oop");
+
+        const stringEscape = /\\(?:[nrt0'"\\]|x[\da-fA-F]{2}|u\{[\da-fA-F]{6}\})/.source;
+
+        const RuneHighlightRules = function () {
+            // regexp must not have capturing parentheses. Use (?:) instead.
+            // regexps are ordered -> the first match is used
+
+            this.$rules = {
+                start:
+                    [{
+                        token: 'variable.other.source.rune',
+                        // `(?![\\\'])` to keep a lifetime name highlighting from continuing one character
+                        // past the name. The end `\'` will block this from matching for a character like
+                        // `'a'` (it should have character highlighting, not variable highlighting).
+                        regex: '\'[a-zA-Z_][a-zA-Z0-9_]*(?![\\\'])'
+                    },
+                    {
+                        token: 'string.quoted.single.source.rune',
+                        regex: "'(?:[^'\\\\]|" + stringEscape + ")'"
+                    },
+                    {
+                        token: 'identifier',
+                        regex: /r#[a-zA-Z_][a-zA-Z0-9_]*\b/
+                    },
+                    {
+                        stateName: "bracketedComment",
+                        onMatch: function (value, currentState, stack) {
+                            stack.unshift(this.next, value.length - 1, currentState);
+                            return "string.quoted.raw.source.rune";
+                        },
+                        regex: /r#*"/,
+                        next: [
+                            {
+                                onMatch: function (value, currentState, stack) {
+                                    var token = "string.quoted.raw.source.rune";
+                                    if (value.length >= stack[1]) {
+                                        if (value.length > stack[1])
+                                            token = "invalid";
+                                        stack.shift();
+                                        stack.shift();
+                                        this.next = stack.shift();
+                                    } else {
+                                        this.next = "";
+                                    }
+                                    return token;
+                                },
+                                regex: /"#*/,
+                                next: "start"
+                            }, {
+                                defaultToken: "string.quoted.raw.source.rune"
+                            }
+                        ]
+                    },
+                    {
+                        token: 'string.quoted.double.source.rune',
+                        regex: '"',
+                        push:
+                            [{
+                                token: 'string.quoted.double.source.rune',
+                                regex: '"',
+                                next: 'pop'
+                            },
+                            {
+                                token: 'constant.character.escape.source.rune',
+                                regex: stringEscape
+                            },
+                            { defaultToken: 'string.quoted.double.source.rune' }]
+                    },
+                    {
+                        token: 'string.quoted.template.source.rune',
+                        regex: '`',
+                        push:
+                            [{
+                                token: 'string.quoted.template.source.rune',
+                                regex: '`',
+                                next: 'pop'
+                            },
+                            {
+                                token: 'constant.character.escape.source.rune',
+                                regex: stringEscape
+                            },
+                            { defaultToken: 'string.quoted.template.source.rune' }]
+                    },
+                    {
+                        token: ['keyword.source.rune', 'text', 'entity.name.function.source.rune'],
+                        regex: '\\b(fn)(\\s+)((?:r#)?[a-zA-Z_][a-zA-Z0-9_]*)'
+                    },
+                    { token: 'support.constant', regex: '\\b[a-zA-Z_][\\w\\d]*::' },
+                    {
+                        token: 'keyword.source.rune',
+                        regex: '\\b(?:abstract|alignof|as|async|await|become|box|break|catch|continue|const|crate|default|do|dyn|else|enum|extern|for|final|if|impl|in|let|loop|macro|match|mod|move|mut|offsetof|override|priv|proc|pub|pure|ref|return|self|sizeof|static|struct|super|trait|type|typeof|union|unsafe|unsized|use|virtual|where|while|yield)\\b'
+                    },
+                    {
+                        token: 'storage.type.source.rune',
+                        regex: '\\b(?:Self|int|float|unit|char|bool|String|Bytes|GeneratorState|Generator|Future|Option|Result)\\b'
+                    },
+                    { token: 'variable.language.source.rune', regex: '\\bself\\b' },
+
+                    {
+                        token: 'comment.line.doc.source.rune',
+                        regex: '//!.*$'
+                    },
+                    {
+                        token: 'comment.line.double-dash.source.rune',
+                        regex: '//.*$'
+                    },
+                    {
+                        token: 'comment.start.block.source.rune',
+                        regex: '/\\*',
+                        stateName: 'comment',
+                        push:
+                            [{
+                                token: 'comment.start.block.source.rune',
+                                regex: '/\\*',
+                                push: 'comment'
+                            },
+                            {
+                                token: 'comment.end.block.source.rune',
+                                regex: '\\*/',
+                                next: 'pop'
+                            },
+                            { defaultToken: 'comment.block.source.rune' }]
+                    },
+
+                    {
+                        token: 'keyword.operator',
+                        // `[*/](?![*/])=?` is separated because `//` and `/* */` become comments and must be
+                        // guarded against. This states either `*` or `/` may be matched as long as the match
+                        // it isn't followed by either of the two. An `=` may be on the end.
+                        regex: /\$|[-=]>|[-+%^=!&|<>]=?|[*/](?![*/])=?/
+                    },
+                    { token: "punctuation.operator", regex: /[?:,;.]/ },
+                    { token: "paren.lparen", regex: /[\[({]/ },
+                    { token: "paren.rparen", regex: /[\])}]/ },
+                    {
+                        token: 'constant.language.source.rune',
+                        regex: '\\b(?:true|false|Some|None|Ok|Err|Resume|Yield)\\b'
+                    },
+                    {
+                        token: 'meta.preprocessor.source.rune',
+                        regex: '\\b\\w\\(\\w\\)*!|#\\[[\\w=\\(\\)_]+\\]\\b'
+                    },
+                    {
+                        token: 'constant.numeric.source.rune',
+                        regex: /\b(?:0x[a-fA-F0-9_]+|0o[0-7_]+|0b[01_]+|[0-9][0-9_]*(?!\.))\b/
+                    },
+                    {
+                        token: 'constant.numeric.source.rune',
+                        regex: /\b(?:[0-9][0-9_]*)(?:\.[0-9][0-9_]*)?(?:[Ee][+-][0-9][0-9_]*)?\b/
+                    }]
+            };
+
+            this.normalizeRules();
+        };
+
+        RuneHighlightRules.metaData = {
+            fileTypes: ['rn'],
+            foldingStartMarker: '^.*\\bfn\\s*(\\w+\\s*)?\\([^\\)]*\\)(\\s*\\{[^\\}]*)?\\s*$',
+            foldingStopMarker: '^\\s*\\}',
+            name: 'Rust',
+            scopeName: 'source.rune',
+        };
+
+        oop.inherits(RuneHighlightRules, TextHighlightRules);
+
+        exports.RuneHighlightRules = RuneHighlightRules;
+    }
+);

--- a/crates/rune/src/ace/static/rune-mode.js
+++ b/crates/rune/src/ace/static/rune-mode.js
@@ -1,0 +1,28 @@
+ace.define('ace/mode/rune',
+    ["require", "exports", "module", "ace/lib/oop", "ace/mode/folding/cstyle", "ace/mode/text", "ace/mode/rune-highlight-rules"],
+    function (require, exports, module) {
+        "use strict";
+
+        const TextMode = require("ace/mode/text").Mode;
+        const FoldMode = require("ace/mode/folding/cstyle").FoldMode;
+        const RuneHighlightRules = require("ace/mode/rune-highlight-rules").RuneHighlightRules;
+        const oop = require("ace/lib/oop");
+
+        const Mode = function () {
+            this.HighlightRules = RuneHighlightRules;
+            this.foldingRules = new FoldMode();
+            this.$behaviour = this.$defaultBehaviour;
+        };
+
+        oop.inherits(Mode, TextMode);
+
+        (function () {
+            this.lineCommentStart = "//";
+            this.blockComment = { start: "/*", end: "*/", nestable: true };
+            this.$quotes = { '"': '"' };
+            this.$id = "ace/mode/rune";
+        }).call(Mode.prototype);
+
+        exports.Mode = Mode;
+    }
+);

--- a/crates/rune/src/cli/ace.rs
+++ b/crates/rune/src/cli/ace.rs
@@ -15,15 +15,18 @@ use crate::{Diagnostics, Options, Source, Sources};
 
 #[derive(Parser, Debug)]
 pub(super) struct Flags {
-    /// Exit with a non-zero exit-code even for warnings
-    #[arg(long)]
-    warnings_are_errors: bool,
-    /// Output directory to write documentation to.
+    /// Output directory to write ace extensions to.
     #[arg(long)]
     output: Option<PathBuf>,
     /// Generate .await and ? extension for functions.
     #[arg(long)]
     extensions: bool,
+    /// Do not include `rune-mode.js`.
+    #[arg(long)]
+    no_mode: bool,
+    /// Exit with a non-zero exit-code even for warnings
+    #[arg(long)]
+    warnings_are_errors: bool,
 }
 
 impl CommandBase for Flags {
@@ -117,7 +120,11 @@ where
     }
 
     let mut artifacts = Artifacts::new();
-    crate::doc::build_autocomplete(&mut artifacts, &context, &visitors, flags.extensions)?;
+    crate::ace::build_autocomplete(&mut artifacts, &context, &visitors, flags.extensions)?;
+
+    if !flags.no_mode {
+        crate::ace::theme(&mut artifacts)?;
+    }
 
     for asset in artifacts.assets() {
         asset.build(&root)?;

--- a/crates/rune/src/compile/context.rs
+++ b/crates/rune/src/compile/context.rs
@@ -508,7 +508,7 @@ impl Context {
     }
 
     /// Get all associated types for the given hash.
-    #[cfg(feature = "cli")]
+    #[cfg(all(feature = "doc", feature = "cli"))]
     pub(crate) fn associated(&self, hash: Hash) -> impl Iterator<Item = Hash> + '_ {
         self.associated
             .get(&hash)
@@ -519,7 +519,7 @@ impl Context {
     }
 
     /// Get all traits implemented for the given hash.
-    #[cfg(feature = "cli")]
+    #[cfg(all(feature = "doc", feature = "cli"))]
     pub(crate) fn traits(&self, hash: Hash) -> impl Iterator<Item = Hash> + '_ {
         self.implemented_traits
             .get(&hash)

--- a/crates/rune/src/doc/mod.rs
+++ b/crates/rune/src/doc/mod.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "cli")]
 mod context;
 #[cfg(feature = "cli")]
-pub(crate) use self::context::Context;
+pub(crate) use self::context::{Context, Function, Kind, Meta, Signature};
 
 #[cfg(feature = "cli")]
 mod artifacts;
@@ -18,12 +18,10 @@ mod build;
 #[cfg(feature = "cli")]
 pub(crate) use self::build::build;
 
-#[cfg(any(feature = "languageserver", feature = "cli"))]
+#[cfg(feature = "languageserver")]
 mod visitor;
-#[cfg(any(feature = "languageserver", feature = "cli"))]
+#[cfg(feature = "languageserver")]
 pub(crate) use self::visitor::{Visitor, VisitorData};
 
 #[cfg(feature = "cli")]
-mod autocomplete;
-#[cfg(feature = "cli")]
-pub(crate) use self::autocomplete::build as build_autocomplete;
+pub(crate) mod markdown;

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -645,6 +645,9 @@ pub use rune_macros::hash;
 pub use rune_macros::item;
 
 #[cfg(feature = "cli")]
+mod ace;
+
+#[cfg(feature = "cli")]
 #[cfg_attr(rune_docsrs, doc(cfg(feature = "cli")))]
 pub mod cli;
 
@@ -653,7 +656,7 @@ pub mod languageserver;
 
 #[cfg(feature = "doc")]
 #[cfg_attr(rune_docsrs, doc(cfg(feature = "doc")))]
-pub mod doc;
+pub(crate) mod doc;
 
 /// Privately exported details.
 #[doc(hidden)]

--- a/examples/ace/.gitignore
+++ b/examples/ace/.gitignore
@@ -1,1 +1,3 @@
-autocomplete.js
+rune-autocomplete.js
+rune-mode.js
+rune-highlight-rules.js

--- a/examples/ace/index.html
+++ b/examples/ace/index.html
@@ -1,7 +1,14 @@
 <html>
     <head>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.35.4/ace.js" integrity="sha512-ADBQV64rzhFIJkiHBan+9UeZRq3DZrP6/S2+FS2EX5icsYw/IQgmFaSmt6UTqZpWXkpCKluztsTpOtxx5GkD2A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.35.4/ext-language_tools.min.js" integrity="sha512-4l33zsqrqf1PBA3iEZ399Jl9on7It0HngOkI3TG2c6W0wUyTiXRxd9Eh8zFBXNy8fMlgda/u4u1metnbEf5Hzg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+        <script src="https://cdn.jsdelivr.net/npm/ace-builds@1.35.4/src-min/ace.js" integrity="sha256-Bd8+jyjInZJnqpfV76IqiyackXEvhXBV/8tbSgLlFjo=" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/ace-builds@1.35.4/src-min/ext-language_tools.js" integrity="sha256-8/WWMrbIl/j2/igDtzDsQnWKouiaoxTziAMcV+uYsUw=" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/ace-builds@1.35.4/src-min/mode-text.js" integrity="sha256-XBKhA4TG5AxpdXaNTIlbEQ7Qc/r42jjOOGw3p5Oe8WI=" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/ace-builds@1.35.4/src-min/mode-c_cpp.js" integrity="sha256-xORy+Qy/mJDg8CIHWxiAdKCrzCKTR2PsJzvxiFK5V1o=" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/ace-builds@1.35.4/src-min/theme-monokai.js" integrity="sha256-2KFkudTravG9kVvHM2WLJvWzr90TX+DGc6T2QxoG1k8=" crossorigin="anonymous"></script>
+
+        <script src="rune-mode.js"></script>
+        <script src="rune-highlight-rules.js"></script>
+        <script src="rune-autocomplete.js"></script>
 
         <style>
             #editor {
@@ -14,28 +21,20 @@
         </style>
     </head>
     <body>
-        <div id="editor">
-println!("Hello World!");
-        </div>
+        <div id="editor">println!("Hello World!");</div>
         <script>
-            let init = async () => {
-                let runeCompleter = (await import("./autocomplete.js")).default;
+            var editor = ace.edit("editor");
+            editor.setTheme("ace/theme/monokai");
+            editor.getSession().setMode("ace/mode/rune");
 
-                var editor = ace.edit("editor");
-                editor.setTheme("ace/theme/monokai");
-                editor.getSession().setMode("ace/mode/rust");
+            editor.setOptions({
+                enableBasicAutocompletion: true,
+                enableLiveAutocompletion: true
+            });
 
-                editor.setOptions({
-                    enableBasicAutocompletion: true,
-                    //enableSnippets: true,
-                    enableLiveAutocompletion: true
-                });
-
-                let langTools = ace.require("ace/ext/language_tools");
-                langTools.addCompleter(runeCompleter);
-            };
-
-            init();
+            let langTools = ace.require("ace/ext/language_tools");
+            let runeCompleter = ace.require("ace/autocomplete/rune").Completer;
+            langTools.addCompleter(runeCompleter);
         </script>
     </body>
 </html>


### PR DESCRIPTION
This adds the rune mode from https://github.com/rune-rs/ace/tree/rune and generates it as part of the `ace` command.

First ace needs to be included with language-tools and c_cpp support, something like this will work:

```html
<script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.35.4/ace.js" integrity="sha512-ADBQV64rzhFIJkiHBan+9UeZRq3DZrP6/S2+FS2EX5icsYw/IQgmFaSmt6UTqZpWXkpCKluztsTpOtxx5GkD2A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
<script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.35.4/ext-language_tools.min.js" integrity="sha512-4l33zsqrqf1PBA3iEZ399Jl9on7It0HngOkI3TG2c6W0wUyTiXRxd9Eh8zFBXNy8fMlgda/u4u1metnbEf5Hzg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
<script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.35.4/mode-c_cpp.min.js" integrity="sha512-Fepj87n1m0/F1Z4nN6Rmz/d/7S4Xd1UoS0x/Qd3tFllh1Fjf8RRVvjp9jcW/FcBPGvbOjSv+dgcidNBnUj2bhg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
<script src="rune-mode.js"></script>
<script src="rune-highlight-rules.js"></script>
<script src="rune-autocomplete.js"></script>
```

Then it can be used like this:

```javascript
var editor = ace.edit("editor");
editor.setTheme("ace/theme/textmate");
editor.getSession().setMode("ace/mode/rune");

editor.setOptions({
    enableBasicAutocompletion: true,
    enableLiveAutocompletion: true
});

let runeCompleter = ace.require("ace/autocomplete/rune").Completer;
let langTools = ace.require("ace/ext/language_tools");
langTools.addCompleter(runeCompleter);
```