### PR TITLE
rune: Store Object in AnyObj instead of Mutable (relates #844)

### DIFF
--- a/crates/rune-macros/src/from_value.rs
+++ b/crates/rune-macros/src/from_value.rs
@@ -159,9 +159,13 @@ impl Expander<'_> {
                     #variant_data::Tuple(tuple) => match name {
                         #(#unnamed_matches,)* #missing,
                     },
-                    #variant_data::Struct(object) => match name {
-                        #(#named_matches,)* #missing,
-                    },
+                    #variant_data::Struct(data) => {
+                        let object = variant.accessor(data);
+
+                        match name {
+                            #(#named_matches,)* #missing,
+                        }
+                    }
                 }
             }
         };

--- a/crates/rune-macros/src/to_value.rs
+++ b/crates/rune-macros/src/to_value.rs
@@ -99,10 +99,10 @@ impl Expander<'_> {
             let ident = self.cx.field_ident(f)?;
             _ = self.cx.field_attrs(&f.attrs);
 
-            let name = &syn::LitStr::new(&ident.to_string(), ident.span());
+            let name = syn::LitStr::new(&ident.to_string(), ident.span());
 
             to_values.push(quote! {
-                object.insert(<#string as #try_from<_>>::try_from(#name)?, #to_value::to_value(self.#ident)?)
+                object.insert(<#string as #try_from<_>>::try_from(#name)?, #to_value::to_value(self.#ident)?)?
             });
         }
 

--- a/crates/rune/src/compile/context.rs
+++ b/crates/rune/src/compile/context.rs
@@ -734,10 +734,10 @@ impl Context {
                                     .copied()
                                     .enumerate()
                                     .map(|(position, name)| {
-                                        Ok((
-                                            Box::<str>::try_from(name)?,
-                                            meta::FieldMeta { position },
-                                        ))
+                                        Ok(meta::FieldMeta {
+                                            name: name.try_into()?,
+                                            position,
+                                        })
                                     })
                                     .try_collect::<alloc::Result<_>>()??,
                             }),
@@ -765,6 +765,7 @@ impl Context {
                                 enum_hash: ty.hash,
                                 hash,
                                 item: item.try_clone()?,
+                                fields: fields.to_fields()?,
                             })),
                             type_parameters: Hash::EMPTY,
                         })?;
@@ -799,10 +800,10 @@ impl Context {
                                                 .copied()
                                                 .enumerate()
                                                 .map(|(position, name)| {
-                                                    Ok((
-                                                        Box::<str>::try_from(name)?,
-                                                        meta::FieldMeta { position },
-                                                    ))
+                                                    Ok(meta::FieldMeta {
+                                                        name: name.try_into()?,
+                                                        position,
+                                                    })
                                                 })
                                                 .try_collect::<alloc::Result<_>>()??,
                                         })
@@ -1116,10 +1117,10 @@ impl Context {
                                         .copied()
                                         .enumerate()
                                         .map(|(position, name)| {
-                                            Ok((
-                                                Box::<str>::try_from(name)?,
-                                                meta::FieldMeta { position },
-                                            ))
+                                            Ok(meta::FieldMeta {
+                                                name: name.try_into()?,
+                                                position,
+                                            })
                                         })
                                         .try_collect::<alloc::Result<_>>()??,
                                 }),

--- a/crates/rune/src/compile/meta.rs
+++ b/crates/rune/src/compile/meta.rs
@@ -295,13 +295,28 @@ pub struct Alias {
 #[non_exhaustive]
 pub struct FieldsNamed {
     /// Fields associated with the type.
-    pub(crate) fields: HashMap<Box<str>, FieldMeta>,
+    pub(crate) fields: Box<[FieldMeta]>,
+}
+
+impl FieldsNamed {
+    /// Coerce into a hashmap of fields.
+    pub(crate) fn to_fields(&self) -> alloc::Result<HashMap<Box<str>, usize>> {
+        let mut fields = HashMap::new();
+
+        for f in self.fields.iter() {
+            fields.try_insert(f.name.try_clone()?, f.position)?;
+        }
+
+        Ok(fields)
+    }
 }
 
 /// Metadata for a single named field.
 #[derive(Debug, TryClone)]
 pub struct FieldMeta {
     /// Position of the field in its containing type declaration.
+    pub(crate) name: Box<str>,
+    /// The position of the field.
     pub(crate) position: usize,
 }
 

--- a/crates/rune/src/compile/unit_builder.rs
+++ b/crates/rune/src/compile/unit_builder.rs
@@ -318,6 +318,7 @@ impl UnitBuilder {
                 let rtti = Arc::new(Rtti {
                     hash,
                     item: pool.item(meta.item_meta.item).try_to_owned()?,
+                    fields: HashMap::new(),
                 });
 
                 self.constants
@@ -348,6 +349,7 @@ impl UnitBuilder {
                 let rtti = Arc::new(Rtti {
                     hash: meta.hash,
                     item: pool.item(meta.item_meta.item).try_to_owned()?,
+                    fields: HashMap::new(),
                 });
 
                 if self
@@ -404,6 +406,7 @@ impl UnitBuilder {
                 let rtti = Arc::new(Rtti {
                     hash: meta.hash,
                     item: pool.item(meta.item_meta.item).try_to_owned()?,
+                    fields: HashMap::new(),
                 });
 
                 if self
@@ -443,12 +446,16 @@ impl UnitBuilder {
                     .functions
                     .try_insert(meta.hash, signature)?;
             }
-            meta::Kind::Struct { .. } => {
+            meta::Kind::Struct {
+                fields: meta::Fields::Named(ref named),
+                ..
+            } => {
                 let hash = pool.item_type_hash(meta.item_meta.item);
 
                 let rtti = Arc::new(Rtti {
                     hash,
                     item: pool.item(meta.item_meta.item).try_to_owned()?,
+                    fields: named.to_fields()?,
                 });
 
                 self.constants
@@ -474,6 +481,7 @@ impl UnitBuilder {
                     enum_hash,
                     hash: meta.hash,
                     item: pool.item(meta.item_meta.item).try_to_owned()?,
+                    fields: HashMap::new(),
                 });
 
                 if self
@@ -522,6 +530,7 @@ impl UnitBuilder {
                     enum_hash,
                     hash: meta.hash,
                     item: pool.item(meta.item_meta.item).try_to_owned()?,
+                    fields: HashMap::new(),
                 });
 
                 if self
@@ -566,7 +575,7 @@ impl UnitBuilder {
             }
             meta::Kind::Variant {
                 enum_hash,
-                fields: meta::Fields::Named(..),
+                fields: meta::Fields::Named(ref named),
                 ..
             } => {
                 let hash = pool.item_type_hash(meta.item_meta.item);
@@ -575,6 +584,7 @@ impl UnitBuilder {
                     enum_hash,
                     hash,
                     item: pool.item(meta.item_meta.item).try_to_owned()?,
+                    fields: named.to_fields()?,
                 });
 
                 if self

--- a/crates/rune/src/internal_macros.rs
+++ b/crates/rune/src/internal_macros.rs
@@ -163,17 +163,3 @@ macro_rules! from_value_ref {
         }
     };
 }
-
-/// Implements a set of common value conversions.
-macro_rules! from_value2 {
-    ($ty:ty, $into_ref:ident, $into_mut:ident, $into:ident) => {
-        impl $crate::runtime::FromValue for $ty {
-            fn from_value(value: Value) -> Result<Self, $crate::runtime::RuntimeError> {
-                let value = value.$into()?;
-                Ok(value)
-            }
-        }
-
-        from_value_ref!($ty, $into_ref, $into_mut, $into);
-    };
-}

--- a/crates/rune/src/module/module_meta.rs
+++ b/crates/rune/src/module/module_meta.rs
@@ -5,6 +5,7 @@ use ::rust_alloc::sync::Arc;
 use crate as rune;
 use crate::alloc;
 use crate::alloc::prelude::*;
+use crate::alloc::HashMap;
 use crate::compile::context::{AttributeMacroHandler, MacroHandler, TraitHandler};
 use crate::compile::{meta, Docs};
 use crate::function_meta::AssociatedName;
@@ -87,6 +88,21 @@ pub(crate) enum Fields {
     Unnamed(usize),
     /// Empty.
     Empty,
+}
+
+impl Fields {
+    /// Coerce into fields hash map.
+    pub(crate) fn to_fields(&self) -> alloc::Result<HashMap<Box<str>, usize>> {
+        let mut fields = HashMap::new();
+
+        if let Fields::Named(names) = self {
+            for (index, name) in names.iter().copied().enumerate() {
+                fields.try_insert(name.try_into()?, index)?;
+            }
+        }
+
+        Ok(fields)
+    }
 }
 
 /// Metadata about a variant.

--- a/crates/rune/src/runtime/mod.rs
+++ b/crates/rune/src/runtime/mod.rs
@@ -167,11 +167,11 @@ pub use self::unit::{Unit, UnitStorage};
 mod value;
 #[cfg(any(test, feature = "cli"))]
 pub(crate) use self::value::OwnedRepr;
-pub(crate) use self::value::{BorrowRefRepr, MutRepr, Mutable, RefRepr};
 pub use self::value::{
-    EmptyStruct, Inline, RawValueGuard, Rtti, Struct, TupleStruct, TypeValue, Value, ValueMutGuard,
-    ValueRefGuard, VariantRtti,
+    Accessor, EmptyStruct, Inline, RawValueGuard, Rtti, Struct, TupleStruct, TypeValue, Value,
+    ValueMutGuard, ValueRefGuard, VariantRtti,
 };
+pub(crate) use self::value::{BorrowRefRepr, MutRepr, Mutable, RefRepr};
 
 mod variant;
 pub use self::variant::{Variant, VariantData};

--- a/crates/rune/src/runtime/static_type.rs
+++ b/crates/rune/src/runtime/static_type.rs
@@ -172,11 +172,9 @@ any_type! {
     ::std::tuple::Tuple {
         impl for rt::Tuple;
     }
-}
 
-static_type! {
     /// The specialized type information for the [`Object`] type.
-    pub(crate) static [OBJECT, OBJECT_HASH] = ::std::object::Object {
+    ::std::object::Object {
         impl for rt::Struct;
         impl<T> for HashMap<::rust_alloc::string::String, T>;
         impl<T> for HashMap<alloc::String, T>;
@@ -189,7 +187,9 @@ static_type! {
         #[cfg_attr(rune_docsrs, doc(cfg(feature = "std")))]
         impl<T> for ::std::collections::HashMap<alloc::String, T>;
     }
+}
 
+static_type! {
     pub(crate) static [RESULT, RESULT_HASH] = ::std::result::Result {
         impl<T, E> for Result<T, E>;
     }

--- a/crates/rune/src/tests.rs
+++ b/crates/rune/src/tests.rs
@@ -15,7 +15,7 @@ pub(crate) mod prelude {
     pub(crate) use crate::module::InstallWith;
     pub(crate) use crate::parse;
     pub(crate) use crate::runtime::{
-        self, Bytes, Formatter, Function, InstAddress, MaybeTypeOf, Mut, Mutable, Object, Output,
+        self, Bytes, Formatter, Function, InstAddress, MaybeTypeOf, Mutable, Object, Output,
         OwnedRepr, OwnedTuple, Protocol, RawAnyGuard, Ref, Stack, Tuple, TypeHash, TypeInfo,
         TypeOf, UnsafeToRef, VecTuple, VmErrorKind, VmResult,
     };
@@ -23,7 +23,7 @@ pub(crate) mod prelude {
     pub(crate) use crate::tests::{eval, run};
     pub(crate) use crate::{
         from_value, prepare, sources, span, vm_try, Any, Context, ContextError, Diagnostics,
-        FromValue, Hash, Item, ItemBuf, Module, Source, Sources, ToValue, Value, Vm,
+        FromValue, Hash, Item, ItemBuf, Module, Source, Sources, Value, Vm,
     };
     pub(crate) use futures_executor::block_on;
 
@@ -432,7 +432,6 @@ mod core_macros;
 mod custom_macros;
 mod debug_fmt;
 mod deprecation;
-mod derive_from_to_value;
 mod destructuring;
 mod esoteric_impls;
 mod external_constructor;

--- a/crates/rune/tests/derive_from_value.rs
+++ b/crates/rune/tests/derive_from_value.rs
@@ -1,11 +1,8 @@
-#![allow(
-    unused,
-    clippy::enum_variant_names,
-    clippy::vec_init_then_push,
-    clippy::needless_return
-)]
+#![allow(unused)]
 
-prelude!();
+use rune::alloc::prelude::*;
+use rune::runtime::{Mut, Object, OwnedTuple, Ref, Tuple};
+use rune::{Any, FromValue, ToValue};
 
 #[derive(Any)]
 struct Custom {}
@@ -15,7 +12,7 @@ struct TestUnit;
 
 #[derive(FromValue)]
 struct TestNamed {
-    a: Mut<alloc::String>,
+    a: Mut<String>,
     b: Mut<Tuple>,
     c: Mut<Object>,
     d: Ref<Custom>,
@@ -23,11 +20,11 @@ struct TestNamed {
 }
 
 #[derive(FromValue)]
-struct TestUnnamed(Mut<alloc::String>, Mut<Custom>);
+struct TestUnnamed(Mut<String>, Mut<Custom>);
 
 #[derive(ToValue)]
 struct Test2 {
-    a: alloc::String,
+    a: String,
     b: OwnedTuple,
     c: Object,
     d: Custom,
@@ -35,20 +32,20 @@ struct Test2 {
 }
 
 #[derive(ToValue)]
-struct Test2Unnamed(alloc::String, Custom);
+struct Test2Unnamed(String, Custom);
 
 #[derive(FromValue)]
 enum TestEnum {
-    TestUnit,
-    TestNamed {
-        a: Mut<alloc::String>,
+    Unit,
+    Named {
+        a: Mut<String>,
         b: Mut<Tuple>,
         c: Mut<Object>,
         d: Ref<Custom>,
         e: Mut<Custom>,
     },
-    TestUnnamed(
-        Mut<alloc::String>,
+    Unnamed(
+        Mut<String>,
         Mut<Tuple>,
         Mut<Object>,
         Ref<Custom>,


### PR DESCRIPTION
Since Object is separated from Struct, this also implements the long-standing change of storing field names separately from the structs themselves. So structs always just stores its struct data as an array.

Note that the field names are needed for dynamic field access methods. Since Rune is dynamic and untyped, we do not know which fields are available at compile-time.