### PR TITLE
Expose String::parse<f64>

### DIFF
--- a/crates/rune/src/modules/string.rs
+++ b/crates/rune/src/modules/string.rs
@@ -64,6 +64,7 @@ pub fn module() -> Result<Module, ContextError> {
     m.function_meta(chars)?;
     m.function_meta(get)?;
     m.function_meta(parse_int)?;
+    m.function_meta(parse_float)?;
     m.function_meta(parse_char)?;
     m.function_meta(to_lowercase)?;
     m.function_meta(to_uppercase)?;


### PR DESCRIPTION
The function is already implemented; it's just not exposed as part of the String module.