### PR TITLE
Remove copypaste from docs of `VecDeque` and `HashSet`

### DIFF
--- a/crates/rune/src/modules/collections/hash_set.rs
+++ b/crates/rune/src/modules/collections/hash_set.rs
@@ -446,8 +446,8 @@ impl HashSet {
 
     /// Convert a [`HashSet`] from an iterator.
     ///
-    /// The hashmap can be converted from anything that implements the
-    /// [`INTO_ITER`] protocol, and each item produces should be a tuple pair.
+    /// The hashset can be converted from anything that implements the
+    /// [`INTO_ITER`] protocol.
     ///
     /// # Examples
     ///

--- a/crates/rune/src/modules/collections/vec_deque.rs
+++ b/crates/rune/src/modules/collections/vec_deque.rs
@@ -513,8 +513,8 @@ impl VecDeque {
 
     /// Build a [`VecDeque`] from an iterator.
     ///
-    /// The hashmap can be converted from anything that implements the
-    /// [`INTO_ITER`] protocol, and each item produces should be a tuple pair.
+    /// The vecdeque can be converted from anything that implements the
+    /// [`INTO_ITER`] protocol.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Seems that docs were copied from `HashMap`, I made it more appropriate to the actual types.