### PR TITLE
rune: Avoid clobbering assigned addresses (fixes #838)

### DIFF
--- a/crates/rune/tests/bug_838.rn
+++ b/crates/rune/tests/bug_838.rn
@@ -1,0 +1,36 @@
+// This ensures that unary operations do not clobber a slot.
+// https://github.com/rune-rs/rune/issues/838
+
+#[test]
+fn negation_simple() {
+    let b = -1;
+    let d = 0 + -b;
+    assert_eq!(d, 1);
+    assert_eq!(b, -1);
+}
+
+#[test]
+fn negation_simple_chain() {
+    let b = -1;
+    let d = 0 + -b;
+    d = 0 + -b;
+    d = 0 + -b;
+    d = 0 + -b;
+    assert_eq!(d, 1);
+    assert_eq!(b, -1);
+}
+
+#[test]
+fn negation() {
+    let a = 1;
+    let b = -2;
+    let c = -b;
+    let d = 1 < -b;
+    let e = 1 < -b;
+
+    assert!(d);
+    assert!(e);
+    assert_eq!(a, 1);
+    assert_eq!(b, -2);
+    assert_eq!(c, 2);
+}

--- a/crates/rune/tests/matching.rn
+++ b/crates/rune/tests/matching.rn
@@ -168,3 +168,49 @@ fn match_enum2() {
 
     assert_eq!(out, Enum::Right);
 }
+
+#[test]
+fn match_extraction_vec() {
+    let v = [42];
+
+    fn inner(v) {
+        match v {
+            [a] => a,
+            _ => 0,
+        }
+    }
+
+    assert_eq!(inner(v), 42);
+}
+
+#[test]
+fn match_extraction_tuple() {
+    let v = (42,);
+
+    fn inner(v) {
+        match v {
+            (a,) => a,
+            _ => 0,
+        }
+    }
+
+    assert_eq!(inner(v), 42);
+}
+
+#[test]
+fn match_extraction_struct() {
+    struct Struct {
+        a,
+    }
+
+    fn inner(v) {
+        match v {
+            Struct { a, .. } => a,
+            _ => 0,
+        }
+    }
+
+    let v = Struct { a: 42 };
+
+    assert_eq!(inner(v), 42);
+}


### PR DESCRIPTION
This should fix #838 and is the real fix for #830.

We introduce another kind of address allocation called `defer-assign`. This address can be read from, but attempting to write to it will force it to be allocated to a new slot.

This is necessary when assembling expressions, because we will otherwise accidentally clobber the address slots in expressions such as:

```rust
let b = -1;
let c = 0 + -b;
```

Before this change, the output of `-b` will be written to `b`, because the inner expression resolves to the address of `b`. After this change, since the unary expression allocates an output a local slot will be allocated instead.

Thanks to @fujiehuang for the original report.
Thanks to @whitingjarod for a reduced test case.