### PR TITLE
Simplify variant protocol

### DIFF
--- a/crates/rune-core/src/hash.rs
+++ b/crates/rune-core/src/hash.rs
@@ -76,9 +76,8 @@ const PARAMETERS: [u64; 32] = [
 /// The primitive hash that among other things is used to reference items,
 /// types, and native functions.
 #[derive(Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-#[cfg_attr(feature = "musli", derive(Decode, Encode))]
+#[cfg_attr(feature = "musli", derive(Decode, Encode), musli(transparent))]
 #[repr(transparent)]
-#[cfg_attr(feature = "musli", musli(transparent))]
 pub struct Hash(#[doc(hidden)] pub u64);
 
 impl Hash {

--- a/crates/rune-core/src/protocol.rs
+++ b/crates/rune-core/src/protocol.rs
@@ -454,7 +454,7 @@ define! {
 
     /// Function used to test if a value is a specific variant.
     ///
-    /// Signature: `fn(self, usize) -> bool`.
+    /// Signature: `fn(self, Hash) -> bool`.
     pub const IS_VARIANT: Protocol = Protocol {
         hash: 0xc030d82bbd4dabe8u64,
         /// Test if the provided argument is a variant.

--- a/crates/rune-macros/src/hash.rs
+++ b/crates/rune-macros/src/hash.rs
@@ -30,8 +30,17 @@ impl Arguments {
         }
     }
 
-    /// Construct a type hash from a Rust path.
+    /// Construct a type hash from a path.
     pub(crate) fn build_type_hash(&self, cx: &Context) -> Result<Hash, ()> {
+        self.build_type_hash_with_inner(cx, None)
+    }
+
+    /// Construct a type hash from a path with an extra string component at the end.
+    pub(crate) fn build_type_hash_with(&self, cx: &Context, extra: &str) -> Result<Hash, ()> {
+        self.build_type_hash_with_inner(cx, Some(extra))
+    }
+
+    fn build_type_hash_with_inner(&self, cx: &Context, extra: Option<&str>) -> Result<Hash, ()> {
         // Construct type hash.
         let mut buf = ItemBuf::new();
         let mut first = self.path.leading_colon.is_some();
@@ -64,6 +73,13 @@ impl Arguments {
                         "Generic arguments are not supported",
                     ));
                 }
+            }
+        }
+
+        if let Some(extra) = extra {
+            if let Err(error) = buf.push(ComponentRef::Str(extra)) {
+                cx.error(syn::Error::new_spanned(&self.path, error));
+                return Err(());
             }
         }
 

--- a/crates/rune-macros/src/lib.rs
+++ b/crates/rune-macros/src/lib.rs
@@ -23,6 +23,7 @@
 //! This is part of the [Rune Language](https://rune-rs.github.io).
 
 #![allow(clippy::manual_map)]
+#![allow(clippy::too_many_arguments)]
 
 mod any;
 mod const_value;

--- a/crates/rune/src/compile/context.rs
+++ b/crates/rune/src/compile/context.rs
@@ -760,11 +760,10 @@ impl Context {
                         constructor,
                         parameters,
                         enum_hash: Hash::EMPTY,
-                        variant_index: 0,
                     }
                 }
                 TypeSpecification::Enum(en) => {
-                    for (index, variant) in en.variants.iter().enumerate() {
+                    for variant in &en.variants {
                         let Some(fields) = &variant.fields else {
                             continue;
                         };
@@ -834,7 +833,6 @@ impl Context {
                                 constructor,
                                 parameters: Hash::EMPTY,
                                 enum_hash: ty.hash,
-                                variant_index: index,
                             },
                             #[cfg(feature = "doc")]
                             deprecated: variant.deprecated.try_clone()?,

--- a/crates/rune/src/compile/context_error.rs
+++ b/crates/rune/src/compile/context_error.rs
@@ -103,8 +103,8 @@ pub enum ContextError {
         type_info: TypeInfo,
     },
     ConflictingVariantMeta {
-        index: usize,
         type_info: TypeInfo,
+        name: &'static str,
     },
     ConflictingMetaHash {
         item: ItemBuf,
@@ -123,7 +123,7 @@ pub enum ContextError {
     },
     VariantConstructorConflict {
         type_info: TypeInfo,
-        index: usize,
+        name: &'static str,
     },
     ConflictingConstConstruct {
         type_info: TypeInfo,
@@ -306,10 +306,10 @@ impl fmt::Display for ContextError {
                     "Type `{item}` at `{type_info}` already has a specification"
                 )?;
             }
-            ContextError::ConflictingVariantMeta { index, type_info } => {
+            ContextError::ConflictingVariantMeta { type_info, name } => {
                 write!(
                     f,
-                    "Variant `{index}` for `{type_info}` already has a specification"
+                    "Variant `{name}` for `{type_info}` already has a specification"
                 )?;
             }
             ContextError::ConflictingMetaHash {
@@ -329,21 +329,18 @@ impl fmt::Display for ContextError {
                 write!(f, "Variant with `{item}` already exists")?;
             }
             ContextError::ConstructorConflict { type_info } => {
-                write!(
-                    f,
-                    "Constructor for type `{type_info}` has already been registered"
-                )?;
+                write!(f, "Constructor for `{type_info}` already exists")?;
             }
-            ContextError::VariantConstructorConflict { type_info, index } => {
+            ContextError::VariantConstructorConflict { type_info, name } => {
                 write!(
                     f,
-                    "Constructor for variant {index} in `{type_info}` has already been registered"
+                    "Constructor for variant `{name}` for `{type_info}` already exists"
                 )?;
             }
             ContextError::ConflictingConstConstruct { type_info, hash } => {
                 write!(
                     f,
-                    "Conflicting constant constructor with hash {hash} for type {type_info}"
+                    "Constant constructor with hash {hash} for `{type_info}` already exists"
                 )?;
             }
             ContextError::MissingType { item, type_info } => {

--- a/crates/rune/src/compile/meta.rs
+++ b/crates/rune/src/compile/meta.rs
@@ -183,10 +183,6 @@ pub enum Kind {
         ///
         /// If this is not a variant, this is [Hash::EMPTY].
         enum_hash: Hash,
-        /// If this is a variant, this is the index of the variant in the enum.
-        ///
-        /// For non-variants, this is set to `0`.
-        variant_index: usize,
     },
     /// An enum item.
     Enum {

--- a/crates/rune/src/compile/named.rs
+++ b/crates/rune/src/compile/named.rs
@@ -3,20 +3,20 @@ use core::fmt;
 use core::marker::PhantomData;
 
 use crate as rune;
-use crate::module::InstallWith;
-use crate::{item, Item};
+use crate::{item, Hash, Item};
 
 /// The trait used for something that can be statically named.
 pub trait Named {
     /// The name item.
     const ITEM: &'static Item;
 
-    /// The exact type name
+    /// The full name of the type.
+    #[inline]
     fn full_name(f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", Self::ITEM)
     }
 
-    /// Return a display wrapper for the named type.
+    /// Return a display wrapper for the full name of the type.
     #[inline]
     fn display() -> impl fmt::Display {
         struct DisplayNamed<T>(PhantomData<T>)
@@ -50,34 +50,26 @@ impl Named for i64 {
     const ITEM: &'static Item = item!(::std::i64);
 }
 
-impl InstallWith for i64 {}
-
 impl Named for u64 {
     const ITEM: &'static Item = item!(::std::u64);
 }
-
-impl InstallWith for u64 {}
 
 impl Named for f64 {
     const ITEM: &'static Item = item!(::std::f64);
 }
 
-impl InstallWith for f64 {}
-
 impl Named for char {
     const ITEM: &'static Item = item!(::std::char);
 }
-
-impl InstallWith for char {}
 
 impl Named for bool {
     const ITEM: &'static Item = item!(::std::bool);
 }
 
-impl InstallWith for bool {}
-
 impl Named for Ordering {
     const ITEM: &'static Item = item!(::std::cmp::Ordering);
 }
 
-impl InstallWith for Ordering {}
+impl Named for Hash {
+    const ITEM: &'static Item = item!(::std::any::Hash);
+}

--- a/crates/rune/src/compile/v1/assemble.rs
+++ b/crates/rune/src/compile/v1/assemble.rs
@@ -766,13 +766,11 @@ fn pat_sequence_kind_to_inst(kind: hir::PatSequenceKind, addr: InstAddress, out:
             out,
         },
         hir::PatSequenceKind::Variant {
-            variant_hash,
             enum_hash,
-            index,
+            variant_hash,
         } => Inst::MatchVariant {
-            variant_hash,
             enum_hash,
-            index,
+            variant_hash,
             addr,
             out,
         },
@@ -827,13 +825,11 @@ fn pat_object<'a, 'hir>(
             out: cond.output(),
         },
         hir::PatSequenceKind::Variant {
-            variant_hash,
             enum_hash,
-            index,
+            variant_hash,
         } => Inst::MatchVariant {
-            variant_hash,
             enum_hash,
-            index,
+            variant_hash,
             addr: addr.addr(),
             out: cond.output(),
         },
@@ -1137,6 +1133,9 @@ fn const_<'a, 'hir>(
             }
             Inline::Ordering(v) => {
                 cx.asm.push(Inst::ordering(v, out), span)?;
+            }
+            Inline::Hash(v) => {
+                cx.asm.push(Inst::hash(v, out), span)?;
             }
         },
         ConstValueKind::String(ref s) => {

--- a/crates/rune/src/function_meta.rs
+++ b/crates/rune/src/function_meta.rs
@@ -81,8 +81,7 @@ impl FunctionData {
     #[inline]
     pub(crate) fn new<F, A, N, K>(name: N, f: F) -> alloc::Result<Self>
     where
-        F: Function<A, K>,
-        F::Return: MaybeTypeOf,
+        F: Function<A, K, Return: MaybeTypeOf>,
         N: IntoComponent,
         A: FunctionArgs,
         K: FunctionKind,
@@ -292,8 +291,7 @@ impl AssociatedFunctionData {
     #[inline]
     pub(crate) fn from_function<F, A, K>(associated: Associated, f: F) -> alloc::Result<Self>
     where
-        F: Function<A, K>,
-        F::Return: MaybeTypeOf,
+        F: Function<A, K, Return: MaybeTypeOf>,
         A: FunctionArgs,
         K: FunctionKind,
     {
@@ -316,8 +314,7 @@ impl AssociatedFunctionData {
     #[inline]
     pub(crate) fn from_instance_function<F, A, K>(name: AssociatedName, f: F) -> alloc::Result<Self>
     where
-        F: InstanceFunction<A, K>,
-        F::Return: MaybeTypeOf,
+        F: InstanceFunction<A, K, Return: MaybeTypeOf>,
         A: FunctionArgs,
         K: FunctionKind,
     {
@@ -355,8 +352,7 @@ impl FunctionMetaKind {
     #[inline]
     pub fn function<N, F, A, K>(name: N, f: F) -> alloc::Result<FunctionBuilder<N, F, A, K>>
     where
-        F: Function<A, K>,
-        F::Return: MaybeTypeOf,
+        F: Function<A, K, Return: MaybeTypeOf>,
         A: FunctionArgs,
         K: FunctionKind,
     {
@@ -368,8 +364,7 @@ impl FunctionMetaKind {
     pub fn instance<N, F, A, K>(name: N, f: F) -> alloc::Result<Self>
     where
         N: ToInstance,
-        F: InstanceFunction<A, K>,
-        F::Return: MaybeTypeOf,
+        F: InstanceFunction<A, K, Return: MaybeTypeOf>,
         A: FunctionArgs,
         K: FunctionKind,
     {
@@ -398,8 +393,7 @@ impl<N, F, A, K> FunctionBuilder<N, F, A, K> {
 
 impl<N, F, A, K> FunctionBuilder<N, F, A, K>
 where
-    F: Function<A, K>,
-    F::Return: MaybeTypeOf,
+    F: Function<A, K, Return: MaybeTypeOf>,
     A: FunctionArgs,
     K: FunctionKind,
 {

--- a/crates/rune/src/hir/hir.rs
+++ b/crates/rune/src/hir/hir.rs
@@ -113,9 +113,8 @@ pub(crate) enum PatSequenceKind {
         type_check: TypeCheck,
     },
     Variant {
-        variant_hash: Hash,
         enum_hash: Hash,
-        index: usize,
+        variant_hash: Hash,
     },
     Anonymous {
         type_check: TypeCheck,

--- a/crates/rune/src/hir/lowering.rs
+++ b/crates/rune/src/hir/lowering.rs
@@ -1640,7 +1640,6 @@ fn struct_match_for(
         meta::Kind::Struct {
             ref fields,
             enum_hash,
-            variant_index,
             ..
         } => {
             let kind = 'kind: {
@@ -1650,9 +1649,8 @@ fn struct_match_for(
 
                 if enum_hash != Hash::EMPTY {
                     break 'kind hir::PatSequenceKind::Variant {
-                        variant_hash: meta.hash,
                         enum_hash,
-                        index: variant_index,
+                        variant_hash: meta.hash,
                     };
                 }
 
@@ -1688,7 +1686,6 @@ fn tuple_match_for(
         meta::Kind::Struct {
             ref fields,
             enum_hash,
-            variant_index,
             ..
         } => {
             let args = match *fields {
@@ -1704,9 +1701,8 @@ fn tuple_match_for(
 
                 if enum_hash != Hash::EMPTY {
                     break 'kind hir::PatSequenceKind::Variant {
-                        variant_hash: meta.hash,
                         enum_hash,
-                        index: variant_index,
+                        variant_hash: meta.hash,
                     };
                 }
 

--- a/crates/rune/src/hir/lowering2.rs
+++ b/crates/rune/src/hir/lowering2.rs
@@ -2629,7 +2629,6 @@ fn struct_match_for(
         meta::Kind::Struct {
             ref fields,
             enum_hash,
-            variant_index,
             ..
         } => {
             let kind = 'kind: {
@@ -2639,9 +2638,8 @@ fn struct_match_for(
 
                 if enum_hash != Hash::EMPTY {
                     break 'kind hir::PatSequenceKind::Variant {
-                        variant_hash: meta.hash,
                         enum_hash,
-                        index: variant_index,
+                        variant_hash: meta.hash,
                     };
                 }
 
@@ -2677,7 +2675,6 @@ fn tuple_match_for(
         meta::Kind::Struct {
             ref fields,
             enum_hash,
-            variant_index,
             ..
         } => {
             let args = fields.as_tuple()?;
@@ -2689,9 +2686,8 @@ fn tuple_match_for(
 
                 if enum_hash != Hash::EMPTY {
                     break 'kind hir::PatSequenceKind::Variant {
-                        variant_hash: meta.hash,
                         enum_hash,
-                        index: variant_index,
+                        variant_hash: meta.hash,
                     };
                 }
 

--- a/crates/rune/src/indexing/index.rs
+++ b/crates/rune/src/indexing/index.rs
@@ -858,7 +858,7 @@ fn item_enum(idx: &mut Indexer<'_, '_>, mut ast: ast::ItemEnum) -> compile::Resu
 
     idx.q.index_enum(enum_item)?;
 
-    for (index, (mut variant, _)) in ast.variants.drain().enumerate() {
+    for (mut variant, _) in ast.variants.drain() {
         let mut p = attrs::Parser::new(&variant.attributes)?;
 
         let docs = Doc::collect_from(resolve_context!(idx.q), &mut p, &variant.attributes)?;
@@ -914,7 +914,6 @@ fn item_enum(idx: &mut Indexer<'_, '_>, mut ast: ast::ItemEnum) -> compile::Resu
             item_meta,
             indexing::Variant {
                 enum_id: enum_item.item,
-                index,
                 fields: convert_fields(resolve_context!(idx.q), variant.body)?,
             },
         )?;

--- a/crates/rune/src/indexing/index2.rs
+++ b/crates/rune/src/indexing/index2.rs
@@ -936,7 +936,6 @@ fn item_enum(
 
     p.eat(K!['{']);
 
-    let mut index = 0;
     let mut comma = Remaining::default();
 
     while let MaybeNode::Some(node) = p.eat(Variant) {
@@ -957,14 +956,12 @@ fn item_enum(
 
         let variant = indexing::Variant {
             enum_id: enum_item_meta.item,
-            index,
             fields,
         };
 
         idx.q.index_variant(item_meta, variant)?;
 
         comma = p.remaining(idx, K![,])?;
-        index += 1;
     }
 
     comma.at_most_one(idx)?;

--- a/crates/rune/src/indexing/mod.rs
+++ b/crates/rune/src/indexing/mod.rs
@@ -112,8 +112,6 @@ pub(crate) struct Struct {
 pub(crate) struct Variant {
     /// Id of of the enum type.
     pub(crate) enum_id: ItemId,
-    /// The index of the variant in its source.
-    pub(crate) index: usize,
     /// The fields of the variant.
     pub(crate) fields: meta::Fields,
 }

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -642,6 +642,9 @@ pub use rune_macros::module;
 #[doc(inline)]
 pub use rune_macros::hash;
 
+#[doc(inline)]
+pub(crate) use rune_macros::hash_in;
+
 pub use rune_macros::item;
 
 #[cfg(feature = "cli")]
@@ -775,4 +778,6 @@ rune_macros::binding! {
     impl<T> ::std::object::Object for std::collections::HashMap<alloc::String, T>;
     #[type_of]
     impl ::std::any::Type for crate::runtime::Type;
+    #[type_of]
+    impl ::std::any::Hash for crate::hash::Hash;
 }

--- a/crates/rune/src/module/enum_mut.rs
+++ b/crates/rune/src/module/enum_mut.rs
@@ -49,7 +49,7 @@ where
         };
 
         Ok(VariantMut {
-            index,
+            name: variant.name,
             docs: &mut variant.docs,
             fields: &mut variant.fields,
             constructor: &mut variant.constructor,

--- a/crates/rune/src/module/install_with.rs
+++ b/crates/rune/src/module/install_with.rs
@@ -1,4 +1,6 @@
-use crate::ContextError;
+use core::cmp::Ordering;
+
+use crate::{ContextError, Hash};
 
 use super::Module;
 
@@ -10,3 +12,11 @@ pub trait InstallWith {
         Ok(())
     }
 }
+
+impl InstallWith for i64 {}
+impl InstallWith for u64 {}
+impl InstallWith for f64 {}
+impl InstallWith for char {}
+impl InstallWith for bool {}
+impl InstallWith for Ordering {}
+impl InstallWith for Hash {}

--- a/crates/rune/src/module/module.rs
+++ b/crates/rune/src/module/module.rs
@@ -324,7 +324,7 @@ impl Module {
         };
 
         Ok(VariantMut {
-            index,
+            name: variant.name,
             docs: &mut variant.docs,
             fields: &mut variant.fields,
             constructor: &mut variant.constructor,
@@ -340,8 +340,7 @@ impl Module {
         constructor: F,
     ) -> Result<(), ContextError>
     where
-        F: Function<A, Plain>,
-        F::Return: TypeOf + Named,
+        F: Function<A, Plain, Return: TypeOf + Named>,
     {
         self.variant_meta::<F::Return>(index)?
             .constructor(constructor)?;
@@ -869,8 +868,7 @@ impl Module {
     /// ```
     pub fn function<F, A, N, K>(&mut self, name: N, f: F) -> ModuleFunctionBuilder<'_, F, A, N, K>
     where
-        F: Function<A, K>,
-        F::Return: MaybeTypeOf,
+        F: Function<A, K, Return: MaybeTypeOf>,
         A: FunctionArgs,
         K: FunctionKind,
     {
@@ -888,8 +886,7 @@ impl Module {
         f: F,
     ) -> Result<ModuleFunctionBuilder<'_, F, A, N, K>, ContextError>
     where
-        F: Function<A, K>,
-        F::Return: MaybeTypeOf,
+        F: Function<A, K, Return: MaybeTypeOf>,
         A: FunctionArgs,
         K: FunctionKind,
     {
@@ -903,8 +900,7 @@ impl Module {
     #[deprecated = "Use Module::function() instead"]
     pub fn async_function<F, A, N>(&mut self, name: N, f: F) -> Result<ItemFnMut<'_>, ContextError>
     where
-        F: Function<A, Async>,
-        F::Return: MaybeTypeOf,
+        F: Function<A, Async, Return: MaybeTypeOf>,
         N: IntoComponent,
         A: FunctionArgs,
     {
@@ -1095,8 +1091,7 @@ impl Module {
     ) -> Result<ItemFnMut<'_>, ContextError>
     where
         N: ToInstance,
-        F: InstanceFunction<A, K>,
-        F::Return: MaybeTypeOf,
+        F: InstanceFunction<A, K, Return: MaybeTypeOf>,
         A: FunctionArgs,
         K: FunctionKind,
     {
@@ -1113,8 +1108,7 @@ impl Module {
     pub fn inst_fn<N, F, A, K>(&mut self, name: N, f: F) -> Result<ItemFnMut<'_>, ContextError>
     where
         N: ToInstance,
-        F: InstanceFunction<A, K>,
-        F::Return: MaybeTypeOf,
+        F: InstanceFunction<A, K, Return: MaybeTypeOf>,
         A: FunctionArgs,
         K: FunctionKind,
     {
@@ -1126,8 +1120,7 @@ impl Module {
     pub fn async_inst_fn<N, F, A>(&mut self, name: N, f: F) -> Result<ItemFnMut<'_>, ContextError>
     where
         N: ToInstance,
-        F: InstanceFunction<A, Async>,
-        F::Return: MaybeTypeOf,
+        F: InstanceFunction<A, Async, Return: MaybeTypeOf>,
         A: FunctionArgs,
     {
         self.associated_function(name, f)
@@ -1145,8 +1138,7 @@ impl Module {
     ) -> Result<ItemFnMut<'_>, ContextError>
     where
         N: ToFieldFunction,
-        F: InstanceFunction<A, Plain>,
-        F::Return: MaybeTypeOf,
+        F: InstanceFunction<A, Plain, Return: MaybeTypeOf>,
         A: FunctionArgs,
     {
         self.insert_associated_function(
@@ -1167,8 +1159,7 @@ impl Module {
     ) -> Result<ItemFnMut<'_>, ContextError>
     where
         N: ToFieldFunction,
-        F: InstanceFunction<A, Plain>,
-        F::Return: MaybeTypeOf,
+        F: InstanceFunction<A, Plain, Return: MaybeTypeOf>,
         A: FunctionArgs,
     {
         self.field_function(protocol, name, f)
@@ -1185,8 +1176,7 @@ impl Module {
         f: F,
     ) -> Result<ItemFnMut<'_>, ContextError>
     where
-        F: InstanceFunction<A, Plain>,
-        F::Return: MaybeTypeOf,
+        F: InstanceFunction<A, Plain, Return: MaybeTypeOf>,
         A: FunctionArgs,
     {
         let name = AssociatedName::index(protocol, index);
@@ -1207,8 +1197,7 @@ impl Module {
         f: F,
     ) -> Result<ItemFnMut<'_>, ContextError>
     where
-        F: InstanceFunction<A, Plain>,
-        F::Return: MaybeTypeOf,
+        F: InstanceFunction<A, Plain, Return: MaybeTypeOf>,
         A: FunctionArgs,
     {
         self.index_function(protocol, index, f)

--- a/crates/rune/src/module/module_function_builder.rs
+++ b/crates/rune/src/module/module_function_builder.rs
@@ -21,8 +21,7 @@ pub struct ModuleFunctionBuilder<'a, F, A, N, K> {
 
 impl<'a, F, A, N, K> ModuleFunctionBuilder<'a, F, A, N, K>
 where
-    F: Function<A, K>,
-    F::Return: MaybeTypeOf,
+    F: Function<A, K, Return: MaybeTypeOf>,
     A: FunctionArgs,
     K: FunctionKind,
 {

--- a/crates/rune/src/module/variant_mut.rs
+++ b/crates/rune/src/module/variant_mut.rs
@@ -14,7 +14,7 @@ pub struct VariantMut<'a, T>
 where
     T: ?Sized + TypeOf,
 {
-    pub(crate) index: usize,
+    pub(crate) name: &'static str,
     pub(crate) docs: &'a mut Docs,
     pub(crate) fields: &'a mut Option<Fields>,
     pub(crate) constructor: &'a mut Option<Arc<FunctionHandler>>,
@@ -68,7 +68,7 @@ where
         if self.constructor.is_some() {
             return Err(ContextError::VariantConstructorConflict {
                 type_info: T::type_info(),
-                index: self.index,
+                name: self.name,
             });
         }
 
@@ -84,8 +84,8 @@ where
 
         if old.is_some() {
             return Err(ContextError::ConflictingVariantMeta {
-                index: self.index,
                 type_info: T::type_info(),
+                name: self.name,
             });
         }
 

--- a/crates/rune/src/modules/any.rs
+++ b/crates/rune/src/modules/any.rs
@@ -4,7 +4,7 @@ use crate as rune;
 use crate::alloc::fmt::TryWrite;
 use crate::alloc::String;
 use crate::runtime::{Formatter, Type, Value, VmResult};
-use crate::{docstring, ContextError, Module};
+use crate::{docstring, ContextError, Hash, Module};
 
 /// Dynamic typing and type reflection.
 ///
@@ -18,6 +18,10 @@ pub fn module() -> Result<Module, ContextError> {
 
     m.ty::<Type>()?.docs(docstring! {
         /// Represents a type in the Rune type system.
+    })?;
+
+    m.ty::<Hash>()?.docs(docstring! {
+        /// Represents an opaque hash in the Rune type system.
     })?;
 
     m.function_meta(type_of_val)?;

--- a/crates/rune/src/modules/cmp.rs
+++ b/crates/rune/src/modules/cmp.rs
@@ -6,7 +6,7 @@ use crate as rune;
 use crate::alloc::fmt::TryWrite;
 use crate::runtime::{Formatter, Protocol, Value, VmResult};
 use crate::shared::Caller;
-use crate::{ContextError, Module};
+use crate::{hash, ContextError, Hash, Module};
 
 /// Comparison and ordering.
 #[rune::module(::std::cmp)]
@@ -57,15 +57,14 @@ pub fn module() -> Result<Module, ContextError> {
                 /// "An ordering where a compared value is greater than another.
             })?;
 
-        m.associated_function(
-            &Protocol::IS_VARIANT,
-            |this: Ordering, index: usize| match (this, index) {
-                (Ordering::Less, 0) => true,
-                (Ordering::Equal, 1) => true,
-                (Ordering::Greater, 2) => true,
+        m.associated_function(&Protocol::IS_VARIANT, |this: Ordering, hash: Hash| {
+            match (this, hash) {
+                (Ordering::Less, hash!(::std::cmp::Ordering::Less)) => true,
+                (Ordering::Equal, hash!(::std::cmp::Ordering::Equal)) => true,
+                (Ordering::Greater, hash!(::std::cmp::Ordering::Greater)) => true,
                 _ => false,
-            },
-        )?;
+            }
+        })?;
     }
 
     m.function_meta(ordering_partial_eq__meta)?;

--- a/crates/rune/src/modules/option.rs
+++ b/crates/rune/src/modules/option.rs
@@ -11,7 +11,7 @@ use crate::runtime::{
     Value, VmResult,
 };
 use crate::Any;
-use crate::{ContextError, Module};
+use crate::{hash_in, ContextError, Hash, Module};
 
 /// The [`Option`] type.
 ///
@@ -35,9 +35,9 @@ pub fn module() -> Result<Module, ContextError> {
 
     m.associated_function(
         &Protocol::IS_VARIANT,
-        |this: &Option<Value>, index: usize| match (this, index) {
-            (Option::Some(_), 0) => true,
-            (Option::None, 1) => true,
+        |this: &Option<Value>, hash: Hash| match (this, hash) {
+            (Option::Some(_), hash_in!(crate, ::std::option::Option::Some)) => true,
+            (Option::None, hash_in!(crate, ::std::option::Option::None)) => true,
             _ => false,
         },
     )?;

--- a/crates/rune/src/modules/result.rs
+++ b/crates/rune/src/modules/result.rs
@@ -9,7 +9,7 @@ use crate::alloc::prelude::*;
 use crate::runtime::{
     ControlFlow, EnvProtocolCaller, Formatter, Function, Hasher, Panic, Protocol, Value, VmResult,
 };
-use crate::{ContextError, Module};
+use crate::{hash_in, ContextError, Hash, Module};
 
 /// The [`Result`] type.
 ///
@@ -38,9 +38,9 @@ pub fn module() -> Result<Module, ContextError> {
 
     m.associated_function(
         &Protocol::IS_VARIANT,
-        |this: &Result<Value, Value>, index: usize| match (this, index) {
-            (Result::Ok(_), 0) => true,
-            (Result::Err(_), 1) => true,
+        |this: &Result<Value, Value>, hash: Hash| match (this, hash) {
+            (Result::Ok(_), hash_in!(crate, ::std::result::Result::Ok)) => true,
+            (Result::Err(_), hash_in!(crate, ::std::result::Result::Err)) => true,
             _ => false,
         },
     )?;

--- a/crates/rune/src/query/query.rs
+++ b/crates/rune/src/query/query.rs
@@ -1616,7 +1616,6 @@ impl<'a, 'arena> Query<'a, 'arena> {
                     constructor: None,
                     parameters: Hash::EMPTY,
                     enum_hash: enum_meta.hash,
-                    variant_index: variant.index,
                 }
             }
             Indexed::Struct(st) => meta::Kind::Struct {
@@ -1624,7 +1623,6 @@ impl<'a, 'arena> Query<'a, 'arena> {
                 constructor: None,
                 parameters: Hash::EMPTY,
                 enum_hash: Hash::EMPTY,
-                variant_index: 0,
             },
             Indexed::Function(f) => {
                 let kind = meta::Kind::Function {

--- a/crates/rune/src/runtime/from_value.rs
+++ b/crates/rune/src/runtime/from_value.rs
@@ -2,6 +2,7 @@ use core::cmp::Ordering;
 
 use crate::alloc::{self, String};
 use crate::any::AnyMarker;
+use crate::hash::Hash;
 
 use super::{
     AnyObj, ConstValue, FromConstValue, Mut, RawAnyGuard, Ref, RuntimeError, Value, VmResult,
@@ -503,5 +504,12 @@ impl FromValue for Ordering {
     #[inline]
     fn from_value(value: Value) -> Result<Self, RuntimeError> {
         value.as_ordering()
+    }
+}
+
+impl FromValue for Hash {
+    #[inline]
+    fn from_value(value: Value) -> Result<Self, RuntimeError> {
+        value.as_hash()
     }
 }

--- a/crates/rune/src/runtime/inst.rs
+++ b/crates/rune/src/runtime/inst.rs
@@ -852,12 +852,10 @@ pub enum Inst {
     /// ```
     #[musli(packed)]
     MatchVariant {
-        /// The exact type hash of the variant.
-        variant_hash: Hash,
-        /// The container type.
+        /// The type hash of the containing enum.
         enum_hash: Hash,
-        /// The index of the variant.
-        index: usize,
+        /// The type hash of the variant.
+        variant_hash: Hash,
         /// The address of the value to test.
         addr: InstAddress,
         /// Where to store the output.
@@ -1135,6 +1133,14 @@ impl Inst {
     pub fn ordering(ordering: Ordering, out: Output) -> Self {
         Self::Store {
             value: InstValue::Ordering(ordering),
+            out,
+        }
+    }
+
+    /// Construct an instruction to push a type hash.
+    pub fn hash(hash: Hash, out: Output) -> Self {
+        Self::Store {
+            value: InstValue::Hash(hash),
             out,
         }
     }
@@ -1670,6 +1676,9 @@ pub enum InstValue {
         #[serde(with = "crate::serde::ordering")]
         Ordering,
     ),
+    /// A hash.
+    #[musli(packed)]
+    Hash(Hash),
 }
 
 impl InstValue {
@@ -1684,6 +1693,7 @@ impl InstValue {
             Self::Float(v) => Value::from(v),
             Self::Type(v) => Value::from(v),
             Self::Ordering(v) => Value::from(v),
+            Self::Hash(v) => Value::from(v),
         }
     }
 }
@@ -1699,6 +1709,7 @@ impl fmt::Display for InstValue {
             Self::Float(v) => write!(f, "{v}")?,
             Self::Type(v) => write!(f, "{}", v.into_hash())?,
             Self::Ordering(v) => write!(f, "{v:?}")?,
+            Self::Hash(v) => write!(f, "{v:?}")?,
         }
 
         Ok(())

--- a/crates/rune/src/runtime/value.rs
+++ b/crates/rune/src/runtime/value.rs
@@ -638,6 +638,13 @@ impl Value {
     }
 
     inline_into! {
+        /// Coerce into [`Hash`][crate::Hash].
+        Hash(Hash),
+        as_hash,
+        as_hash_mut,
+    }
+
+    inline_into! {
         /// Coerce into [`bool`].
         Bool(bool),
         as_bool,
@@ -1558,6 +1565,7 @@ inline_from! {
     Float => f64,
     Type => Type,
     Ordering => Ordering,
+    Hash => Hash,
 }
 
 any_from! {

--- a/crates/rune/src/runtime/value/serde.rs
+++ b/crates/rune/src/runtime/value/serde.rs
@@ -37,6 +37,7 @@ impl ser::Serialize for Value {
                 Inline::Float(value) => serializer.serialize_f64(value),
                 Inline::Type(..) => Err(ser::Error::custom("cannot serialize types")),
                 Inline::Ordering(..) => Err(ser::Error::custom("cannot serialize orderings")),
+                Inline::Hash(..) => Err(ser::Error::custom("cannot serialize type hashes")),
             },
             Repr::Dynamic(value) => match value.rtti().kind {
                 RttiKind::Empty => Err(ser::Error::custom(format!(


### PR DESCRIPTION
This changes the IS_VARIANT protocol to receive the type hash rather than the variant index.

This is more portable, as it doesn't require any particular variant ordering to apply across the virtual machine and it makes the instruction to match a variant simpler.