### PR TITLE
rune: Fix freed address with diverging conditions

### DIFF
--- a/crates/rune/tests/bug_830.rn
+++ b/crates/rune/tests/bug_830.rn
@@ -36,3 +36,17 @@ fn while_stmt() {
 
     assert!(value);
 }
+
+#[test]
+fn match_stmt() {
+    let value = true;
+
+    let value2 = match true {
+        false => false,
+        _ if value && false => panic!("should not be reached"),
+        true => true,
+    };
+
+    assert!(value);
+    assert!(value2);
+}

--- a/crates/rune/tests/diverging.rn
+++ b/crates/rune/tests/diverging.rn
@@ -1,0 +1,36 @@
+#[test]
+fn diverging_if() {
+    fn inner() {
+        if return true {
+        }
+
+        false
+    }
+
+    assert!(inner());
+}
+
+#[test]
+fn diverging_condition_while() {
+    fn inner() {
+        while return true {
+        }
+
+        false
+    }
+
+    assert!(inner());
+}
+
+#[test]
+fn diverging_condition_match() {
+    fn inner() {
+        match true {
+            false => false,
+            _ if return true => false,
+            true => false,
+        }
+    }
+
+    assert!(inner());
+}


### PR DESCRIPTION
This is a compilation bug that was discovered in conjunction with #830.

Fully diverging conditions like these were incorrectly freed after the scope they were associated with has been popped:

```rust
if return true {
}
```