### PR TITLE
Rework how constants are registered

### DIFF
--- a/crates/rune-macros/src/any.rs
+++ b/crates/rune-macros/src/any.rs
@@ -282,6 +282,7 @@ fn expand_enum_install_with(
         to_value,
         type_of,
         vm_result,
+        vm_try,
         ..
     } = tokens;
 
@@ -337,9 +338,9 @@ fn expand_enum_install_with(
                         let fields = field_fns.entry(f_name).or_default();
 
                         let value = if attrs.copy {
-                            quote!(#to_value::to_value(*#f_ident))
+                            quote!(#vm_result::Ok(#vm_try!(#to_value::to_value(*#f_ident))))
                         } else {
-                            quote!(#to_value::to_value(#f_ident.clone()))
+                            quote!(#vm_result::Ok(#vm_try!(#to_value::to_value(#f_ident.clone()))))
                         };
 
                         fields.push(quote!(#ident::#variant_ident { #f_ident, .. } => #value));
@@ -365,9 +366,9 @@ fn expand_enum_install_with(
                         let n = syn::LitInt::new(&n.to_string(), span);
 
                         let value = if attrs.copy {
-                            quote!(#to_value::to_value(*value))
+                            quote!(#vm_result::Ok(#vm_try!(#to_value::to_value(*value))))
                         } else {
-                            quote!(#to_value::to_value(value.clone()))
+                            quote!(#vm_result::Ok(#vm_try!(#to_value::to_value(value.clone()))))
                         };
 
                         fields.push(quote!(#ident::#variant_ident { #n: value, .. } => #value));

--- a/crates/rune-macros/src/const_value.rs
+++ b/crates/rune-macros/src/const_value.rs
@@ -1,0 +1,204 @@
+use core::fmt;
+
+use proc_macro2::{Span, TokenStream};
+use quote::{quote, ToTokens};
+use syn::parse::{Parse, ParseStream};
+use syn::spanned::Spanned;
+use syn::DeriveInput;
+
+use crate::context::{Context, Tokens};
+
+/// An internal call to the macro.
+pub(super) struct Derive {
+    input: DeriveInput,
+}
+
+impl Parse for Derive {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        Ok(Self {
+            input: input.parse()?,
+        })
+    }
+}
+
+pub(super) struct ConstBuilder<T> {
+    ident: T,
+    tokens: Tokens,
+    body: TokenStream,
+    variables: Vec<syn::Ident>,
+    members: Vec<syn::Member>,
+    from_const_fields: Vec<TokenStream>,
+    from_value_fields: Vec<TokenStream>,
+}
+
+impl Derive {
+    pub(super) fn into_builder(self, cx: &Context) -> Result<ConstBuilder<syn::Ident>, ()> {
+        let attr = cx.const_value_type_attrs(&self.input.attrs)?;
+        let tokens = cx.tokens_with_module(attr.module.as_ref());
+        let body;
+
+        let Tokens {
+            const_value,
+            from_const_value_t,
+            to_const_value_t,
+            type_hash_t,
+            from_value,
+            value,
+            ..
+        } = &tokens;
+
+        let mut variables = Vec::new();
+        let mut members = Vec::new();
+        let mut from_const_fields = Vec::new();
+        let mut from_value_fields = Vec::new();
+
+        match self.input.data {
+            syn::Data::Struct(data) => {
+                let mut fields = Vec::new();
+
+                for (index, field) in data.fields.iter().enumerate() {
+                    let attr = cx.const_value_field_attrs(&field.attrs)?;
+
+                    let member = match &field.ident {
+                        Some(ident) => syn::Member::Named(ident.clone()),
+                        None => syn::Member::Unnamed(syn::Index::from(index)),
+                    };
+
+                    let ty = &field.ty;
+
+                    let var = syn::Ident::new(&format!("v{index}"), Span::call_site());
+
+                    if let Some(path) = &attr.with {
+                        let to_const_value: syn::Path =
+                            syn::parse_quote_spanned!(path.span() => #path::to_const_value);
+                        let from_const_value: syn::Path =
+                            syn::parse_quote_spanned!(path.span() => #path::from_const_value);
+                        let from_value: syn::Path =
+                            syn::parse_quote_spanned!(path.span() => #path::from_value);
+
+                        fields.push(quote!(#to_const_value(self.#member)?));
+                        from_const_fields.push(quote!(#from_const_value(#var)?));
+                        from_value_fields.push(quote!(#from_value(#value::take(#var))?));
+                    } else {
+                        fields.push(quote! {
+                            <#ty as #to_const_value_t>::to_const_value(self.#member)?
+                        });
+
+                        from_const_fields.push(quote! {
+                            <#ty as #from_const_value_t>::from_const_value(#var)?
+                        });
+
+                        from_value_fields.push(quote! {
+                            <#ty as #from_value>::from_value(#value::take(#var)).into_result()?
+                        });
+                    }
+
+                    variables.push(var);
+                    members.push(member);
+                }
+
+                body = quote! {
+                    #const_value::for_struct(<Self as #type_hash_t>::HASH, [#(#fields),*])?
+                };
+            }
+            syn::Data::Enum(..) => {
+                cx.error(syn::Error::new(
+                    Span::call_site(),
+                    "ToConstValue: enums are not supported",
+                ));
+                return Err(());
+            }
+            syn::Data::Union(..) => {
+                cx.error(syn::Error::new(
+                    Span::call_site(),
+                    "ToConstValue: unions are not supported",
+                ));
+                return Err(());
+            }
+        }
+
+        Ok(ConstBuilder {
+            ident: self.input.ident,
+            tokens,
+            body,
+            variables,
+            members,
+            from_const_fields,
+            from_value_fields,
+        })
+    }
+}
+
+impl<T> ConstBuilder<T>
+where
+    T: ToTokens + fmt::Display,
+{
+    pub(super) fn expand(self) -> TokenStream {
+        let Tokens {
+            arc,
+            const_construct_t,
+            const_value,
+            option,
+            result,
+            runtime_error,
+            to_const_value_t,
+            value,
+            ..
+        } = &self.tokens;
+
+        let ident = self.ident;
+        let construct = syn::Ident::new(&format!("{ident}Construct"), Span::call_site());
+        let body = self.body;
+        let members = &self.members;
+        let variables = &self.variables;
+        let from_const_fields = &self.from_const_fields;
+        let from_value_fields = &self.from_value_fields;
+
+        let expected = self.members.len();
+
+        quote! {
+            #[automatically_derived]
+            impl #to_const_value_t for #ident {
+                #[inline]
+                fn to_const_value(self) -> #result<#const_value, #runtime_error> {
+                    #result::Ok(#body)
+                }
+
+                #[inline]
+                fn construct() -> #option<#arc<dyn #const_construct_t>> {
+                    struct #construct;
+
+                    impl #const_construct_t for #construct {
+                        #[inline]
+                        fn const_construct(&self, values: &[#const_value]) -> #result<#value, #runtime_error> {
+                            let [#(#variables),*] = values else {
+                                return #result::Err(#runtime_error::bad_argument_count(values.len(), #expected));
+                            };
+
+                            let value = #ident {
+                                #(#members: #from_const_fields,)*
+                            };
+
+                            #result::Ok(Value::new(value)?)
+                        }
+
+                        #[inline]
+                        fn runtime_construct(&self, values: &mut [#value]) -> #result<#value, #runtime_error> {
+                            let [#(#variables),*] = values else {
+                                return #result::Err(#runtime_error::bad_argument_count(values.len(), #expected));
+                            };
+
+                            let value = #ident {
+                                #(#members: #from_value_fields,)*
+                            };
+
+                            #result::Ok(Value::new(value)?)
+                        }
+                    }
+
+                    #option::Some(#arc::new(#construct))
+                }
+            }
+        }
+    }
+}

--- a/crates/rune-macros/src/const_value.rs
+++ b/crates/rune-macros/src/const_value.rs
@@ -89,7 +89,7 @@ impl Derive {
                         });
 
                         from_value_fields.push(quote! {
-                            <#ty as #from_value>::from_value(#value::take(#var)).into_result()?
+                            <#ty as #from_value>::from_value(#value::take(#var))?
                         });
                     }
 
@@ -98,7 +98,7 @@ impl Derive {
                 }
 
                 body = quote! {
-                    #const_value::for_struct(<Self as #type_hash_t>::HASH, [#(#fields),*])?
+                    #const_value::for_struct(<Self as #type_hash_t>::HASH, [#(#fields),*])
                 };
             }
             syn::Data::Enum(..) => {
@@ -161,7 +161,7 @@ where
             impl #to_const_value_t for #ident {
                 #[inline]
                 fn to_const_value(self) -> #result<#const_value, #runtime_error> {
-                    #result::Ok(#body)
+                    #body
                 }
 
                 #[inline]

--- a/crates/rune-macros/src/context.rs
+++ b/crates/rune-macros/src/context.rs
@@ -211,10 +211,10 @@ impl Context {
                     return Ok(());
                 }
 
-                return Err(syn::Error::new_spanned(
+                Err(syn::Error::new_spanned(
                     &meta.path,
                     "Unsupported field attribute",
-                ));
+                ))
             });
 
             if let Err(e) = result {
@@ -493,10 +493,10 @@ impl Context {
                     return Ok(());
                 }
 
-                return Err(syn::Error::new_spanned(
+                Err(syn::Error::new_spanned(
                     &meta.path,
                     "Unsupported type attribute",
-                ));
+                ))
             });
 
             if let Err(e) = result {

--- a/crates/rune-macros/src/internals.rs
+++ b/crates/rune-macros/src/internals.rs
@@ -6,6 +6,7 @@ use std::fmt;
 pub struct Symbol(&'static str);
 
 pub const RUNE: Symbol = Symbol("rune");
+pub const CONST_VALUE: Symbol = Symbol("const_value");
 pub const ID: Symbol = Symbol("id");
 pub const SKIP: Symbol = Symbol("skip");
 pub const ITER: Symbol = Symbol("iter");

--- a/crates/rune-macros/src/lib.rs
+++ b/crates/rune-macros/src/lib.rs
@@ -30,6 +30,7 @@ use syn::{Generics, Path};
 extern crate proc_macro;
 
 mod any;
+mod const_value;
 mod context;
 mod from_value;
 mod function;
@@ -185,6 +186,18 @@ pub fn any(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let cx = Context::new();
 
     let Ok(builder) = derive.into_any_builder(&cx) else {
+        return to_compile_errors(cx.errors.into_inner()).into();
+    };
+
+    builder.expand().into()
+}
+
+#[proc_macro_derive(ToConstValue, attributes(const_value))]
+pub fn const_value(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let derive = syn::parse_macro_input!(input as const_value::Derive);
+    let cx = Context::new();
+
+    let Ok(builder) = derive.into_builder(&cx) else {
         return to_compile_errors(cx.errors.into_inner()).into();
     };
 

--- a/crates/rune/src/cli/run.rs
+++ b/crates/rune/src/cli/run.rs
@@ -252,7 +252,10 @@ pub(super) async fn run(
         VmResult::Ok(result) => {
             if c.verbose || args.time || args.dump_return {
                 let duration = Instant::now().saturating_duration_since(last);
-                writeln!(io.stderr, "== {:?} ({:?})", result, duration)?;
+
+                execution
+                    .vm()
+                    .with(|| writeln!(io.stderr, "== {result:?} ({duration:?})"))?;
             }
 
             None
@@ -260,7 +263,10 @@ pub(super) async fn run(
         VmResult::Err(error) => {
             if c.verbose || args.time || args.dump_return {
                 let duration = Instant::now().saturating_duration_since(last);
-                writeln!(io.stderr, "== ! ({}) ({:?})", error, duration)?;
+
+                execution
+                    .vm()
+                    .with(|| writeln!(io.stderr, "== ! ({error}) ({duration:?})"))?;
             }
 
             Some(error)

--- a/crates/rune/src/compile/ir/compiler.rs
+++ b/crates/rune/src/compile/ir/compiler.rs
@@ -51,7 +51,7 @@ pub(crate) fn expr(hir: &hir::Expr<'_>, c: &mut Ctxt<'_, '_>) -> compile::Result
                 ));
             };
 
-            let value = value.to_value().with_span(span)?;
+            let value = value.to_value(c.q.context).with_span(span)?;
             ir::Ir::new(span, value)
         }
         hir::ExprKind::Variable(name) => {

--- a/crates/rune/src/compile/ir/compiler.rs
+++ b/crates/rune/src/compile/ir/compiler.rs
@@ -51,7 +51,7 @@ pub(crate) fn expr(hir: &hir::Expr<'_>, c: &mut Ctxt<'_, '_>) -> compile::Result
                 ));
             };
 
-            let value = value.to_value(c.q.context).with_span(span)?;
+            let value = value.to_value_with(c.q.context).with_span(span)?;
             ir::Ir::new(span, value)
         }
         hir::ExprKind::Variable(name) => {

--- a/crates/rune/src/compile/ir/interpreter.rs
+++ b/crates/rune/src/compile/ir/interpreter.rs
@@ -105,7 +105,7 @@ impl Interpreter<'_, '_> {
                 .alloc_item(base.extended(name.try_to_string()?)?)?;
 
             if let Some(const_value) = self.q.consts.get(item) {
-                return Ok(const_value.to_value(self.q.context).with_span(span)?);
+                return Ok(const_value.to_value_with(self.q.context).with_span(span)?);
             }
 
             if let Some(meta) = self.q.query_meta(span, item, used)? {
@@ -118,7 +118,7 @@ impl Interpreter<'_, '_> {
                             ));
                         };
 
-                        return Ok(const_value.to_value(self.q.context).with_span(span)?);
+                        return Ok(const_value.to_value_with(self.q.context).with_span(span)?);
                     }
                     _ => {
                         return Err(compile::Error::new(

--- a/crates/rune/src/compile/ir/interpreter.rs
+++ b/crates/rune/src/compile/ir/interpreter.rs
@@ -105,7 +105,7 @@ impl Interpreter<'_, '_> {
                 .alloc_item(base.extended(name.try_to_string()?)?)?;
 
             if let Some(const_value) = self.q.consts.get(item) {
-                return Ok(const_value.to_value().with_span(span)?);
+                return Ok(const_value.to_value(self.q.context).with_span(span)?);
             }
 
             if let Some(meta) = self.q.query_meta(span, item, used)? {
@@ -118,7 +118,7 @@ impl Interpreter<'_, '_> {
                             ));
                         };
 
-                        return Ok(const_value.to_value().with_span(span)?);
+                        return Ok(const_value.to_value(self.q.context).with_span(span)?);
                     }
                     _ => {
                         return Err(compile::Error::new(

--- a/crates/rune/src/compile/unit_builder.rs
+++ b/crates/rune/src/compile/unit_builder.rs
@@ -323,7 +323,7 @@ impl UnitBuilder {
                 self.constants
                     .try_insert(
                         Hash::associated_function(hash, Protocol::INTO_TYPE_NAME),
-                        ConstValue::String(rtti.item.try_to_string()?),
+                        ConstValue::from(rtti.item.try_to_string()?),
                     )
                     .with_span(span)?;
 
@@ -379,7 +379,7 @@ impl UnitBuilder {
                 self.constants
                     .try_insert(
                         Hash::associated_function(meta.hash, Protocol::INTO_TYPE_NAME),
-                        ConstValue::String(signature.path.try_to_string()?),
+                        ConstValue::from(signature.path.try_to_string()?),
                     )
                     .with_span(span)?;
 
@@ -435,7 +435,7 @@ impl UnitBuilder {
                 self.constants
                     .try_insert(
                         Hash::associated_function(meta.hash, Protocol::INTO_TYPE_NAME),
-                        ConstValue::String(signature.path.try_to_string()?),
+                        ConstValue::from(signature.path.try_to_string()?),
                     )
                     .with_span(span)?;
 
@@ -454,7 +454,7 @@ impl UnitBuilder {
                 self.constants
                     .try_insert(
                         Hash::associated_function(hash, Protocol::INTO_TYPE_NAME),
-                        ConstValue::String(rtti.item.try_to_string()?),
+                        ConstValue::from(rtti.item.try_to_string()?),
                     )
                     .with_span(span)?;
 
@@ -598,7 +598,7 @@ impl UnitBuilder {
                 self.constants
                     .try_insert(
                         Hash::associated_function(meta.hash, Protocol::INTO_TYPE_NAME),
-                        ConstValue::String(name),
+                        ConstValue::from(name),
                     )
                     .with_span(span)?;
             }
@@ -723,7 +723,7 @@ impl UnitBuilder {
         self.constants
             .try_insert(
                 Hash::associated_function(hash, Protocol::INTO_TYPE_NAME),
-                ConstValue::String(signature.path.try_to_string().with_span(location.span)?),
+                ConstValue::from(signature.path.try_to_string().with_span(location.span)?),
             )
             .with_span(location.span)?;
 

--- a/crates/rune/src/hir/lowering2.rs
+++ b/crates/rune/src/hir/lowering2.rs
@@ -18,7 +18,7 @@ use crate::hash::ParametersBuilder;
 use crate::hir;
 use crate::parse::{NonZeroId, Resolve};
 use crate::query::{self, GenericsParameters, Named2, Named2Kind, Used};
-use crate::runtime::{format, ConstValue, Type, TypeCheck};
+use crate::runtime::{format, ConstValue, ConstValueKind, Inline, Type, TypeCheck};
 use crate::Hash;
 
 use super::{Ctxt, Needs};
@@ -2551,14 +2551,27 @@ fn pat_const_value<'hir>(
     alloc_with!(cx, span);
 
     let kind = 'kind: {
-        let lit = match *const_value {
-            ConstValue::Bool(b) => hir::Lit::Bool(b),
-            ConstValue::Byte(b) => hir::Lit::Byte(b),
-            ConstValue::Char(ch) => hir::Lit::Char(ch),
-            ConstValue::String(ref string) => hir::Lit::Str(alloc_str!(string.as_ref())),
-            ConstValue::Bytes(ref bytes) => hir::Lit::ByteStr(alloc_bytes!(bytes.as_ref())),
-            ConstValue::Integer(integer) => hir::Lit::Integer(integer),
-            ConstValue::Vec(ref items) => {
+        let lit = match *const_value.as_kind() {
+            ConstValueKind::Inline(value) => match value {
+                Inline::Unit => {
+                    break 'kind hir::PatKind::Sequence(alloc!(hir::PatSequence {
+                        kind: hir::PatSequenceKind::Anonymous {
+                            type_check: TypeCheck::Unit,
+                            count: 0,
+                            is_open: false,
+                        },
+                        items: &[],
+                    }));
+                }
+                Inline::Bool(b) => hir::Lit::Bool(b),
+                Inline::Byte(b) => hir::Lit::Byte(b),
+                Inline::Char(ch) => hir::Lit::Char(ch),
+                Inline::Integer(value) => hir::Lit::Integer(value),
+                _ => return Err(Error::msg(span, "Unsupported constant value in pattern")),
+            },
+            ConstValueKind::String(ref string) => hir::Lit::Str(alloc_str!(string.as_ref())),
+            ConstValueKind::Bytes(ref bytes) => hir::Lit::ByteStr(alloc_bytes!(bytes.as_ref())),
+            ConstValueKind::Vec(ref items) => {
                 let items = iter!(items.iter(), items.len(), |value| pat_const_value(
                     cx, value, span
                 )?);
@@ -2572,17 +2585,7 @@ fn pat_const_value<'hir>(
                     items,
                 }));
             }
-            ConstValue::Unit => {
-                break 'kind hir::PatKind::Sequence(alloc!(hir::PatSequence {
-                    kind: hir::PatSequenceKind::Anonymous {
-                        type_check: TypeCheck::Unit,
-                        count: 0,
-                        is_open: false,
-                    },
-                    items: &[],
-                }));
-            }
-            ConstValue::Tuple(ref items) => {
+            ConstValueKind::Tuple(ref items) => {
                 let items = iter!(items.iter(), items.len(), |value| pat_const_value(
                     cx, value, span
                 )?);
@@ -2596,7 +2599,7 @@ fn pat_const_value<'hir>(
                     items,
                 }));
             }
-            ConstValue::Object(ref fields) => {
+            ConstValueKind::Object(ref fields) => {
                 let bindings = iter!(fields.iter(), fields.len(), |(key, value)| {
                     let pat = alloc!(pat_const_value(cx, value, span)?);
 

--- a/crates/rune/src/internal_macros.rs
+++ b/crates/rune/src/internal_macros.rs
@@ -116,16 +116,16 @@ macro_rules! from_value_ref {
         }
 
         impl $crate::runtime::FromValue for $crate::runtime::Ref<$ty> {
-            fn from_value(value: Value) -> $crate::runtime::VmResult<Self> {
-                let value = vm_try!(value.$into_ref());
-                $crate::runtime::VmResult::Ok(value)
+            fn from_value(value: Value) -> Result<Self, $crate::runtime::RuntimeError> {
+                let value = value.$into_ref()?;
+                Ok(value)
             }
         }
 
         impl $crate::runtime::FromValue for $crate::runtime::Mut<$ty> {
-            fn from_value(value: Value) -> VmResult<Self> {
-                let value = vm_try!(value.$into_mut());
-                $crate::runtime::VmResult::Ok(value)
+            fn from_value(value: Value) -> Result<Self, $crate::runtime::RuntimeError> {
+                let value = value.$into_mut()?;
+                Ok(value)
             }
         }
     };
@@ -135,9 +135,9 @@ macro_rules! from_value_ref {
 macro_rules! from_value2 {
     ($ty:ty, $into_ref:ident, $into_mut:ident, $into:ident) => {
         impl $crate::runtime::FromValue for $ty {
-            fn from_value(value: Value) -> $crate::runtime::VmResult<Self> {
-                let value = vm_try!(value.$into());
-                $crate::runtime::VmResult::Ok(value)
+            fn from_value(value: Value) -> Result<Self, $crate::runtime::RuntimeError> {
+                let value = value.$into()?;
+                Ok(value)
             }
         }
 

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -254,7 +254,9 @@ pub mod query;
 
 pub mod runtime;
 #[doc(inline)]
-pub use self::runtime::{from_value, to_value, FromValue, ToValue, TypeHash, Unit, Value, Vm};
+pub use self::runtime::{
+    from_value, to_value, FromValue, ToConstValue, ToValue, TypeHash, Unit, Value, Vm,
+};
 
 mod shared;
 
@@ -669,7 +671,11 @@ pub mod __private {
     pub use crate::params::Params;
     pub use crate::runtime::{TypeHash, TypeOf};
     pub use rust_alloc::boxed::Box;
+    pub use rust_alloc::sync::Arc;
 }
+
+mod musli;
+mod serde;
 
 #[cfg(test)]
 mod tests;

--- a/crates/rune/src/module/module_constant_builder.rs
+++ b/crates/rune/src/module/module_constant_builder.rs
@@ -2,8 +2,7 @@ use crate::compile::ContextError;
 use crate::function_meta::{Associated, ToInstance};
 use crate::item::IntoComponent;
 use crate::module::ItemMut;
-use crate::runtime::{ToValue, TypeOf};
-use crate::ItemBuf;
+use crate::runtime::{ToConstValue, TypeHash, TypeOf};
 
 use super::Module;
 
@@ -21,7 +20,7 @@ pub struct ModuleConstantBuilder<'a, N, V> {
 
 impl<'a, N, V> ModuleConstantBuilder<'a, N, V>
 where
-    V: ToValue,
+    V: TypeHash + TypeOf + ToConstValue,
 {
     /// Add the free constant directly to the module.
     ///
@@ -39,8 +38,7 @@ where
     where
         N: IntoComponent,
     {
-        let item = ItemBuf::with_item([self.name])?;
-        self.module.insert_constant(item, self.value)
+        self.module.insert_constant(self.name, self.value)
     }
 
     /// Build a constant that is associated with the static type `T`.

--- a/crates/rune/src/modules/future.rs
+++ b/crates/rune/src/modules/future.rs
@@ -110,15 +110,21 @@ async fn join(value: Value) -> VmResult<Value> {
             ]),
         },
         BorrowRefRepr::Mutable(value) => match *value {
-            Mutable::Tuple(ref tuple) => VmResult::Ok(vm_try!(
-                try_join_impl(tuple.iter(), tuple.len(), |vec| VmResult::Ok(vm_try!(
-                    Value::tuple(vec)
-                )))
-                .await
-            )),
-            Mutable::Vec(ref vec) => VmResult::Ok(vm_try!(
-                try_join_impl(vec.iter(), vec.len(), Value::vec).await
-            )),
+            Mutable::Tuple(ref tuple) => {
+                let result = try_join_impl(tuple.iter(), tuple.len(), |vec| {
+                    VmResult::Ok(vm_try!(Value::tuple(vec)))
+                })
+                .await;
+
+                VmResult::Ok(vm_try!(result))
+            }
+            Mutable::Vec(ref vec) => {
+                let result = try_join_impl(vec.iter(), vec.len(), |vec| {
+                    VmResult::Ok(vm_try!(Value::vec(vec)))
+                })
+                .await;
+                VmResult::Ok(vm_try!(result))
+            }
             ref value => VmResult::err([
                 VmErrorKind::bad_argument(0),
                 VmErrorKind::expected::<crate::runtime::Vec>(value.type_info()),

--- a/crates/rune/src/musli.rs
+++ b/crates/rune/src/musli.rs
@@ -1,0 +1,28 @@
+pub(crate) mod ordering {
+    use core::cmp::Ordering;
+
+    use musli::{Context, Decoder, Encoder};
+
+    pub(crate) fn encode<E>(ordering: &Ordering, _: &E::Cx, encoder: E) -> Result<E::Ok, E::Error>
+    where
+        E: Encoder,
+    {
+        match ordering {
+            Ordering::Less => encoder.encode_i8(-1),
+            Ordering::Equal => encoder.encode_i8(0),
+            Ordering::Greater => encoder.encode_i8(1),
+        }
+    }
+
+    pub(crate) fn decode<'de, D>(cx: &D::Cx, decoder: D) -> Result<Ordering, D::Error>
+    where
+        D: Decoder<'de>,
+    {
+        match decoder.decode_i8()? {
+            -1 => Ok(Ordering::Less),
+            0 => Ok(Ordering::Equal),
+            1 => Ok(Ordering::Greater),
+            _ => Err(cx.message("invalid ordering")),
+        }
+    }
+}

--- a/crates/rune/src/runtime/const_value.rs
+++ b/crates/rune/src/runtime/const_value.rs
@@ -8,7 +8,7 @@ use crate::alloc::prelude::*;
 use crate::alloc::{self, HashMap};
 use crate::runtime::{
     self, BorrowRefRepr, Bytes, FromValue, Inline, Mutable, Object, OwnedTuple, RawStr, ToValue,
-    TypeInfo, Value, VmErrorKind, VmResult,
+    TypeInfo, Value, VmErrorKind,
 };
 use crate::{Hash, TypeHash};
 
@@ -295,11 +295,8 @@ impl FromValue for ConstValue {
 
 impl ToValue for ConstValue {
     #[inline]
-    fn to_value(self) -> VmResult<Value> {
-        VmResult::Ok(vm_try!(ConstValue::to_value_with(
-            &self,
-            &EmptyConstContext
-        )))
+    fn to_value(self) -> Result<Value, RuntimeError> {
+        ConstValue::to_value_with(&self, &EmptyConstContext)
     }
 }
 

--- a/crates/rune/src/runtime/control_flow.rs
+++ b/crates/rune/src/runtime/control_flow.rs
@@ -172,15 +172,13 @@ where
     C: ToValue,
 {
     #[inline]
-    fn to_value(self) -> VmResult<Value> {
+    fn to_value(self) -> Result<Value, RuntimeError> {
         let value = match self {
-            ops::ControlFlow::Continue(value) => {
-                ControlFlow::Continue(vm_try!(ToValue::to_value(value)))
-            }
-            ops::ControlFlow::Break(value) => ControlFlow::Break(vm_try!(ToValue::to_value(value))),
+            ops::ControlFlow::Continue(value) => ControlFlow::Continue(C::to_value(value)?),
+            ops::ControlFlow::Break(value) => ControlFlow::Break(B::to_value(value)?),
         };
 
-        VmResult::Ok(vm_try!(Value::try_from(value)))
+        Ok(Value::try_from(value)?)
     }
 }
 

--- a/crates/rune/src/runtime/function.rs
+++ b/crates/rune/src/runtime/function.rs
@@ -319,7 +319,7 @@ impl Function {
     /// let pony: Function = rune::from_value(pony)?;
     ///
     /// // This is fine, since `pony` is a free function.
-    /// let pony = pony.into_sync().into_result()?;
+    /// let pony = pony.into_sync()?;
     ///
     /// assert_eq!(pony.type_hash(), Hash::type_hash(["pony"]));
     /// # Ok::<_, rune::support::Error>(())

--- a/crates/rune/src/runtime/future.rs
+++ b/crates/rune/src/runtime/future.rs
@@ -45,7 +45,10 @@ impl Future {
                 poll: |future, cx| unsafe {
                     match Pin::new_unchecked(&mut *future.cast::<T>()).poll(cx) {
                         Poll::Pending => Poll::Pending,
-                        Poll::Ready(VmResult::Ok(result)) => Poll::Ready(result.to_value()),
+                        Poll::Ready(VmResult::Ok(result)) => match result.to_value() {
+                            Ok(value) => Poll::Ready(VmResult::Ok(value)),
+                            Err(err) => Poll::Ready(VmResult::Err(err.into())),
+                        },
                         Poll::Ready(VmResult::Err(err)) => Poll::Ready(VmResult::Err(err)),
                     }
                 },

--- a/crates/rune/src/runtime/hasher.rs
+++ b/crates/rune/src/runtime/hasher.rs
@@ -54,7 +54,19 @@ impl Hasher {
     }
 
     /// Construct a hash.
-    pub fn finish(self) -> u64 {
+    pub fn finish(&self) -> u64 {
         self.hasher.finish()
+    }
+}
+
+impl core::hash::Hasher for Hasher {
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.hasher.finish()
+    }
+
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        self.hasher.write(bytes);
     }
 }

--- a/crates/rune/src/runtime/iterator.rs
+++ b/crates/rune/src/runtime/iterator.rs
@@ -1,7 +1,7 @@
 use crate::alloc;
 use crate::compile::meta;
 
-use super::{FromValue, MaybeTypeOf, Value, VmResult};
+use super::{FromValue, MaybeTypeOf, RuntimeError, Value, VmResult};
 
 /// An owning iterator.
 #[derive(Debug)]
@@ -27,8 +27,8 @@ impl Iterator {
 
 impl FromValue for Iterator {
     #[inline]
-    fn from_value(value: Value) -> VmResult<Self> {
-        value.into_iter()
+    fn from_value(value: Value) -> Result<Self, RuntimeError> {
+        value.into_iter().into_result().map_err(RuntimeError::from)
     }
 }
 

--- a/crates/rune/src/runtime/mod.rs
+++ b/crates/rune/src/runtime/mod.rs
@@ -40,7 +40,8 @@ mod call;
 pub use self::call::Call;
 
 mod const_value;
-pub use self::const_value::ConstValue;
+pub use self::const_value::{ConstConstruct, ConstValue, ToConstValue};
+pub(crate) use self::const_value::{ConstContext, ConstValueKind, EmptyConstContext};
 
 pub mod debug;
 pub use self::debug::{DebugInfo, DebugInst};
@@ -164,11 +165,9 @@ pub(crate) use self::unit::UnitFn;
 pub use self::unit::{Unit, UnitStorage};
 
 mod value;
-pub(crate) use self::value::{
-    BorrowRefRepr, Inline, MutRepr, Mutable, OwnedRepr, RefRepr, ValueShared,
-};
+pub(crate) use self::value::{BorrowRefRepr, MutRepr, Mutable, OwnedRepr, RefRepr, ValueShared};
 pub use self::value::{
-    EmptyStruct, RawValueGuard, Rtti, Struct, TupleStruct, TypeValue, Value, ValueMutGuard,
+    EmptyStruct, Inline, RawValueGuard, Rtti, Struct, TupleStruct, TypeValue, Value, ValueMutGuard,
     ValueRefGuard, VariantRtti,
 };
 

--- a/crates/rune/src/runtime/mod.rs
+++ b/crates/rune/src/runtime/mod.rs
@@ -149,7 +149,7 @@ mod stream;
 pub use self::stream::Stream;
 
 mod to_value;
-pub use self::to_value::{to_value, ToValue, UnsafeToValue};
+pub use self::to_value::{to_value, ToReturn, ToValue, UnsafeToValue};
 
 mod tuple;
 pub use self::tuple::{OwnedTuple, Tuple};

--- a/crates/rune/src/runtime/range.rs
+++ b/crates/rune/src/runtime/range.rs
@@ -5,8 +5,8 @@ use core::ops;
 use crate as rune;
 use crate::alloc::clone::TryClone;
 use crate::runtime::{
-    EnvProtocolCaller, FromValue, Inline, ProtocolCaller, RefRepr, ToValue, Value, VmErrorKind,
-    VmResult,
+    EnvProtocolCaller, FromValue, Inline, ProtocolCaller, RefRepr, RuntimeError, ToValue, Value,
+    VmErrorKind, VmResult,
 };
 use crate::Any;
 
@@ -316,11 +316,11 @@ where
     Idx: FromValue,
 {
     #[inline]
-    fn from_value(value: Value) -> VmResult<Self> {
-        let range = vm_try!(value.into_any::<Range>());
-        let start = vm_try!(Idx::from_value(range.start));
-        let end = vm_try!(Idx::from_value(range.end));
-        VmResult::Ok(ops::Range { start, end })
+    fn from_value(value: Value) -> Result<Self, RuntimeError> {
+        let range = value.into_any::<Range>()?;
+        let start = Idx::from_value(range.start)?;
+        let end = Idx::from_value(range.end)?;
+        Ok(ops::Range { start, end })
     }
 }
 

--- a/crates/rune/src/runtime/range.rs
+++ b/crates/rune/src/runtime/range.rs
@@ -303,11 +303,11 @@ impl<Idx> ToValue for ops::Range<Idx>
 where
     Idx: ToValue,
 {
-    fn to_value(self) -> VmResult<Value> {
-        let start = vm_try!(self.start.to_value());
-        let end = vm_try!(self.end.to_value());
+    fn to_value(self) -> Result<Value, RuntimeError> {
+        let start = self.start.to_value()?;
+        let end = self.end.to_value()?;
         let range = Range::new(start, end);
-        VmResult::Ok(vm_try!(Value::new(range)))
+        Ok(Value::new(range)?)
     }
 }
 

--- a/crates/rune/src/runtime/range_from.rs
+++ b/crates/rune/src/runtime/range_from.rs
@@ -5,8 +5,8 @@ use core::ops;
 use crate as rune;
 use crate::alloc::clone::TryClone;
 use crate::runtime::{
-    EnvProtocolCaller, FromValue, Inline, ProtocolCaller, RefRepr, ToValue, Value, VmErrorKind,
-    VmResult,
+    EnvProtocolCaller, FromValue, Inline, ProtocolCaller, RefRepr, RuntimeError, ToValue, Value,
+    VmErrorKind, VmResult,
 };
 use crate::Any;
 
@@ -286,10 +286,10 @@ where
     Idx: FromValue,
 {
     #[inline]
-    fn from_value(value: Value) -> VmResult<Self> {
-        let range = vm_try!(value.into_any::<RangeFrom>());
-        let start = vm_try!(Idx::from_value(range.start));
-        VmResult::Ok(ops::RangeFrom { start })
+    fn from_value(value: Value) -> Result<Self, RuntimeError> {
+        let range = value.into_any::<RangeFrom>()?;
+        let start = Idx::from_value(range.start)?;
+        Ok(ops::RangeFrom { start })
     }
 }
 

--- a/crates/rune/src/runtime/range_from.rs
+++ b/crates/rune/src/runtime/range_from.rs
@@ -274,10 +274,10 @@ impl<Idx> ToValue for ops::RangeFrom<Idx>
 where
     Idx: ToValue,
 {
-    fn to_value(self) -> VmResult<Value> {
-        let start = vm_try!(self.start.to_value());
+    fn to_value(self) -> Result<Value, RuntimeError> {
+        let start = self.start.to_value()?;
         let range = RangeFrom::new(start);
-        VmResult::Ok(vm_try!(Value::new(range)))
+        Ok(Value::new(range)?)
     }
 }
 

--- a/crates/rune/src/runtime/range_full.rs
+++ b/crates/rune/src/runtime/range_full.rs
@@ -126,9 +126,9 @@ impl fmt::Debug for RangeFull {
 }
 
 impl ToValue for ops::RangeFull {
-    fn to_value(self) -> VmResult<Value> {
+    fn to_value(self) -> Result<Value, RuntimeError> {
         let range = RangeFull::new();
-        VmResult::Ok(vm_try!(Value::new(range)))
+        Ok(Value::new(range)?)
     }
 }
 

--- a/crates/rune/src/runtime/range_full.rs
+++ b/crates/rune/src/runtime/range_full.rs
@@ -4,7 +4,7 @@ use core::ops;
 
 use crate as rune;
 use crate::alloc::clone::TryClone;
-use crate::runtime::{FromValue, ToValue, Value, VmResult};
+use crate::runtime::{FromValue, RuntimeError, ToValue, Value, VmResult};
 use crate::Any;
 
 /// Type for a full range expression `..`.
@@ -134,8 +134,8 @@ impl ToValue for ops::RangeFull {
 
 impl FromValue for ops::RangeFull {
     #[inline]
-    fn from_value(value: Value) -> VmResult<Self> {
-        let RangeFull = vm_try!(value.into_any::<RangeFull>());
-        VmResult::Ok(ops::RangeFull)
+    fn from_value(value: Value) -> Result<Self, RuntimeError> {
+        let RangeFull = value.into_any::<RangeFull>()?;
+        Ok(ops::RangeFull)
     }
 }

--- a/crates/rune/src/runtime/range_inclusive.rs
+++ b/crates/rune/src/runtime/range_inclusive.rs
@@ -304,11 +304,11 @@ impl<Idx> ToValue for ops::RangeInclusive<Idx>
 where
     Idx: ToValue,
 {
-    fn to_value(self) -> VmResult<Value> {
+    fn to_value(self) -> Result<Value, RuntimeError> {
         let (start, end) = self.into_inner();
-        let start = vm_try!(start.to_value());
-        let end = vm_try!(end.to_value());
-        VmResult::Ok(vm_try!(Value::new(RangeInclusive::new(start, end))))
+        let start = start.to_value()?;
+        let end = end.to_value()?;
+        Ok(Value::new(RangeInclusive::new(start, end))?)
     }
 }
 

--- a/crates/rune/src/runtime/range_inclusive.rs
+++ b/crates/rune/src/runtime/range_inclusive.rs
@@ -5,8 +5,8 @@ use core::ops;
 use crate as rune;
 use crate::alloc::clone::TryClone;
 use crate::runtime::{
-    EnvProtocolCaller, FromValue, Inline, ProtocolCaller, RefRepr, ToValue, Value, VmErrorKind,
-    VmResult,
+    EnvProtocolCaller, FromValue, Inline, ProtocolCaller, RefRepr, RuntimeError, ToValue, Value,
+    VmErrorKind, VmResult,
 };
 use crate::Any;
 
@@ -317,11 +317,11 @@ where
     Idx: FromValue,
 {
     #[inline]
-    fn from_value(value: Value) -> VmResult<Self> {
-        let range = vm_try!(value.into_any::<RangeInclusive>());
-        let start = vm_try!(Idx::from_value(range.start));
-        let end = vm_try!(Idx::from_value(range.end));
-        VmResult::Ok(start..=end)
+    fn from_value(value: Value) -> Result<Self, RuntimeError> {
+        let range = value.into_any::<RangeInclusive>()?;
+        let start = Idx::from_value(range.start)?;
+        let end = Idx::from_value(range.end)?;
+        Ok(start..=end)
     }
 }
 

--- a/crates/rune/src/runtime/range_to.rs
+++ b/crates/rune/src/runtime/range_to.rs
@@ -190,9 +190,9 @@ impl<Idx> ToValue for ops::RangeTo<Idx>
 where
     Idx: ToValue,
 {
-    fn to_value(self) -> VmResult<Value> {
-        let end = vm_try!(self.end.to_value());
-        VmResult::Ok(vm_try!(Value::new(RangeTo::new(end))))
+    fn to_value(self) -> Result<Value, RuntimeError> {
+        let end = self.end.to_value()?;
+        Ok(Value::new(RangeTo::new(end))?)
     }
 }
 

--- a/crates/rune/src/runtime/range_to.rs
+++ b/crates/rune/src/runtime/range_to.rs
@@ -4,7 +4,9 @@ use core::ops;
 
 use crate as rune;
 use crate::alloc::clone::TryClone;
-use crate::runtime::{EnvProtocolCaller, FromValue, ProtocolCaller, ToValue, Value, VmResult};
+use crate::runtime::{
+    EnvProtocolCaller, FromValue, ProtocolCaller, RuntimeError, ToValue, Value, VmResult,
+};
 use crate::Any;
 
 /// Type for an inclusive range expression `..end`.
@@ -199,9 +201,9 @@ where
     Idx: FromValue,
 {
     #[inline]
-    fn from_value(value: Value) -> VmResult<Self> {
-        let range = vm_try!(value.into_any::<RangeTo>());
-        let end = vm_try!(Idx::from_value(range.end));
-        VmResult::Ok(ops::RangeTo { end })
+    fn from_value(value: Value) -> Result<Self, RuntimeError> {
+        let range = value.into_any::<RangeTo>()?;
+        let end = Idx::from_value(range.end)?;
+        Ok(ops::RangeTo { end })
     }
 }

--- a/crates/rune/src/runtime/range_to_inclusive.rs
+++ b/crates/rune/src/runtime/range_to_inclusive.rs
@@ -188,9 +188,9 @@ impl<Idx> ToValue for ops::RangeToInclusive<Idx>
 where
     Idx: ToValue,
 {
-    fn to_value(self) -> VmResult<Value> {
-        let end = vm_try!(self.end.to_value());
-        VmResult::Ok(vm_try!(Value::new(RangeToInclusive::new(end))))
+    fn to_value(self) -> Result<Value, RuntimeError> {
+        let end = self.end.to_value()?;
+        Ok(Value::new(RangeToInclusive::new(end))?)
     }
 }
 

--- a/crates/rune/src/runtime/range_to_inclusive.rs
+++ b/crates/rune/src/runtime/range_to_inclusive.rs
@@ -4,7 +4,9 @@ use core::ops;
 
 use crate as rune;
 use crate::alloc::clone::TryClone;
-use crate::runtime::{EnvProtocolCaller, FromValue, ProtocolCaller, ToValue, Value, VmResult};
+use crate::runtime::{
+    EnvProtocolCaller, FromValue, ProtocolCaller, RuntimeError, ToValue, Value, VmResult,
+};
 use crate::Any;
 
 /// Type for an inclusive range expression `..=end`.
@@ -197,9 +199,9 @@ where
     Idx: FromValue,
 {
     #[inline]
-    fn from_value(value: Value) -> VmResult<Self> {
-        let range = vm_try!(value.into_any::<RangeToInclusive>());
-        let end = vm_try!(Idx::from_value(range.end));
-        VmResult::Ok(ops::RangeToInclusive { end })
+    fn from_value(value: Value) -> Result<Self, RuntimeError> {
+        let range = value.into_any::<RangeToInclusive>()?;
+        let end = Idx::from_value(range.end)?;
+        Ok(ops::RangeToInclusive { end })
     }
 }

--- a/crates/rune/src/runtime/runtime_context.rs
+++ b/crates/rune/src/runtime/runtime_context.rs
@@ -5,7 +5,7 @@ use ::rust_alloc::sync::Arc;
 use crate as rune;
 use crate::alloc::prelude::*;
 use crate::hash;
-use crate::runtime::{ConstValue, InstAddress, Memory, Output, VmResult};
+use crate::runtime::{ConstConstruct, ConstValue, InstAddress, Memory, Output, VmResult};
 use crate::Hash;
 
 /// A type-reduced function handler.
@@ -24,16 +24,20 @@ pub struct RuntimeContext {
     functions: hash::Map<Arc<FunctionHandler>>,
     /// Named constant values
     constants: hash::Map<ConstValue>,
+    /// Constant constructors.
+    construct: hash::Map<Arc<dyn ConstConstruct>>,
 }
 
 impl RuntimeContext {
     pub(crate) fn new(
         functions: hash::Map<Arc<FunctionHandler>>,
         constants: hash::Map<ConstValue>,
+        construct: hash::Map<Arc<dyn ConstConstruct>>,
     ) -> Self {
         Self {
             functions,
             constants,
+            construct,
         }
     }
 
@@ -42,9 +46,14 @@ impl RuntimeContext {
         self.functions.get(&hash)
     }
 
-    /// Read a constant value from the unit.
+    /// Read a constant value.
     pub fn constant(&self, hash: Hash) -> Option<&ConstValue> {
         self.constants.get(&hash)
+    }
+
+    /// Read a constant constructor.
+    pub(crate) fn construct(&self, hash: Hash) -> Option<&dyn ConstConstruct> {
+        Some(&**self.construct.get(&hash)?)
     }
 }
 

--- a/crates/rune/src/runtime/to_value.rs
+++ b/crates/rune/src/runtime/to_value.rs
@@ -1,8 +1,6 @@
-use core::any;
-
 use crate::alloc::prelude::*;
 use crate::alloc::{self, HashMap};
-use crate::runtime::{AnyObj, Object, Value, VmError, VmErrorKind, VmIntegerRepr, VmResult};
+use crate::runtime::{AnyObj, Object, Value, VmError, VmResult};
 use crate::Any;
 
 /// Derive macro for the [`ToValue`] trait for converting types into the dynamic
@@ -234,43 +232,6 @@ where
         };
 
         VmResult::Ok(vm_try!(Value::try_from(result)))
-    }
-}
-
-// number impls
-
-macro_rules! number_value_trait {
-    ($ty:ty) => {
-        impl ToValue for $ty {
-            fn to_value(self) -> VmResult<Value> {
-                match <i64>::try_from(self) {
-                    Ok(number) => VmResult::Ok(vm_try!(Value::try_from(number))),
-                    #[allow(unreachable_patterns)]
-                    Err(..) => VmResult::err(VmErrorKind::IntegerToValueCoercionError {
-                        from: VmIntegerRepr::from(self),
-                        to: any::type_name::<i64>(),
-                    }),
-                }
-            }
-        }
-    };
-}
-
-number_value_trait!(u16);
-number_value_trait!(u32);
-number_value_trait!(u64);
-number_value_trait!(u128);
-number_value_trait!(usize);
-number_value_trait!(i8);
-number_value_trait!(i16);
-number_value_trait!(i32);
-number_value_trait!(i128);
-number_value_trait!(isize);
-
-impl ToValue for f32 {
-    #[inline]
-    fn to_value(self) -> VmResult<Value> {
-        VmResult::Ok(Value::from(self as f64))
     }
 }
 

--- a/crates/rune/src/runtime/tuple.rs
+++ b/crates/rune/src/runtime/tuple.rs
@@ -6,8 +6,8 @@ use crate as rune;
 use crate::alloc::clone::TryClone;
 use crate::alloc::{self, Box};
 use crate::runtime::{
-    ConstValue, FromValue, Mut, Mutable, OwnedRepr, RawAnyGuard, Ref, ToValue, UnsafeToMut,
-    UnsafeToRef, Value, ValueShared, VmErrorKind, VmResult,
+    ConstValue, EmptyConstContext, FromValue, Mut, Mutable, OwnedRepr, RawAnyGuard, Ref,
+    RuntimeError, ToValue, UnsafeToMut, UnsafeToRef, Value, ValueShared, VmErrorKind, VmResult,
 };
 #[cfg(feature = "alloc")]
 use crate::runtime::{Hasher, ProtocolCaller};
@@ -226,9 +226,9 @@ impl From<alloc::Box<[Value]>> for OwnedTuple {
 }
 
 impl TryFrom<alloc::Box<[ConstValue]>> for OwnedTuple {
-    type Error = alloc::Error;
+    type Error = RuntimeError;
 
-    fn try_from(inner: alloc::Box<[ConstValue]>) -> alloc::Result<Self> {
+    fn try_from(inner: alloc::Box<[ConstValue]>) -> Result<Self, RuntimeError> {
         if inner.is_empty() {
             return Ok(OwnedTuple::new());
         }
@@ -236,7 +236,7 @@ impl TryFrom<alloc::Box<[ConstValue]>> for OwnedTuple {
         let mut out = alloc::Vec::try_with_capacity(inner.len())?;
 
         for value in inner.iter() {
-            out.try_push(value.to_value()?)?;
+            out.try_push(value.to_value(&EmptyConstContext)?)?;
         }
 
         Ok(Self {
@@ -259,9 +259,9 @@ impl TryFrom<::rust_alloc::boxed::Box<[Value]>> for OwnedTuple {
 
 #[cfg(feature = "alloc")]
 impl TryFrom<::rust_alloc::boxed::Box<[ConstValue]>> for OwnedTuple {
-    type Error = alloc::Error;
+    type Error = RuntimeError;
 
-    fn try_from(inner: ::rust_alloc::boxed::Box<[ConstValue]>) -> alloc::Result<Self> {
+    fn try_from(inner: ::rust_alloc::boxed::Box<[ConstValue]>) -> Result<Self, RuntimeError> {
         if inner.is_empty() {
             return Ok(OwnedTuple::new());
         }
@@ -269,7 +269,7 @@ impl TryFrom<::rust_alloc::boxed::Box<[ConstValue]>> for OwnedTuple {
         let mut out = alloc::Vec::try_with_capacity(inner.len())?;
 
         for value in inner.iter() {
-            out.try_push(value.to_value()?)?;
+            out.try_push(value.to_value(&EmptyConstContext)?)?;
         }
 
         Ok(Self {

--- a/crates/rune/src/runtime/type_.rs
+++ b/crates/rune/src/runtime/type_.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::compile::Named;
 use crate::module::InstallWith;
-use crate::runtime::{RawStr, VmResult};
+use crate::runtime::{RawStr, RuntimeError};
 use crate::{FromValue, Hash, Value};
 
 /// A value representing a type in the virtual machine.
@@ -32,8 +32,8 @@ impl InstallWith for Type {}
 
 impl FromValue for Type {
     #[inline]
-    fn from_value(value: Value) -> VmResult<Self> {
-        VmResult::Ok(vm_try!(value.as_type()))
+    fn from_value(value: Value) -> Result<Self, RuntimeError> {
+        value.as_type()
     }
 }
 

--- a/crates/rune/src/runtime/value.rs
+++ b/crates/rune/src/runtime/value.rs
@@ -1,6 +1,9 @@
 #[macro_use]
 mod macros;
 
+mod inline;
+pub use self::inline::Inline;
+
 mod serde;
 
 mod rtti;
@@ -10,8 +13,9 @@ mod data;
 pub use self::data::{EmptyStruct, Struct, TupleStruct};
 
 use core::any;
-use core::cmp::{Ord, Ordering, PartialOrd};
+use core::cmp::Ordering;
 use core::fmt;
+use core::mem::replace;
 use core::ptr::NonNull;
 
 use ::rust_alloc::sync::Arc;
@@ -25,10 +29,10 @@ use crate::{Any, Hash};
 use super::static_type;
 use super::{
     AccessError, AnyObj, AnyObjDrop, BorrowMut, BorrowRef, Bytes, CallResultOnly, ConstValue,
-    ControlFlow, DynGuardedArgs, EnvProtocolCaller, Format, Formatter, FromValue, Function, Future,
-    Generator, GeneratorState, IntoOutput, Iterator, MaybeTypeOf, Mut, Object, OwnedTuple,
-    Protocol, ProtocolCaller, RawAnyObjGuard, Ref, RuntimeError, Shared, Snapshot, Stream, ToValue,
-    Type, TypeInfo, Variant, Vec, Vm, VmErrorKind, VmIntegerRepr, VmResult,
+    ConstValueKind, ControlFlow, DynGuardedArgs, EnvProtocolCaller, Format, Formatter, FromValue,
+    Function, Future, Generator, GeneratorState, IntoOutput, Iterator, MaybeTypeOf, Mut, Object,
+    OwnedTuple, Protocol, ProtocolCaller, RawAnyObjGuard, Ref, RuntimeError, Shared, Snapshot,
+    Stream, ToValue, Type, TypeInfo, Variant, Vec, Vm, VmErrorKind, VmIntegerRepr, VmResult,
 };
 #[cfg(feature = "alloc")]
 use super::{Hasher, Tuple};
@@ -141,6 +145,12 @@ pub struct Value {
 }
 
 impl Value {
+    /// Take a mutable value, replacing the original location with an empty value.
+    #[inline]
+    pub fn take(value: &mut Self) -> Self {
+        replace(value, Self::empty())
+    }
+
     /// Construct a value from a type that implements [`Any`] which owns the
     /// underlying value.
     pub fn new<T>(data: T) -> alloc::Result<Self>
@@ -591,8 +601,8 @@ impl Value {
 
         crate::runtime::env::shared(|context, unit| {
             if let Some(name) = context.constant(hash) {
-                match name {
-                    ConstValue::String(s) => {
+                match name.as_kind() {
+                    ConstValueKind::String(s) => {
                         return VmResult::Ok(vm_try!(String::try_from(s.as_str())))
                     }
                     _ => return err(VmErrorKind::expected::<String>(name.type_info())),
@@ -600,8 +610,8 @@ impl Value {
             }
 
             if let Some(name) = unit.constant(hash) {
-                match name {
-                    ConstValue::String(s) => {
+                match name.as_kind() {
+                    ConstValueKind::String(s) => {
                         return VmResult::Ok(vm_try!(String::try_from(s.as_str())))
                     }
                     _ => return err(VmErrorKind::expected::<String>(name.type_info())),
@@ -1946,6 +1956,14 @@ from_container! {
     Result => Result<Value, Value>,
 }
 
+number_value_trait! {
+    u16, u32, u64, u128, usize, i8, i16, i32, i128, isize,
+}
+
+float_value_trait! {
+    f32,
+}
+
 impl MaybeTypeOf for Value {
     #[inline]
     fn maybe_type_of() -> alloc::Result<meta::DocType> {
@@ -2049,163 +2067,6 @@ impl TypeValue {
             TypeValue::NotTypedInline(value) => value.0.type_info(),
             TypeValue::NotTypedMutable(value) => value.0.type_info(),
             TypeValue::NotTypedRef(value) => value.0.type_info(),
-        }
-    }
-}
-
-#[derive(Clone, Copy)]
-pub(crate) enum Inline {
-    /// The unit value.
-    Unit,
-    /// A boolean.
-    Bool(bool),
-    /// A single byte.
-    Byte(u8),
-    /// A character.
-    Char(char),
-    /// A number.
-    Integer(i64),
-    /// A float.
-    Float(f64),
-    /// A type hash. Describes a type in the virtual machine.
-    Type(Type),
-    /// Ordering.
-    Ordering(Ordering),
-}
-
-impl Inline {
-    /// Perform a partial equality check over two inline values.
-    pub(crate) fn partial_eq(&self, other: &Self) -> VmResult<bool> {
-        match (self, other) {
-            (Inline::Unit, Inline::Unit) => VmResult::Ok(true),
-            (Inline::Bool(a), Inline::Bool(b)) => VmResult::Ok(*a == *b),
-            (Inline::Byte(a), Inline::Byte(b)) => VmResult::Ok(*a == *b),
-            (Inline::Char(a), Inline::Char(b)) => VmResult::Ok(*a == *b),
-            (Inline::Integer(a), Inline::Integer(b)) => VmResult::Ok(*a == *b),
-            (Inline::Float(a), Inline::Float(b)) => VmResult::Ok(*a == *b),
-            (Inline::Type(a), Inline::Type(b)) => VmResult::Ok(*a == *b),
-            (Inline::Ordering(a), Inline::Ordering(b)) => VmResult::Ok(*a == *b),
-            (lhs, rhs) => err(VmErrorKind::UnsupportedBinaryOperation {
-                op: Protocol::PARTIAL_EQ.name,
-                lhs: lhs.type_info(),
-                rhs: rhs.type_info(),
-            }),
-        }
-    }
-
-    /// Perform a total equality check over two inline values.
-    pub(crate) fn eq(&self, other: &Self) -> VmResult<bool> {
-        match (self, other) {
-            (Inline::Unit, Inline::Unit) => VmResult::Ok(true),
-            (Inline::Bool(a), Inline::Bool(b)) => VmResult::Ok(*a == *b),
-            (Inline::Byte(a), Inline::Byte(b)) => VmResult::Ok(*a == *b),
-            (Inline::Char(a), Inline::Char(b)) => VmResult::Ok(*a == *b),
-            (Inline::Float(a), Inline::Float(b)) => {
-                let Some(ordering) = a.partial_cmp(b) else {
-                    return VmResult::err(VmErrorKind::IllegalFloatComparison { lhs: *a, rhs: *b });
-                };
-
-                VmResult::Ok(matches!(ordering, Ordering::Equal))
-            }
-            (Inline::Integer(a), Inline::Integer(b)) => VmResult::Ok(*a == *b),
-            (Inline::Type(a), Inline::Type(b)) => VmResult::Ok(*a == *b),
-            (Inline::Ordering(a), Inline::Ordering(b)) => VmResult::Ok(*a == *b),
-            (lhs, rhs) => err(VmErrorKind::UnsupportedBinaryOperation {
-                op: Protocol::EQ.name,
-                lhs: lhs.type_info(),
-                rhs: rhs.type_info(),
-            }),
-        }
-    }
-
-    /// Partial comparison implementation for inline.
-    pub(crate) fn partial_cmp(&self, other: &Self) -> VmResult<Option<Ordering>> {
-        match (self, other) {
-            (Inline::Unit, Inline::Unit) => VmResult::Ok(Some(Ordering::Equal)),
-            (Inline::Bool(lhs), Inline::Bool(rhs)) => VmResult::Ok(lhs.partial_cmp(rhs)),
-            (Inline::Byte(lhs), Inline::Byte(rhs)) => VmResult::Ok(lhs.partial_cmp(rhs)),
-            (Inline::Char(lhs), Inline::Char(rhs)) => VmResult::Ok(lhs.partial_cmp(rhs)),
-            (Inline::Float(lhs), Inline::Float(rhs)) => VmResult::Ok(lhs.partial_cmp(rhs)),
-            (Inline::Integer(lhs), Inline::Integer(rhs)) => VmResult::Ok(lhs.partial_cmp(rhs)),
-            (Inline::Type(lhs), Inline::Type(rhs)) => VmResult::Ok(lhs.partial_cmp(rhs)),
-            (Inline::Ordering(lhs), Inline::Ordering(rhs)) => VmResult::Ok(lhs.partial_cmp(rhs)),
-            (lhs, rhs) => err(VmErrorKind::UnsupportedBinaryOperation {
-                op: Protocol::PARTIAL_CMP.name,
-                lhs: lhs.type_info(),
-                rhs: rhs.type_info(),
-            }),
-        }
-    }
-
-    /// Total comparison implementation for inline.
-    pub(crate) fn cmp(&self, other: &Self) -> VmResult<Ordering> {
-        match (self, other) {
-            (Inline::Unit, Inline::Unit) => VmResult::Ok(Ordering::Equal),
-            (Inline::Bool(a), Inline::Bool(b)) => VmResult::Ok(a.cmp(b)),
-            (Inline::Byte(a), Inline::Byte(b)) => VmResult::Ok(a.cmp(b)),
-            (Inline::Char(a), Inline::Char(b)) => VmResult::Ok(a.cmp(b)),
-            (Inline::Float(a), Inline::Float(b)) => {
-                let Some(ordering) = a.partial_cmp(b) else {
-                    return VmResult::err(VmErrorKind::IllegalFloatComparison { lhs: *a, rhs: *b });
-                };
-
-                VmResult::Ok(ordering)
-            }
-            (Inline::Integer(a), Inline::Integer(b)) => VmResult::Ok(a.cmp(b)),
-            (Inline::Type(a), Inline::Type(b)) => VmResult::Ok(a.cmp(b)),
-            (Inline::Ordering(a), Inline::Ordering(b)) => VmResult::Ok(a.cmp(b)),
-            (lhs, rhs) => VmResult::err(VmErrorKind::UnsupportedBinaryOperation {
-                op: Protocol::CMP.name,
-                lhs: lhs.type_info(),
-                rhs: rhs.type_info(),
-            }),
-        }
-    }
-}
-
-impl fmt::Debug for Inline {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match *self {
-            Inline::Unit => write!(f, "()"),
-            Inline::Bool(value) => value.fmt(f),
-            Inline::Byte(value) => value.fmt(f),
-            Inline::Char(value) => value.fmt(f),
-            Inline::Integer(value) => value.fmt(f),
-            Inline::Float(value) => value.fmt(f),
-            Inline::Type(value) => value.fmt(f),
-            Inline::Ordering(value) => value.fmt(f),
-        }
-    }
-}
-
-impl Inline {
-    pub(crate) fn type_info(&self) -> TypeInfo {
-        match self {
-            Inline::Unit => TypeInfo::static_type(static_type::TUPLE),
-            Inline::Bool(..) => TypeInfo::static_type(static_type::BOOL),
-            Inline::Byte(..) => TypeInfo::static_type(static_type::BYTE),
-            Inline::Char(..) => TypeInfo::static_type(static_type::CHAR),
-            Inline::Integer(..) => TypeInfo::static_type(static_type::INTEGER),
-            Inline::Float(..) => TypeInfo::static_type(static_type::FLOAT),
-            Inline::Type(..) => TypeInfo::static_type(static_type::TYPE),
-            Inline::Ordering(..) => TypeInfo::static_type(static_type::ORDERING),
-        }
-    }
-
-    /// Get the type hash for the current value.
-    ///
-    /// One notable feature is that the type of a variant is its container
-    /// *enum*, and not the type hash of the variant itself.
-    pub(crate) fn type_hash(&self) -> Hash {
-        match self {
-            Inline::Unit => static_type::TUPLE.hash,
-            Inline::Bool(..) => static_type::BOOL.hash,
-            Inline::Byte(..) => static_type::BYTE.hash,
-            Inline::Char(..) => static_type::CHAR.hash,
-            Inline::Integer(..) => static_type::INTEGER.hash,
-            Inline::Float(..) => static_type::FLOAT.hash,
-            Inline::Type(..) => static_type::TYPE.hash,
-            Inline::Ordering(..) => static_type::ORDERING.hash,
         }
     }
 }

--- a/crates/rune/src/runtime/value.rs
+++ b/crates/rune/src/runtime/value.rs
@@ -393,7 +393,7 @@ impl Value {
         let result =
             vm_try!(caller.call_protocol_fn(Protocol::STRING_DISPLAY, self.clone(), &mut args));
 
-        <()>::from_value(result)
+        VmResult::Ok(vm_try!(<()>::from_value(result)))
     }
 
     /// Perform a shallow clone of the value using the [`CLONE`] protocol.
@@ -933,18 +933,19 @@ impl Value {
     /// a future without the use of a [`Vm`] and one is not provided through the
     /// environment.
     #[inline]
-    pub fn into_future(self) -> VmResult<Future> {
-        let target = match vm_try!(self.take_repr()) {
-            OwnedRepr::Mutable(Mutable::Future(future)) => return VmResult::Ok(future),
+    pub fn into_future(self) -> Result<Future, RuntimeError> {
+        let target = match self.take_repr()? {
+            OwnedRepr::Mutable(Mutable::Future(future)) => return Ok(future),
             OwnedRepr::Inline(value) => Value::from(value),
-            OwnedRepr::Mutable(value) => vm_try!(Value::try_from(value)),
+            OwnedRepr::Mutable(value) => Value::try_from(value)?,
             OwnedRepr::Any(value) => Value::from(value),
         };
 
-        let value =
-            vm_try!(EnvProtocolCaller.call_protocol_fn(Protocol::INTO_FUTURE, target, &mut ()));
+        let value = EnvProtocolCaller
+            .call_protocol_fn(Protocol::INTO_FUTURE, target, &mut ())
+            .into_result()?;
 
-        VmResult::Ok(vm_try!(Future::from_value(value)))
+        Future::from_value(value)
     }
 
     /// Try to coerce value into a typed reference.
@@ -1208,7 +1209,7 @@ impl Value {
             self.clone(),
             &mut Some((b.clone(),))
         )) {
-            return <_>::from_value(value);
+            return VmResult::Ok(vm_try!(<_>::from_value(value)));
         }
 
         err(VmErrorKind::UnsupportedBinaryOperation {
@@ -1277,7 +1278,7 @@ impl Value {
         if let CallResultOnly::Ok(value) =
             vm_try!(caller.try_call_protocol_fn(Protocol::HASH, self.clone(), &mut args))
         {
-            return <_>::from_value(value);
+            return VmResult::Ok(vm_try!(<_>::from_value(value)));
         }
 
         err(VmErrorKind::UnsupportedUnaryOperation {
@@ -1374,7 +1375,7 @@ impl Value {
             self.clone(),
             &mut Some((b.clone(),))
         )) {
-            return <_>::from_value(value);
+            return VmResult::Ok(vm_try!(<_>::from_value(value)));
         }
 
         err(VmErrorKind::UnsupportedBinaryOperation {
@@ -1476,7 +1477,7 @@ impl Value {
             self.clone(),
             &mut Some((b.clone(),))
         )) {
-            return <_>::from_value(value);
+            return VmResult::Ok(vm_try!(<_>::from_value(value)));
         }
 
         err(VmErrorKind::UnsupportedBinaryOperation {
@@ -1578,7 +1579,7 @@ impl Value {
             self.clone(),
             &mut Some((b.clone(),))
         )) {
-            return <_>::from_value(value);
+            return VmResult::Ok(vm_try!(<_>::from_value(value)));
         }
 
         err(VmErrorKind::UnsupportedBinaryOperation {
@@ -1725,14 +1726,14 @@ impl Value {
         let value =
             vm_try!(EnvProtocolCaller.call_protocol_fn(Protocol::NEXT, self.clone(), &mut ()));
 
-        FromValue::from_value(value)
+        VmResult::Ok(vm_try!(FromValue::from_value(value)))
     }
 
     pub(crate) fn protocol_next_back(&self) -> VmResult<Option<Value>> {
         let value =
             vm_try!(EnvProtocolCaller.call_protocol_fn(Protocol::NEXT_BACK, self.clone(), &mut ()));
 
-        FromValue::from_value(value)
+        VmResult::Ok(vm_try!(FromValue::from_value(value)))
     }
 
     pub(crate) fn protocol_nth_back(&self, n: usize) -> VmResult<Option<Value>> {
@@ -1742,21 +1743,21 @@ impl Value {
             &mut Some((n,))
         ));
 
-        FromValue::from_value(value)
+        VmResult::Ok(vm_try!(FromValue::from_value(value)))
     }
 
     pub(crate) fn protocol_len(&self) -> VmResult<usize> {
         let value =
             vm_try!(EnvProtocolCaller.call_protocol_fn(Protocol::LEN, self.clone(), &mut ()));
 
-        FromValue::from_value(value)
+        VmResult::Ok(vm_try!(FromValue::from_value(value)))
     }
 
     pub(crate) fn protocol_size_hint(&self) -> VmResult<(usize, Option<usize>)> {
         let value =
             vm_try!(EnvProtocolCaller.call_protocol_fn(Protocol::SIZE_HINT, self.clone(), &mut ()));
 
-        FromValue::from_value(value)
+        VmResult::Ok(vm_try!(FromValue::from_value(value)))
     }
 }
 

--- a/crates/rune/src/runtime/value.rs
+++ b/crates/rune/src/runtime/value.rs
@@ -32,7 +32,7 @@ use super::{
     ConstValueKind, ControlFlow, DynGuardedArgs, EnvProtocolCaller, Format, Formatter, FromValue,
     Function, Future, Generator, GeneratorState, IntoOutput, Iterator, MaybeTypeOf, Mut, Object,
     OwnedTuple, Protocol, ProtocolCaller, RawAnyObjGuard, Ref, RuntimeError, Shared, Snapshot,
-    Stream, ToValue, Type, TypeInfo, Variant, Vec, Vm, VmErrorKind, VmIntegerRepr, VmResult,
+    Stream, Type, TypeInfo, Variant, Vec, Vm, VmErrorKind, VmIntegerRepr, VmResult,
 };
 #[cfg(feature = "alloc")]
 use super::{Hasher, Tuple};
@@ -623,17 +623,15 @@ impl Value {
     }
 
     /// Construct a vector.
-    pub fn vec(vec: alloc::Vec<Value>) -> VmResult<Self> {
+    pub fn vec(vec: alloc::Vec<Value>) -> alloc::Result<Self> {
         let data = Vec::from(vec);
-
-        VmResult::Ok(vm_try!(Value::try_from(data)))
+        Value::try_from(data)
     }
 
     /// Construct a tuple.
-    pub fn tuple(vec: alloc::Vec<Value>) -> VmResult<Self> {
-        let data = vm_try!(OwnedTuple::try_from(vec));
-
-        VmResult::Ok(vm_try!(Value::try_from(data)))
+    pub fn tuple(vec: alloc::Vec<Value>) -> alloc::Result<Self> {
+        let data = OwnedTuple::try_from(vec)?;
+        Value::try_from(data)
     }
 
     /// Construct an empty.
@@ -1909,13 +1907,6 @@ impl IntoOutput for Mutable {
 
     #[inline]
     fn into_output(self) -> VmResult<Self::Output> {
-        VmResult::Ok(self)
-    }
-}
-
-impl ToValue for Value {
-    #[inline]
-    fn to_value(self) -> VmResult<Value> {
         VmResult::Ok(self)
     }
 }

--- a/crates/rune/src/runtime/value/inline.rs
+++ b/crates/rune/src/runtime/value/inline.rs
@@ -1,0 +1,172 @@
+use core::cmp::Ordering;
+use core::fmt;
+
+use musli::{Decode, Encode};
+use serde::{Deserialize, Serialize};
+
+use crate::hash::Hash;
+use crate::runtime::{static_type, Protocol, Type, TypeInfo, VmErrorKind, VmResult};
+
+use super::err;
+
+/// An inline value.
+#[derive(Clone, Copy, Encode, Decode, Deserialize, Serialize)]
+pub enum Inline {
+    /// The unit value.
+    Unit,
+    /// A boolean.
+    Bool(bool),
+    /// A single byte.
+    Byte(u8),
+    /// A character.
+    Char(char),
+    /// A number.
+    Integer(i64),
+    /// A float.
+    Float(f64),
+    /// A type hash. Describes a type in the virtual machine.
+    Type(Type),
+    /// Ordering.
+    Ordering(
+        #[musli(with = crate::musli::ordering)]
+        #[serde(with = "crate::serde::ordering")]
+        Ordering,
+    ),
+}
+
+impl Inline {
+    /// Perform a partial equality check over two inline values.
+    pub(crate) fn partial_eq(&self, other: &Self) -> VmResult<bool> {
+        match (self, other) {
+            (Inline::Unit, Inline::Unit) => VmResult::Ok(true),
+            (Inline::Bool(a), Inline::Bool(b)) => VmResult::Ok(*a == *b),
+            (Inline::Byte(a), Inline::Byte(b)) => VmResult::Ok(*a == *b),
+            (Inline::Char(a), Inline::Char(b)) => VmResult::Ok(*a == *b),
+            (Inline::Integer(a), Inline::Integer(b)) => VmResult::Ok(*a == *b),
+            (Inline::Float(a), Inline::Float(b)) => VmResult::Ok(*a == *b),
+            (Inline::Type(a), Inline::Type(b)) => VmResult::Ok(*a == *b),
+            (Inline::Ordering(a), Inline::Ordering(b)) => VmResult::Ok(*a == *b),
+            (lhs, rhs) => err(VmErrorKind::UnsupportedBinaryOperation {
+                op: Protocol::PARTIAL_EQ.name,
+                lhs: lhs.type_info(),
+                rhs: rhs.type_info(),
+            }),
+        }
+    }
+
+    /// Perform a total equality check over two inline values.
+    pub(crate) fn eq(&self, other: &Self) -> VmResult<bool> {
+        match (self, other) {
+            (Inline::Unit, Inline::Unit) => VmResult::Ok(true),
+            (Inline::Bool(a), Inline::Bool(b)) => VmResult::Ok(*a == *b),
+            (Inline::Byte(a), Inline::Byte(b)) => VmResult::Ok(*a == *b),
+            (Inline::Char(a), Inline::Char(b)) => VmResult::Ok(*a == *b),
+            (Inline::Float(a), Inline::Float(b)) => {
+                let Some(ordering) = a.partial_cmp(b) else {
+                    return VmResult::err(VmErrorKind::IllegalFloatComparison { lhs: *a, rhs: *b });
+                };
+
+                VmResult::Ok(matches!(ordering, Ordering::Equal))
+            }
+            (Inline::Integer(a), Inline::Integer(b)) => VmResult::Ok(*a == *b),
+            (Inline::Type(a), Inline::Type(b)) => VmResult::Ok(*a == *b),
+            (Inline::Ordering(a), Inline::Ordering(b)) => VmResult::Ok(*a == *b),
+            (lhs, rhs) => err(VmErrorKind::UnsupportedBinaryOperation {
+                op: Protocol::EQ.name,
+                lhs: lhs.type_info(),
+                rhs: rhs.type_info(),
+            }),
+        }
+    }
+
+    /// Partial comparison implementation for inline.
+    pub(crate) fn partial_cmp(&self, other: &Self) -> VmResult<Option<Ordering>> {
+        match (self, other) {
+            (Inline::Unit, Inline::Unit) => VmResult::Ok(Some(Ordering::Equal)),
+            (Inline::Bool(lhs), Inline::Bool(rhs)) => VmResult::Ok(lhs.partial_cmp(rhs)),
+            (Inline::Byte(lhs), Inline::Byte(rhs)) => VmResult::Ok(lhs.partial_cmp(rhs)),
+            (Inline::Char(lhs), Inline::Char(rhs)) => VmResult::Ok(lhs.partial_cmp(rhs)),
+            (Inline::Float(lhs), Inline::Float(rhs)) => VmResult::Ok(lhs.partial_cmp(rhs)),
+            (Inline::Integer(lhs), Inline::Integer(rhs)) => VmResult::Ok(lhs.partial_cmp(rhs)),
+            (Inline::Type(lhs), Inline::Type(rhs)) => VmResult::Ok(lhs.partial_cmp(rhs)),
+            (Inline::Ordering(lhs), Inline::Ordering(rhs)) => VmResult::Ok(lhs.partial_cmp(rhs)),
+            (lhs, rhs) => err(VmErrorKind::UnsupportedBinaryOperation {
+                op: Protocol::PARTIAL_CMP.name,
+                lhs: lhs.type_info(),
+                rhs: rhs.type_info(),
+            }),
+        }
+    }
+
+    /// Total comparison implementation for inline.
+    pub(crate) fn cmp(&self, other: &Self) -> VmResult<Ordering> {
+        match (self, other) {
+            (Inline::Unit, Inline::Unit) => VmResult::Ok(Ordering::Equal),
+            (Inline::Bool(a), Inline::Bool(b)) => VmResult::Ok(a.cmp(b)),
+            (Inline::Byte(a), Inline::Byte(b)) => VmResult::Ok(a.cmp(b)),
+            (Inline::Char(a), Inline::Char(b)) => VmResult::Ok(a.cmp(b)),
+            (Inline::Float(a), Inline::Float(b)) => {
+                let Some(ordering) = a.partial_cmp(b) else {
+                    return VmResult::err(VmErrorKind::IllegalFloatComparison { lhs: *a, rhs: *b });
+                };
+
+                VmResult::Ok(ordering)
+            }
+            (Inline::Integer(a), Inline::Integer(b)) => VmResult::Ok(a.cmp(b)),
+            (Inline::Type(a), Inline::Type(b)) => VmResult::Ok(a.cmp(b)),
+            (Inline::Ordering(a), Inline::Ordering(b)) => VmResult::Ok(a.cmp(b)),
+            (lhs, rhs) => VmResult::err(VmErrorKind::UnsupportedBinaryOperation {
+                op: Protocol::CMP.name,
+                lhs: lhs.type_info(),
+                rhs: rhs.type_info(),
+            }),
+        }
+    }
+}
+
+impl fmt::Debug for Inline {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Inline::Unit => write!(f, "()"),
+            Inline::Bool(value) => value.fmt(f),
+            Inline::Byte(value) => value.fmt(f),
+            Inline::Char(value) => value.fmt(f),
+            Inline::Integer(value) => value.fmt(f),
+            Inline::Float(value) => value.fmt(f),
+            Inline::Type(value) => value.fmt(f),
+            Inline::Ordering(value) => value.fmt(f),
+        }
+    }
+}
+
+impl Inline {
+    pub(crate) fn type_info(&self) -> TypeInfo {
+        match self {
+            Inline::Unit => TypeInfo::static_type(static_type::TUPLE),
+            Inline::Bool(..) => TypeInfo::static_type(static_type::BOOL),
+            Inline::Byte(..) => TypeInfo::static_type(static_type::BYTE),
+            Inline::Char(..) => TypeInfo::static_type(static_type::CHAR),
+            Inline::Integer(..) => TypeInfo::static_type(static_type::INTEGER),
+            Inline::Float(..) => TypeInfo::static_type(static_type::FLOAT),
+            Inline::Type(..) => TypeInfo::static_type(static_type::TYPE),
+            Inline::Ordering(..) => TypeInfo::static_type(static_type::ORDERING),
+        }
+    }
+
+    /// Get the type hash for the current value.
+    ///
+    /// One notable feature is that the type of a variant is its container
+    /// *enum*, and not the type hash of the variant itself.
+    pub(crate) fn type_hash(&self) -> Hash {
+        match self {
+            Inline::Unit => static_type::TUPLE.hash,
+            Inline::Bool(..) => static_type::BOOL.hash,
+            Inline::Byte(..) => static_type::BYTE.hash,
+            Inline::Char(..) => static_type::CHAR.hash,
+            Inline::Integer(..) => static_type::INTEGER.hash,
+            Inline::Float(..) => static_type::FLOAT.hash,
+            Inline::Type(..) => static_type::TYPE.hash,
+            Inline::Ordering(..) => static_type::ORDERING.hash,
+        }
+    }
+}

--- a/crates/rune/src/runtime/value/macros.rs
+++ b/crates/rune/src/runtime/value/macros.rs
@@ -410,8 +410,8 @@ macro_rules! number_value_trait {
 
             impl $crate::runtime::ToConstValue for $ty {
                 #[inline]
-                fn to_const_value(self) -> Result<ConstValue, $crate::runtime::RuntimeError> {
-                    Ok(ConstValue::try_from(self)?)
+                fn to_const_value(self) -> Result<$crate::runtime::ConstValue, $crate::runtime::RuntimeError> {
+                    $crate::runtime::ConstValue::try_from(self)
                 }
             }
 
@@ -421,7 +421,7 @@ macro_rules! number_value_trait {
                 #[inline]
                 fn try_from(value: $ty) -> Result<Self, $crate::runtime::RuntimeError> {
                     match <i64>::try_from(value) {
-                        Ok(number) => Ok(ConstValue::from(number)),
+                        Ok(number) => Ok($crate::runtime::ConstValue::from(number)),
                         #[allow(unreachable_patterns)]
                         Err(..) => Err($crate::runtime::RuntimeError::from(VmErrorKind::IntegerToValueCoercionError {
                             from: VmIntegerRepr::from(value),

--- a/crates/rune/src/runtime/value/macros.rs
+++ b/crates/rune/src/runtime/value/macros.rs
@@ -264,7 +264,7 @@ macro_rules! from {
     ($($variant:ident => $ty:ty),* $(,)*) => {
         $(
             impl TryFrom<$ty> for Value {
-                type Error = alloc::Error;
+                type Error = $crate::alloc::Error;
 
                 #[inline]
                 fn try_from(value: $ty) -> Result<Self, Self::Error> {
@@ -276,15 +276,15 @@ macro_rules! from {
                 type Output = $ty;
 
                 #[inline]
-                fn into_output(self) -> VmResult<Self::Output> {
-                    VmResult::Ok(self)
+                fn into_output(self) -> $crate::runtime::VmResult<Self::Output> {
+                    $crate::runtime::VmResult::Ok(self)
                 }
             }
 
-            impl ToValue for $ty {
+            impl $crate::runtime::ToValue for $ty {
                 #[inline]
-                fn to_value(self) -> VmResult<Value> {
-                    VmResult::Ok(vm_try!(Value::try_from(self)))
+                fn to_value(self) -> Result<Value, $crate::runtime::RuntimeError> {
+                    Ok($crate::runtime::Value::try_from(self)?)
                 }
             }
         )*
@@ -343,8 +343,8 @@ macro_rules! inline_from {
 
             impl $crate::runtime::ToValue for $ty {
                 #[inline]
-                fn to_value(self) -> $crate::runtime::VmResult<Value> {
-                    $crate::runtime::VmResult::Ok($crate::runtime::Value::from(self))
+                fn to_value(self) -> Result<Value, $crate::runtime::RuntimeError> {
+                    Ok($crate::runtime::Value::from(self))
                 }
             }
 
@@ -387,8 +387,8 @@ macro_rules! number_value_trait {
         $(
             impl $crate::runtime::ToValue for $ty {
                 #[inline]
-                fn to_value(self) -> $crate::runtime::VmResult<Value> {
-                    $crate::runtime::VmResult::Ok(vm_try!(Value::try_from(self)))
+                fn to_value(self) -> Result<Value, $crate::runtime::RuntimeError> {
+                    Value::try_from(self)
                 }
             }
 
@@ -439,8 +439,8 @@ macro_rules! float_value_trait {
         $(
             impl $crate::runtime::ToValue for $ty {
                 #[inline]
-                fn to_value(self) -> $crate::runtime::VmResult<$crate::runtime::Value> {
-                    $crate::runtime::VmResult::Ok($crate::runtime::Value::from(self as f64))
+                fn to_value(self) -> Result<Value, $crate::runtime::RuntimeError> {
+                    Ok($crate::runtime::Value::from(self as f64))
                 }
             }
 

--- a/crates/rune/src/runtime/vec.rs
+++ b/crates/rune/src/runtime/vec.rs
@@ -566,14 +566,15 @@ impl<T> ToValue for alloc::Vec<T>
 where
     T: ToValue,
 {
-    fn to_value(self) -> VmResult<Value> {
-        let mut inner = vm_try!(alloc::Vec::try_with_capacity(self.len()));
+    fn to_value(self) -> Result<Value, RuntimeError> {
+        let mut inner = alloc::Vec::try_with_capacity(self.len())?;
 
         for value in self {
-            vm_try!(inner.try_push(vm_try!(value.to_value())));
+            let value = value.to_value()?;
+            inner.try_push(value)?;
         }
 
-        VmResult::Ok(vm_try!(Value::try_from(Vec { inner })))
+        Ok(Value::try_from(Vec { inner })?)
     }
 }
 
@@ -582,13 +583,14 @@ impl<T> ToValue for ::rust_alloc::vec::Vec<T>
 where
     T: ToValue,
 {
-    fn to_value(self) -> VmResult<Value> {
-        let mut inner = vm_try!(alloc::Vec::try_with_capacity(self.len()));
+    fn to_value(self) -> Result<Value, RuntimeError> {
+        let mut inner = alloc::Vec::try_with_capacity(self.len())?;
 
         for value in self {
-            vm_try!(inner.try_push(vm_try!(value.to_value())));
+            let value = value.to_value()?;
+            inner.try_push(value)?;
         }
 
-        VmResult::Ok(vm_try!(Value::try_from(Vec { inner })))
+        Ok(Value::try_from(Vec { inner })?)
     }
 }

--- a/crates/rune/src/runtime/vec.rs
+++ b/crates/rune/src/runtime/vec.rs
@@ -16,7 +16,8 @@ use crate::{Any, TypeHash};
 
 use super::{
     Formatter, FromValue, ProtocolCaller, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo,
-    RangeToInclusive, RawAnyGuard, Ref, ToValue, UnsafeToRef, Value, VmErrorKind, VmResult,
+    RangeToInclusive, RawAnyGuard, Ref, RuntimeError, ToValue, UnsafeToRef, Value, VmErrorKind,
+    VmResult,
 };
 
 /// Struct representing a dynamic vector.
@@ -519,16 +520,16 @@ impl<T> FromValue for ::rust_alloc::vec::Vec<T>
 where
     T: FromValue,
 {
-    fn from_value(value: Value) -> VmResult<Self> {
-        let vec = vm_try!(value.into_vec());
+    fn from_value(value: Value) -> Result<Self, RuntimeError> {
+        let vec = value.into_vec()?;
 
         let mut output = ::rust_alloc::vec::Vec::with_capacity(vec.len());
 
         for value in vec {
-            output.push(vm_try!(T::from_value(value)));
+            output.push(T::from_value(value)?);
         }
 
-        VmResult::Ok(output)
+        Ok(output)
     }
 }
 
@@ -536,16 +537,16 @@ impl<T> FromValue for alloc::Vec<T>
 where
     T: FromValue,
 {
-    fn from_value(value: Value) -> VmResult<Self> {
-        let vec = vm_try!(value.into_vec());
+    fn from_value(value: Value) -> Result<Self, RuntimeError> {
+        let vec = value.into_vec()?;
 
-        let mut output = vm_try!(alloc::Vec::try_with_capacity(vec.len()));
+        let mut output = alloc::Vec::try_with_capacity(vec.len())?;
 
         for value in vec {
-            vm_try!(output.try_push(vm_try!(T::from_value(value))));
+            output.try_push(T::from_value(value)?)?;
         }
 
-        VmResult::Ok(output)
+        Ok(output)
     }
 }
 

--- a/crates/rune/src/runtime/vm.rs
+++ b/crates/rune/src/runtime/vm.rs
@@ -1931,7 +1931,7 @@ impl Vm {
 
     #[cfg_attr(feature = "bench", inline(never))]
     fn op_await(&mut self, addr: InstAddress) -> VmResult<Future> {
-        vm_try!(self.stack.at(addr)).clone().into_future()
+        VmResult::Ok(vm_try!(vm_try!(self.stack.at(addr)).clone().into_future()))
     }
 
     #[cfg_attr(feature = "bench", inline(never))]

--- a/crates/rune/src/runtime/vm_error.rs
+++ b/crates/rune/src/runtime/vm_error.rs
@@ -268,7 +268,7 @@ impl<T> VmResult<T> {
 
     /// Construct a new error from a type that can be converted into a
     /// [`VmError`].
-    pub(crate) fn err<E>(error: E) -> Self
+    pub fn err<E>(error: E) -> Self
     where
         VmError: From<E>,
     {
@@ -313,53 +313,6 @@ impl<T> VmResult<T> {
                 Self::Err(err)
             }
         }
-    }
-}
-
-#[allow(non_snake_case)]
-impl<T> VmResult<T> {
-    #[doc(hidden)]
-    #[inline]
-    pub fn __rune_macros__missing_struct_field(target: &'static str, name: &'static str) -> Self {
-        Self::err(VmErrorKind::MissingStructField { target, name })
-    }
-
-    #[doc(hidden)]
-    #[inline]
-    pub fn __rune_macros__missing_variant(name: &str) -> alloc::Result<Self> {
-        Ok(Self::err(VmErrorKind::MissingVariant {
-            name: name.try_to_owned()?,
-        }))
-    }
-
-    #[doc(hidden)]
-    #[inline]
-    pub fn __rune_macros__expected_variant(actual: TypeInfo) -> Self {
-        Self::err(VmErrorKind::ExpectedVariant { actual })
-    }
-
-    #[doc(hidden)]
-    #[inline]
-    pub fn __rune_macros__missing_variant_name() -> Self {
-        Self::err(VmErrorKind::MissingVariantName)
-    }
-
-    #[doc(hidden)]
-    #[inline]
-    pub fn __rune_macros__missing_tuple_index(target: &'static str, index: usize) -> Self {
-        Self::err(VmErrorKind::MissingTupleIndex { target, index })
-    }
-
-    #[doc(hidden)]
-    #[inline]
-    pub fn __rune_macros__unsupported_object_field_get(target: TypeInfo) -> Self {
-        Self::err(VmErrorKind::UnsupportedObjectFieldGet { target })
-    }
-
-    #[doc(hidden)]
-    #[inline]
-    pub fn __rune_macros__unsupported_tuple_index_get(target: TypeInfo, index: usize) -> Self {
-        Self::err(VmErrorKind::UnsupportedTupleIndexGet { target, index })
     }
 }
 
@@ -478,7 +431,7 @@ impl RuntimeError {
     }
 
     /// Construct an expected error.
-    pub(crate) fn expected<T>(actual: TypeInfo) -> Self
+    pub fn expected<T>(actual: TypeInfo) -> Self
     where
         T: ?Sized + TypeOf,
     {
@@ -507,6 +460,53 @@ impl RuntimeError {
     /// Indicate that a constant constructor is missing.
     pub(crate) fn missing_constant_constructor(hash: Hash) -> Self {
         Self::new(VmErrorKind::MissingConstantConstructor { hash })
+    }
+}
+
+#[allow(non_snake_case)]
+impl RuntimeError {
+    #[doc(hidden)]
+    #[inline]
+    pub fn __rune_macros__missing_struct_field(target: &'static str, name: &'static str) -> Self {
+        Self::new(VmErrorKind::MissingStructField { target, name })
+    }
+
+    #[doc(hidden)]
+    #[inline]
+    pub fn __rune_macros__missing_variant(name: &str) -> alloc::Result<Self> {
+        Ok(Self::new(VmErrorKind::MissingVariant {
+            name: name.try_to_owned()?,
+        }))
+    }
+
+    #[doc(hidden)]
+    #[inline]
+    pub fn __rune_macros__expected_variant(actual: TypeInfo) -> Self {
+        Self::new(VmErrorKind::ExpectedVariant { actual })
+    }
+
+    #[doc(hidden)]
+    #[inline]
+    pub fn __rune_macros__missing_variant_name() -> Self {
+        Self::new(VmErrorKind::MissingVariantName)
+    }
+
+    #[doc(hidden)]
+    #[inline]
+    pub fn __rune_macros__missing_tuple_index(target: &'static str, index: usize) -> Self {
+        Self::new(VmErrorKind::MissingTupleIndex { target, index })
+    }
+
+    #[doc(hidden)]
+    #[inline]
+    pub fn __rune_macros__unsupported_object_field_get(target: TypeInfo) -> Self {
+        Self::new(VmErrorKind::UnsupportedObjectFieldGet { target })
+    }
+
+    #[doc(hidden)]
+    #[inline]
+    pub fn __rune_macros__unsupported_tuple_index_get(target: TypeInfo, index: usize) -> Self {
+        Self::new(VmErrorKind::UnsupportedTupleIndexGet { target, index })
     }
 }
 

--- a/crates/rune/src/serde.rs
+++ b/crates/rune/src/serde.rs
@@ -1,0 +1,28 @@
+pub(crate) mod ordering {
+    use core::cmp::Ordering;
+
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<Ordering, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        match i8::deserialize(deserializer)? {
+            -1 => Ok(Ordering::Less),
+            0 => Ok(Ordering::Equal),
+            1 => Ok(Ordering::Greater),
+            _ => Err(serde::de::Error::custom("invalid ordering")),
+        }
+    }
+
+    pub(crate) fn serialize<S>(ordering: &Ordering, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match ordering {
+            Ordering::Less => serializer.serialize_i8(-1),
+            Ordering::Equal => serializer.serialize_i8(0),
+            Ordering::Greater => serializer.serialize_i8(1),
+        }
+    }
+}

--- a/crates/rune/src/shared/caller.rs
+++ b/crates/rune/src/shared/caller.rs
@@ -57,7 +57,7 @@ where
             unreachable!();
         };
 
-        T::from_value(value)
+        VmResult::Ok(vm_try!(T::from_value(value)))
     }
 }
 

--- a/crates/rune/src/support.rs
+++ b/crates/rune/src/support.rs
@@ -87,6 +87,14 @@ pub(crate) mod no_std {
         }
     }
 
+    impl From<runtime::RuntimeError> for Error {
+        fn from(error: runtime::RuntimeError) -> Self {
+            Self {
+                kind: ErrorKind::Runtime(error),
+            }
+        }
+    }
+
     impl From<anyhow::Error> for Error {
         fn from(error: anyhow::Error) -> Self {
             Self {
@@ -111,6 +119,7 @@ pub(crate) mod no_std {
                 ErrorKind::Context(error) => error.fmt(f),
                 ErrorKind::Compile(error) => error.fmt(f),
                 ErrorKind::Build(error) => error.fmt(f),
+                ErrorKind::Runtime(error) => error.fmt(f),
                 ErrorKind::Vm(error) => error.fmt(f),
                 ErrorKind::Custom(error) => error.fmt(f),
                 #[cfg(test)]
@@ -126,6 +135,7 @@ pub(crate) mod no_std {
         Compile(compile::Error),
         Build(build::BuildError),
         Vm(runtime::VmError),
+        Runtime(runtime::RuntimeError),
         Custom(anyhow::Error),
         #[cfg(test)]
         Test(tests::TestError),
@@ -139,6 +149,7 @@ pub(crate) mod no_std {
                 ErrorKind::Compile(error) => Some(error),
                 ErrorKind::Build(error) => Some(error),
                 ErrorKind::Vm(error) => Some(error),
+                ErrorKind::Runtime(error) => Some(error),
                 ErrorKind::Custom(error) => Some(error.as_ref()),
                 #[cfg(test)]
                 ErrorKind::Test(error) => Some(error),

--- a/crates/rune/src/tests.rs
+++ b/crates/rune/src/tests.rs
@@ -155,7 +155,7 @@ where
         .into_result()
         .map_err(TestError::VmError)?;
 
-    crate::from_value(output).map_err(TestError::VmError)
+    crate::from_value(output).map_err(|error| TestError::VmError(error.into()))
 }
 
 #[doc(hidden)]

--- a/crates/rune/src/tests/bug_344.rs
+++ b/crates/rune/src/tests/bug_344.rs
@@ -88,11 +88,7 @@ fn bug_344_async_function() -> Result<()> {
     let mut stack = Stack::new();
     stack.push(rune::to_value(GuardCheck::new())?)?;
     function(&mut stack, InstAddress::new(0), 1, Output::keep(0)).into_result()?;
-    let future = stack
-        .at(InstAddress::new(0))?
-        .clone()
-        .into_future()
-        .into_result()?;
+    let future = stack.at(InstAddress::new(0))?.clone().into_future()?;
     assert_eq!(block_on(future).into_result()?.as_integer()?, 42);
     return Ok(());
 
@@ -129,11 +125,7 @@ fn bug_344_async_inst_fn() -> Result<()> {
     stack.push(rune::to_value(GuardCheck::new())?)?;
     function(&mut stack, InstAddress::new(0), 2, Output::keep(0)).into_result()?;
 
-    let future = stack
-        .at(InstAddress::new(0))?
-        .clone()
-        .into_future()
-        .into_result()?;
+    let future = stack.at(InstAddress::new(0))?.clone().into_future()?;
     assert_eq!(block_on(future).into_result()?.as_integer()?, 42);
 
     Ok(())

--- a/crates/rune/src/tests/external_ops.rs
+++ b/crates/rune/src/tests/external_ops.rs
@@ -220,7 +220,7 @@ fn ordering_struct() -> Result<()> {
                 foo.value = $initial;
 
                 let output = vm.try_clone()?.call(["type"], (&mut foo,))?;
-                let a = <bool as FromValue>::from_value(output).into_result()?;
+                let a: bool = rune::from_value(output)?;
 
                 assert_eq!(a, $expected, "{} != {} (value)", foo.value, $expected);
             }
@@ -289,7 +289,7 @@ fn eq_struct() -> Result<()> {
                 foo.value = $initial;
 
                 let output = vm.try_clone()?.call(["type"], (&mut foo,))?;
-                let a = <bool as FromValue>::from_value(output).into_result()?;
+                let a: bool = rune::from_value(output)?;
 
                 assert_eq!(a, $expected, "{} != {} (value)", foo.value, $expected);
             }


### PR DESCRIPTION
This introduces the `ToConstValue` derive, which can be used to allow using third-party external types as constant values:

This adds the necessary pre-requisite to register the external constants in #819

# Example

```rust
/// An HTTP status code.
#[derive(Debug, Any, PartialEq, Eq, PartialOrd, Ord, ToConstValue)]
#[rune(item = ::http)]
pub struct StatusCode {
    #[const_value(with = self::const_status_code)]
    inner: reqwest::StatusCode,
}

mod const_status_code {
    use rune::runtime::{RuntimeError, ConstValue, Value};

    #[inline]
    pub(super) fn to_const_value(status: reqwest::StatusCode) -> Result<ConstValue, RuntimeError> {
        ConstValue::try_from(status.as_u16())
    }

    #[inline]
    pub(super) fn from_const_value(status: &ConstValue) -> Result<reqwest::StatusCode, RuntimeError> {
        let Some(value) = status.as_i64() else {
            return Err(RuntimeError::panic(format!("Unsupported reqwest status {status:?}")));
        };

        match reqwest::StatusCode::from_u16(value as u16) {
            Ok(status) => Ok(status),
            Err(error) => Err(RuntimeError::panic(error)),
        }
    }

    #[inline]
    pub(super) fn from_value(value: Value) -> Result<reqwest::StatusCode, RuntimeError> {
        match reqwest::StatusCode::from_u16(rune::from_value(value)?) {
            Ok(status) => Ok(status),
            Err(error) => Err(RuntimeError::panic(error)),
        }
    }
}
```