### PR TITLE
rune-modules: Switch to upstream rand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,28 @@ jobs:
     - run: cargo check --release -p rune --no-default-features --features ${{matrix.feature}}
     - run: cargo clippy --all-targets --no-default-features --features ${{matrix.feature}}
 
+  build_rune_modules_feature:
+    runs-on: ubuntu-latest
+    needs: basics
+    strategy:
+      fail-fast: false
+      matrix:
+        feature:
+        - rand
+        - rand,small_rng,os_rng
+        - rand,std_rng,os_rng
+    env:
+      RUSTFLAGS: -D warnings
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        components: clippy
+    - uses: Swatinem/rust-cache@v2
+    - run: cargo check -p rune-modules --no-default-features --features ${{matrix.feature}}
+    - run: cargo check --release -p rune-modules --no-default-features --features ${{matrix.feature}}
+    - run: cargo clippy -p rune-modules --no-default-features --features ${{matrix.feature}}
+
   wasm:
     runs-on: ubuntu-latest
     needs: basics

--- a/crates/rune-modules/Cargo.toml
+++ b/crates/rune-modules/Cargo.toml
@@ -24,36 +24,48 @@ full = [
     "process",
     "signal",
     "rand",
+    "small_rng",
+    "std_rng",
+    "os_rng",
     "io",
     "fmt",
     "base64",
 ]
-time = ["tokio", "tokio?/time"]
-fs = ["tokio", "tokio?/fs"]
+time = ["tokio/time"]
+fs = ["tokio/fs"]
 http = ["reqwest"]
 json = ["serde_json"]
 process = ["tokio/process", "rune/std"]
 signal = ["tokio/signal"]
-rand = ["nanorand"]
 test = []
 core = []
 io = []
 fmt = []
 macros = []
+rand = ["dep:rand"]
+os_rng = ["getrandom", "rand?/os_rng"]
+small_rng = ["rand?/small_rng"]
+std_rng = ["rand?/std_rng"]
 
 [dependencies]
 base64 = { version = "0.22.0", optional = true }
-reqwest = { version = "0.12.8", optional = true, default-features = false, features = [
-    "rustls-tls",
-    "gzip",
-    "json",
-] }
 tokio = { version = "1.28.1", optional = true }
 serde_json = { version = "1.0.96", optional = true }
 toml = { version = "0.8.19", optional = true }
-nanorand = { version = "0.7.0", optional = true, features = ["getrandom"] }
+rand = { version = "0.9.0", optional = true, default-features = false }
+getrandom = { version = "0.3.0", optional = true }
 
 rune = { version = "0.14.0", path = "../rune" }
+
+[dependencies.reqwest]
+version = "0.12.8"
+optional = true
+default-features = false
+features = [
+    "rustls-tls",
+    "gzip",
+    "json",
+]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/rune-modules/src/http.rs
+++ b/crates/rune-modules/src/http.rs
@@ -1376,6 +1376,7 @@ pub struct Error {
 }
 
 impl From<reqwest::Error> for Error {
+    #[inline]
     fn from(inner: reqwest::Error) -> Self {
         Self { inner }
     }

--- a/crates/rune-modules/src/rand.rs
+++ b/crates/rune-modules/src/rand.rs
@@ -23,148 +23,386 @@
 //!
 //! ```rust,ignore
 //! fn main() {
-//!     let rng = rand::WyRand::new();
-//!     let rand_int = rng.int();
+//!     let rng = rand::StdRng::try_from_os_rng()?;
+//!     let rand_int = rng.random::<u64>();
 //!     println(`Random int: {rand_int}`);
-//!     let rand_int_range = rng.int_range(-100, 100);
+//!     let rand_int_range = rng.random_range::<i64>(-100..100);
 //!     println(`Random int between -100 and 100: {rand_int_range}`);
 //! }
 //! ```
 
-use nanorand::Rng;
-use rune::{Any, ContextError, Module};
+#[cfg(any(feature = "small_rng", feature = "std_rng"))]
+use rand::{Rng, SeedableRng};
+#[cfg(feature = "os_rng")]
+use rune::alloc::fmt::TryWrite;
+#[cfg(feature = "os_rng")]
+use rune::runtime::Formatter;
+#[cfg(any(feature = "small_rng", feature = "std_rng", feature = "os_rng"))]
+use rune::runtime::VmResult;
+#[cfg(any(feature = "small_rng", feature = "std_rng"))]
+use rune::runtime::{Range, RangeInclusive, TypeHash, Value};
+#[cfg(any(feature = "small_rng", feature = "std_rng"))]
+use rune::{vm_try, Any};
+use rune::{ContextError, Module};
+
+#[cfg(any(feature = "small_rng", feature = "std_rng"))]
+macro_rules! random {
+    ($m:ident, $ty:ty, $(($name:ident, $out:ty)),* $(,)?) => {
+        $(
+            #[doc = concat!(" Return a random `", stringify!($out), "` value via a standard uniform distribution.")]
+            ///
+            /// # Example
+            ///
+            /// ```rune
+            #[doc = concat!(" use rand::", stringify!($ty), ";")]
+            ///
+            #[doc = concat!(" let rng = ", stringify!($ty), "::try_from_os_rng()?;")]
+            #[doc = concat!(" let x = rng.random::<", stringify!($out), ">();")]
+            /// println!("{x}");
+            /// ```
+            #[rune::function(instance, path = random<$out>)]
+            fn $name(this: &mut $ty) -> $out {
+                this.inner.random::<$out>()
+            }
+
+            $m.function_meta($name)?;
+        )*
+    }
+}
+
+#[cfg(any(feature = "small_rng", feature = "std_rng"))]
+macro_rules! random_ranges {
+    ($m:ident, $ty:ty, $(($name:ident, $out:ty, $as:path, $range:expr)),* $(,)?) => {
+        $(
+            #[doc = concat!(" Return a random `", stringify!($out), "` value via a standard uniform constrained with a range.")]
+            ///
+            /// # Example
+            ///
+            /// ```rune
+            #[doc = concat!(" use rand::", stringify!($ty), ";")]
+            ///
+            #[doc = concat!(" let rng = ", stringify!($ty), "::try_from_os_rng()?;")]
+            #[doc = concat!(" let x = rng.random_range::<", stringify!($out), ">(", stringify!($range), ");")]
+            /// println!("{x}");
+            /// ```
+            #[rune::function(instance, path = random_range<$out>)]
+            fn $name(this: &mut $ty, range: Value) -> VmResult<$out> {
+                let value = match range.as_any() {
+                    Some(value) => match value.type_hash() {
+                        RangeInclusive::HASH => {
+                            let range = vm_try!(value.borrow_ref::<RangeInclusive>());
+                            let start = vm_try!($as(&range.start));
+                            let end = vm_try!($as(&range.end));
+                            this.inner.random_range(start..=end)
+                        }
+                        Range::HASH => {
+                            let range = vm_try!(value.borrow_ref::<Range>());
+                            let start = vm_try!($as(&range.start));
+                            let end = vm_try!($as(&range.end));
+                            this.inner.random_range(start..end)
+                        }
+                        _ => {
+                            return VmResult::panic("unsupported range");
+                        }
+                    },
+                    _ => {
+                        return VmResult::panic("unsupported range");
+                    }
+                };
+
+                VmResult::Ok(value)
+            }
+
+            $m.function_meta($name)?;
+        )*
+    }
+}
 
 /// Construct the `rand` module.
 pub fn module(_stdio: bool) -> Result<Module, ContextError> {
-    let mut module = Module::with_crate("rand")?;
+    #[allow(unused_mut)]
+    let mut m = Module::with_crate("rand")?;
 
-    module.ty::<WyRand>()?;
-    module
-        .function("new", WyRand::new)
-        .build_associated::<WyRand>()?;
-    module
-        .function("new_seed", WyRand::new_seed)
-        .build_associated::<WyRand>()?;
-    module.associated_function("int", WyRand::int)?;
-    module.associated_function("int_range", WyRand::int_range)?;
+    #[cfg(feature = "os_rng")]
+    {
+        m.ty::<Error>()?;
+        m.function_meta(Error::display_fmt)?;
+    }
 
-    module.ty::<Pcg64>()?;
-    module
-        .function("new", Pcg64::new)
-        .build_associated::<Pcg64>()?;
-    module
-        .function("new_seed", Pcg64::new_seed)
-        .build_associated::<Pcg64>()?;
-    module.associated_function("int", Pcg64::int)?;
-    module.associated_function("int_range", Pcg64::int_range)?;
+    #[cfg(any(feature = "small_rng", feature = "std_rng"))]
+    macro_rules! call_random {
+        ($ty:ty) => {
+            random! {
+                m, $ty,
+                (random_u64, u64),
+                (random_i64, i64),
+                (random_char, char),
+            };
 
-    module.function("int", int).build()?;
-    module.function("int_range", int_range).build()?;
-    Ok(module)
+            random_ranges! {
+                m,
+                $ty,
+                (random_range_u64, u64, Value::as_integer::<u64>, 0..100),
+                (random_range_i64, i64, Value::as_integer::<i64>, -100..100),
+                (random_range_char, char, Value::as_char, 'a'..'z'),
+            };
+        };
+    }
+
+    #[cfg(feature = "small_rng")]
+    {
+        m.ty::<SmallRng>()?;
+        #[cfg(feature = "os_rng")]
+        m.function_meta(SmallRng::from_os_rng)?;
+        #[cfg(feature = "os_rng")]
+        m.function_meta(SmallRng::try_from_os_rng)?;
+        m.function_meta(SmallRng::from_seed)?;
+        m.function_meta(SmallRng::seed_from_u64)?;
+        call_random!(SmallRng);
+    }
+
+    #[cfg(feature = "std_rng")]
+    {
+        m.ty::<StdRng>()?;
+        #[cfg(feature = "os_rng")]
+        m.function_meta(StdRng::from_os_rng)?;
+        #[cfg(feature = "os_rng")]
+        m.function_meta(StdRng::try_from_os_rng)?;
+        m.function_meta(StdRng::from_seed)?;
+        m.function_meta(StdRng::seed_from_u64)?;
+        call_random!(StdRng);
+    }
+
+    Ok(m)
+}
+
+/// An error returned by methods in the `http` module.
+#[derive(Debug, Any)]
+#[rune(item = ::rand)]
+#[cfg(feature = "os_rng")]
+pub struct Error {
+    inner: getrandom::Error,
+}
+
+#[cfg(feature = "os_rng")]
+impl From<getrandom::Error> for Error {
+    #[inline]
+    fn from(inner: getrandom::Error) -> Self {
+        Self { inner }
+    }
+}
+
+#[cfg(feature = "os_rng")]
+impl Error {
+    /// Write a display representation the error.
+    #[rune::function(instance, protocol = DISPLAY_FMT)]
+    fn display_fmt(&self, f: &mut Formatter) -> VmResult<()> {
+        rune::vm_write!(f, "{}", self.inner)
+    }
 }
 
 #[derive(Any)]
 #[rune(item = ::rand)]
-struct WyRand {
-    inner: nanorand::WyRand,
+#[cfg(feature = "small_rng")]
+struct SmallRng {
+    inner: rand::rngs::SmallRng,
 }
 
-impl WyRand {
-    /// Create a new RNG instance.
-    fn new() -> Self {
-        Self {
-            inner: nanorand::WyRand::new(),
+#[cfg(feature = "small_rng")]
+impl SmallRng {
+    /// Creates a new instance of the RNG seeded via [`getrandom`].
+    ///
+    /// This method is the recommended way to construct non-deterministic PRNGs
+    /// since it is convenient and secure.
+    ///
+    /// Note that this method may panic on (extremely unlikely) [`getrandom`]
+    /// errors. If it's not desirable, use the [`try_from_os_rng`] method
+    /// instead.
+    ///
+    /// # Panics
+    ///
+    /// If [`getrandom`] is unable to provide secure entropy this method will
+    /// panic.
+    ///
+    /// [`getrandom`]: https://docs.rs/getrandom
+    /// [`try_from_os_rng`]: StdRng::try_from_os_rng
+    #[rune::function(path = SmallRng::from_os_rng)]
+    #[cfg(feature = "os_rng")]
+    fn from_os_rng() -> VmResult<Self> {
+        match rand::rngs::SmallRng::try_from_os_rng() {
+            Ok(inner) => VmResult::Ok(Self { inner }),
+            Err(e) => VmResult::panic(e),
         }
     }
 
-    /// Create a new RNG instance, using a custom seed.
-    fn new_seed(seed: i64) -> Self {
-        Self {
-            inner: nanorand::WyRand::new_seed(seed as u64),
+    /// Creates a new instance of the RNG seeded via [`getrandom`] without
+    /// unwrapping potential [`getrandom`] errors.
+    ///
+    /// [`getrandom`]: https://docs.rs/getrandom
+    #[rune::function(path = SmallRng::try_from_os_rng)]
+    #[cfg(feature = "os_rng")]
+    fn try_from_os_rng() -> Result<Self, Error> {
+        match rand::rngs::SmallRng::try_from_os_rng() {
+            Ok(inner) => Ok(Self { inner }),
+            Err(inner) => Err(Error { inner }),
         }
     }
 
-    /// Generate a random integer
-    fn int(&mut self) -> i64 {
-        self.inner.generate::<u64>() as i64
+    /// Create a new PRNG using the given seed.
+    ///
+    /// PRNG implementations are allowed to assume that bits in the seed are
+    /// well distributed. That means usually that the number of one and zero
+    /// bits are roughly equal, and values like 0, 1 and (size - 1) are
+    /// unlikely. Note that many non-cryptographic PRNGs will show poor quality
+    /// output if this is not adhered to. If you wish to seed from simple
+    /// numbers, use [`seed_from_u64`] instead.
+    ///
+    /// All PRNG implementations should be reproducible unless otherwise noted:
+    /// given a fixed `seed`, the same sequence of output should be produced on
+    /// all runs, library versions and architectures (e.g. check endianness).
+    /// Any "value-breaking" changes to the generator should require bumping at
+    /// least the minor version and documentation of the change.
+    ///
+    /// It is not required that this function yield the same state as a
+    /// reference implementation of the PRNG given equivalent seed; if necessary
+    /// another constructor replicating behaviour from a reference
+    /// implementation can be added.
+    ///
+    /// PRNG implementations should make sure `from_seed` never panics. In the
+    /// case that some special values (like an all zero seed) are not viable
+    /// seeds it is preferable to map these to alternative constant value(s),
+    /// for example `0xBAD5EEDu32` or `0x0DDB1A5E5BAD5EEDu64` ("odd biases? bad
+    /// seed"). This is assuming only a small number of values must be rejected.
+    ///
+    /// [`seed_from_u64`]: SmallRng::seed_from_u64
+    #[rune::function(path = Self::from_seed)]
+    fn from_seed(seed: [u8; 32]) -> Self {
+        Self {
+            inner: rand::rngs::SmallRng::from_seed(seed),
+        }
     }
 
-    /// Generate a random integer within the specified range
-    fn int_range(&mut self, lower: i64, upper: i64) -> i64 {
-        self.inner.generate_range(0..(upper - lower) as u64) as i64 + lower
+    /// Create a new PRNG using a `u64` seed.
+    ///
+    /// This is a convenience-wrapper around `from_seed` to allow construction
+    /// of any `SeedableRng` from a simple `u64` value. It is designed such that
+    /// low Hamming Weight numbers like 0 and 1 can be used and should still
+    /// result in good, independent seeds to the PRNG which is returned.
+    ///
+    /// This **is not suitable for cryptography**, as should be clear given that
+    /// the input size is only 64 bits.
+    ///
+    /// Implementations for PRNGs *may* provide their own implementations of
+    /// this function, but the default implementation should be good enough for
+    /// all purposes. *Changing* the implementation of this function should be
+    /// considered a value-breaking change.
+    #[rune::function(path = Self::seed_from_u64)]
+    fn seed_from_u64(state: u64) -> Self {
+        Self {
+            inner: rand::rngs::SmallRng::seed_from_u64(state),
+        }
     }
 }
 
 #[derive(Any)]
 #[rune(item = ::rand)]
-struct Pcg64 {
-    inner: nanorand::Pcg64,
+#[cfg(feature = "std_rng")]
+struct StdRng {
+    inner: rand::rngs::StdRng,
 }
 
-impl Pcg64 {
-    /// Create a new RNG instance.
-    fn new() -> Self {
+#[cfg(feature = "std_rng")]
+impl StdRng {
+    /// Creates a new instance of the RNG seeded via [`getrandom`].
+    ///
+    /// This method is the recommended way to construct non-deterministic PRNGs
+    /// since it is convenient and secure.
+    ///
+    /// Note that this method may panic on (extremely unlikely) [`getrandom`]
+    /// errors. If it's not desirable, use the [`try_from_os_rng`] method
+    /// instead.
+    ///
+    /// # Panics
+    ///
+    /// If [`getrandom`] is unable to provide secure entropy this method will
+    /// panic.
+    ///
+    /// [`getrandom`]: https://docs.rs/getrandom
+    /// [`try_from_os_rng`]: StdRng::try_from_os_rng
+    #[rune::function(path = StdRng::from_os_rng)]
+    #[cfg(feature = "os_rng")]
+    fn from_os_rng() -> VmResult<Self> {
+        match rand::rngs::StdRng::try_from_os_rng() {
+            Ok(inner) => VmResult::Ok(Self { inner }),
+            Err(e) => VmResult::panic(e),
+        }
+    }
+
+    /// Creates a new instance of the RNG seeded via [`getrandom`] without
+    /// unwrapping potential [`getrandom`] errors.
+    ///
+    /// [`getrandom`]: https://docs.rs/getrandom
+    #[rune::function(path = StdRng::try_from_os_rng)]
+    #[cfg(feature = "os_rng")]
+    fn try_from_os_rng() -> Result<Self, Error> {
+        match rand::rngs::StdRng::try_from_os_rng() {
+            Ok(inner) => Ok(Self { inner }),
+            Err(inner) => Err(Error { inner }),
+        }
+    }
+
+    /// Create a new PRNG using the given seed.
+    ///
+    /// PRNG implementations are allowed to assume that bits in the seed are
+    /// well distributed. That means usually that the number of one and zero
+    /// bits are roughly equal, and values like 0, 1 and (size - 1) are
+    /// unlikely. Note that many non-cryptographic PRNGs will show poor quality
+    /// output if this is not adhered to. If you wish to seed from simple
+    /// numbers, use [`seed_from_u64`] instead.
+    ///
+    /// All PRNG implementations should be reproducible unless otherwise noted:
+    /// given a fixed `seed`, the same sequence of output should be produced on
+    /// all runs, library versions and architectures (e.g. check endianness).
+    /// Any "value-breaking" changes to the generator should require bumping at
+    /// least the minor version and documentation of the change.
+    ///
+    /// It is not required that this function yield the same state as a
+    /// reference implementation of the PRNG given equivalent seed; if necessary
+    /// another constructor replicating behaviour from a reference
+    /// implementation can be added.
+    ///
+    /// PRNG implementations should make sure `from_seed` never panics. In the
+    /// case that some special values (like an all zero seed) are not viable
+    /// seeds it is preferable to map these to alternative constant value(s),
+    /// for example `0xBAD5EEDu32` or `0x0DDB1A5E5BAD5EEDu64` ("odd biases? bad
+    /// seed"). This is assuming only a small number of values must be rejected.
+    ///
+    /// [`seed_from_u64`]: StdRng::seed_from_u64
+    #[rune::function(path = Self::from_seed)]
+    fn from_seed(seed: [u8; 32]) -> Self {
         Self {
-            inner: nanorand::Pcg64::new(),
+            inner: rand::rngs::StdRng::from_seed(seed),
         }
     }
 
-    /// Create a new RNG instance, using a custom seed.
-    fn new_seed(seed: i64) -> Self {
+    /// Create a new PRNG using a `u64` seed.
+    ///
+    /// This is a convenience-wrapper around `from_seed` to allow construction
+    /// of any `SeedableRng` from a simple `u64` value. It is designed such that
+    /// low Hamming Weight numbers like 0 and 1 can be used and should still
+    /// result in good, independent seeds to the PRNG which is returned.
+    ///
+    /// This **is not suitable for cryptography**, as should be clear given that
+    /// the input size is only 64 bits.
+    ///
+    /// Implementations for PRNGs *may* provide their own implementations of
+    /// this function, but the default implementation should be good enough for
+    /// all purposes. *Changing* the implementation of this function should be
+    /// considered a value-breaking change.
+    #[rune::function(path = Self::seed_from_u64)]
+    fn seed_from_u64(state: u64) -> Self {
         Self {
-            inner: nanorand::Pcg64::new_seed(seed as u128),
+            inner: rand::rngs::StdRng::seed_from_u64(state),
         }
-    }
-
-    /// Generate a random integer
-    fn int(&mut self) -> i64 {
-        self.inner.generate::<u64>() as i64
-    }
-
-    /// Generate a random integer within the specified range
-    fn int_range(&mut self, lower: i64, upper: i64) -> i64 {
-        self.inner.generate_range(0..(upper - lower) as u64) as i64 + lower
-    }
-}
-
-fn int() -> rune::support::Result<i64> {
-    Ok(nanorand::WyRand::new().generate::<u64>() as i64)
-}
-
-fn int_range(lower: i64, upper: i64) -> rune::support::Result<i64> {
-    Ok(nanorand::WyRand::new().generate_range(0..(upper - lower) as u64) as i64 + lower)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{int, int_range};
-
-    #[test]
-    fn test_range_is_exclusive() {
-        for _ in 0..100 {
-            assert_eq!(int_range(0, 1).unwrap(), 0);
-        }
-    }
-
-    #[test]
-    fn test_range_can_be_negative() {
-        for _ in 0..100 {
-            assert_eq!(int_range(-2, -1).unwrap(), -2);
-        }
-    }
-
-    #[test]
-    fn test_int_is_properly_signed() {
-        let mut any_negative = false;
-        let mut any_positive = false;
-
-        for _ in 0..100 {
-            let v: i64 = int().unwrap();
-            any_negative = any_negative || v < 0;
-            any_positive = any_positive || v > 0;
-        }
-
-        assert!(any_positive);
-        assert!(any_negative);
     }
 }

--- a/crates/rune/Cargo.toml
+++ b/crates/rune/Cargo.toml
@@ -77,7 +77,6 @@ similar = { version = "2.2.1", optional = true, features = ["inline", "bytes"] }
 sha2 = { version = "0.10.6", optional = true }
 base64 = { version = "0.22.0", optional = true }
 rand = { version = "0.8.5", optional = true }
-memchr = "2.7.4"
 unicode-ident = "1.0.12"
 
 [dev-dependencies]

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -919,6 +919,8 @@ rune_macros::binding! {
     #[type_of]
     impl<T> ::std::vec::Vec for crate::alloc::Vec<T>;
     #[type_of]
+    impl<T, const N: usize> ::std::vec::Vec for [T; N];
+    #[type_of]
     impl<T> ::std::vec::Vec for crate::runtime::VecTuple<T>;
     #[type_of]
     impl ::std::tuple::Tuple for crate::runtime::Tuple;

--- a/crates/rune/src/runtime/any_obj.rs
+++ b/crates/rune/src/runtime/any_obj.rs
@@ -495,8 +495,8 @@ impl AnyObj {
         vtable(self).debug(f)
     }
 
-    /// Access the underlying type id for the data.
-    pub(crate) fn type_hash(&self) -> Hash {
+    /// Access the underlying type hash for the data.
+    pub fn type_hash(&self) -> Hash {
         vtable(self).type_hash()
     }
 

--- a/crates/rune/src/runtime/value.rs
+++ b/crates/rune/src/runtime/value.rs
@@ -1452,7 +1452,7 @@ impl Value {
     ///
     /// Any empty value will cause an access error.
     #[inline]
-    pub(crate) fn as_any(&self) -> Option<&AnyObj> {
+    pub fn as_any(&self) -> Option<&AnyObj> {
         match &self.repr {
             Repr::Inline(..) => None,
             Repr::Dynamic(..) => None,

--- a/crates/rune/src/runtime/vec_tuple.rs
+++ b/crates/rune/src/runtime/vec_tuple.rs
@@ -30,7 +30,7 @@ macro_rules! impl_from_value_tuple_vec {
                 let vec = value.into_ref::<$crate::runtime::Vec>()?;
 
                 let [$($var,)*] = vec.as_slice() else {
-                    return Err(RuntimeError::new(VmErrorKind::ExpectedTupleLength {
+                    return Err(RuntimeError::new(VmErrorKind::ExpectedVecLength {
                         actual: vec.len(),
                         expected: $count,
                     }));

--- a/crates/rune/src/runtime/vm_error.rs
+++ b/crates/rune/src/runtime/vm_error.rs
@@ -835,6 +835,10 @@ pub(crate) enum VmErrorKind {
         actual: usize,
         expected: usize,
     },
+    ExpectedVecLength {
+        actual: usize,
+        expected: usize,
+    },
     ConstNotSupported {
         actual: TypeInfo,
     },
@@ -1051,6 +1055,10 @@ impl fmt::Display for VmErrorKind {
             VmErrorKind::ExpectedTupleLength { actual, expected } => write!(
                 f,
                 "Expected a tuple of length `{expected}`, but found one with length `{actual}`",
+            ),
+            VmErrorKind::ExpectedVecLength { actual, expected } => write!(
+                f,
+                "Expected a vector of length `{expected}`, but found one with length `{actual}`",
             ),
             VmErrorKind::ConstNotSupported { actual } => {
                 write!(f, "Type `{actual}` can't be converted to a constant value")

--- a/crates/rune/src/shared/fixed_vec.rs
+++ b/crates/rune/src/shared/fixed_vec.rs
@@ -43,6 +43,7 @@ impl<T, const N: usize> FixedVec<T, N> {
     }
 
     /// Try to push an element onto the fixed vector.
+    #[inline]
     pub(crate) fn try_push(&mut self, element: T) -> alloc::Result<()> {
         if self.len >= N {
             return Err(alloc::Error::CapacityOverflow);
@@ -56,6 +57,8 @@ impl<T, const N: usize> FixedVec<T, N> {
         Ok(())
     }
 
+    /// Clear the fixed vector.
+    #[inline]
     pub(crate) fn clear(&mut self) {
         if self.len == 0 {
             return;

--- a/scripts/rand.rn
+++ b/scripts/rand.rn
@@ -1,11 +1,15 @@
-let rng = rand::WyRand::new();
-let rand_int = rng.int();
-println!("Random int: {}", rand_int);
-let rand_int_range = rng.int_range(-100, 100);
-println!("Random int between -100 and 100: {}", rand_int_range);
+let rng = rand::SmallRng::try_from_os_rng()?;
+let v = rng.random::<u64>();
+println!("Random u64: {v}");
+let v = rng.random_range::<i64>(-100..100);
+println!("Random i64 in range: {v}");
+let v = rng.random::<char>();
+println!("Random char: {v:?}");
 
-let rng = rand::Pcg64::new();
-let rand_int = rng.int();
-println!("Random int: {}", rand_int);
-let rand_int_range = rng.int_range(-100, 100);
-println!("Random int between -100 and 100: {}", rand_int_range);
+let rng = rand::StdRng::try_from_os_rng()?;
+let v = rng.random::<u64>();
+println!("Random u64: {v}");
+let v = rng.random_range::<i64>(-100..100);
+println!("Random i64 in range: {v}");
+let v = rng.random_range::<char>('a'..'z');
+println!("Random char between 'a' and 'z': {v:?}");


### PR DESCRIPTION
This ensures we provide the same API as rand and improves documentation and makes it easier to add support for more randomly generated types.

The `Rng` trait hasn't been implemented yet, since we cannot define external protocols.