### PR TITLE
Add thread module

### DIFF
--- a/crates/rune-modules/Cargo.toml
+++ b/crates/rune-modules/Cargo.toml
@@ -23,6 +23,7 @@ full = [
     "fs",
     "process",
     "signal",
+    "thread",
     "rand",
     "io",
     "fmt",
@@ -34,6 +35,7 @@ http = ["reqwest"]
 json = ["serde_json"]
 process = ["tokio/process", "rune/std"]
 signal = ["tokio/signal"]
+thread = []
 rand = ["nanorand"]
 test = []
 core = []

--- a/crates/rune-modules/README.md
+++ b/crates/rune-modules/README.md
@@ -36,6 +36,7 @@ See each module for documentation:
 * [process]
 * [rand]
 * [signal]
+* [thread]
 * [test]
 * [time]
 * [toml]
@@ -55,6 +56,7 @@ See each module for documentation:
 * `process` for the [process module][process]
 * `rand` for the [rand module][rand]
 * `signal` for the [signal module][signal]
+* `thread` for the [thread module][thread]
 * `test` for the [test module][test]
 * `time` for the [time module][time]
 * `toml` for the [toml module][toml]
@@ -69,6 +71,7 @@ See each module for documentation:
 [process]: https://docs.rs/rune-modules/0/rune_modules/process/
 [rand]: https://docs.rs/rune-modules/0/rune_modules/rand/
 [signal]: https://docs.rs/rune-modules/0/rune_modules/signal/
+[thread]: https://docs.rs/rune-modules/0/rune_modules/thread/
 [test]: https://docs.rs/rune-modules/0/rune_modules/test/
 [time]: https://docs.rs/rune-modules/0/rune_modules/time/
 [toml]: https://docs.rs/rune-modules/0/rune_modules/toml/

--- a/crates/rune-modules/src/lib.rs
+++ b/crates/rune-modules/src/lib.rs
@@ -36,6 +36,7 @@
 //! * [process]
 //! * [rand]
 //! * [signal]
+//! * [thread]
 //! * [test]
 //! * [time]
 //! * [toml]
@@ -55,6 +56,7 @@
 //! * `process` for the [process module][process]
 //! * `rand` for the [rand module][rand]
 //! * `signal` for the [signal module][signal]
+//! * `thread` for the [thread module][thread]
 //! * `test` for the [test module][test]
 //! * `time` for the [time module][time]
 //! * `toml` for the [toml module][toml]
@@ -69,6 +71,7 @@
 //! [process]: https://docs.rs/rune-modules/0/rune_modules/process/
 //! [rand]: https://docs.rs/rune-modules/0/rune_modules/rand/
 //! [signal]: https://docs.rs/rune-modules/0/rune_modules/signal/
+//! [thread]: https://docs.rs/rune-modules/0/rune_modules/thread/
 //! [test]: https://docs.rs/rune-modules/0/rune_modules/test/
 //! [time]: https://docs.rs/rune-modules/0/rune_modules/time/
 //! [toml]: https://docs.rs/rune-modules/0/rune_modules/toml/
@@ -126,6 +129,9 @@ pub mod rand;
 #[cfg(feature = "signal")]
 pub mod signal;
 
+#[cfg(feature = "thread")]
+pub mod thread;
+
 #[cfg(feature = "test")]
 pub mod test;
 
@@ -143,6 +149,7 @@ entry! {
     {process, "process"},
     {rand, "rand"},
     {signal, "signal"},
+    {thread, "thread"},
     {test, "test"},
     {time, "time"},
     {toml, "toml", ser, de},

--- a/crates/rune-modules/src/thread.rs
+++ b/crates/rune-modules/src/thread.rs
@@ -1,0 +1,45 @@
+//! The native `thread` module for the [Rune Language].
+//!
+//! [Rune Language]: https://rune-rs.github.io
+//!
+//! ## Usage
+//!
+//! Add the following to your `Cargo.toml`:
+//!
+//! ```toml
+//! rune-modules = { version = "0.14.0", features = ["thread"] }
+//! ```
+//!
+//! Install it into your context:
+//!
+//! ```rust
+//! let mut context = rune::Context::with_default_modules()?;
+//! context.install(rune_modules::thread::module(true)?)?;
+//! # Ok::<_, rune::support::Error>(())
+//! ```
+//!
+//! Use it in Rune:
+//!
+//! ```rust,ignore
+//! use time::Duration;
+//!
+//! fn main() {
+//!     thread::sleep(Duration::from_seconds(3));
+//! }
+//! ```
+
+use crate::time::Duration;
+use rune::{ContextError, Module};
+use std::thread;
+
+/// Construct the `thread` module.
+pub fn module(_stdio: bool) -> Result<Module, ContextError> {
+    let mut module = Module::with_crate("thread")?;
+    module.function("sleep", sleep).build()?;
+    Ok(module)
+}
+
+/// Puts the current thread to sleep for at least the specified amount of time.
+fn sleep(duration: &Duration) {
+    thread::sleep(duration.into_std())
+}


### PR DESCRIPTION
With this module, it will be possible to use `thread::sleep(...)`, unlike `time::sleep(...)`, which is asyn.