### PR TITLE
rune::cli: Unify coloring and improve test naming

### DIFF
--- a/crates/rune-core/src/protocol.rs
+++ b/crates/rune-core/src/protocol.rs
@@ -139,7 +139,7 @@ macro_rules! define {
 define! {
     /// The function to access a field.
     pub const [GET, GET_HASH]: Protocol = Protocol {
-        name: "get",
+        name: "GET",
         hash: 0x504007af1a8485a4u64,
         repr: Some("let output = $value"),
         doc: ["Allows a get operation to work."],
@@ -147,7 +147,7 @@ define! {
 
     /// The function to set a field.
     pub const [SET, SET_HASH]: Protocol = Protocol {
-        name: "set",
+        name: "SET",
         hash: 0x7d13d47fd8efef5au64,
         repr: Some("$value = input"),
         doc: ["Allows a set operation to work."],
@@ -155,7 +155,7 @@ define! {
 
     /// The function to access an index.
     pub const [INDEX_GET, INDEX_GET_HASH]: Protocol = Protocol {
-        name: "index_get",
+        name: "INDEX_GET",
         hash: 0xadb5b27e2a4d2decu64,
         repr: Some("let output = $value[index]"),
         doc: ["Allows an indexing get operation to work."],
@@ -163,7 +163,7 @@ define! {
 
     /// The function to set an index.
     pub const [INDEX_SET, INDEX_SET_HASH]: Protocol = Protocol {
-        name: "index_set",
+        name: "INDEX_SET",
         hash: 0x162943f7bd03ad36u64,
         repr: Some("$value[index] = input"),
         doc: ["Allows an indexing set operation to work."],
@@ -171,7 +171,7 @@ define! {
 
     /// Check two types for partial equality.
     pub const [PARTIAL_EQ, PARTIAL_EQ_HASH]: Protocol = Protocol {
-        name: "partial_eq",
+        name: "PARTIAL_EQ",
         hash: 0x4b6bc4701445e318u64,
         repr: Some("if $value == b { }"),
         doc: ["Allows for partial equality operations to work."],
@@ -179,7 +179,7 @@ define! {
 
     /// Check two types for total equality.
     pub const [EQ, EQ_HASH]: Protocol = Protocol {
-        name: "eq",
+        name: "EQ",
         hash: 0x418f5becbf885806u64,
         repr: Some("if $value == b { }"),
         doc: ["Allows an equality operation to work."],
@@ -187,7 +187,7 @@ define! {
 
     /// Perform an partial comparison between two values.
     pub const [PARTIAL_CMP, PARTIAL_CMP_HASH]: Protocol = Protocol {
-        name: "partial_cmp",
+        name: "PARTIAL_CMP",
         hash: 0x8d4430991253343cu64,
         repr: Some("if $value < b { }"),
         doc: ["Allows for partial ordering to work."],
@@ -195,7 +195,7 @@ define! {
 
     /// Perform an total comparison between two values.
     pub const [CMP, CMP_HASH]: Protocol = Protocol {
-        name: "cmp",
+        name: "CMP",
         hash: 0x240f1b75466cd1a3u64,
         repr: Some("if $value < b { }"),
         doc: ["Allows for total ordering to work."],
@@ -203,7 +203,7 @@ define! {
 
     /// The function to implement for the addition operation.
     pub const [ADD, ADD_HASH]: Protocol = Protocol {
-        name: "add",
+        name: "ADD",
         hash: 0xe4ecf51fa0bf1076u64,
         repr: Some("let output = $value + b"),
         doc: [
@@ -213,7 +213,7 @@ define! {
 
     /// The function to implement for the addition assign operation.
     pub const [ADD_ASSIGN, ADD_ASSIGN_HASH]: Protocol = Protocol {
-        name: "add_assign",
+        name: "ADD_ASSIGN",
         hash: 0x42451ccb0a2071a9u64,
         repr: Some("$value += b"),
         doc: [
@@ -223,7 +223,7 @@ define! {
 
     /// The function to implement for the subtraction operation.
     pub const [SUB, SUB_HASH]: Protocol = Protocol {
-        name: "sub",
+        name: "SUB",
         hash: 0x6fa86a5f18d0bf71u64,
         repr: Some("let output = $value - b"),
         doc: [
@@ -233,7 +233,7 @@ define! {
 
     /// The function to implement for the subtraction assign operation.
     pub const [SUB_ASSIGN, SUB_ASSIGN_HASH]: Protocol = Protocol {
-        name: "sub_assign",
+        name: "SUB_ASSIGN",
         hash: 0x5939bb56a1415284u64,
         repr: Some("$value -= b"),
         doc: [
@@ -243,7 +243,7 @@ define! {
 
     /// The function to implement for the multiply operation.
     pub const [MUL, MUL_HASH]: Protocol = Protocol {
-        name: "mul",
+        name: "MUL",
         hash: 0xb09e99dc94091d1cu64,
         repr: Some("let output = $value * b"),
         doc: [
@@ -253,7 +253,7 @@ define! {
 
     /// The function to implement for the multiply assign operation.
     pub const [MUL_ASSIGN, MUL_ASSIGN_HASH]: Protocol = Protocol {
-        name: "mul_assign",
+        name: "MUL_ASSIGN",
         hash: 0x29a54b727f980ebfu64,
         repr: Some("$value *= b"),
         doc: [
@@ -263,7 +263,7 @@ define! {
 
     /// The function to implement for the division operation.
     pub const [DIV, DIV_HASH]: Protocol = Protocol {
-        name: "div",
+        name: "DIV",
         hash: 0xf26d6eea1afca6e8u64,
         repr: Some("let output = $value / b"),
         doc: [
@@ -273,7 +273,7 @@ define! {
 
     /// The function to implement for the division assign operation.
     pub const [DIV_ASSIGN, DIV_ASSIGN_HASH]: Protocol = Protocol {
-        name: "div_assign",
+        name: "DIV_ASSIGN",
         hash: 0x4dd087a8281c04e6u64,
         repr: Some("$value /= b"),
         doc: [
@@ -283,7 +283,7 @@ define! {
 
     /// The function to implement for the remainder operation.
     pub const [REM, REM_HASH]: Protocol = Protocol {
-        name: "rem",
+        name: "REM",
         hash: 0x5c6293639c74e671u64,
         repr: Some("let output = $value % b"),
         doc: [
@@ -293,7 +293,7 @@ define! {
 
     /// The function to implement for the remainder assign operation.
     pub const [REM_ASSIGN, REM_ASSIGN_HASH]: Protocol = Protocol {
-        name: "rem_assign",
+        name: "REM_ASSIGN",
         hash: 0x3a8695980e77baf4u64,
         repr: Some("$value %= b"),
         doc: [
@@ -303,7 +303,7 @@ define! {
 
     /// The function to implement for the bitwise and operation.
     pub const [BIT_AND, BIT_AND_HASH]: Protocol = Protocol {
-        name: "bit_and",
+        name: "BIT_AND",
         hash: 0x0e11f20d940eebe8u64,
         repr: Some("let output = $value & b"),
         doc: [
@@ -313,7 +313,7 @@ define! {
 
     /// The function to implement for the bitwise and assign operation.
     pub const [BIT_AND_ASSIGN, BIT_AND_ASSIGN_HASH]: Protocol = Protocol {
-        name: "bit_and_assign",
+        name: "BIT_AND_ASSIGN",
         hash: 0x95cb1ba235dfb5ecu64,
         repr: Some("$value &= b"),
         doc: [
@@ -323,7 +323,7 @@ define! {
 
     /// The function to implement for the bitwise xor operation.
     pub const [BIT_XOR, BIT_XOR_HASH]: Protocol = Protocol {
-        name: "bit_xor",
+        name: "BIT_XOR",
         hash: 0xa3099c54e1de4cbfu64,
         repr: Some("let output = $value ^ b"),
         doc: [
@@ -333,7 +333,7 @@ define! {
 
     /// The function to implement for the bitwise xor assign operation.
     pub const [BIT_XOR_ASSIGN, BIT_XOR_ASSIGN_HASH]: Protocol = Protocol {
-        name: "bit_xor_assign",
+        name: "BIT_XOR_ASSIGN",
         hash: 0x01fa9706738f9867u64,
         repr: Some("$value ^= b"),
         doc: [
@@ -343,7 +343,7 @@ define! {
 
     /// The function to implement for the bitwise or operation.
     pub const [BIT_OR, BIT_OR_HASH]: Protocol = Protocol {
-        name: "bit_or",
+        name: "BIT_OR",
         hash: 0x05010afceb4a03d0u64,
         repr: Some("let output = $value | b"),
         doc: [
@@ -353,7 +353,7 @@ define! {
 
     /// The function to implement for the bitwise xor assign operation.
     pub const [BIT_OR_ASSIGN, BIT_OR_ASSIGN_HASH]: Protocol = Protocol {
-        name: "bit_or_assign",
+        name: "BIT_OR_ASSIGN",
         hash: 0x606d79ff1750a7ecu64,
         repr: Some("$value |= b"),
         doc: [
@@ -363,7 +363,7 @@ define! {
 
     /// The function to implement for the bitwise shift left operation.
     pub const [SHL, SHL_HASH]: Protocol = Protocol {
-        name: "shl",
+        name: "SHL",
         hash: 0x6845f7d0cc9e002du64,
         repr: Some("let output = $value << b"),
         doc: [
@@ -373,7 +373,7 @@ define! {
 
     /// The function to implement for the bitwise shift left assign operation.
     pub const [SHL_ASSIGN, SHL_ASSIGN_HASH]: Protocol = Protocol {
-        name: "shl_assign",
+        name: "SHL_ASSIGN",
         hash: 0xdc4702d0307ba27bu64,
         repr: Some("$value <<= b"),
         doc: [
@@ -383,7 +383,7 @@ define! {
 
     /// The function to implement for the bitwise shift right operation.
     pub const [SHR, SHR_HASH]: Protocol = Protocol {
-        name: "shr",
+        name: "SHR",
         hash: 0x6b485e8e6e58fbc8u64,
         repr: Some("let output = $value >> b"),
         doc: [
@@ -393,7 +393,7 @@ define! {
 
     /// The function to implement for the bitwise shift right assign operation.
     pub const [SHR_ASSIGN, SHR_ASSIGN_HASH]: Protocol = Protocol {
-        name: "shr_assign",
+        name: "SHR_ASSIGN",
         hash: 0x61ff7c46ff00e74au64,
         repr: Some("$value >>= b"),
         doc: [
@@ -403,7 +403,7 @@ define! {
 
     /// Protocol function used by template strings.
     pub const [STRING_DISPLAY, STRING_DISPLAY_HASH]: Protocol = Protocol {
-        name: "string_display",
+        name: "STRING_DISPLAY",
         hash: 0x811b62957ea9d9f9u64,
         repr: Some("println(\"{}\", $value)"),
         doc: ["Allows the value to be display printed."],
@@ -411,7 +411,7 @@ define! {
 
     /// Protocol function used by custom debug impls.
     pub const [STRING_DEBUG, STRING_DEBUG_HASH]: Protocol = Protocol {
-        name: "string_debug",
+        name: "STRING_DEBUG",
         hash: 0x4064e3867aaa0717u64,
         repr: Some("println(\"{:?}\", $value)"),
         doc: ["Allows the value to be debug printed."],
@@ -419,7 +419,7 @@ define! {
 
     /// Function used to convert an argument into an iterator.
     pub const [INTO_ITER, INTO_ITER_HASH]: Protocol = Protocol {
-        name: "into_iter",
+        name: "INTO_ITER",
         hash: 0x15a85c8d774b4065u64,
         repr: Some("for item in $value { }"),
         doc: ["Allows the value to be converted into an iterator in a for-loop."],
@@ -427,7 +427,7 @@ define! {
 
     /// The function to call to continue iteration.
     pub const [NEXT, NEXT_HASH]: Protocol = Protocol {
-        name: "next",
+        name: "NEXT",
         hash: 0xc3cde069de2ba320u64,
         repr: None,
         doc: ["Allows iteration to be advanced for the type, this is used for iterators."],
@@ -435,7 +435,7 @@ define! {
 
     /// The function to call to continue iteration at the nth element.
     pub const [NTH, NTH_HASH]: Protocol = Protocol {
-        name: "nth",
+        name: "NTH",
         hash: 0x6704550736c82a58u64,
         repr: None,
         doc: ["Allows iteration to be advanced for the type to the nth element, this is used for iterators."],
@@ -443,7 +443,7 @@ define! {
 
     /// The function to call to continue iteration at the nth element form the back.
     pub const [NTH_BACK, NTH_BACK_HASH]: Protocol = Protocol {
-        name: "nth_back",
+        name: "NTH_BACK",
         hash: 0x4885ca2fd53a08c8u64,
         repr: None,
         doc: ["Allows iteration to be advanced for the type to the nth element from the back, this is used for iterators."],
@@ -451,7 +451,7 @@ define! {
 
     /// Protocol used when getting the size hint of an iterator.
     pub const [SIZE_HINT, SIZE_HINT_HASH]: Protocol = Protocol {
-        name: "size_hint",
+        name: "SIZE_HINT",
         hash: 0x1a7b50baabc6e094u64,
         repr: Some("let output = $value.size_hint()"),
         doc: ["Get the size hint of an iterator."],
@@ -459,7 +459,7 @@ define! {
 
     /// Protocol used when getting the exact length of an iterator.
     pub const [LEN, LEN_HASH]: Protocol = Protocol {
-        name: "len",
+        name: "LEN",
         hash: 0x52dd3b9489d39c42u64,
         repr: Some("let output = $value.len()"),
         doc: ["Get the length of an iterator."],
@@ -467,7 +467,7 @@ define! {
 
     /// Protocol used when cloning a value.
     pub const [NEXT_BACK, NEXT_BACK_HASH]: Protocol = Protocol {
-        name: "next_back",
+        name: "NEXT_BACK",
         hash: 0x91149fef42c0a8aeu64,
         repr: Some("let output = $value.next_back()"),
         doc: ["Get the next value from the back of the iterator."],
@@ -477,7 +477,7 @@ define! {
     ///
     /// Signature: `fn(Value) -> Future`.
     pub const [INTO_FUTURE, INTO_FUTURE_HASH]: Protocol = Protocol {
-        name: "into_future",
+        name: "INTO_FUTURE",
         hash: 0x596e6428deabfda2u64,
         repr: Some("value.await"),
         doc: ["This protocol allows the type to be converted into a future by awaiting them."],
@@ -485,7 +485,7 @@ define! {
 
     /// Coerce a value into a type name. This is stored as a constant.
     pub const [INTO_TYPE_NAME, INTO_TYPE_NAME_HASH]: Protocol = Protocol {
-        name: "into_type_name",
+        name: "INTO_TYPE_NAME",
         hash: 0xbffd08b816c24682u64,
         repr: None,
         doc: [
@@ -497,7 +497,7 @@ define! {
     ///
     /// Signature: `fn(self, usize) -> bool`.
     pub const [IS_VARIANT, IS_VARIANT_HASH]: Protocol = Protocol {
-        name: "is_variant",
+        name: "IS_VARIANT",
         hash: 0xc030d82bbd4dabe8u64,
         repr: None,
         doc: ["Test if the provided argument is a variant."],
@@ -513,7 +513,7 @@ define! {
     /// [`Try`]: core::ops::Try
     /// [`ControlFlow`]: core::ops::ControlFlow
     pub const [TRY, TRY_HASH]: Protocol = Protocol {
-        name: "try",
+        name: "TRY",
         hash: 0x5da1a80787003354u64,
         repr: Some("value?"),
         doc: ["Allows the `?` operator to apply to values of this type."],
@@ -521,7 +521,7 @@ define! {
 
     /// Protocol used when calculating a hash.
     pub const [HASH, HASH_HASH]: Protocol = Protocol {
-        name: "hash",
+        name: "HASH",
         hash: 0xf6cf2d9f416cef08u64,
         repr: Some("let output = hash($value)"),
         doc: ["Hash a value."],
@@ -529,7 +529,7 @@ define! {
 
     /// Protocol used when cloning a value.
     pub const [CLONE, CLONE_HASH]: Protocol = Protocol {
-        name: "clone",
+        name: "CLONE",
         hash: 0x2af2c875e36971eu64,
         repr: Some("let output = clone($value)"),
         doc: ["Clone a value."],

--- a/crates/rune/src/cli/out.rs
+++ b/crates/rune/src/cli/out.rs
@@ -1,0 +1,180 @@
+use std::fmt;
+use std::io::{self, Write};
+
+use crate::termcolor::{self, ColorSpec, StandardStream, WriteColor};
+
+pub(super) enum Stream {
+    Stdout,
+    Stderr,
+}
+
+impl Stream {
+    fn find<'a>(
+        &self,
+        stdout: &'a mut StandardStream,
+        stderr: &'a mut StandardStream,
+    ) -> &'a mut StandardStream {
+        match self {
+            Stream::Stdout => stdout,
+            Stream::Stderr => stderr,
+        }
+    }
+}
+
+pub(super) enum Color {
+    Error,
+    Passed,
+    Ignore,
+    Highlight,
+    Important,
+}
+
+impl Color {
+    fn find<'a>(&self, colors: &'a Colors) -> &'a ColorSpec {
+        match self {
+            Color::Error => &colors.error,
+            Color::Passed => &colors.passed,
+            Color::Ignore => &colors.ignored,
+            Color::Highlight => &colors.highlight,
+            Color::Important => &colors.important,
+        }
+    }
+}
+
+pub(super) struct Io<'io> {
+    pub(super) stdout: &'io mut StandardStream,
+    pub(super) stderr: &'io mut StandardStream,
+    colors: Option<Colors>,
+}
+
+impl<'io> Io<'io> {
+    pub(super) fn new(stdout: &'io mut StandardStream, stderr: &'io mut StandardStream) -> Self {
+        Self {
+            stdout,
+            stderr,
+            colors: None,
+        }
+    }
+
+    pub(super) fn with_color(
+        &mut self,
+        stream: Stream,
+        color: Color,
+    ) -> io::Result<&mut ColorStream> {
+        let stream = stream.find(self.stdout, self.stderr);
+        let colors = self.colors.get_or_insert_with(Colors::new);
+        stream.set_color(color.find(colors))?;
+        Ok(ColorStream::new(stream))
+    }
+
+    pub(super) fn section(
+        &mut self,
+        title: impl fmt::Display,
+        stream: Stream,
+        color: Color,
+    ) -> io::Result<Section<'_>> {
+        let io = stream.find(self.stdout, self.stderr);
+        let colors = self.colors.get_or_insert_with(Colors::new);
+
+        io.set_color(color.find(colors))?;
+        write!(io, "{title:>12}")?;
+        io.reset()?;
+
+        Ok(Section { io, colors })
+    }
+
+    pub(super) fn write(
+        &mut self,
+        title: impl fmt::Display,
+        stream: Stream,
+        color: Color,
+    ) -> io::Result<()> {
+        let stream = stream.find(self.stdout, self.stderr);
+        let colors = self.colors.get_or_insert_with(Colors::new);
+
+        stream.set_color(color.find(colors))?;
+        write!(stream, "{title}")?;
+        stream.reset()?;
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct Colors {
+    error: ColorSpec,
+    passed: ColorSpec,
+    highlight: ColorSpec,
+    important: ColorSpec,
+    ignored: ColorSpec,
+}
+
+impl Colors {
+    fn new() -> Self {
+        let mut this = Self::default();
+        this.error.set_fg(Some(termcolor::Color::Red));
+        this.passed.set_fg(Some(termcolor::Color::Green));
+        this.highlight.set_fg(Some(termcolor::Color::Green));
+        this.highlight.set_bold(true);
+        this.important.set_fg(Some(termcolor::Color::White));
+        this.important.set_bold(true);
+        this.ignored.set_fg(Some(termcolor::Color::Yellow));
+        this.ignored.set_bold(true);
+        this
+    }
+}
+
+#[must_use = "Section must be closed"]
+pub(super) struct Section<'a> {
+    pub(super) io: &'a mut StandardStream,
+    colors: &'a Colors,
+}
+
+impl Section<'_> {
+    pub(super) fn append(&mut self, text: impl fmt::Display) -> io::Result<()> {
+        write!(self.io, "{text}")
+    }
+
+    pub(super) fn append_with(&mut self, text: impl fmt::Display, color: Color) -> io::Result<()> {
+        self.io.set_color(color.find(self.colors))?;
+        write!(self.io, "{text}")?;
+        self.io.reset()?;
+        Ok(())
+    }
+
+    pub(super) fn error(&mut self, text: impl fmt::Display) -> io::Result<()> {
+        self.append_with(text, Color::Error)
+    }
+
+    pub(super) fn passed(&mut self, text: impl fmt::Display) -> io::Result<()> {
+        self.append_with(text, Color::Passed)
+    }
+
+    pub(super) fn close(self) -> io::Result<()> {
+        writeln!(self.io)
+    }
+}
+
+#[repr(transparent)]
+pub(super) struct ColorStream(StandardStream);
+
+impl ColorStream {
+    fn new(io: &mut StandardStream) -> &mut Self {
+        unsafe { &mut *(io as *mut StandardStream as *mut Self) }
+    }
+
+    pub(super) fn close(&mut self) -> io::Result<()> {
+        self.0.reset()
+    }
+}
+
+impl io::Write for ColorStream {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.write(buf)
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.flush()
+    }
+}

--- a/crates/rune/src/doc/artifacts.rs
+++ b/crates/rune/src/doc/artifacts.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 
 use crate::alloc::borrow::Cow;
 use crate::alloc::{String, Vec};
+use crate::runtime::Protocol;
 use crate::ItemBuf;
 
 use anyhow::{Context as _, Error, Result};
@@ -27,10 +28,22 @@ pub(crate) struct TestParams {
     pub(crate) ignore: bool,
 }
 
+/// The kind of a test.
+#[derive(Default, Debug, Clone, Copy)]
+pub(crate) enum TestKind {
+    /// The test originates from a free function.
+    #[default]
+    Free,
+    /// The test originates from a protocol function.
+    Protocol(Protocol),
+}
+
 /// A discovered test.
 pub(crate) struct Test {
     /// Item of the test.
     pub(crate) item: ItemBuf,
+    /// The kind of a test.
+    pub(crate) kind: TestKind,
     /// Lines that make up the tests.
     pub(crate) content: String,
     /// Test parameters.

--- a/crates/rune/src/doc/build.rs
+++ b/crates/rune/src/doc/build.rs
@@ -19,7 +19,7 @@ use crate::alloc::fmt::TryWrite;
 use crate::alloc::prelude::*;
 use crate::alloc::{self, HashSet, VecDeque};
 use crate::compile::meta;
-use crate::doc::artifacts::Test;
+use crate::doc::artifacts::{Test, TestKind};
 use crate::doc::context::{Function, Kind, Meta, Signature};
 use crate::doc::templating;
 use crate::doc::{Artifacts, Context, Visitor};
@@ -340,6 +340,8 @@ pub(crate) struct State<'m> {
     path: RelativePathBuf,
     #[try_clone(copy)]
     item: &'m Item,
+    #[try_clone(copy)]
+    kind: TestKind,
 }
 
 pub(crate) struct Ctxt<'a, 'm> {
@@ -375,6 +377,7 @@ impl<'m> Ctxt<'_, 'm> {
             kind => bail!("Cannot set path for {kind:?}"),
         };
 
+        self.state.kind = TestKind::default();
         self.state.path = RelativePathBuf::new();
         self.state.item = meta.item;
 
@@ -514,6 +517,7 @@ impl<'m> Ctxt<'_, 'm> {
         for (content, params) in tests {
             self.tests.try_push(Test {
                 item: self.state.item.try_to_owned()?,
+                kind: self.state.kind,
                 content,
                 params,
             })?;

--- a/crates/rune/src/doc/build/type_.rs
+++ b/crates/rune/src/doc/build/type_.rs
@@ -7,6 +7,7 @@ use serde::Serialize;
 use crate::alloc::borrow::Cow;
 use crate::alloc::fmt::TryWrite;
 use crate::alloc::prelude::*;
+use crate::doc::artifacts::TestKind;
 use crate::doc::context::{Assoc, AssocFnKind, Kind, Meta};
 use crate::item::ComponentRef;
 use crate::{Hash, Item};
@@ -218,11 +219,15 @@ fn associated_for_hash<'m>(
                         }
                     };
 
+                    let kind = replace(&mut cx.state.kind, TestKind::Protocol(protocol));
+
                     let doc = if assoc.docs.is_empty() {
                         cx.render_docs(meta, protocol.doc, false)?
                     } else {
                         cx.render_docs(meta, assoc.docs, capture_tests)?
                     };
+
+                    cx.state.kind = kind;
 
                     let repr = if let Some(repr) = protocol.repr {
                         Some(cx.render_code([repr.replace("$value", value.as_ref())])?)

--- a/crates/rune/src/doc/mod.rs
+++ b/crates/rune/src/doc/mod.rs
@@ -8,7 +8,7 @@ pub(crate) use self::context::{Context, Function, Kind, Meta, Signature};
 #[cfg(feature = "cli")]
 mod artifacts;
 #[cfg(feature = "cli")]
-pub(crate) use self::artifacts::{Artifacts, TestParams};
+pub(crate) use self::artifacts::{Artifacts, TestKind, TestParams};
 
 #[cfg(feature = "cli")]
 mod templating;


### PR DESCRIPTION
This makes sure that protocols that tests are associated with are displayed during testing:

![image](https://github.com/user-attachments/assets/722b37a7-6f38-423f-b2c1-90cfe425be4f)