### PR TITLE
Eagerly allocate slots for conditions to fix #830

### DIFF
--- a/crates/rune/tests/bug_830.rn
+++ b/crates/rune/tests/bug_830.rn
@@ -1,0 +1,38 @@
+// This tests an issue where the temporary value inside of the `&&` operator
+// overwrites the left hand side slot.
+// https://github.com/rune-rs/rune/issues/830
+
+#[test]
+fn if_stmt() {
+    let value = true;
+
+    if value && false {
+        panic!("should not be reached");
+    }
+
+    assert!(value);
+}
+
+#[test]
+fn else_if_stmt() {
+    let value = true;
+
+    if false {
+        panic!("should not be reached");
+    } else if value && false {
+        panic!("should not be reached");
+    }
+
+    assert!(value);
+}
+
+#[test]
+fn while_stmt() {
+    let value = true;
+
+    while value && false {
+        panic!("should not be reached");
+    }
+
+    assert!(value);
+}

--- a/crates/rune/tests/lazy_and_or.rn
+++ b/crates/rune/tests/lazy_and_or.rn
@@ -1,5 +1,5 @@
 #[test]
-fn test_lazy_and_or() {
+fn lazy_and_or() {
     let result = (|| true || return false)();
     assert_eq!(result, true);
 


### PR DESCRIPTION
Thanks to @dstoza for the report.

This fixes the issue by ensuring that conditions utilise their own eagerly allocated conditional slot rather than rely on deferred slots. The overarching assumption during assembly is that the `needs` slot if allocated can be used as a temporary location which is exactly what's happening for literal expression.

However this assumption is broken for certain linear expressions such as `a && b` and `a || b` if we defer slot allocation since the slot might be assigned to the place pointed to by `a`.