### PR TITLE
fmt: mark out items in grammar

### DIFF
--- a/assets/tokens.yaml
+++ b/assets/tokens.yaml
@@ -403,6 +403,7 @@
 - {kind: "syntax", variant: "ItemFn", doc: "a function declaration"}
 - {kind: "syntax", variant: "ItemImpl", doc: "an impl"}
 - {kind: "syntax", variant: "ItemMod", doc: "an module declaration"}
+- {kind: "syntax", variant: "ItemFileMod", doc: "a file module declaration"}
 - {kind: "syntax", variant: "ItemUse", doc: "a use import"}
 - {kind: "syntax", variant: "ItemUsePath", doc: "a nested use path"}
 - {kind: "syntax", variant: "ItemUseGroup", doc: "a nested use group"}

--- a/crates/rune/src/ast/generated.rs
+++ b/crates/rune/src/ast/generated.rs
@@ -5698,6 +5698,8 @@ pub enum Kind {
     ItemImpl,
     /// an module declaration
     ItemMod,
+    /// a file module declaration
+    ItemFileMod,
     /// a use import
     ItemUse,
     /// a nested use path
@@ -6152,6 +6154,7 @@ impl parse::IntoExpectation for Kind {
             Self::ItemFn => parse::Expectation::Syntax("a function declaration"),
             Self::ItemImpl => parse::Expectation::Syntax("an impl"),
             Self::ItemMod => parse::Expectation::Syntax("an module declaration"),
+            Self::ItemFileMod => parse::Expectation::Syntax("a file module declaration"),
             Self::ItemUse => parse::Expectation::Syntax("a use import"),
             Self::ItemUsePath => parse::Expectation::Syntax("a nested use path"),
             Self::ItemUseGroup => parse::Expectation::Syntax("a nested use group"),

--- a/crates/rune/src/grammar/tree.rs
+++ b/crates/rune/src/grammar/tree.rs
@@ -369,6 +369,16 @@ impl<'a> Node<'a> {
         Self { inner }
     }
 
+    /// Get the last node.
+    pub(crate) fn last(&self) -> Option<Node<'a>> {
+        self.inner.last().map(Node::new)
+    }
+
+    /// Iterate over the children of the node.
+    pub(crate) fn children(&self) -> impl Iterator<Item = Node<'a>> + '_ {
+        self.inner.children().map(Node::new)
+    }
+
     pub(crate) fn unsupported(&self, what: &'static str) -> Error {
         Error::new(
             self.span(),


### PR DESCRIPTION
This makes it easier to parse out items.