### PR TITLE
rune: Handle diverging if statement (fixes #952)

### DIFF
--- a/crates/rune/tests/diverging.rn
+++ b/crates/rune/tests/diverging.rn
@@ -34,3 +34,36 @@ fn diverging_condition_match() {
 
     assert!(inner());
 }
+
+#[test]
+fn divering_if_branches() {
+    fn inner(cond) {
+        if cond == 0 {
+            return 1;
+        } else {
+            return 2;
+        }
+    }
+
+    assert_eq!(inner(0), 1);
+    assert_eq!(inner(1), 2);
+    assert_eq!(inner(2), 2);
+}
+
+#[test]
+fn divering_if_else() {
+    fn inner(cond) {
+        if cond == 0 {
+            return 1;
+        } else if cond == 1 {
+            return 2;
+        } else {
+            return 3;
+        }
+    }
+
+    assert_eq!(inner(0), 1);
+    assert_eq!(inner(1), 2);
+    assert_eq!(inner(2), 3);
+    assert_eq!(inner(3), 3);
+}

--- a/crates/rune/tests/ifs.rn
+++ b/crates/rune/tests/ifs.rn
@@ -28,3 +28,78 @@ fn test_control_flow() {
     assert_eq!(foo(0), "less than one");
     assert_eq!(foo(10), "something else");
 }
+
+#[test]
+fn converging_if_branches() {
+    fn inner1(cond) {
+        if cond == 0 {
+            1
+        } else {
+            return 2;
+        }
+    }
+
+    assert_eq!(inner1(0), 1);
+    assert_eq!(inner1(1), 2);
+    assert_eq!(inner1(2), 2);
+
+    fn inner2(cond) {
+        if cond == 0 {
+            return 1;
+        } else {
+            2
+        }
+    }
+
+    assert_eq!(inner2(0), 1);
+    assert_eq!(inner2(1), 2);
+    assert_eq!(inner2(2), 2);
+}
+
+#[test]
+fn converging_if_else() {
+    fn inner1(cond) {
+        if cond == 0 {
+            1
+        } else if cond == 1 {
+            return 2;
+        } else {
+            return 3;
+        }
+    }
+
+    assert_eq!(inner1(0), 1);
+    assert_eq!(inner1(1), 2);
+    assert_eq!(inner1(2), 3);
+    assert_eq!(inner1(3), 3);
+
+    fn inner2(cond) {
+        if cond == 0 {
+            return 1;
+        } else if cond == 1 {
+            2
+        } else {
+            return 3;
+        }
+    }
+
+    assert_eq!(inner2(0), 1);
+    assert_eq!(inner2(1), 2);
+    assert_eq!(inner2(2), 3);
+    assert_eq!(inner2(3), 3);
+
+    fn inner3(cond) {
+        if cond == 0 {
+            return 1;
+        } else if cond == 1 {
+            return 2;
+        } else {
+            3
+        }
+    }
+
+    assert_eq!(inner3(0), 1);
+    assert_eq!(inner3(1), 2);
+    assert_eq!(inner3(2), 3);
+    assert_eq!(inner3(3), 3);
+}


### PR DESCRIPTION
This fixes #952 which incorrectly returned a converging assembly for if statements which diverges, like these:

```rust
let value = if cond {
    return 0;
} else {
    return 1;
};

value + 1
```

In the statement above `value` diverges and `value + 1` should not generate any instructions since no code paths can provide a value for it. But we currently treat it like it does produce a value resulting in `value` being associated with an uninhabited slot.