### PR TITLE
languageserver: add support for utf-8 and format selection

### DIFF
--- a/crates/rune/src/compile/mod.rs
+++ b/crates/rune/src/compile/mod.rs
@@ -46,6 +46,8 @@ pub(crate) use self::unit_builder::UnitBuilder;
 pub(crate) mod v1;
 
 mod options;
+#[cfg(any(test, feature = "languageserver"))]
+pub(crate) use self::options::FmtOptions;
 pub use self::options::{Options, ParseOptionError};
 
 mod location;

--- a/crates/rune/src/compile/options.rs
+++ b/crates/rune/src/compile/options.rs
@@ -25,9 +25,18 @@ pub(crate) struct FmtOptions {
     pub(crate) print_tree: bool,
     /// Attempt to format even when faced with syntax errors.
     pub(crate) error_recovery: bool,
+    /// Force newline at end of document.
+    pub(crate) force_newline: bool,
 }
 
 impl FmtOptions {
+    /// The default format option.
+    pub(crate) const DEFAULT: Self = Self {
+        print_tree: false,
+        error_recovery: false,
+        force_newline: true,
+    };
+
     /// Parse a rune-fmt option.
     pub(crate) fn parse_option(&mut self, option: &str) -> Result<(), ParseOptionError> {
         let (head, tail) = if let Some((head, tail)) = option.trim().split_once('=') {
@@ -43,6 +52,9 @@ impl FmtOptions {
             "error-recovery" => {
                 self.error_recovery = tail.map_or(true, |s| s == "true");
             }
+            "force-newline" => {
+                self.force_newline = tail.map_or(true, |s| s == "true");
+            }
             _ => {
                 return Err(ParseOptionError {
                     option: option.into(),
@@ -51,6 +63,13 @@ impl FmtOptions {
         }
 
         Ok(())
+    }
+}
+
+impl Default for FmtOptions {
+    #[inline]
+    fn default() -> Self {
+        FmtOptions::DEFAULT
     }
 }
 
@@ -108,10 +127,7 @@ impl Options {
         function_body: false,
         test_std: false,
         lowering: 0,
-        fmt: FmtOptions {
-            print_tree: false,
-            error_recovery: false,
-        },
+        fmt: FmtOptions::DEFAULT,
     };
 
     /// Get a list and documentation for all available compiler options.
@@ -224,6 +240,15 @@ impl Options {
                     /// contains invalid syntax.
                 },
                 default: "false",
+                options: BOOL,
+            },
+            OptionMeta {
+                key: "fmt.force-newline",
+                unstable: true,
+                doc: &docstring! {
+                    /// Force newline at end of document.
+                },
+                default: "true",
                 options: BOOL,
             },
         ];

--- a/crates/rune/src/fmt/format.rs
+++ b/crates/rune/src/fmt/format.rs
@@ -660,7 +660,7 @@ fn expr_with_kind<'a>(o: &mut Output<'a>, p: &mut Stream<'a>) -> Result<Kind> {
             expr_chain(o, p)?;
         }
         Error => {
-            if o.options.fmt.error_recovery {
+            if o.options.error_recovery {
                 p.write_remaining_trimmed(o)?;
             } else {
                 return Err(p.unsupported("expression"));

--- a/crates/rune/src/fmt/output.rs
+++ b/crates/rune/src/fmt/output.rs
@@ -3,9 +3,8 @@ use core::mem::take;
 use crate::alloc::prelude::*;
 use crate::alloc::{self, VecDeque};
 use crate::ast::{Kind, Span};
-use crate::compile::{Error, ErrorKind, Result, WithSpan};
+use crate::compile::{Error, ErrorKind, FmtOptions, Result, WithSpan};
 use crate::grammar::{Node, Tree};
-use crate::Options;
 
 use super::{INDENT, NL, NL_CHAR, WS};
 
@@ -111,7 +110,7 @@ pub(crate) struct Output<'a> {
     span: Span,
     pub(super) source: &'a Source,
     o: &'a mut Buffer,
-    pub(super) options: &'a Options,
+    pub(super) options: &'a FmtOptions,
     comments: VecDeque<Comment>,
     lines: usize,
     use_lines: bool,
@@ -125,7 +124,7 @@ impl<'a> Output<'a> {
         span: Span,
         source: &'a str,
         o: &'a mut String,
-        options: &'a Options,
+        options: &'a FmtOptions,
     ) -> Self {
         Self {
             span,

--- a/crates/rune/src/fmt/tests/macros.rs
+++ b/crates/rune/src/fmt/tests/macros.rs
@@ -53,7 +53,7 @@ macro_rules! assert_format_with {
         let input = lines($input).join("\n");
 
         #[allow(unused_mut)]
-        let mut options = $crate::Options::default();
+        let mut options = $crate::compile::FmtOptions::default();
 
         $(options.parse_option($option).unwrap();)*
 

--- a/crates/rune/src/fmt/tests/mod.rs
+++ b/crates/rune/src/fmt/tests/mod.rs
@@ -1033,10 +1033,10 @@ fn runefmt_skip() {
 // Test that we can format syntactically invalid sequences.
 #[test]
 fn test_error_patterns() {
-    assert_format_with!({ "fmt.error-recovery=true" }, "let var = +/-=;",);
+    assert_format_with!({ "error-recovery=true" }, "let var = +/-=;",);
 
     assert_format_with!(
-        { "fmt.error-recovery=true" },
+        { "error-recovery=true" },
         r#"
         let var = +/-=;
 
@@ -1045,7 +1045,7 @@ fn test_error_patterns() {
     );
 
     assert_format_with!(
-        { "fmt.error-recovery=true" },
+        { "error-recovery=true" },
         r#"
         let var = +/-= // Hi Bob
         ;

--- a/crates/rune/src/indexing/indexer.rs
+++ b/crates/rune/src/indexing/indexer.rs
@@ -342,7 +342,7 @@ impl<'a, 'arena> Indexer<'a, 'arena> {
             .q
             .sources
             .get(self.source_id)
-            .map(|s| s.pos_to_utf16cu_linecol(ast.open.span.start.into_usize()))
+            .map(|s| s.pos_to_utf8_linecol(ast.open.span.start.into_usize()))
             .unwrap_or_default();
 
         // 1-indexed as that is what most editors will use

--- a/crates/rune/src/source.rs
+++ b/crates/rune/src/source.rs
@@ -221,12 +221,15 @@ impl Source {
     }
 
     /// Convert the given offset to a utf-16 line and character.
+    #[cfg(feature = "languageserver")]
     pub(crate) fn pos_to_utf16cu_linecol(&self, offset: usize) -> (usize, usize) {
         let (line, offset, rest) = self.position(offset);
+
         let col = rest
             .char_indices()
             .flat_map(|(n, c)| (n < offset).then(|| c.encode_utf16(&mut [0u16; 2]).len()))
             .sum();
+
         (line, col)
     }
 


### PR DESCRIPTION
Thanks to the new formatter in #790, we can now format basically any code fragment. So I've implemented selection-based formatting for the language server.