### PR TITLE
Fix missing interface error in rune-wasm

### DIFF
--- a/crates/rune-wasm/src/lib.rs
+++ b/crates/rune-wasm/src/lib.rs
@@ -37,7 +37,7 @@ use rune::ast::Spanned;
 use rune::compile::LinkerError;
 use rune::diagnostics::{Diagnostic, FatalDiagnosticKind};
 use rune::modules::capture_io::CaptureIo;
-use rune::runtime::{budget, Value, VmResult};
+use rune::runtime::{budget, VmResult};
 use rune::{Context, ContextError, Options};
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
@@ -106,7 +106,7 @@ impl WasmCompileResult {
     /// Construct output from compile result.
     fn output(
         io: &CaptureIo,
-        output: Value,
+        result: String,
         diagnostics_output: Option<String>,
         diagnostics: Vec<WasmDiagnostic>,
         instructions: Option<String>,
@@ -115,7 +115,7 @@ impl WasmCompileResult {
             error: None,
             diagnostics_output,
             diagnostics,
-            result: Some(format!("{:?}", output)),
+            result: Some(result),
             output: io.drain_utf8().ok().map(|s| s.into_std()),
             instructions,
         }
@@ -352,9 +352,11 @@ async fn inner_compile(
         }
     };
 
+    let result = vm.with(|| format!("{output:?}"));
+
     Ok(WasmCompileResult::output(
         io,
-        output,
+        result,
         diagnostics_output(writer),
         diagnostics,
         instructions,

--- a/crates/rune/src/runtime/value.rs
+++ b/crates/rune/src/runtime/value.rs
@@ -286,20 +286,18 @@ impl Value {
         }
     }
 
-    /// Format the value using the [Protocol::DISPLAY_FMT] protocol.
-    ///
-    /// Requires a work buffer `buf` which will be used in case the value
-    /// provided requires out-of-line formatting. This must be cleared between
-    /// calls and can be re-used.
+    /// Format the value using the [`DISPLAY_FMT`] protocol.
     ///
     /// You must use [`Vm::with`] to specify which virtual machine this function
     /// is called inside.
     ///
     /// [`Vm::with`]: crate::Vm::with
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// This function will panic if called outside of a virtual machine.
+    /// This function errors if called outside of a virtual machine.
+    ///
+    /// [`DISPLAY_FMT`]: Protocol::DISPLAY_FMT
     pub fn display_fmt(&self, f: &mut Formatter) -> VmResult<()> {
         self.display_fmt_with(f, &mut EnvProtocolCaller)
     }
@@ -355,16 +353,14 @@ impl Value {
 
     /// Perform a shallow clone of the value using the [`CLONE`] protocol.
     ///
-    /// This requires read access to the underlying value.
-    ///
     /// You must use [`Vm::with`] to specify which virtual machine this function
     /// is called inside.
     ///
     /// [`Vm::with`]: crate::Vm::with
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// This function will panic if called outside of a virtual machine.
+    /// This function errors if called outside of a virtual machine.
     ///
     /// [`CLONE`]: Protocol::CLONE
     pub fn clone_(&self) -> VmResult<Self> {
@@ -401,9 +397,9 @@ impl Value {
     ///
     /// [`Vm::with`]: crate::Vm::with
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// This function will panic if called outside of a virtual machine.
+    /// This function errors if called outside of a virtual machine.
     ///
     /// [`DEBUG_FMT`]: Protocol::DEBUG_FMT
     pub fn debug_fmt(&self, f: &mut Formatter) -> VmResult<()> {


### PR DESCRIPTION
On the website rune-wasm currently raises a missing interface error when debug printing the return value. This is due to the virtual machine not being specified when debug printing is performed.

This PR adds that, and fixes the outdated documentation for public methods (they no longer panic).