### PR TITLE
Add optional static typing to functions and structs

### DIFF
--- a/crates/rune/src/ast/item_fn.rs
+++ b/crates/rune/src/ast/item_fn.rs
@@ -65,12 +65,9 @@ pub struct ItemFn {
     pub name: ast::Ident,
     /// The arguments of the function.
     pub args: ast::Parenthesized<ast::FnArg, T![,]>,
-    /// The arrow token.
-    #[rune(option)]
-    pub arrow: Option<ast::Arrow>,
     /// The function type.
     #[rune(option)]
-    pub fn_type: Option<ast::Ident>,
+    pub fn_type: Option<(ast::Arrow, ast::Type)>,
     /// The body of the function.
     pub body: ast::Block,
     /// Opaque identifier for fn item.

--- a/crates/rune/src/ast/item_fn.rs
+++ b/crates/rune/src/ast/item_fn.rs
@@ -67,7 +67,7 @@ pub struct ItemFn {
     pub args: ast::Parenthesized<ast::FnArg, T![,]>,
     /// The function type.
     #[rune(option)]
-    pub fn_type: Option<(ast::Arrow, ast::Type)>,
+    pub output: Option<(T![->], ast::Type)>,
     /// The body of the function.
     pub body: ast::Block,
     /// Opaque identifier for fn item.

--- a/crates/rune/src/ast/item_fn.rs
+++ b/crates/rune/src/ast/item_fn.rs
@@ -38,8 +38,7 @@ fn ast_parse() {
     assert!(item.const_token.is_some());
 
     let item_with_type = rt::<ast::ItemFn>("pub async fn hello(foo, bar) -> Type {}");
-    assert!(item_with_type.arrow.is_some());
-    assert!(item_with_type.fn_type.is_some());
+    assert!(item_with_type.output.is_some());
 }
 
 /// A function item.

--- a/crates/rune/src/ast/item_fn.rs
+++ b/crates/rune/src/ast/item_fn.rs
@@ -36,6 +36,10 @@ fn ast_parse() {
     assert_eq!(item.attributes.len(), 1);
     assert!(item.async_token.is_none());
     assert!(item.const_token.is_some());
+
+    let item_with_type = rt::<ast::ItemFn>("pub async fn hello(foo, bar) -> Type {}");
+    assert!(item_with_type.arrow.is_some());
+    assert!(item_with_type.fn_type.is_some());
 }
 
 /// A function item.
@@ -61,6 +65,12 @@ pub struct ItemFn {
     pub name: ast::Ident,
     /// The arguments of the function.
     pub args: ast::Parenthesized<ast::FnArg, T![,]>,
+    /// The arrow token.
+    #[rune(option)]
+    pub arrow: Option<ast::Arrow>,
+    /// The function type.
+    #[rune(option)]
+    pub fn_type: Option<ast::Ident>,
     /// The body of the function.
     pub body: ast::Block,
     /// Opaque identifier for fn item.

--- a/crates/rune/src/ast/item_struct.rs
+++ b/crates/rune/src/ast/item_struct.rs
@@ -77,10 +77,7 @@ pub struct Field {
     pub visibility: ast::Visibility,
     /// Name of the field.
     pub name: ast::Ident,
-    /// Colon token for the optional type.
-    #[rune(option)]
-    pub colon: Option<ast::Colon>,
     /// The type.
     #[rune(option)]
-    pub field_type: Option<ast::Ident>,
+    pub field_type: Option<(ast::Colon, ast::Type)>,
 }

--- a/crates/rune/src/ast/item_struct.rs
+++ b/crates/rune/src/ast/item_struct.rs
@@ -79,5 +79,5 @@ pub struct Field {
     pub name: ast::Ident,
     /// The type.
     #[rune(option)]
-    pub field_type: Option<(ast::Colon, ast::Type)>,
+    pub ty: Option<(T![:], ast::Type)>,
 }

--- a/crates/rune/src/ast/item_struct.rs
+++ b/crates/rune/src/ast/item_struct.rs
@@ -24,12 +24,13 @@ fn ast_parse() {
     rt::<ast::Field>("a");
     rt::<ast::Field>("#[x] a");
 
-    rt::<ast::ItemStruct>(r"
+    rt::<ast::ItemStruct>(
+        r"
         struct Foo { 
             a: i32, 
             b: f64, 
             c: CustomType, 
-        }"
+        }",
     );
 }
 

--- a/crates/rune/src/ast/item_struct.rs
+++ b/crates/rune/src/ast/item_struct.rs
@@ -23,6 +23,14 @@ fn ast_parse() {
 
     rt::<ast::Field>("a");
     rt::<ast::Field>("#[x] a");
+
+    rt::<ast::ItemStruct>(r"
+        struct Foo { 
+            a: i32, 
+            b: f64, 
+            c: CustomType, 
+        }"
+    );
 }
 
 /// A struct item.
@@ -69,4 +77,10 @@ pub struct Field {
     pub visibility: ast::Visibility,
     /// Name of the field.
     pub name: ast::Ident,
+    /// Colon token for the optional type.
+    #[rune(option)]
+    pub colon: ast::Colon,
+    /// The type.
+    #[rune(option)]
+    pub field_type: ast::Ident,
 }

--- a/crates/rune/src/ast/item_struct.rs
+++ b/crates/rune/src/ast/item_struct.rs
@@ -79,8 +79,8 @@ pub struct Field {
     pub name: ast::Ident,
     /// Colon token for the optional type.
     #[rune(option)]
-    pub colon: ast::Colon,
+    pub colon: Option<ast::Colon>,
     /// The type.
     #[rune(option)]
-    pub field_type: ast::Ident,
+    pub field_type: Option<ast::Ident>,
 }

--- a/crates/rune/src/ast/mod.rs
+++ b/crates/rune/src/ast/mod.rs
@@ -160,8 +160,8 @@ mod macro_utils;
 mod pat;
 mod path;
 mod prelude;
-mod span;
 mod rn_type;
+mod span;
 pub(crate) mod spanned;
 mod stmt;
 mod to_ast;
@@ -226,12 +226,12 @@ pub use self::lit_str::LitStr;
 pub use self::local::Local;
 pub use self::macro_call::MacroCall;
 pub use self::macro_utils::{EqValue, Group};
-pub use self::rn_type::Type;
 pub use self::pat::{
     Pat, PatBinding, PatIgnore, PatLit, PatObject, PatPath, PatRest, PatTuple, PatVec,
 };
 pub use self::path::{Path, PathKind, PathSegment, PathSegmentExpr};
 use self::prelude::*;
+pub use self::rn_type::Type;
 pub use self::span::{ByteIndex, Span};
 pub use self::spanned::{OptionSpanned, Spanned};
 pub use self::stmt::{ItemOrExpr, Stmt, StmtSemi, StmtSortKey};

--- a/crates/rune/src/ast/mod.rs
+++ b/crates/rune/src/ast/mod.rs
@@ -161,6 +161,7 @@ mod pat;
 mod path;
 mod prelude;
 mod span;
+mod rn_type;
 pub(crate) mod spanned;
 mod stmt;
 mod to_ast;
@@ -225,6 +226,7 @@ pub use self::lit_str::LitStr;
 pub use self::local::Local;
 pub use self::macro_call::MacroCall;
 pub use self::macro_utils::{EqValue, Group};
+pub use self::rn_type::Type;
 pub use self::pat::{
     Pat, PatBinding, PatIgnore, PatLit, PatObject, PatPath, PatRest, PatTuple, PatVec,
 };

--- a/crates/rune/src/ast/rn_type.rs
+++ b/crates/rune/src/ast/rn_type.rs
@@ -1,0 +1,36 @@
+use crate::ast::prelude::*;
+
+#[test]
+#[cfg(not(miri))]
+fn ast_parse() {
+    rt::<ast::Type>("Bar");
+    rt::<ast::Type>("do::re::mi::fa::sol::la::si::Do");
+    rt::<ast::Type>("Self");
+}
+
+/// A type, used for static typing.
+#[derive(Debug, TryClone, PartialEq, Eq, ToTokens, Spanned)]
+#[non_exhaustive]
+pub enum Type {
+	/// If the type is an identifier or a path.
+	Path(ast::Path),
+	/// If the type is "Self".
+	SelfType(T![Self]),
+	/// If the type should return nothing (a.k.a the "never" type in Rust).
+	Bang(T![!]),
+}
+
+impl Parse for Type {
+    fn parse(p: &mut Parser<'_>) -> Result<Self> {
+        let segment = match p.nth(0)? {
+            K![Self] => Self::SelfType(p.parse()?),
+            K![ident] => Self::Path(p.parse()?),
+            K![!] => Self::Bang(p.parse()?),
+            _ => {
+                return Err(compile::Error::expected(p.tok_at(0)?, "type"));
+            }
+        };
+
+        Ok(segment)
+    }
+}

--- a/crates/rune/src/ast/rn_type.rs
+++ b/crates/rune/src/ast/rn_type.rs
@@ -12,10 +12,10 @@ fn ast_parse() {
 #[derive(Debug, TryClone, PartialEq, Eq, ToTokens, Spanned)]
 #[non_exhaustive]
 pub enum Type {
-	/// If the type is an identifier or a path.
-	Path(ast::Path),
-	/// If the type should return nothing (a.k.a the "never" type in Rust).
-	Bang(T![!]),
+    /// If the type is an identifier or a path.
+    Path(ast::Path),
+    /// If the type should return nothing (a.k.a the "never" type in Rust).
+    Bang(T![!]),
 }
 
 impl Parse for Type {

--- a/crates/rune/src/ast/rn_type.rs
+++ b/crates/rune/src/ast/rn_type.rs
@@ -14,8 +14,6 @@ fn ast_parse() {
 pub enum Type {
 	/// If the type is an identifier or a path.
 	Path(ast::Path),
-	/// If the type is "Self".
-	SelfType(T![Self]),
 	/// If the type should return nothing (a.k.a the "never" type in Rust).
 	Bang(T![!]),
 }
@@ -23,8 +21,7 @@ pub enum Type {
 impl Parse for Type {
     fn parse(p: &mut Parser<'_>) -> Result<Self> {
         let segment = match p.nth(0)? {
-            K![Self] => Self::SelfType(p.parse()?),
-            K![ident] => Self::Path(p.parse()?),
+            K![ident] | K![Self] => Self::Path(p.parse()?),
             K![!] => Self::Bang(p.parse()?),
             _ => {
                 return Err(compile::Error::expected(p.tok_at(0)?, "type"));

--- a/crates/rune/src/ast/rn_type.rs
+++ b/crates/rune/src/ast/rn_type.rs
@@ -4,7 +4,7 @@ use crate::ast::prelude::*;
 #[cfg(not(miri))]
 fn ast_parse() {
     rt::<ast::Type>("Bar");
-    rt::<ast::Type>("do::re::mi::fa::sol::la::si::Do");
+    rt::<ast::Type>("one::two::three::four::Five");
     rt::<ast::Type>("Self");
     rt::<ast::Type>("(one::One, two::Two)");
     rt::<ast::Type>("(one::One, (two::Two, three::Three))");
@@ -25,12 +25,9 @@ pub enum Type {
 impl Parse for Type {
     fn parse(p: &mut Parser<'_>) -> Result<Self> {
         let segment = match p.nth(0)? {
-            K![ident] | K![Self] => Self::Path(p.parse()?),
             K![!] => Self::Bang(p.parse()?),
             K!['('] => Self::Tuple(p.parse()?),
-            _ => {
-                return Err(compile::Error::expected(p.tok_at(0)?, "type"));
-            }
+            _ => Self::Path(p.parse()?),
         };
 
         Ok(segment)

--- a/crates/rune/src/ast/rn_type.rs
+++ b/crates/rune/src/ast/rn_type.rs
@@ -6,6 +6,8 @@ fn ast_parse() {
     rt::<ast::Type>("Bar");
     rt::<ast::Type>("do::re::mi::fa::sol::la::si::Do");
     rt::<ast::Type>("Self");
+    rt::<ast::Type>("(one::One, two::Two)");
+    rt::<ast::Type>("(one::One, (two::Two, three::Three))");
 }
 
 /// A type, used for static typing.
@@ -16,6 +18,8 @@ pub enum Type {
     Path(ast::Path),
     /// If the type should return nothing (a.k.a the "never" type in Rust).
     Bang(T![!]),
+    /// If the type is a tuple.
+    Tuple(ast::Parenthesized<Box<Type>, T![,]>),
 }
 
 impl Parse for Type {
@@ -23,6 +27,7 @@ impl Parse for Type {
         let segment = match p.nth(0)? {
             K![ident] | K![Self] => Self::Path(p.parse()?),
             K![!] => Self::Bang(p.parse()?),
+            K!['('] => Self::Tuple(p.parse()?),
             _ => {
                 return Err(compile::Error::expected(p.tok_at(0)?, "type"));
             }

--- a/crates/rune/src/indexing/index.rs
+++ b/crates/rune/src/indexing/index.rs
@@ -317,6 +317,13 @@ pub(crate) fn item_fn(idx: &mut Indexer<'_, '_>, mut ast: ast::ItemFn) -> compil
         ));
     }
 
+    if ast.output.is_some() {
+        return Err(compile::Error::msg(
+            &ast,
+            "Adding a return type in functions is not supported",
+        ));
+    }
+
     let is_instance = ast.is_instance();
 
     if is_instance {
@@ -949,6 +956,13 @@ fn item_struct(idx: &mut Indexer<'_, '_>, mut ast: ast::ItemStruct) -> compile::
             return Err(compile::Error::msg(
                 first,
                 "Attributes on fields are not supported",
+            ));
+        }
+
+        if field.ty.is_some() {
+            return Err(compile::Error::msg(
+                field,
+                "Static typing on fields is not supported",
             ));
         }
 

--- a/crates/rune/src/tests.rs
+++ b/crates/rune/src/tests.rs
@@ -551,3 +551,5 @@ mod vm_test_mod;
 mod vm_try;
 #[cfg(not(miri))]
 mod wildcard_imports;
+#[cfg(not(miri))]
+mod static_typing;

--- a/crates/rune/src/tests.rs
+++ b/crates/rune/src/tests.rs
@@ -504,6 +504,8 @@ mod rename_type;
 #[cfg(not(miri))]
 mod result;
 #[cfg(not(miri))]
+mod static_typing;
+#[cfg(not(miri))]
 mod tuple;
 #[cfg(not(miri))]
 mod type_name_native;
@@ -551,5 +553,3 @@ mod vm_test_mod;
 mod vm_try;
 #[cfg(not(miri))]
 mod wildcard_imports;
-#[cfg(not(miri))]
-mod static_typing;

--- a/crates/rune/src/tests/static_typing.rs
+++ b/crates/rune/src/tests/static_typing.rs
@@ -1,0 +1,23 @@
+prelude!();
+
+use ErrorKind::*;
+
+#[test]
+fn deny_static_typing_function() {
+	assert_errors! {
+        "fn foo() -> Bar {}",
+        span!(0, 18), Custom { error } => {
+            assert_eq!(error.to_string(), "Adding a return type in functions is not supported");
+        }
+    }
+}
+
+#[test]
+fn deny_static_typing_field() {
+	assert_errors! {
+        "struct Struct { foo: Bar }",
+        span!(16, 24), Custom { error } => {
+            assert_eq!(error.to_string(), "Static typing on fields is not supported");
+        }
+    }
+}

--- a/crates/rune/src/tests/static_typing.rs
+++ b/crates/rune/src/tests/static_typing.rs
@@ -4,7 +4,7 @@ use ErrorKind::*;
 
 #[test]
 fn deny_static_typing_function() {
-	assert_errors! {
+    assert_errors! {
         "fn foo() -> Bar {}",
         span!(0, 18), Custom { error } => {
             assert_eq!(error.to_string(), "Adding a return type in functions is not supported");
@@ -14,7 +14,7 @@ fn deny_static_typing_function() {
 
 #[test]
 fn deny_static_typing_field() {
-	assert_errors! {
+    assert_errors! {
         "struct Struct { foo: Bar }",
         span!(16, 24), Custom { error } => {
             assert_eq!(error.to_string(), "Static typing on fields is not supported");


### PR DESCRIPTION
This tiny PR adds the option for the parser to detect "-> Type" at the end of the function if its detected.