### PR TITLE
rune: Simplify the empty sentinel value

### DIFF
--- a/crates/rune/src/cli/run.rs
+++ b/crates/rune/src/cli/run.rs
@@ -181,6 +181,8 @@ pub(super) async fn run(
 
         let mut functions = unit.iter_functions().peekable();
         let mut strings = unit.iter_static_strings().peekable();
+        let mut bytes = unit.iter_static_bytes().peekable();
+        let mut drop_sets = unit.iter_static_drop_sets().peekable();
         let mut keys = unit.iter_static_object_keys().peekable();
         let mut constants = unit.iter_constants().peekable();
 
@@ -199,16 +201,16 @@ pub(super) async fn run(
         if strings.peek().is_some() {
             writeln!(io.stdout, "# strings")?;
 
-            for string in strings {
-                writeln!(io.stdout, "{} = {:?}", string.hash(), string)?;
+            for (i, string) in strings.enumerate() {
+                writeln!(io.stdout, "{i} = {string:?}")?;
             }
         }
 
-        if args.dump_constants && constants.peek().is_some() {
-            writeln!(io.stdout, "# constants")?;
+        if bytes.peek().is_some() {
+            writeln!(io.stdout, "# bytes")?;
 
-            for constant in constants {
-                writeln!(io.stdout, "{} = {:?}", constant.0, constant.1)?;
+            for (i, bytes) in bytes.enumerate() {
+                writeln!(io.stdout, "{i} = {bytes:?}")?;
             }
         }
 
@@ -217,6 +219,22 @@ pub(super) async fn run(
 
             for (hash, keys) in keys {
                 writeln!(io.stdout, "{} = {:?}", hash, keys)?;
+            }
+        }
+
+        if drop_sets.peek().is_some() {
+            writeln!(io.stdout, "# drop sets")?;
+
+            for (i, set) in drop_sets.enumerate() {
+                writeln!(io.stdout, "{i} = {set:?}")?;
+            }
+        }
+
+        if args.dump_constants && constants.peek().is_some() {
+            writeln!(io.stdout, "# constants")?;
+
+            for (hash, constant) in constants {
+                writeln!(io.stdout, "{hash} = {constant:?}")?;
             }
         }
     }

--- a/crates/rune/src/cli/tests.rs
+++ b/crates/rune/src/cli/tests.rs
@@ -18,7 +18,7 @@ use crate::cli::{
 use crate::compile::FileSourceLoader;
 use crate::doc::{TestKind, TestParams};
 use crate::modules::capture_io::CaptureIo;
-use crate::runtime::{ReprRef, Value, Vm, VmError, VmResult};
+use crate::runtime::{Repr, Value, Vm, VmError, VmResult};
 use crate::{Diagnostics, Hash, Item, ItemBuf, Source, Sources, TypeHash, Unit};
 
 mod cli {
@@ -534,8 +534,8 @@ impl TestCase {
         capture_io.drain_into(&mut self.output)?;
 
         self.outcome = match result {
-            VmResult::Ok(v) => match v.as_ref()? {
-                ReprRef::Any(value) => match value.type_hash() {
+            VmResult::Ok(v) => match v.as_ref() {
+                Repr::Any(value) => match value.type_hash() {
                     Result::<Value, Value>::HASH => {
                         let result = value.borrow_ref::<Result<Value, Value>>()?;
 

--- a/crates/rune/src/compile/ir.rs
+++ b/crates/rune/src/compile/ir.rs
@@ -534,8 +534,8 @@ impl IrAssignOp {
     where
         S: Copy + Spanned,
     {
-        if let Some(Inline::Signed(target)) = target.as_inline_mut().with_span(spanned)? {
-            if let Some(Inline::Signed(operand)) = operand.as_inline().with_span(spanned)? {
+        if let Some(Inline::Signed(target)) = target.as_inline_mut() {
+            if let Some(Inline::Signed(operand)) = operand.as_inline() {
                 return self.assign_int(spanned, target, *operand);
             }
         }

--- a/crates/rune/src/compile/v1/assemble.rs
+++ b/crates/rune/src/compile/v1/assemble.rs
@@ -1101,6 +1101,12 @@ fn const_<'a, 'hir>(
 
     match *value.as_kind() {
         ConstValueKind::Inline(value) => match value {
+            Inline::Empty => {
+                return Err(compile::Error::msg(
+                    span,
+                    "Empty inline constant value is not supported",
+                ));
+            }
             Inline::Unit => {
                 cx.asm.push(Inst::unit(out), span)?;
             }

--- a/crates/rune/src/macros/format_args.rs
+++ b/crates/rune/src/macros/format_args.rs
@@ -572,7 +572,7 @@ fn expand_format_spec<'a>(
 
             let value = cx.eval(expr)?;
 
-            let number = match value.as_inline().with_span(expr)? {
+            let number = match value.as_inline() {
                 Some(Inline::Signed(n)) => n.to_usize(),
                 _ => None,
             };
@@ -589,7 +589,7 @@ fn expand_format_spec<'a>(
                         to be a positive number in use as precision, \
                         but got `{}`",
                         count,
-                        value.type_info().with_span(span)?
+                        value.type_info()
                     ),
                 ));
             };

--- a/crates/rune/src/modules/any.rs
+++ b/crates/rune/src/modules/any.rs
@@ -39,8 +39,8 @@ pub fn module() -> Result<Module, ContextError> {
 /// ```
 #[rune::function(free, path = Type::of_val)]
 #[inline]
-fn type_of_val(value: Value) -> VmResult<Type> {
-    VmResult::Ok(Type::new(vm_try!(value.type_hash())))
+fn type_of_val(value: Value) -> Type {
+    Type::new(value.type_hash())
 }
 
 /// Formatting a type.

--- a/crates/rune/src/modules/iter.rs
+++ b/crates/rune/src/modules/iter.rs
@@ -8,8 +8,8 @@ use crate::modules::collections::VecDeque;
 use crate::modules::collections::{HashMap, HashSet};
 use crate::runtime::range::RangeIter;
 use crate::runtime::{
-    FromValue, Function, Inline, InstAddress, Object, Output, OwnedTuple, Protocol, ReprRef,
-    TypeHash, Value, Vec, VmErrorKind, VmResult,
+    FromValue, Function, Inline, InstAddress, Object, Output, OwnedTuple, Protocol, Repr, TypeHash,
+    Value, Vec, VmErrorKind, VmResult,
 };
 use crate::shared::Caller;
 use crate::{Any, ContextError, Module, Params};
@@ -473,17 +473,17 @@ pub fn module() -> Result<Module, ContextError> {
                         let mut string = String::new();
 
                         while let Some(value) = vm_try!(next.call((iter.clone(),))) {
-                            match vm_try!(value.as_ref()) {
-                                ReprRef::Inline(Inline::Char(c)) => {
+                            match value.as_ref() {
+                                Repr::Inline(Inline::Char(c)) => {
                                     vm_try!(string.try_push(*c));
                                 }
-                                ReprRef::Inline(value) => {
+                                Repr::Inline(value) => {
                                     return VmResult::expected::<String>(value.type_info());
                                 }
-                                ReprRef::Dynamic(value) => {
+                                Repr::Dynamic(value) => {
                                     return VmResult::expected::<String>(value.type_info());
                                 }
-                                ReprRef::Any(value) => match value.type_hash() {
+                                Repr::Any(value) => match value.type_hash() {
                                     String::HASH => {
                                         let s = vm_try!(value.borrow_ref::<String>());
                                         vm_try!(string.try_push_str(&s));

--- a/crates/rune/src/runtime/access.rs
+++ b/crates/rune/src/runtime/access.rs
@@ -28,13 +28,6 @@ pub struct AccessError {
 
 impl AccessError {
     #[inline]
-    pub(crate) const fn empty() -> Self {
-        Self {
-            kind: AccessErrorKind::Empty,
-        }
-    }
-
-    #[inline]
     pub(crate) const fn not_owned(type_info: TypeInfo) -> Self {
         Self {
             kind: AccessErrorKind::NotAccessibleOwned(type_info),
@@ -50,7 +43,6 @@ impl AccessError {
 impl fmt::Display for AccessError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self.kind {
-            AccessErrorKind::Empty => write!(f, "Empty value"),
             AccessErrorKind::NotAccessibleRef(s) => write!(f, "Cannot read, value is {s}"),
             AccessErrorKind::NotAccessibleMut(s) => write!(f, "Cannot write, value is {s}"),
             AccessErrorKind::NotAccessibleTake(s) => write!(f, "Cannot take, value is {s}"),
@@ -73,7 +65,6 @@ impl From<AccessErrorKind> for AccessError {
 #[derive(Debug)]
 #[cfg_attr(test, derive(PartialEq))]
 pub(crate) enum AccessErrorKind {
-    Empty,
     NotAccessibleRef(Snapshot),
     NotAccessibleMut(Snapshot),
     NotAccessibleTake(Snapshot),

--- a/crates/rune/src/runtime/const_value.rs
+++ b/crates/rune/src/runtime/const_value.rs
@@ -16,7 +16,7 @@ use crate::runtime;
 use crate::{Hash, TypeHash};
 
 use super::{
-    Bytes, FromValue, Inline, Object, OwnedTuple, ReprRef, ToValue, Tuple, Type, TypeInfo, Value,
+    Bytes, FromValue, Inline, Object, OwnedTuple, Repr, ToValue, Tuple, Type, TypeInfo, Value,
     VmErrorKind,
 };
 
@@ -234,14 +234,14 @@ impl ConstValue {
 
     /// Construct a constant value from a reference to a value..
     pub(crate) fn from_value_ref(value: &Value) -> Result<ConstValue, RuntimeError> {
-        let inner = match value.as_ref()? {
-            ReprRef::Inline(value) => ConstValueKind::Inline(*value),
-            ReprRef::Dynamic(value) => {
+        let inner = match value.as_ref() {
+            Repr::Inline(value) => ConstValueKind::Inline(*value),
+            Repr::Dynamic(value) => {
                 return Err(RuntimeError::from(VmErrorKind::ConstNotSupported {
                     actual: value.type_info(),
                 }));
             }
-            ReprRef::Any(value) => match value.type_hash() {
+            Repr::Any(value) => match value.type_hash() {
                 Option::<Value>::HASH => {
                     let option = value.borrow_ref::<Option<Value>>()?;
 

--- a/crates/rune/src/runtime/dynamic.rs
+++ b/crates/rune/src/runtime/dynamic.rs
@@ -4,7 +4,7 @@ use core::ops::Deref;
 
 use crate::alloc::{Box, Vec};
 
-use super::{FromValue, ReprOwned, Rtti, RttiKind, RuntimeError, Tuple, TypeInfo, Value};
+use super::{FromValue, Repr, Rtti, RttiKind, RuntimeError, Tuple, TypeInfo, Value};
 
 use rust_alloc::sync::Arc;
 
@@ -16,8 +16,8 @@ pub struct DynamicEmpty {
 impl FromValue for DynamicEmpty {
     #[inline]
     fn from_value(value: Value) -> Result<Self, RuntimeError> {
-        match value.take_repr()? {
-            ReprOwned::Dynamic(value) if matches!(value.rtti().kind, RttiKind::Empty) => Ok(Self {
+        match value.take_repr() {
+            Repr::Dynamic(value) if matches!(value.rtti().kind, RttiKind::Empty) => Ok(Self {
                 rtti: value.rtti().clone(),
             }),
             value => Err(RuntimeError::expected_empty(value.type_info())),
@@ -44,8 +44,8 @@ pub struct DynamicTuple {
 impl FromValue for DynamicTuple {
     #[inline]
     fn from_value(value: Value) -> Result<Self, RuntimeError> {
-        match value.take_repr()? {
-            ReprOwned::Dynamic(value) if matches!(value.rtti().kind, RttiKind::Tuple) => {
+        match value.take_repr() {
+            Repr::Dynamic(value) if matches!(value.rtti().kind, RttiKind::Tuple) => {
                 let mut values = Vec::try_with_capacity(value.len())?;
 
                 for value in value.borrow_ref()?.iter() {
@@ -87,8 +87,8 @@ pub struct DynamicStruct {
 impl FromValue for DynamicStruct {
     #[inline]
     fn from_value(value: Value) -> Result<Self, RuntimeError> {
-        match value.take_repr()? {
-            ReprOwned::Dynamic(value) if matches!(value.rtti().kind, RttiKind::Struct) => {
+        match value.take_repr() {
+            Repr::Dynamic(value) if matches!(value.rtti().kind, RttiKind::Struct) => {
                 let mut values = Vec::try_with_capacity(value.len())?;
 
                 for value in value.borrow_ref()?.iter() {

--- a/crates/rune/src/runtime/format.rs
+++ b/crates/rune/src/runtime/format.rs
@@ -13,7 +13,7 @@ use crate as rune;
 use crate::alloc::clone::TryClone;
 use crate::alloc::fmt::TryWrite;
 use crate::alloc::String;
-use crate::runtime::{Formatter, Inline, ProtocolCaller, ReprRef, Value, VmErrorKind, VmResult};
+use crate::runtime::{Formatter, Inline, ProtocolCaller, Repr, Value, VmErrorKind, VmResult};
 use crate::{Any, TypeHash};
 
 /// Error raised when trying to parse a type string and it fails.
@@ -208,8 +208,8 @@ impl FormatSpec {
         caller: &mut dyn ProtocolCaller,
     ) -> VmResult<()> {
         'fallback: {
-            match vm_try!(value.as_ref()) {
-                ReprRef::Inline(value) => match value {
+            match value.as_ref() {
+                Repr::Inline(value) => match value {
                     Inline::Char(c) => {
                         vm_try!(f.buf_mut().try_push(*c));
                         vm_try!(self.format_fill(f, self.align, self.fill, None));
@@ -228,10 +228,10 @@ impl FormatSpec {
                         break 'fallback;
                     }
                 },
-                ReprRef::Dynamic(..) => {
+                Repr::Dynamic(..) => {
                     break 'fallback;
                 }
-                ReprRef::Any(value) => match value.type_hash() {
+                Repr::Any(value) => match value.type_hash() {
                     String::HASH => {
                         let s = vm_try!(value.borrow_ref::<String>());
                         vm_try!(f.buf_mut().try_push_str(&s));
@@ -256,8 +256,8 @@ impl FormatSpec {
         caller: &mut dyn ProtocolCaller,
     ) -> VmResult<()> {
         'fallback: {
-            match vm_try!(value.as_ref()) {
-                ReprRef::Inline(value) => match value {
+            match value.as_ref() {
+                Repr::Inline(value) => match value {
                     Inline::Signed(n) => {
                         let (n, align, fill, sign) = self.int_traits(*n);
                         vm_try!(self.format_number(f.buf_mut(), n));
@@ -272,10 +272,10 @@ impl FormatSpec {
                         break 'fallback;
                     }
                 },
-                ReprRef::Dynamic(..) => {
+                Repr::Dynamic(..) => {
                     break 'fallback;
                 }
-                ReprRef::Any(value) => match value.type_hash() {
+                Repr::Any(value) => match value.type_hash() {
                     String::HASH => {
                         let s = vm_try!(value.borrow_ref::<String>());
                         vm_try!(vm_write!(f, "{s:?}"));
@@ -293,7 +293,7 @@ impl FormatSpec {
     }
 
     fn format_upper_hex(&self, value: &Value, f: &mut Formatter) -> VmResult<()> {
-        match vm_try!(value.as_inline()) {
+        match value.as_inline() {
             Some(Inline::Signed(n)) => {
                 let (n, align, fill, sign) = self.int_traits(*n);
                 vm_try!(vm_write!(f.buf_mut(), "{:X}", n));
@@ -308,7 +308,7 @@ impl FormatSpec {
     }
 
     fn format_lower_hex(&self, value: &Value, f: &mut Formatter) -> VmResult<()> {
-        match vm_try!(value.as_inline()) {
+        match value.as_inline() {
             Some(Inline::Signed(n)) => {
                 let (n, align, fill, sign) = self.int_traits(*n);
                 vm_try!(vm_write!(f.buf_mut(), "{:x}", n));
@@ -323,7 +323,7 @@ impl FormatSpec {
     }
 
     fn format_binary(&self, value: &Value, f: &mut Formatter) -> VmResult<()> {
-        match vm_try!(value.as_inline()) {
+        match value.as_inline() {
             Some(Inline::Signed(n)) => {
                 let (n, align, fill, sign) = self.int_traits(*n);
                 vm_try!(vm_write!(f.buf_mut(), "{:b}", n));
@@ -338,7 +338,7 @@ impl FormatSpec {
     }
 
     fn format_pointer(&self, value: &Value, f: &mut Formatter) -> VmResult<()> {
-        match vm_try!(value.as_inline()) {
+        match value.as_inline() {
             Some(Inline::Signed(n)) => {
                 let (n, align, fill, sign) = self.int_traits(*n);
                 vm_try!(vm_write!(f.buf_mut(), "{:p}", n as *const ()));

--- a/crates/rune/src/runtime/inst.rs
+++ b/crates/rune/src/runtime/inst.rs
@@ -414,18 +414,11 @@ pub enum Inst {
         /// Where the value is being moved to.
         out: Output,
     },
-    /// Drop the value in the given frame offset, cleaning out it's slot in
-    /// memory.
-    ///
-    /// # Operation
-    ///
-    /// ```text
-    /// => *noop*
-    /// ```
+    /// Drop the given value set.
     #[musli(packed)]
     Drop {
-        /// Address of the value being dropped.
-        addr: InstAddress,
+        /// An indicator of the set of addresses to drop.
+        set: usize,
     },
     /// Swap two values on the stack using their offsets relative to the current
     /// stack frame.

--- a/crates/rune/src/runtime/mod.rs
+++ b/crates/rune/src/runtime/mod.rs
@@ -165,7 +165,7 @@ pub use self::value::{
     Accessor, EmptyStruct, Inline, RawValueGuard, Rtti, Struct, TupleStruct, TypeValue, Value,
     ValueMutGuard, ValueRefGuard,
 };
-pub(crate) use self::value::{Dynamic, DynamicTakeError, ReprMut, ReprOwned, ReprRef, RttiKind};
+pub(crate) use self::value::{Dynamic, DynamicTakeError, Repr, RttiKind};
 
 pub mod slice;
 

--- a/crates/rune/src/runtime/protocol_caller.rs
+++ b/crates/rune/src/runtime/protocol_caller.rs
@@ -18,7 +18,7 @@ pub(crate) trait ProtocolCaller: 'static {
             CallResultOnly::Unsupported(value) => {
                 VmResult::err(VmErrorKind::MissingProtocolFunction {
                     protocol,
-                    instance: vm_try!(value.type_info()),
+                    instance: value.type_info(),
                 })
             }
         }
@@ -59,7 +59,7 @@ impl ProtocolCaller for EnvProtocolCaller {
 
         crate::runtime::env::shared(|context, unit| {
             let count = args.count() + 1;
-            let hash = Hash::associated_function(vm_try!(target.type_hash()), protocol.hash);
+            let hash = Hash::associated_function(target.type_hash(), protocol.hash);
 
             if let Some(UnitFn::Offset {
                 offset,

--- a/crates/rune/src/runtime/protocol_caller.rs
+++ b/crates/rune/src/runtime/protocol_caller.rs
@@ -66,19 +66,19 @@ impl ProtocolCaller for EnvProtocolCaller {
                 args: expected,
                 call,
                 ..
-            }) = unit.function(hash)
+            }) = unit.function(&hash)
             {
-                vm_try!(check_args(count, expected));
+                vm_try!(check_args(count, *expected));
 
                 let mut stack = vm_try!(Stack::with_capacity(count));
                 vm_try!(stack.push(target));
                 vm_try!(args.push_to_stack(&mut stack));
                 let mut vm = Vm::with_stack(context.clone(), unit.clone(), stack);
-                vm.set_ip(offset);
+                vm.set_ip(*offset);
                 return VmResult::Ok(CallResultOnly::Ok(vm_try!(call.call_with_vm(vm))));
             }
 
-            if let Some(handler) = context.function(hash) {
+            if let Some(handler) = context.function(&hash) {
                 let mut stack = vm_try!(Stack::with_capacity(count));
                 let addr = stack.addr();
                 vm_try!(stack.push(target));

--- a/crates/rune/src/runtime/range.rs
+++ b/crates/rune/src/runtime/range.rs
@@ -5,7 +5,7 @@ use core::ops;
 use crate as rune;
 use crate::alloc::clone::TryClone;
 use crate::runtime::{
-    EnvProtocolCaller, FromValue, Inline, ProtocolCaller, ReprRef, RuntimeError, ToValue, Value,
+    EnvProtocolCaller, FromValue, Inline, ProtocolCaller, Repr, RuntimeError, ToValue, Value,
     VmErrorKind, VmResult,
 };
 use crate::Any;
@@ -94,16 +94,16 @@ impl Range {
     /// ```
     #[rune::function(keep)]
     pub fn iter(&self) -> VmResult<Value> {
-        let value = match (&vm_try!(self.start.as_ref()), vm_try!(self.end.as_ref())) {
-            (ReprRef::Inline(Inline::Unsigned(start)), ReprRef::Inline(end)) => {
+        let value = match (self.start.as_ref(), self.end.as_ref()) {
+            (Repr::Inline(Inline::Unsigned(start)), Repr::Inline(end)) => {
                 let end = vm_try!(end.as_integer::<u64>());
                 vm_try!(rune::to_value(RangeIter::new(*start..end)))
             }
-            (ReprRef::Inline(Inline::Signed(start)), ReprRef::Inline(end)) => {
+            (Repr::Inline(Inline::Signed(start)), Repr::Inline(end)) => {
                 let end = vm_try!(end.as_integer::<i64>());
                 vm_try!(rune::to_value(RangeIter::new(*start..end)))
             }
-            (ReprRef::Inline(Inline::Char(start)), ReprRef::Inline(Inline::Char(end))) => {
+            (Repr::Inline(Inline::Char(start)), Repr::Inline(Inline::Char(end))) => {
                 vm_try!(rune::to_value(RangeIter::new(*start..*end)))
             }
             (start, end) => {

--- a/crates/rune/src/runtime/range_from.rs
+++ b/crates/rune/src/runtime/range_from.rs
@@ -5,7 +5,7 @@ use core::ops;
 use crate as rune;
 use crate::alloc::clone::TryClone;
 use crate::runtime::{
-    EnvProtocolCaller, FromValue, Inline, ProtocolCaller, ReprRef, RuntimeError, ToValue, Value,
+    EnvProtocolCaller, FromValue, Inline, ProtocolCaller, Repr, RuntimeError, ToValue, Value,
     VmErrorKind, VmResult,
 };
 use crate::Any;
@@ -88,14 +88,14 @@ impl RangeFrom {
     /// ```
     #[rune::function(keep)]
     pub fn iter(&self) -> VmResult<Value> {
-        let value = match vm_try!(self.start.as_ref()) {
-            ReprRef::Inline(Inline::Unsigned(start)) => {
+        let value = match self.start.as_ref() {
+            Repr::Inline(Inline::Unsigned(start)) => {
                 vm_try!(crate::to_value(RangeFromIter::new(*start..)))
             }
-            ReprRef::Inline(Inline::Signed(start)) => {
+            Repr::Inline(Inline::Signed(start)) => {
                 vm_try!(crate::to_value(RangeFromIter::new(*start..)))
             }
-            ReprRef::Inline(Inline::Char(start)) => {
+            Repr::Inline(Inline::Char(start)) => {
                 vm_try!(crate::to_value(RangeFromIter::new(*start..)))
             }
             start => {

--- a/crates/rune/src/runtime/range_inclusive.rs
+++ b/crates/rune/src/runtime/range_inclusive.rs
@@ -5,7 +5,7 @@ use core::ops;
 use crate as rune;
 use crate::alloc::clone::TryClone;
 use crate::runtime::{
-    EnvProtocolCaller, FromValue, Inline, ProtocolCaller, ReprRef, RuntimeError, ToValue, Value,
+    EnvProtocolCaller, FromValue, Inline, ProtocolCaller, Repr, RuntimeError, ToValue, Value,
     VmErrorKind, VmResult,
 };
 use crate::Any;
@@ -95,16 +95,16 @@ impl RangeInclusive {
     /// ```
     #[rune::function(keep)]
     pub fn iter(&self) -> VmResult<Value> {
-        let value = match (vm_try!(self.start.as_ref()), vm_try!(self.end.as_ref())) {
-            (ReprRef::Inline(Inline::Unsigned(start)), ReprRef::Inline(end)) => {
+        let value = match (self.start.as_ref(), self.end.as_ref()) {
+            (Repr::Inline(Inline::Unsigned(start)), Repr::Inline(end)) => {
                 let end = vm_try!(end.as_integer::<u64>());
                 vm_try!(rune::to_value(RangeInclusiveIter::new(*start..=end)))
             }
-            (ReprRef::Inline(Inline::Signed(start)), ReprRef::Inline(end)) => {
+            (Repr::Inline(Inline::Signed(start)), Repr::Inline(end)) => {
                 let end = vm_try!(end.as_integer::<i64>());
                 vm_try!(rune::to_value(RangeInclusiveIter::new(*start..=end)))
             }
-            (ReprRef::Inline(Inline::Char(start)), ReprRef::Inline(Inline::Char(end))) => {
+            (Repr::Inline(Inline::Char(start)), Repr::Inline(Inline::Char(end))) => {
                 vm_try!(rune::to_value(RangeInclusiveIter::new(*start..=*end)))
             }
             (start, end) => {

--- a/crates/rune/src/runtime/runtime_context.rs
+++ b/crates/rune/src/runtime/runtime_context.rs
@@ -42,18 +42,21 @@ impl RuntimeContext {
     }
 
     /// Lookup the given native function handler in the context.
-    pub fn function(&self, hash: Hash) -> Option<&Arc<FunctionHandler>> {
-        self.functions.get(&hash)
+    #[inline]
+    pub fn function(&self, hash: &Hash) -> Option<&Arc<FunctionHandler>> {
+        self.functions.get(hash)
     }
 
     /// Read a constant value.
-    pub fn constant(&self, hash: Hash) -> Option<&ConstValue> {
-        self.constants.get(&hash)
+    #[inline]
+    pub fn constant(&self, hash: &Hash) -> Option<&ConstValue> {
+        self.constants.get(hash)
     }
 
     /// Read a constant constructor.
-    pub(crate) fn construct(&self, hash: Hash) -> Option<&dyn ConstConstruct> {
-        Some(&**self.construct.get(&hash)?)
+    #[inline]
+    pub(crate) fn construct(&self, hash: &Hash) -> Option<&dyn ConstConstruct> {
+        Some(&**self.construct.get(hash)?)
     }
 }
 

--- a/crates/rune/src/runtime/type_info.rs
+++ b/crates/rune/src/runtime/type_info.rs
@@ -38,6 +38,14 @@ impl TypeInfo {
         Self { kind }
     }
 
+    /// Construct type info for the empty type.
+    pub const fn empty() -> Self {
+        Self::new(TypeInfoKind::Any(AnyTypeInfo {
+            full_name: |f| write!(f, "empty"),
+            hash: crate::hash!(::std::empty::Empty),
+        }))
+    }
+
     /// Construct type info from an statically known [`Any`] type.
     #[inline]
     pub const fn any<T>() -> Self

--- a/crates/rune/src/runtime/value.rs
+++ b/crates/rune/src/runtime/value.rs
@@ -492,7 +492,7 @@ impl Value {
         let hash = Hash::associated_function(self.type_hash(), Protocol::INTO_TYPE_NAME);
 
         crate::runtime::env::shared(|context, unit| {
-            if let Some(name) = context.constant(hash) {
+            if let Some(name) = context.constant(&hash) {
                 match name.as_kind() {
                     ConstValueKind::String(s) => {
                         return VmResult::Ok(vm_try!(String::try_from(s.as_str())))
@@ -501,7 +501,7 @@ impl Value {
                 }
             }
 
-            if let Some(name) = unit.constant(hash) {
+            if let Some(name) = unit.constant(&hash) {
                 match name.as_kind() {
                     ConstValueKind::String(s) => {
                         return VmResult::Ok(vm_try!(String::try_from(s.as_str())))

--- a/crates/rune/src/runtime/value/inline.rs
+++ b/crates/rune/src/runtime/value/inline.rs
@@ -6,6 +6,7 @@ use core::hash::Hash as _;
 use musli::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
+use crate as rune;
 use crate::hash::Hash;
 use crate::runtime::{
     Hasher, OwnedTuple, Protocol, RuntimeError, Type, TypeInfo, VmErrorKind, VmIntegerRepr,
@@ -15,6 +16,14 @@ use crate::TypeHash;
 /// An inline value.
 #[derive(Clone, Copy, Encode, Decode, Deserialize, Serialize)]
 pub enum Inline {
+    /// An empty value.
+    ///
+    /// Note that this value *can not* be instantiated. Internally any
+    /// operations over it will result in a type error, even when operating with
+    /// itself.
+    ///
+    /// Some operations will return a "falsy" value, like type checks.
+    Empty,
     /// The unit value.
     Unit,
     /// A boolean.
@@ -214,6 +223,7 @@ impl Inline {
 impl fmt::Debug for Inline {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
+            Inline::Empty => write!(f, "<empty>"),
             Inline::Unit => write!(f, "()"),
             Inline::Bool(value) => value.fmt(f),
             Inline::Char(value) => value.fmt(f),
@@ -229,6 +239,7 @@ impl fmt::Debug for Inline {
 impl Inline {
     pub(crate) fn type_info(&self) -> TypeInfo {
         match self {
+            Inline::Empty => TypeInfo::empty(),
             Inline::Unit => TypeInfo::any::<OwnedTuple>(),
             Inline::Bool(..) => TypeInfo::named::<bool>(),
             Inline::Char(..) => TypeInfo::named::<char>(),
@@ -246,6 +257,7 @@ impl Inline {
     /// *enum*, and not the type hash of the variant itself.
     pub(crate) fn type_hash(&self) -> Hash {
         match self {
+            Inline::Empty => crate::hash!(::std::empty::Empty),
             Inline::Unit => OwnedTuple::HASH,
             Inline::Bool(..) => bool::HASH,
             Inline::Char(..) => char::HASH,

--- a/crates/rune/src/runtime/value/macros.rs
+++ b/crates/rune/src/runtime/value/macros.rs
@@ -23,9 +23,6 @@ macro_rules! inline_into {
                 Repr::Any(value) => {
                     Err(RuntimeError::expected::<$ty>(value.type_info()))
                 }
-                Repr::Empty => {
-                    Err(RuntimeError::from(AccessError::empty()))
-                }
             }
         }
 
@@ -46,9 +43,6 @@ macro_rules! inline_into {
                 }
                 Repr::Any(value) => {
                     Err(RuntimeError::expected::<$ty>(value.type_info()))
-                }
-                Repr::Empty => {
-                    Err(RuntimeError::from(AccessError::empty()))
                 }
             }
         }

--- a/crates/rune/src/runtime/vec.rs
+++ b/crates/rune/src/runtime/vec.rs
@@ -368,7 +368,7 @@ impl Vec {
     /// types, such as vectors and tuples.
     pub(crate) fn index_get(this: &[Value], index: Value) -> VmResult<Option<Value>> {
         let slice: Option<&[Value]> = 'out: {
-            if let Some(value) = vm_try!(index.as_any()) {
+            if let Some(value) = index.as_any() {
                 match value.type_hash() {
                     RangeFrom::HASH => {
                         let range = vm_try!(value.borrow_ref::<RangeFrom>());

--- a/crates/rune/src/runtime/vm_error.rs
+++ b/crates/rune/src/runtime/vm_error.rs
@@ -700,8 +700,14 @@ pub(crate) enum VmErrorKind {
     MissingStaticString {
         slot: usize,
     },
+    MissingStaticBytes {
+        slot: usize,
+    },
     MissingStaticObjectKeys {
         slot: usize,
+    },
+    MissingDropSet {
+        set: usize,
     },
     MissingRtti {
         hash: Hash,
@@ -914,10 +920,16 @@ impl fmt::Display for VmErrorKind {
                 write!(f, "Unsupported unary operation `{op}` on {operand}")
             }
             VmErrorKind::MissingStaticString { slot } => {
-                write!(f, "Static string slot `{slot}` does not exist")
+                write!(f, "Static string slot {slot} does not exist")
+            }
+            VmErrorKind::MissingStaticBytes { slot } => {
+                write!(f, "Static bytes slot {slot} does not exist")
             }
             VmErrorKind::MissingStaticObjectKeys { slot } => {
-                write!(f, "Static object keys slot `{slot}` does not exist")
+                write!(f, "Static object keys slot {slot} does not exist")
+            }
+            VmErrorKind::MissingDropSet { set } => {
+                write!(f, "Static drop set {set} does not exist")
             }
             VmErrorKind::MissingRtti { hash } => {
                 write!(f, "Missing runtime information for type with hash `{hash}`")

--- a/crates/rune/src/tests.rs
+++ b/crates/rune/src/tests.rs
@@ -12,6 +12,7 @@ pub(crate) mod prelude {
     pub(crate) use crate::ast;
     pub(crate) use crate::compile::{self, ErrorKind, Located, Named};
     pub(crate) use crate::diagnostics::{self, WarningDiagnosticKind};
+    pub(crate) use crate::hash;
     pub(crate) use crate::macros;
     pub(crate) use crate::module::InstallWith;
     pub(crate) use crate::parse;

--- a/crates/rune/src/tests/bug_344.rs
+++ b/crates/rune/src/tests/bug_344.rs
@@ -25,9 +25,7 @@ fn bug_344_function() -> Result<()> {
     context.install(module)?;
     let runtime = context.runtime()?;
 
-    let hash = Hash::type_hash(["function"]);
-
-    let function = runtime.function(hash).expect("expect function");
+    let function = runtime.function(&hash!(function)).expect("expect function");
 
     let mut stack = Stack::new();
     stack.push(rune::to_value(GuardCheck::new())?)?;
@@ -60,8 +58,7 @@ fn bug_344_inst_fn() -> Result<()> {
     let runtime = context.runtime()?;
 
     let hash = Hash::associated_function(GuardCheck::HASH, "function");
-
-    let function = runtime.function(hash).expect("expect function");
+    let function = runtime.function(&hash).expect("expect function");
 
     let mut stack = Stack::new();
     stack.push(rune::to_value(GuardCheck::new())?)?;
@@ -82,9 +79,7 @@ fn bug_344_async_function() -> Result<()> {
     context.install(module)?;
     let runtime = context.runtime()?;
 
-    let hash = Hash::type_hash(["function"]);
-
-    let function = runtime.function(hash).expect("expect function");
+    let function = runtime.function(&hash!(function)).expect("expect function");
 
     let mut stack = Stack::new();
     stack.push(rune::to_value(GuardCheck::new())?)?;
@@ -118,8 +113,7 @@ fn bug_344_async_inst_fn() -> Result<()> {
     let runtime = context.runtime()?;
 
     let hash = Hash::associated_function(GuardCheck::HASH, "function");
-
-    let function = runtime.function(hash).expect("expect function");
+    let function = runtime.function(&hash).expect("expect function");
 
     let mut stack = Stack::new();
     stack.push(rune::to_value(GuardCheck::new())?)?;

--- a/crates/rune/src/tests/unit_constants.rs
+++ b/crates/rune/src/tests/unit_constants.rs
@@ -13,7 +13,7 @@ fn test_get_const() -> Result<()> {
     let unit = prepare(&mut sources).with_context(&context).build()?;
 
     assert_eq!(
-        unit.constant(Hash::type_hash(["LEET"]))
+        unit.constant(&hash!(LEET))
             .context("missing constant")?
             .to_value()?
             .as_signed()?,
@@ -39,7 +39,7 @@ fn test_get_const_re_export() -> Result<()> {
     let unit = prepare(&mut sources).with_context(&context).build()?;
 
     assert_eq!(
-        unit.constant(Hash::type_hash(["LEET"]))
+        unit.constant(&hash!(LEET))
             .context("missing constant")?
             .to_value()?
             .as_signed()?,
@@ -63,7 +63,7 @@ fn test_get_const_nested() -> Result<()> {
     let unit = prepare(&mut sources).with_context(&context).build()?;
 
     assert_eq!(
-        unit.constant(Hash::type_hash(["inner", "LEET"]))
+        unit.constant(&hash!(inner::LEET))
             .expect("successful lookup")
             .to_value()
             .expect("could not allocate value")


### PR DESCRIPTION
This both simplifies *a ton* of code while having a very positive performance impact.

The `nbodies` benchmark got from 263ms to 231ms.