### PR TITLE
Fixed tokio error in hot reload example

### DIFF
--- a/examples/examples/hot_reloading.rs
+++ b/examples/examples/hot_reloading.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use anyhow::{Context as _, Result};
 use rune::{Context, Vm};
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
     let root =
         PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").context("missing CARGO_MANIFEST_DIR")?);


### PR DESCRIPTION
`#[tokio::main]` macro refused to compile because it uses multithreaded runtime by default but the example disabled multithreading.