### PR TITLE
rune: Introduce Shared<T> again

### DIFF
--- a/crates/rune/src/any.rs
+++ b/crates/rune/src/any.rs
@@ -3,6 +3,86 @@ use core::any;
 use crate::compile::Named;
 use crate::runtime::{AnyTypeInfo, TypeHash};
 
+/// The trait implemented for types which can be used inside of Rune.
+///
+/// This can only be implemented correctly through the [`Any`] derive.
+/// Implementing it manually is not supported.
+///
+/// Rune only supports two types, *built-in* types like [`i64`] and *external*
+/// types which derive `Any`. Before they can be used they must be registered in
+/// [`Context::install`] through a [`Module`].
+///
+/// This is typically used in combination with declarative macros to register
+/// functions and macros, such as [`rune::function`].
+///
+/// [`AnyObj`]: crate::runtime::AnyObj
+/// [`Context::install`]: crate::Context::install
+/// [`Module`]: crate::Module
+/// [`String`]: std::string::String
+/// [`rune::function`]: macro@crate::function
+/// [`rune::macro_`]: macro@crate::macro_
+/// [`Any`]: derive@crate::Any
+///
+/// # Examples
+///
+/// ```
+/// use rune::Any;
+///
+/// #[derive(Any)]
+/// struct Npc {
+///     #[rune(get)]
+///     health: u32,
+/// }
+///
+/// impl Npc {
+///     /// Construct a new NPC.
+///     #[rune::function(path = Self::new)]
+///     fn new(health: u32) -> Self {
+///         Self {
+///             health
+///         }
+///     }
+///
+///     /// Damage the NPC with the given `amount`.
+///     #[rune::function]
+///     fn damage(&mut self, amount: u32) {
+///         self.health -= amount;
+///     }
+/// }
+///
+/// fn install() -> Result<rune::Module, rune::ContextError> {
+///     let mut module = rune::Module::new();
+///     module.ty::<Npc>()?;
+///     module.function_meta(Npc::new)?;
+///     module.function_meta(Npc::damage)?;
+///     Ok(module)
+/// }
+/// ```
+pub trait Any: TypeHash + Named + any::Any {
+    /// The compile-time type information know for the type.
+    const ANY_TYPE_INFO: AnyTypeInfo = AnyTypeInfo::new(Self::full_name, Self::HASH);
+}
+
+/// Trait implemented for types which can be automatically converted to a
+/// [`Value`].
+///
+/// We can't use a blanked implementation over `T: Any` because it only governs
+/// what can be stored in any [`AnyObj`].
+///
+/// This trait in contrast is selectively implemented for types which we want to
+/// generate [`ToValue`] and [`FromValue`] implementations for.
+///
+/// [`Value`]: crate::runtime::Value
+/// [`AnyObj`]: crate::runtime::AnyObj
+/// [`ToValue`]: crate::runtime::ToValue
+/// [`FromValue`]: crate::runtime::FromValue
+///
+/// Note that you are *not* supposed to implement this directly. Make use of the
+/// [`Any`] derive instead.
+///
+/// [`Any`]: derive@crate::Any
+pub trait AnyMarker: Any {}
+
 /// Macro to mark a value as external, which will implement all the appropriate
 /// traits.
 ///
@@ -226,82 +306,3 @@ use crate::runtime::{AnyTypeInfo, TypeHash};
 /// [`rune::alloc`]: crate::alloc
 /// [`TryClone` trait]: crate::alloc::clone::TryClone
 pub use rune_macros::Any;
-
-/// Derive for types which can be used inside of Rune.
-///
-/// Rune only supports two types, *built-in* types [`String`] and *external*
-/// types which derive `Any`. Before they can be used they must be registered in
-/// [`Context::install`] through a [`Module`].
-///
-/// This is typically used in combination with declarative macros to register
-/// functions and macros, such as:
-///
-/// * [`#[rune::function]`]
-/// * [`#[rune::macro_]`]
-///
-/// [`AnyObj`]: crate::runtime::AnyObj
-/// [`Context::install`]: crate::Context::install
-/// [`Module`]: crate::Module
-/// [`String`]: std::string::String
-/// [`#[rune::function]`]: macro@crate::function
-/// [`#[rune::macro_]`]: crate::macro_
-///
-/// # Examples
-///
-/// ```
-/// use rune::Any;
-///
-/// #[derive(Any)]
-/// struct Npc {
-///     #[rune(get)]
-///     health: u32,
-/// }
-///
-/// impl Npc {
-///     /// Construct a new NPC.
-///     #[rune::function(path = Self::new)]
-///     fn new(health: u32) -> Self {
-///         Self {
-///             health
-///         }
-///     }
-///
-///     /// Damage the NPC with the given `amount`.
-///     #[rune::function]
-///     fn damage(&mut self, amount: u32) {
-///         self.health -= amount;
-///     }
-/// }
-///
-/// fn install() -> Result<rune::Module, rune::ContextError> {
-///     let mut module = rune::Module::new();
-///     module.ty::<Npc>()?;
-///     module.function_meta(Npc::new)?;
-///     module.function_meta(Npc::damage)?;
-///     Ok(module)
-/// }
-/// ```
-pub trait Any: TypeHash + Named + any::Any {
-    /// The compile-time type information know for the type.
-    const ANY_TYPE_INFO: AnyTypeInfo = AnyTypeInfo::new(Self::full_name, Self::HASH);
-}
-
-/// Trait implemented for types which can be automatically converted to a
-/// [`Value`].
-///
-/// We can't use a blanked implementation over `T: Any` because it only governs
-/// what can be stored in any [`AnyObj`].
-///
-/// This trait in contrast is selectively implemented for types which we want to
-/// generate [`ToValue`] and [`FromValue`] implementations for.
-///
-/// [`Value`]: crate::runtime::Value
-/// [`AnyObj`]: crate::runtime::AnyObj
-/// [`ToValue`]: crate::runtime::ToValue
-/// [`FromValue`]: crate::runtime::FromValue
-///
-/// Note that you are *not* supposed to implement this directly. Make use of the
-/// [`Any`] derive instead.
-///
-/// [`Any`]: derive@Any
-pub trait AnyMarker: Any {}

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -202,6 +202,7 @@ pub mod fmt;
 pub use ::codespan_reporting::term::termcolor;
 
 pub(crate) mod any;
+#[doc(inline)]
 pub use self::any::Any;
 
 mod build;
@@ -254,8 +255,8 @@ pub mod query;
 pub mod runtime;
 #[doc(inline)]
 pub use self::runtime::{
-    from_const_value, from_value, to_const_value, to_value, FromValue, Mut, Ref, ToConstValue,
-    ToValue, TypeHash, Unit, Value, Vm,
+    from_const_value, from_value, to_const_value, to_value, FromConstValue, FromValue, Mut, Ref,
+    ToConstValue, ToValue, TypeHash, Unit, Value, Vm,
 };
 
 mod shared;

--- a/crates/rune/src/runtime/from_value.rs
+++ b/crates/rune/src/runtime/from_value.rs
@@ -4,7 +4,9 @@ use crate::alloc::{self, String};
 use crate::any::AnyMarker;
 use crate::hash::Hash;
 
-use super::{AnyObj, ConstValue, FromConstValue, Mut, RawAnyGuard, Ref, RuntimeError, Value};
+use super::{
+    AnyObj, ConstValue, FromConstValue, Mut, RawAnyGuard, Ref, RuntimeError, Shared, Value,
+};
 
 /// Derive macro for the [`FromValue`] trait for converting types from the
 /// dynamic `Value` container.
@@ -243,6 +245,16 @@ impl FromValue for AnyObj {
     #[inline]
     fn from_value(value: Value) -> Result<Self, RuntimeError> {
         value.into_any_obj()
+    }
+}
+
+impl<T> FromValue for Shared<T>
+where
+    T: AnyMarker,
+{
+    #[inline]
+    fn from_value(value: Value) -> Result<Self, RuntimeError> {
+        value.into_shared()
     }
 }
 

--- a/crates/rune/src/runtime/mod.rs
+++ b/crates/rune/src/runtime/mod.rs
@@ -27,6 +27,9 @@ use self::any_obj::AnyObjErrorKind;
 pub use self::any_obj::{AnyObj, AnyObjError};
 pub(crate) use self::any_obj::{AnyObjDrop, RawAnyObjGuard};
 
+mod shared;
+pub use self::shared::Shared;
+
 mod args;
 pub use self::args::{Args, FixedArgs};
 pub(crate) use self::args::{DynArgs, DynArgsUsed, DynGuardedArgs};

--- a/crates/rune/src/runtime/shared.rs
+++ b/crates/rune/src/runtime/shared.rs
@@ -1,0 +1,280 @@
+use core::fmt;
+use core::marker::PhantomData;
+use core::mem::ManuallyDrop;
+use core::ptr::{addr_of, NonNull};
+
+use crate::{Any, Hash};
+
+use super::any_obj::{AnyObjData, AnyObjError, AnyObjErrorKind, Kind, Vtable};
+use super::{AccessError, BorrowMut, BorrowRef, Mut, RawAnyGuard, Ref, RefVtable, TypeInfo};
+
+/// A typed wrapper for a reference.
+///
+/// This is identical in layout to [`AnyObj`], but provides a statically
+/// type-checked value.
+///
+/// [`AnyObj`]: super::AnyObj
+pub struct Shared<T> {
+    /// The shared value.
+    shared: NonNull<AnyObjData>,
+    /// The statically known type of the value.
+    _marker: PhantomData<T>,
+}
+
+impl<T> Shared<T>
+where
+    T: Any,
+{
+    /// Construct a new typed object.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure that the type is of the value `T`.
+    pub(super) unsafe fn new(shared: NonNull<AnyObjData<T>>) -> Self {
+        Self {
+            shared: shared.cast(),
+            _marker: PhantomData,
+        }
+    }
+
+    /// Take the owned value of type `T`.
+    ///
+    /// This consumes any live references of the value and accessing them in the
+    /// future will result in an error.
+    ///
+    /// # Errors
+    ///
+    /// This errors if the underlying value is not owned.
+    pub fn take(self) -> Result<T, AnyObjError> {
+        let vtable = vtable(&self);
+
+        if !matches!(vtable.kind, Kind::Own) {
+            return Err(AnyObjError::from(AccessError::not_owned(
+                vtable.type_info(),
+            )));
+        }
+
+        // SAFETY: We've checked for the appropriate type just above.
+        unsafe {
+            self.shared.as_ref().access.try_take()?;
+            let data = vtable.as_ptr::<T>(self.shared);
+            Ok(data.read())
+        }
+    }
+
+    /// Drop the value.
+    ///
+    /// This consumes any live references of the value and accessing them in the
+    /// future will result in an error.
+    pub fn drop(self) -> Result<(), AccessError> {
+        let vtable = vtable(&self);
+
+        if !matches!(vtable.kind, Kind::Own) {
+            return Err(AccessError::not_owned(vtable.type_info()));
+        }
+
+        // SAFETY: We've checked for the appropriate type just above.
+        unsafe {
+            self.shared.as_ref().access.try_take()?;
+
+            if let Some(drop_value) = vtable.drop_value {
+                drop_value(self.shared);
+            }
+
+            Ok(())
+        }
+    }
+
+    /// Downcast into an owned value of type [`Ref<T>`].
+    ///
+    /// # Errors
+    ///
+    /// This errors in case the underlying value is not owned, non-owned
+    /// references cannot be coerced into [`Ref<T>`].
+    pub fn into_ref(self) -> Result<Ref<T>, AnyObjError> {
+        let vtable = vtable(&self);
+
+        if !matches!(vtable.kind, Kind::Own) {
+            return Err(AnyObjError::from(AccessError::not_owned(
+                vtable.type_info(),
+            )));
+        }
+
+        // SAFETY: We've checked for the appropriate type just above.
+        unsafe {
+            self.shared.as_ref().access.try_shared()?;
+            let this = ManuallyDrop::new(self);
+            let data = vtable.as_ptr(this.shared);
+
+            let vtable = &RefVtable {
+                drop: |shared: NonNull<()>| {
+                    let shared = shared.cast::<AnyObjData>();
+                    shared.as_ref().access.release();
+                    AnyObjData::dec(shared)
+                },
+            };
+
+            let guard = RawAnyGuard::new(this.shared.cast(), vtable);
+            Ok(Ref::new(data, guard))
+        }
+    }
+
+    /// Downcast into an owned value of type [`Mut<T>`].
+    ///
+    /// # Errors
+    ///
+    /// This errors in case the underlying value is not owned, non-owned
+    /// references cannot be coerced into [`Mut<T>`].
+    pub fn into_mut(self) -> Result<Mut<T>, AnyObjError> {
+        let vtable = vtable(&self);
+
+        if !matches!(vtable.kind, Kind::Own) {
+            return Err(AnyObjError::from(AccessError::not_owned(
+                vtable.type_info(),
+            )));
+        }
+
+        // SAFETY: We've checked for the appropriate type just above.
+        unsafe {
+            self.shared.as_ref().access.try_exclusive()?;
+            let this = ManuallyDrop::new(self);
+            let data = vtable.as_ptr(this.shared);
+
+            let vtable = &RefVtable {
+                drop: |shared: NonNull<()>| {
+                    let shared = shared.cast::<AnyObjData>();
+                    shared.as_ref().access.release();
+                    AnyObjData::dec(shared)
+                },
+            };
+
+            let guard = RawAnyGuard::new(this.shared.cast(), vtable);
+            Ok(Mut::new(data, guard))
+        }
+    }
+
+    /// Borrow a shared reference to the value while checking for shared access.
+    ///
+    /// This prevents other exclusive accesses from being performed while the
+    /// guard returned from this function is live.
+    pub fn borrow_ref(&self) -> Result<BorrowRef<'_, T>, AnyObjError> {
+        let vtable = vtable(self);
+
+        // SAFETY: We've checked for the appropriate type just above.
+        unsafe {
+            let guard = self.shared.as_ref().access.shared()?;
+            let data = vtable.as_ptr(self.shared);
+            Ok(BorrowRef::new(data, guard.into_raw()))
+        }
+    }
+
+    /// Try to borrow an shared reference to the value.
+    ///
+    /// Returns `None` if the value is not `T`.
+    ///
+    /// This prevents other exclusive accesses from being performed while the
+    /// guard returned from this function is live.
+    pub fn try_borrow_ref(&self) -> Result<Option<BorrowRef<'_, T>>, AccessError> {
+        let vtable = vtable(self);
+
+        // SAFETY: We've checked for the appropriate type just above.
+        unsafe {
+            let guard = self.shared.as_ref().access.shared()?;
+            let data = vtable.as_ptr(self.shared);
+            Ok(Some(BorrowRef::new(data, guard.into_raw())))
+        }
+    }
+
+    /// Borrow an exclusive reference to the value.
+    ///
+    /// This prevents other accesses from being performed while the guard
+    /// returned from this function is live.
+    pub fn borrow_mut(&self) -> Result<BorrowMut<'_, T>, AnyObjError> {
+        let vtable = vtable(self);
+
+        if matches!(vtable.kind, Kind::Ref) {
+            return Err(AnyObjError::new(AnyObjErrorKind::Cast(
+                T::ANY_TYPE_INFO,
+                vtable.type_info(),
+            )));
+        }
+
+        // SAFETY: We've checked for the appropriate type just above.
+        unsafe {
+            let guard = self.shared.as_ref().access.exclusive()?;
+            let data = vtable.as_ptr(self.shared);
+            Ok(BorrowMut::new(data, guard.into_raw()))
+        }
+    }
+
+    /// Try to borrow an exlucisve reference to the value.
+    ///
+    /// Returns `None` if the value is not `T`.
+    ///
+    /// This prevents other exclusive accesses from being performed while the
+    /// guard returned from this function is live.
+    pub fn try_borrow_mut(&self) -> Result<Option<BorrowMut<'_, T>>, AccessError> {
+        let vtable = vtable(self);
+
+        // SAFETY: We've checked for the appropriate type just above.
+        unsafe {
+            let guard = self.shared.as_ref().access.exclusive()?;
+            let data = vtable.as_ptr(self.shared);
+            Ok(Some(BorrowMut::new(data, guard.into_raw())))
+        }
+    }
+
+    /// Test if the value is sharable.
+    pub fn is_readable(&self) -> bool {
+        // Safety: Since we have a reference to this shared, we know that the
+        // inner is available.
+        unsafe { self.shared.as_ref().access.is_shared() }
+    }
+
+    /// Test if the value is exclusively accessible.
+    pub fn is_writable(&self) -> bool {
+        unsafe {
+            let shared = self.shared.as_ref();
+            !matches!(shared.vtable.kind, Kind::Ref) && shared.access.is_exclusive()
+        }
+    }
+
+    /// Debug format the current any type.
+    pub(crate) fn debug(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        (vtable(self).debug)(f)
+    }
+
+    /// Access the underlying type id for the data.
+    pub fn type_hash(&self) -> Hash {
+        vtable(self).type_hash
+    }
+
+    /// Access full type info for the underlying type.
+    pub fn type_info(&self) -> TypeInfo {
+        TypeInfo::any_type_info(vtable(self).type_info)
+    }
+}
+
+impl<T> fmt::Debug for Shared<T>
+where
+    T: Any,
+{
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.debug(f)
+    }
+}
+
+impl<T> Drop for Shared<T> {
+    fn drop(&mut self) {
+        // Safety: We know that the inner value is live in this instance.
+        unsafe {
+            AnyObjData::dec(self.shared);
+        }
+    }
+}
+
+#[inline]
+pub(super) fn vtable<T>(any: &Shared<T>) -> &'static Vtable {
+    unsafe { addr_of!((*any.shared.as_ptr()).vtable).read() }
+}


### PR DESCRIPTION
This reintroduces `Shared<T>` under the new data layouts.

Relates #924