### PR TITLE
rune: Support using Shared<T> as field

### DIFF
--- a/crates/rune/src/runtime/tests.rs
+++ b/crates/rune/src/runtime/tests.rs
@@ -35,7 +35,16 @@ impl Wake for NoopWaker {
 #[test]
 fn test_take() -> Result<()> {
     let thing = Value::from(AnyObj::new(Thing(0))?);
-    let _ = thing.into_any_obj()?;
+    let _ = thing.into_any_obj()?.take()?;
+    Ok(())
+}
+
+#[test]
+fn test_take_shared() -> Result<()> {
+    let thing = Value::from(AnyObj::new(Thing(0))?);
+    let shared = thing.into_shared::<Thing>()?;
+    let inner = shared.take()?;
+    assert_eq!(inner, Thing(0));
     Ok(())
 }
 
@@ -46,6 +55,18 @@ fn test_clone_take() -> Result<()> {
     let v3 = v.clone();
     assert_eq!(Thing(0), v2.downcast::<Thing>()?);
     assert!(v3.downcast::<Thing>().is_err());
+    let any = v.into_any_obj()?;
+    assert_eq!(any.type_hash(), Thing::HASH);
+    Ok(())
+}
+
+#[test]
+fn test_clone_take_shared() -> Result<()> {
+    let v = Value::from(AnyObj::new(Thing(0))?);
+    let v2 = v.clone();
+    let v3 = v.clone().into_shared::<Thing>()?;
+    assert_eq!(Thing(0), v2.downcast::<Thing>()?);
+    assert!(v3.take().is_err());
     let any = v.into_any_obj()?;
     assert_eq!(any.type_hash(), Thing::HASH);
     Ok(())

--- a/crates/rune/src/runtime/value.rs
+++ b/crates/rune/src/runtime/value.rs
@@ -45,7 +45,7 @@ use super::{
 
 /// Defined guard for a reference value.
 ///
-/// See [Value::from_ref].
+/// See [`Value::from_ref`].
 pub struct ValueRefGuard {
     #[allow(unused)]
     guard: AnyObjDrop,
@@ -53,19 +53,20 @@ pub struct ValueRefGuard {
 
 /// Defined guard for a reference value.
 ///
-/// See [Value::from_mut].
+/// See [`Value::from_mut`].
 pub struct ValueMutGuard {
     #[allow(unused)]
     guard: AnyObjDrop,
 }
 
-/// The guard returned by [Value::into_any_mut_ptr].
+/// The guard returned by [`Value::into_any_mut_ptr`].
 pub struct RawValueGuard {
     #[allow(unused)]
     guard: RawAnyObjGuard,
 }
 
 // Small helper function to build errors.
+#[inline]
 fn err<T, E>(error: E) -> VmResult<T>
 where
     VmErrorKind: From<E>,

--- a/crates/rune/src/runtime/vm_error.rs
+++ b/crates/rune/src/runtime/vm_error.rs
@@ -578,6 +578,7 @@ impl From<alloc::alloc::AllocError> for RuntimeError {
 impl From<AnyObjError> for RuntimeError {
     fn from(value: AnyObjError) -> Self {
         match value.into_kind() {
+            AnyObjErrorKind::Alloc(error) => Self::from(error),
             AnyObjErrorKind::Cast(expected, actual) => Self::new(VmErrorKind::Expected {
                 expected: TypeInfo::any_type_info(expected),
                 actual,

--- a/crates/rune/src/tests.rs
+++ b/crates/rune/src/tests.rs
@@ -18,7 +18,7 @@ pub(crate) mod prelude {
     pub(crate) use crate::parse;
     pub(crate) use crate::runtime::{
         self, Bytes, DynamicTuple, Formatter, Function, InstAddress, MaybeTypeOf, Object, Output,
-        OwnedTuple, Protocol, RawAnyGuard, Ref, Stack, Tuple, TypeHash, TypeInfo, TypeOf,
+        OwnedTuple, Protocol, RawAnyGuard, Ref, Shared, Stack, Tuple, TypeHash, TypeInfo, TypeOf,
         UnsafeToRef, VecTuple, VmErrorKind, VmResult,
     };
     pub(crate) use crate::support::Result;

--- a/crates/rune/src/tests/getter_setter.rs
+++ b/crates/rune/src/tests/getter_setter.rs
@@ -1,13 +1,17 @@
 prelude!();
 
+use crate::alloc::String;
+
 use std::sync::Arc;
 
-#[derive(Any, Debug, Default)]
+#[derive(Any, Debug)]
 struct Foo {
     #[rune(get, set, copy)]
     number: i64,
     #[rune(get, set)]
     string: String,
+    #[rune(get, set)]
+    shared_string: Shared<String>,
 }
 
 #[test]
@@ -23,6 +27,8 @@ fn test_getter_setter() -> Result<()> {
             pub fn main(foo) {
                 foo.number = foo.number + 1;
                 foo.string = format!("{} World", foo.string);
+                foo.shared_string = format!("{} Shared World", foo.shared_string);
+                foo.shared_string
             }
         }
     };
@@ -33,14 +39,17 @@ fn test_getter_setter() -> Result<()> {
 
     let mut foo = Foo {
         number: 42,
-        string: String::from("Hello"),
+        string: String::try_from("Hello")?,
+        shared_string: Shared::new(String::try_from("Hello")?)?,
     };
 
     let output = vm.call(["main"], (&mut foo,))?;
 
     assert_eq!(foo.number, 43);
     assert_eq!(foo.string, "Hello World");
+    assert_eq!(&*foo.shared_string.borrow_ref()?, "Hello Shared World");
 
-    output.into_unit().unwrap();
+    let string = output.downcast::<String>().unwrap();
+    assert_eq!(string, "Hello Shared World");
     Ok(())
 }


### PR DESCRIPTION
Last step towards allowing `Any` types to be used as `Shared<T>` fields again. :sweat:

Relates #924