### PR TITLE
rune::doc: Fix rendering of conflicting hashes

### DIFF
--- a/crates/rune/src/modules/f64.rs
+++ b/crates/rune/src/modules/f64.rs
@@ -380,7 +380,10 @@ fn round(this: f64) -> f64 {
     this.round()
 }
 
-/// Test two integers for partial equality.
+/// Clone a `f64`.
+///
+/// Note that since the type is copy, cloning has the same effect as assigning
+/// it.
 ///
 /// # Examples
 ///
@@ -392,7 +395,7 @@ fn round(this: f64) -> f64 {
 /// a += 1.0;
 ///
 /// assert_eq!(a, 6.0);
-/// assert_eq!(b, 6.0);
+/// assert_eq!(b, 5.0);
 /// assert_eq!(c, 5.0);
 /// ```
 #[rune::function(keep, instance, protocol = CLONE)]

--- a/crates/rune/src/modules/i64.rs
+++ b/crates/rune/src/modules/i64.rs
@@ -530,7 +530,10 @@ fn is_negative(this: i64) -> bool {
     i64::is_negative(this)
 }
 
-/// Test two integers for partial equality.
+/// Clone a `i64`.
+///
+/// Note that since the type is copy, cloning has the same effect as assigning
+/// it.
 ///
 /// # Examples
 ///
@@ -542,7 +545,7 @@ fn is_negative(this: i64) -> bool {
 /// a += 1;
 ///
 /// assert_eq!(a, 6);
-/// assert_eq!(b, 6);
+/// assert_eq!(b, 5);
 /// assert_eq!(c, 5);
 /// ```
 #[rune::function(keep, instance, protocol = CLONE)]


### PR DESCRIPTION
This fixes an issue where we inadvertently do not render items which have the same hash after `Build` was refactored.

Items such as `module ::std::i64` and `type ::std::i64` have the same type hash `hash!(::std::I64)` but are obviously different types.

Thanks to @chevyray for the report!