### PR TITLE
Fix clippy lints

### DIFF
--- a/crates/rune-alloc/src/btree/map/tests.rs
+++ b/crates/rune-alloc/src/btree/map/tests.rs
@@ -116,7 +116,7 @@ impl<K, V> BTreeMap<K, V> {
         let mut keys = self.keys();
         if let Some(mut previous) = keys.next() {
             for next in keys {
-                assert!(previous < next, "{:?} >= {:?}", previous, next);
+                assert!(previous < next, "{previous:?} >= {next:?}");
                 previous = next;
             }
         }

--- a/crates/rune-alloc/src/hashbrown/map.rs
+++ b/crates/rune-alloc/src/hashbrown/map.rs
@@ -8104,7 +8104,7 @@ mod test_map {
         map.insert(2, 1);
         map.insert(3, 4);
 
-        #[allow(clippy::no_effect)] // false positive lint
+        #[allow(clippy::no_effect, clippy::unnecessary_operation)] // false positive lint
         map[&4];
     }
 
@@ -9265,7 +9265,7 @@ mod test_map {
             }
 
             for (k, v) in map {
-                println!("{}, {}", k, v);
+                println!("{k}, {v}");
             }
         }
 
@@ -9375,8 +9375,7 @@ mod test_map {
             for ((key, value), (panic_in_clone, panic_in_drop)) in guard.iter().zip(iter) {
                 if *key != check_count {
                     return Err(format!(
-                        "key != check_count,\nkey: `{}`,\ncheck_count: `{}`",
-                        key, check_count
+                        "key != check_count,\nkey: `{key}`,\ncheck_count: `{check_count}`",
                     ));
                 }
                 if value.dropped
@@ -9403,8 +9402,7 @@ mod test_map {
 
             if count != check_count {
                 return Err(format!(
-                    "count != check_count,\ncount: `{}`,\ncheck_count: `{}`",
-                    count, check_count
+                    "count != check_count,\ncount: `{count}`,\ncheck_count: `{check_count}`",
                 ));
             }
             core::mem::forget(guard);

--- a/crates/rune-cli/build.rs
+++ b/crates/rune-cli/build.rs
@@ -15,7 +15,7 @@ fn main() -> anyhow::Result<()> {
             .output()?;
 
         let rev = std::str::from_utf8(&output.stdout)?.trim();
-        format!("git-{}", rev)
+        format!("git-{rev}")
     };
 
     fs::write(out_dir.join("version.txt"), version).context("writing version.txt")?;

--- a/crates/rune-core/src/item/component.rs
+++ b/crates/rune-core/src/item/component.rs
@@ -54,9 +54,9 @@ impl TryClone for Component {
 impl fmt::Display for Component {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Crate(s) => write!(fmt, "::{}", s),
-            Self::Str(s) => write!(fmt, "{}", s),
-            Self::Id(n) => write!(fmt, "${}", n),
+            Self::Crate(s) => write!(fmt, "::{s}"),
+            Self::Str(s) => write!(fmt, "{s}"),
+            Self::Id(n) => write!(fmt, "${n}"),
         }
     }
 }

--- a/crates/rune-core/src/item/component_ref.rs
+++ b/crates/rune-core/src/item/component_ref.rs
@@ -52,9 +52,9 @@ impl<'a> ComponentRef<'a> {
 impl fmt::Display for ComponentRef<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Crate(s) => write!(fmt, "::{}", s),
-            Self::Str(s) => write!(fmt, "{}", s),
-            Self::Id(n) => write!(fmt, "${}", n),
+            Self::Crate(s) => write!(fmt, "::{s}"),
+            Self::Str(s) => write!(fmt, "{s}"),
+            Self::Id(n) => write!(fmt, "${n}"),
         }
     }
 }

--- a/crates/rune-core/src/item/item.rs
+++ b/crates/rune-core/src/item/item.rs
@@ -468,7 +468,7 @@ impl fmt::Display for Item {
 
 impl fmt::Debug for Item {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{self}")
     }
 }
 
@@ -536,7 +536,7 @@ impl fmt::Display for Unqualified<'_> {
                 }
             }
 
-            write!(f, "{}", last)?;
+            write!(f, "{last}")?;
         } else {
             f.write_str("{root}")?;
         }

--- a/crates/rune-core/src/item/item_buf.rs
+++ b/crates/rune-core/src/item/item_buf.rs
@@ -275,7 +275,7 @@ where
 {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.content.cmp(&other.content))
+        Some(self.cmp(other))
     }
 }
 

--- a/crates/rune-languageserver/build.rs
+++ b/crates/rune-languageserver/build.rs
@@ -15,7 +15,7 @@ fn main() -> anyhow::Result<()> {
             .output()?;
 
         let rev = std::str::from_utf8(&output.stdout)?.trim();
-        format!("git-{}", rev)
+        format!("git-{rev}")
     };
 
     fs::write(out_dir.join("version.txt"), version).context("writing version.txt")?;

--- a/crates/rune-languageserver/src/main.rs
+++ b/crates/rune-languageserver/src/main.rs
@@ -60,7 +60,7 @@ fn main() -> Result<()> {
     for arg in it {
         match arg.as_str() {
             "--version" => {
-                println!("Rune language server {}", VERSION);
+                println!("Rune language server {VERSION}");
                 return Ok(());
             }
             "language-server" => {

--- a/crates/rune-macros/src/context.rs
+++ b/crates/rune-macros/src/context.rs
@@ -706,7 +706,7 @@ impl Context {
                         other => {
                             return Err(syn::Error::new(
                                 meta.input.span(),
-                                format!("Unsupported `#[rune(parse = ..)]` argument `{}`", other),
+                                format!("Unsupported `#[rune(parse = ..)]` argument `{other}`"),
                             ));
                         }
                     };

--- a/crates/rune-macros/src/to_tokens.rs
+++ b/crates/rune-macros/src/to_tokens.rs
@@ -236,7 +236,7 @@ impl Expander<'_> {
         let Tokens { to_tokens, .. } = &self.tokens;
 
         for (n, field) in named.unnamed.iter().enumerate() {
-            let ident = syn::Ident::new(&format!("f{}", n), field.span());
+            let ident = syn::Ident::new(&format!("f{n}"), field.span());
             let attrs = self.cx.field_attrs(&field.attrs);
 
             idents.push(ident.clone());

--- a/crates/rune-wasm/src/lib.rs
+++ b/crates/rune-wasm/src/lib.rs
@@ -227,7 +227,7 @@ async fn inner_compile(
                                         kind: WasmDiagnosticKind::Error,
                                         start,
                                         end,
-                                        message: format!("missing function (hash: {})", hash),
+                                        message: format!("missing function (hash: {hash})"),
                                     });
                                 }
                             }

--- a/crates/rune/src/ast/token.rs
+++ b/crates/rune/src/ast/token.rs
@@ -30,11 +30,11 @@ impl Token {
             }
             Kind::Ident(s) => {
                 let literal = cx.literal_source(*s, self.span).ok_or(fmt::Error)?;
-                write!(f, "{}", literal)?;
+                write!(f, "{literal}")?;
             }
             Kind::Label(s) => {
                 let literal = cx.literal_source(*s, self.span).ok_or(fmt::Error)?;
-                write!(f, "'{}", literal)?;
+                write!(f, "'{literal}")?;
             }
             Kind::Byte(s) => match s {
                 CopySource::Text(source_id) => {
@@ -44,10 +44,10 @@ impl Token {
                         .sources
                         .source(*source_id, self.span)
                         .ok_or(fmt::Error)?;
-                    write!(f, "{}", s)?;
+                    write!(f, "{s}")?;
                 }
                 CopySource::Inline(b) => {
-                    write!(f, "{:?}", b)?;
+                    write!(f, "{b:?}")?;
                 }
             },
             Kind::ByteStr(s) => match s {
@@ -65,7 +65,7 @@ impl Token {
                         .source(text.source_id, span)
                         .ok_or(fmt::Error)?;
 
-                    write!(f, "b\"{}\"", s)?;
+                    write!(f, "b\"{s}\"")?;
                 }
                 StrSource::Synthetic(id) => {
                     let b = cx.idx.q.storage.get_byte_string(*id).ok_or(fmt::Error)?;
@@ -86,11 +86,11 @@ impl Token {
                         .sources
                         .source(text.source_id, span)
                         .ok_or(fmt::Error)?;
-                    write!(f, "\"{}\"", s)?;
+                    write!(f, "\"{s}\"")?;
                 }
                 StrSource::Synthetic(id) => {
                     let s = cx.idx.q.storage.get_string(*id).ok_or(fmt::Error)?;
-                    write!(f, "{:?}", s)?;
+                    write!(f, "{s:?}")?;
                 }
             },
             Kind::Char(s) => match s {
@@ -101,10 +101,10 @@ impl Token {
                         .sources
                         .source(*source_id, self.span)
                         .ok_or(fmt::Error)?;
-                    write!(f, "{}", s)?;
+                    write!(f, "{s}")?;
                 }
                 CopySource::Inline(c) => {
-                    write!(f, "{:?}", c)?;
+                    write!(f, "{c:?}")?;
                 }
             },
             Kind::Number(s) => match s {
@@ -115,16 +115,16 @@ impl Token {
                         .sources
                         .source(text.source_id, self.span)
                         .ok_or(fmt::Error)?;
-                    write!(f, "{}", s)?;
+                    write!(f, "{s}")?;
                 }
                 NumberSource::Synthetic(id) => {
                     let n = cx.idx.q.storage.get_number(*id).ok_or(fmt::Error)?;
-                    write!(f, "{}", n)?;
+                    write!(f, "{n}")?;
                 }
             },
             other => {
                 let s = other.as_literal_str().ok_or(fmt::Error)?;
-                write!(f, "{}", s)?;
+                write!(f, "{s}")?;
             }
         }
 
@@ -366,8 +366,8 @@ impl From<f64> for Number {
 impl fmt::Display for Number {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.value {
-            NumberValue::Float(n) => write!(f, "{}", n),
-            NumberValue::Integer(n) => write!(f, "{}", n),
+            NumberValue::Float(n) => write!(f, "{n}"),
+            NumberValue::Integer(n) => write!(f, "{n}"),
         }
     }
 }

--- a/crates/rune/src/cli/benches.rs
+++ b/crates/rune/src/cli/benches.rs
@@ -86,7 +86,7 @@ pub(super) async fn run(
         let mut bencher = Bencher::default();
 
         if let Err(error) = vm.call(*hash, (&mut bencher,)) {
-            writeln!(io.stdout, "{}: Error in benchmark", item)?;
+            writeln!(io.stdout, "{item}: Error in benchmark")?;
             error.emit(io.stdout, sources)?;
             any_error = true;
 
@@ -116,7 +116,7 @@ pub(super) async fn run(
             };
 
             if let Err(e) = bench_fn(io, item, args, f) {
-                writeln!(io.stdout, "{}: Error in bench iteration: {}", item, e)?;
+                writeln!(io.stdout, "{item}: Error in bench iteration: {e}")?;
 
                 if let Some(capture_io) = capture_io {
                     if !capture_io.is_empty() {

--- a/crates/rune/src/cli/format.rs
+++ b/crates/rune/src/cli/format.rs
@@ -180,28 +180,28 @@ where
 
     if shared.verbose && unchanged > 0 {
         io.stdout.set_color(&col.green)?;
-        write!(io.stdout, "{}", unchanged)?;
+        write!(io.stdout, "{unchanged}")?;
         io.stdout.reset()?;
         writeln!(io.stdout, " unchanged")?;
     }
 
     if shared.verbose && changed > 0 {
         io.stdout.set_color(&col.yellow)?;
-        write!(io.stdout, "{}", changed)?;
+        write!(io.stdout, "{changed}")?;
         io.stdout.reset()?;
         writeln!(io.stdout, " changed")?;
     }
 
     if shared.verbose || failed > 0 {
         io.stdout.set_color(&col.red)?;
-        write!(io.stdout, "{}", failed)?;
+        write!(io.stdout, "{failed}")?;
         io.stdout.reset()?;
         writeln!(io.stdout, " failed")?;
     }
 
     if shared.verbose || failed_builds > 0 {
         io.stdout.set_color(&col.red)?;
-        write!(io.stdout, "{}", failed_builds)?;
+        write!(io.stdout, "{failed_builds}")?;
         io.stdout.reset()?;
         writeln!(io.stdout, " failed builds")?;
     }

--- a/crates/rune/src/cli/mod.rs
+++ b/crates/rune/src/cli/mod.rs
@@ -173,7 +173,7 @@ impl<'a> Entry<'a> {
                     o.write_all(about.as_bytes())?;
                     writeln!(o)?;
                     writeln!(o)?;
-                    writeln!(o, "{}", e)?;
+                    writeln!(o, "{e}")?;
                     o.flush()?;
                     ExitCode::Failure
                 } else {
@@ -182,7 +182,7 @@ impl<'a> Entry<'a> {
                     o.write_all(about.as_bytes())?;
                     writeln!(o)?;
                     writeln!(o)?;
-                    writeln!(o, "{}", e)?;
+                    writeln!(o, "{e}")?;
                     o.flush()?;
                     ExitCode::Success
                 };
@@ -719,10 +719,10 @@ fn format_errors<O>(o: &mut O, error: &Error) -> io::Result<()>
 where
     O: ?Sized + io::Write,
 {
-    writeln!(o, "Error: {}", error)?;
+    writeln!(o, "Error: {error}")?;
 
     for error in error.chain().skip(1) {
-        writeln!(o, "Caused by: {}", error)?;
+        writeln!(o, "Caused by: {error}")?;
     }
 
     Ok(())

--- a/crates/rune/src/cli/run.rs
+++ b/crates/rune/src/cli/run.rs
@@ -166,7 +166,7 @@ pub(super) async fn run(
         writeln!(io.stdout, "# types")?;
 
         for (i, (hash, ty)) in context.iter_types().enumerate() {
-            writeln!(io.stdout, "{:04} = {} ({})", i, ty, hash)?;
+            writeln!(io.stdout, "{i:04} = {ty} ({hash})")?;
         }
     }
 
@@ -195,9 +195,9 @@ pub(super) async fn run(
 
             for (hash, kind) in functions {
                 if let Some(signature) = unit.debug_info().and_then(|d| d.functions.get(&hash)) {
-                    writeln!(io.stdout, "{} = {}", hash, signature)?;
+                    writeln!(io.stdout, "{hash} = {signature}")?;
                 } else {
-                    writeln!(io.stdout, "{} = {}", hash, kind)?;
+                    writeln!(io.stdout, "{hash} = {kind}")?;
                 }
             }
         }
@@ -222,7 +222,7 @@ pub(super) async fn run(
             writeln!(io.stdout, "# object keys")?;
 
             for (hash, keys) in keys {
-                writeln!(io.stdout, "{} = {:?}", hash, keys)?;
+                writeln!(io.stdout, "{hash} = {keys:?}")?;
             }
         }
 
@@ -320,7 +320,7 @@ pub(super) async fn run(
 
             let values = stack.get(frame.top..stack_top).expect("bad stack slice");
 
-            writeln!(io.stdout, "  frame #{} (+{})", count, frame.top)?;
+            writeln!(io.stdout, "  frame #{count} (+{})", frame.top)?;
 
             if values.is_empty() {
                 writeln!(io.stdout, "    *empty*")?;
@@ -382,13 +382,13 @@ where
         }
 
         if let Some((hash, signature)) = vm.unit().debug_info().and_then(|d| d.function_at(ip)) {
-            writeln!(o, "fn {} ({}):", signature, hash)?;
+            writeln!(o, "fn {signature} ({hash}):")?;
         }
 
         let debug = vm.unit().debug_info().and_then(|d| d.instruction_at(ip));
 
         for label in debug.map(|d| d.labels.as_slice()).unwrap_or_default() {
-            writeln!(o, "{}:", label)?;
+            writeln!(o, "{label}:")?;
         }
 
         if dump_stack {
@@ -414,13 +414,13 @@ where
         }
 
         if let Some((inst, _)) = vm.unit().instruction_at(ip).map_err(VmError::from)? {
-            write!(o, "  {:04} = {}", ip, inst)?;
+            write!(o, "  {ip:04} = {inst}")?;
         } else {
-            write!(o, "  {:04} = *out of bounds*", ip)?;
+            write!(o, "  {ip:04} = *out of bounds*")?;
         }
 
         if let Some(comment) = debug.and_then(|d| d.comment.as_ref()) {
-            write!(o, " // {}", comment)?;
+            write!(o, " // {comment}")?;
         }
 
         writeln!(o)?;

--- a/crates/rune/src/compile/error.rs
+++ b/crates/rune/src/compile/error.rs
@@ -954,8 +954,6 @@ impl fmt::Display for ErrorKind {
                 write!(
                     f,
                     "Missing static object keys for hash `{hash}` and slot `{slot}`",
-                    hash = hash,
-                    slot = slot
                 )?;
             }
             ErrorKind::StaticObjectKeysHashConflict {
@@ -1062,7 +1060,7 @@ impl fmt::Display for ErrorKind {
                 write!(f, "Expected byte literal to be closed")?;
             }
             ErrorKind::UnexpectedChar { c } => {
-                write!(f, "Unexpected character `{c}`", c = c)?;
+                write!(f, "Unexpected character `{c}`")?;
             }
             ErrorKind::PrecedenceGroupRequired => {
                 write!(f, "Group required in expression to determine precedence")?;
@@ -1148,7 +1146,7 @@ impl fmt::Display for ErrorKind {
                 write!(f, "Cycle in import")?;
             }
             ErrorKind::ImportRecursionLimit { count, .. } => {
-                write!(f, "Import recursion limit reached ({count})", count = count)?;
+                write!(f, "Import recursion limit reached ({count})")?;
             }
             ErrorKind::LastUseComponent => {
                 write!(f, "Missing last use component")?;
@@ -1159,16 +1157,11 @@ impl fmt::Display for ErrorKind {
             ErrorKind::TypeRttiConflict { hash } => {
                 write!(
                     f,
-                    "Tried to insert runtime type information, but conflicted with hash `{hash}`",
-                    hash = hash
+                    "Tried to insert runtime type information, but conflicted with hash `{hash}`"
                 )?;
             }
             ErrorKind::ArenaWriteSliceOutOfBounds { index } => {
-                write!(
-                    f,
-                    "Writing arena slice out of bounds for index {index}",
-                    index = index
-                )?;
+                write!(f, "Writing arena slice out of bounds for index {index}")?;
             }
             ErrorKind::ArenaAllocError { requested } => {
                 write!(f, "Allocation error for {requested} bytes")?;

--- a/crates/rune/src/compile/meta.rs
+++ b/crates/rune/src/compile/meta.rs
@@ -558,7 +558,7 @@ impl fmt::Display for AssociatedKind {
             AssociatedKind::IndexFn(protocol, index) => {
                 write!(f, ".{index}<{}>", protocol.name)
             }
-            AssociatedKind::Instance(name) => write!(f, "{}", name),
+            AssociatedKind::Instance(name) => write!(f, "{name}"),
         }
     }
 }

--- a/crates/rune/src/compile/unit_builder.rs
+++ b/crates/rune/src/compile/unit_builder.rs
@@ -864,28 +864,28 @@ impl UnitBuilder {
 
             match inst {
                 AssemblyInst::Jump { label } => {
-                    write!(comment, "label:{}", label)?;
+                    write!(comment, "label:{label}")?;
                     let jump = build_label(label)?;
                     storage
                         .encode(Inst::new(inst::Kind::Jump { jump }))
                         .with_span(span)?;
                 }
                 AssemblyInst::JumpIf { addr, label } => {
-                    write!(comment, "label:{}", label)?;
+                    write!(comment, "label:{label}")?;
                     let jump = build_label(label)?;
                     storage
                         .encode(Inst::new(inst::Kind::JumpIf { cond: addr, jump }))
                         .with_span(span)?;
                 }
                 AssemblyInst::JumpIfNot { addr, label } => {
-                    write!(comment, "label:{}", label)?;
+                    write!(comment, "label:{label}")?;
                     let jump = build_label(label)?;
                     storage
                         .encode(Inst::new(inst::Kind::JumpIfNot { cond: addr, jump }))
                         .with_span(span)?;
                 }
                 AssemblyInst::IterNext { addr, label, out } => {
-                    write!(comment, "label:{}", label)?;
+                    write!(comment, "label:{label}")?;
                     let jump = build_label(label)?;
                     storage
                         .encode(Inst::new(inst::Kind::IterNext { addr, jump, out }))

--- a/crates/rune/src/diagnostics/emit.rs
+++ b/crates/rune/src/diagnostics/emit.rs
@@ -222,10 +222,7 @@ impl VmError {
                     ]);
                 }
                 VmErrorKind::BadArgumentCount { actual, expected } => {
-                    notes.extend([
-                        format!("Expected `{}`", expected),
-                        format!("Got `{}`", actual),
-                    ]);
+                    notes.extend([format!("Expected `{expected}`"), format!("Got `{actual}`")]);
                 }
                 _ => {}
             };
@@ -387,17 +384,17 @@ impl Unit {
                     writeln!(out)?;
                 }
 
-                writeln!(out, "fn {} ({}):", signature, hash)?;
+                writeln!(out, "fn {signature} ({hash}):")?;
             }
 
             for label in debug.map(|d| d.labels.as_slice()).unwrap_or_default() {
-                writeln!(out, "{}:", label)?;
+                writeln!(out, "{label}:")?;
             }
 
             write!(out, "  {n:04} = {inst}")?;
 
             if let Some(comment) = debug.and_then(|d| d.comment.as_ref()) {
-                write!(out, " // {}", comment)?;
+                write!(out, " // {comment}")?;
             }
 
             writeln!(out)?;
@@ -442,7 +439,7 @@ where
             if let Some(binding) = sources.source(this.source_id(), *span) {
                 let mut note = String::new();
                 writeln!(note, "Hint: Rewrite to:")?;
-                writeln!(note, "if {} {{", binding)?;
+                writeln!(note, "if {binding} {{")?;
                 writeln!(note, "    // ..")?;
                 writeln!(note, "}}")?;
                 notes.push(note.into_std());
@@ -451,7 +448,7 @@ where
         WarningDiagnosticKind::RemoveTupleCallParams { variant, .. } => {
             if let Some(variant) = sources.source(this.source_id(), *variant) {
                 let mut note = String::new();
-                writeln!(note, "Hint: Rewrite to `{}`", variant)?;
+                writeln!(note, "Hint: Rewrite to `{variant}`")?;
                 notes.push(note.into_std());
             }
         }
@@ -506,13 +503,13 @@ where
                 Some(e) => e.try_to_string()?,
                 None => hash.try_to_string()?,
             };
-            writeln!(message, "Used deprecated function: {}", name)?;
+            writeln!(message, "Used deprecated function: {name}")?;
 
             // Deprecation message if it's availble
             if let Some(context) = context {
                 if let Some(deprecation) = context.lookup_deprecation(hash) {
                     let mut note = String::new();
-                    writeln!(note, "Deprecated: {}", deprecation)?;
+                    writeln!(note, "Deprecated: {deprecation}")?;
                     notes.push(note.into_std());
                 }
             }
@@ -558,7 +555,7 @@ where
 
     match this.kind() {
         FatalDiagnosticKind::Internal(message) => {
-            writeln!(out, "internal error: {}", message)?;
+            writeln!(out, "internal error: {message}")?;
             return Ok(());
         }
         FatalDiagnosticKind::LinkError(error) => {
@@ -574,10 +571,7 @@ where
                     }
 
                     let diagnostic = d::Diagnostic::error()
-                        .with_message(format!(
-                            "linker error: missing function with hash `{}`",
-                            hash
-                        ))
+                        .with_message(format!("linker error: missing function with hash `{hash}`",))
                         .with_labels(labels);
 
                     term::emit(out, config, sources, &diagnostic)?;
@@ -711,7 +705,7 @@ where
 
                 if let Some(binding) = binding {
                     let mut note = String::new();
-                    writeln!(note, "Hint: Rewrite to `{};`", binding)?;
+                    writeln!(note, "Hint: Rewrite to `{binding};`")?;
                     notes.push(note.into_std());
                 }
             }
@@ -740,7 +734,7 @@ where
 
                 labels.push(
                     d::Label::secondary(this.source_id(), span.range())
-                        .with_message(format!("Missing {}: {}", pl, fields)),
+                        .with_message(format!("Missing {pl}: {fields}")),
                 );
 
                 notes.push(

--- a/crates/rune/src/doc/markdown.rs
+++ b/crates/rune/src/doc/markdown.rs
@@ -117,7 +117,7 @@ where
                     escape_html(&mut self.out, &name)?;
                     self.write("\">")?;
                     let number = *self.numbers.entry(name).or_try_insert(len)?;
-                    write!(&mut self.out, "{}", number)?;
+                    write!(&mut self.out, "{number}")?;
                     self.write("</a></sup>")?;
                 }
                 TaskListMarker(true) => {
@@ -155,7 +155,7 @@ where
             } => {
                 self.write("<")?;
 
-                write!(&mut self.out, "{}", level)?;
+                write!(&mut self.out, "{level}")?;
 
                 if let Some(id) = id {
                     self.write(" id=\"")?;
@@ -230,7 +230,7 @@ where
             }
             Tag::List(Some(start)) => {
                 self.write("<ol start=\"")?;
-                write!(&mut self.out, "{}", start)?;
+                write!(&mut self.out, "{start}")?;
                 self.write("\">")?;
             }
             Tag::List(None) => {
@@ -294,7 +294,7 @@ where
                 self.write("\"><sup class=\"footnote-definition-label\">")?;
                 let len = self.numbers.len() + 1;
                 let number = *self.numbers.entry(name).or_try_insert(len)?;
-                write!(&mut self.out, "{}", number)?;
+                write!(&mut self.out, "{number}")?;
                 self.write("</sup>")?;
             }
             Tag::HtmlBlock => {}
@@ -390,7 +390,7 @@ where
             }
             TagEnd::Heading(level) => {
                 self.write("</")?;
-                write!(&mut self.out, "{}", level)?;
+                write!(&mut self.out, "{level}")?;
                 self.write(">")?;
             }
             TagEnd::Table => {
@@ -490,7 +490,7 @@ where
                 FootnoteReference(name) => {
                     let len = self.numbers.len() + 1;
                     let number = *self.numbers.entry(name).or_try_insert(len)?;
-                    write!(self.out, "[{}]", number)?;
+                    write!(self.out, "[{number}]")?;
                 }
                 TaskListMarker(true) => self.write("[x]")?,
                 TaskListMarker(false) => self.write("[ ]")?,

--- a/crates/rune/src/hir/arena.rs
+++ b/crates/rune/src/hir/arena.rs
@@ -102,6 +102,7 @@ impl Arena {
     }
 
     /// Allocate a new object of the given type.
+    #[expect(clippy::mut_from_ref)]
     pub(crate) fn alloc<T>(&self, object: T) -> Result<&mut T, ArenaAllocError> {
         assert!(!mem::needs_drop::<T>());
 

--- a/crates/rune/src/languageserver/state.rs
+++ b/crates/rune/src/languageserver/state.rs
@@ -705,7 +705,7 @@ impl<'a> State<'a> {
 
                                 diagnostics.try_push(to_error(
                                     range,
-                                    format_args!("Missing function with hash `{}`", hash),
+                                    format_args!("Missing function with hash `{hash}`"),
                                 )?)?;
                             }
                         }

--- a/crates/rune/src/languageserver/url.rs
+++ b/crates/rune/src/languageserver/url.rs
@@ -88,7 +88,7 @@ fn path_to_file_url_segments_windows(path: &Path, buf: &mut String) -> Result<()
                 };
 
                 let host = url::Host::parse(server)?;
-                write!(buf, "{}", host)?;
+                write!(buf, "{host}")?;
                 buf.try_push('/')?;
 
                 let Some(share) = share.to_str() else {

--- a/crates/rune/src/macros/format_args.rs
+++ b/crates/rune/src/macros/format_args.rs
@@ -81,7 +81,7 @@ impl FormatArgs {
         if let Some((key, span)) = unused_named.into_iter().next() {
             return Err(compile::Error::msg(
                 span,
-                format!("unused named argument `{}`", key),
+                format!("unused named argument `{key}`"),
             ));
         }
 
@@ -542,7 +542,7 @@ fn expand_format_spec<'a>(
                         c => {
                             return Err(compile::Error::msg(
                                 span,
-                                format!("unsupported char `{}` in spec", c),
+                                format!("unsupported char `{c}` in spec"),
                             ));
                         }
                     }
@@ -560,9 +560,8 @@ fn expand_format_spec<'a>(
                     return Err(compile::Error::msg(
                         span,
                         format!(
-                            "missing positional argument #{} \
+                            "missing positional argument #{count} \
                             which is required for position parameter",
-                            count
                         ),
                     ));
                 }
@@ -622,7 +621,7 @@ fn expand_format_spec<'a>(
                     None => {
                         return Err(compile::Error::msg(
                             span,
-                            format!("missing positional argument #{}", n),
+                            format!("missing positional argument #{n}"),
                         ));
                     }
                 };

--- a/crates/rune/src/modules/capture_io.rs
+++ b/crates/rune/src/modules/capture_io.rs
@@ -35,7 +35,7 @@ pub fn module(io: &CaptureIo) -> Result<Module, ContextError> {
 
     module
         .function("print", move |m: &str| {
-            write!(o.inner.lock(), "{}", m).map_err(VmError::panic)
+            write!(o.inner.lock(), "{m}").map_err(VmError::panic)
         })
         .build()?;
 
@@ -43,7 +43,7 @@ pub fn module(io: &CaptureIo) -> Result<Module, ContextError> {
 
     module
         .function("println", move |m: &str| {
-            writeln!(o.inner.lock(), "{}", m).map_err(VmError::panic)
+            writeln!(o.inner.lock(), "{m}").map_err(VmError::panic)
         })
         .build()?;
 

--- a/crates/rune/src/modules/io.rs
+++ b/crates/rune/src/modules/io.rs
@@ -102,7 +102,7 @@ fn dbg_impl(
     let mut stdout = stdout.lock();
 
     for value in memory.slice_at(addr, args)? {
-        writeln!(stdout, "{:?}", value).map_err(VmError::panic)?;
+        writeln!(stdout, "{value:?}").map_err(VmError::panic)?;
     }
 
     memory.store(out, ())?;

--- a/crates/rune/src/parse/expectation.rs
+++ b/crates/rune/src/parse/expectation.rs
@@ -33,8 +33,8 @@ impl fmt::Display for Expectation {
         match self {
             Expectation::Description(s) => s.fmt(f),
             Expectation::Keyword(k) => write!(f, "`{k}` keyword"),
-            Expectation::Delimiter(d) => write!(f, "`{}` delimiter", d),
-            Expectation::Punctuation(p) => write!(f, "`{}`", p),
+            Expectation::Delimiter(d) => write!(f, "`{d}` delimiter"),
+            Expectation::Punctuation(p) => write!(f, "`{p}`"),
             Expectation::OpenDelimiter => write!(f, "`(`, `[`, or `{{`"),
             Expectation::Boolean => write!(f, "true or false"),
             Expectation::Literal => write!(f, r#"literal like `"a string"` or 42"#),

--- a/crates/rune/src/runtime/format.rs
+++ b/crates/rune/src/runtime/format.rs
@@ -300,7 +300,7 @@ impl FormatSpec {
         match value.as_inline() {
             Some(Inline::Signed(n)) => {
                 let (n, align, fill, sign) = self.int_traits(*n);
-                write!(f.buf_mut(), "{:X}", n)?;
+                write!(f.buf_mut(), "{n:X}")?;
                 self.format_fill(f, align, fill, sign)?;
             }
             _ => {
@@ -315,7 +315,7 @@ impl FormatSpec {
         match value.as_inline() {
             Some(Inline::Signed(n)) => {
                 let (n, align, fill, sign) = self.int_traits(*n);
-                write!(f.buf_mut(), "{:x}", n)?;
+                write!(f.buf_mut(), "{n:x}")?;
                 self.format_fill(f, align, fill, sign)?;
             }
             _ => {
@@ -330,7 +330,7 @@ impl FormatSpec {
         match value.as_inline() {
             Some(Inline::Signed(n)) => {
                 let (n, align, fill, sign) = self.int_traits(*n);
-                write!(f.buf_mut(), "{:b}", n)?;
+                write!(f.buf_mut(), "{n:b}")?;
                 self.format_fill(f, align, fill, sign)?;
             }
             _ => {
@@ -404,7 +404,7 @@ where
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
-            Some(value) => write!(f, "{}", value),
+            Some(value) => write!(f, "{value}"),
             None => write!(f, "?"),
         }
     }

--- a/crates/rune/src/runtime/inst.rs
+++ b/crates/rune/src/runtime/inst.rs
@@ -1567,7 +1567,7 @@ impl fmt::Display for InstValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Unit => write!(f, "()")?,
-            Self::Bool(v) => write!(f, "{}", v)?,
+            Self::Bool(v) => write!(f, "{v}")?,
             Self::Char(v) => write!(f, "{v:?}")?,
             Self::Unsigned(v) => write!(f, "{v}u64")?,
             Self::Integer(v) => write!(f, "{v}i64")?,

--- a/crates/rune/src/runtime/tuple.rs
+++ b/crates/rune/src/runtime/tuple.rs
@@ -242,11 +242,11 @@ impl fmt::Debug for OwnedTuple {
         let last = it.next_back();
 
         for el in it {
-            write!(f, "{:?}, ", el)?;
+            write!(f, "{el:?}, ")?;
         }
 
         if let Some(last) = last {
-            write!(f, "{:?}", last)?;
+            write!(f, "{last:?}")?;
         }
 
         write!(f, ")")?;

--- a/crates/rune/src/tests/bug_344.rs
+++ b/crates/rune/src/tests/bug_344.rs
@@ -152,8 +152,7 @@ impl GuardCheck {
     fn ensure_not_dropped(&self, what: &str) {
         assert!(
             !self.dropped.get(),
-            "value has was previously dropped: {}",
-            what
+            "value has was previously dropped: {what}",
         );
     }
 }

--- a/crates/rune/src/tests/compiler_docs.rs
+++ b/crates/rune/src/tests/compiler_docs.rs
@@ -58,13 +58,13 @@ impl DocVisitor {
                 if let Some(collected) = against.get(i) {
                     assert_eq!(collected, expected, "mismatched docstring");
                 } else {
-                    panic!("missing docstrings, expected: {:?}", expected);
+                    panic!("missing docstrings, expected: {expected:?}");
                 }
             }
 
             if expected.len() < against.len() {
                 let (_, extras) = against.split_at(expected.len());
-                panic!("extra docstrings: {:?}", extras);
+                panic!("extra docstrings: {extras:?}");
             }
         }
 

--- a/crates/rune/src/tests/debug_fmt.rs
+++ b/crates/rune/src/tests/debug_fmt.rs
@@ -56,7 +56,6 @@ fn test_without_debug_fmt() {
 
     assert!(
         result.starts_with("<::native_crate::NativeStructWithoutProtocol object at 0x"),
-        "Expected '<::native_crate::NativeStructWithoutProtocol object at 0x', got: {:?}",
-        result
+        "Expected '<::native_crate::NativeStructWithoutProtocol object at 0x', got: {result:?}",
     );
 }

--- a/crates/rune/src/tests/rename_type.rs
+++ b/crates/rune/src/tests/rename_type.rs
@@ -18,7 +18,7 @@ fn test_rename() -> Result<()> {
             assert_eq!(item, ItemBuf::with_item(["Bar"])?);
         }
         actual => {
-            panic!("Expected conflicting type but got: {:?}", actual);
+            panic!("Expected conflicting type but got: {actual:?}");
         }
     }
 

--- a/examples/examples/checked_add_assign.rs
+++ b/examples/examples/checked_add_assign.rs
@@ -55,7 +55,7 @@ fn main() -> rune::support::Result<()> {
 
     let input = External { value: i64::MAX };
     let err = vm.call(["main"], (input,)).unwrap_err();
-    println!("{:?}", err);
+    println!("{err:?}");
     Ok(())
 }
 

--- a/examples/examples/custom_instance_fn.rs
+++ b/examples/examples/custom_instance_fn.rs
@@ -40,7 +40,7 @@ async fn main() -> rune::support::Result<()> {
     let output = vm.execute(["main"], (33i64,))?.complete()?;
     let output: i64 = rune::from_value(output)?;
 
-    println!("output: {}", output);
+    println!("output: {output}");
     Ok(())
 }
 

--- a/examples/examples/custom_mul.rs
+++ b/examples/examples/custom_mul.rs
@@ -48,7 +48,7 @@ fn main() -> rune::support::Result<()> {
     let output = vm.call(["main"], (Foo { field: 5 },))?;
     let output: Foo = rune::from_value(output)?;
 
-    println!("output: {:?}", output);
+    println!("output: {output:?}");
     Ok(())
 }
 

--- a/examples/examples/external_enum.rs
+++ b/examples/examples/external_enum.rs
@@ -59,19 +59,19 @@ fn main() -> rune::support::Result<()> {
 
     let output = vm.call(["main"], (External::First(42),))?;
     let output: External = rune::from_value(output)?;
-    println!("{:?}", output);
+    println!("{output:?}");
 
     let output = vm.call(["main"], (External::Second(42, 12345),))?;
     let output: External = rune::from_value(output)?;
-    println!("{:?}", output);
+    println!("{output:?}");
 
     let output = vm.call(["main"], (External::Third,))?;
     let output: External = rune::from_value(output)?;
-    println!("{:?}", output);
+    println!("{output:?}");
 
     let output = vm.call(["main"], (External::Fourth { a: 42, b: 2 },))?;
     let output: External = rune::from_value(output)?;
-    println!("{:?}", output);
+    println!("{output:?}");
     Ok(())
 }
 

--- a/examples/examples/external_struct.rs
+++ b/examples/examples/external_struct.rs
@@ -62,7 +62,7 @@ fn main() -> rune::support::Result<()> {
 
     let output = vm.call(["main"], (Request { url: "/".into() },))?;
     let output: Response = rune::from_value(output)?;
-    println!("{:?}", output);
+    println!("{output:?}");
 
     let output = vm.call(
         ["main"],
@@ -71,7 +71,7 @@ fn main() -> rune::support::Result<()> {
         },),
     )?;
     let output: Response = rune::from_value(output)?;
-    println!("{:?}", output);
+    println!("{output:?}");
 
     Ok(())
 }

--- a/examples/examples/hot_reloading.rs
+++ b/examples/examples/hot_reloading.rs
@@ -42,12 +42,12 @@ async fn main() -> Result<()> {
             match event.kind {
                 path_reloader::EventKind::Added => {
                     if let Err(error) = vm.call(["hello"], ()) {
-                        println!("Error: {}", error);
+                        println!("Error: {error}");
                     }
                 }
                 path_reloader::EventKind::Removed => {
                     if let Err(error) = vm.call(["goodbye"], ()) {
-                        println!("Error: {}", error);
+                        println!("Error: {error}");
                     }
                 }
             }

--- a/examples/examples/minimal.rs
+++ b/examples/examples/minimal.rs
@@ -33,6 +33,6 @@ fn main() -> rune::support::Result<()> {
     let output = vm.execute(["main"], (33i64,))?.complete()?;
     let output: i64 = rune::from_value(output)?;
 
-    println!("output: {}", output);
+    println!("output: {output}");
     Ok(())
 }

--- a/examples/examples/native_function.rs
+++ b/examples/examples/native_function.rs
@@ -37,7 +37,7 @@ fn main() -> rune::support::Result<()> {
     let output = vm.call(["main"], (1u32,))?;
     let output: i64 = rune::from_value(output)?;
 
-    println!("{}", output);
+    println!("{output}");
     Ok(())
 }
 

--- a/examples/examples/parsing_in_macro.rs
+++ b/examples/examples/parsing_in_macro.rs
@@ -41,7 +41,7 @@ pub fn main() -> rune::support::Result<()> {
     let output = vm.execute(["main"], ())?.complete()?;
     let output: (u32, u32) = rune::from_value(output)?;
 
-    println!("{:?}", output);
+    println!("{output:?}");
     Ok(())
 }
 

--- a/examples/examples/references.rs
+++ b/examples/examples/references.rs
@@ -52,6 +52,6 @@ fn main() -> rune::support::Result<()> {
 
     let mut foo = Foo::default();
     let _ = vm.call(["main"], (&mut foo,))?;
-    println!("{:?}", foo);
+    println!("{foo:?}");
     Ok(())
 }

--- a/examples/examples/rune_function_macro.rs
+++ b/examples/examples/rune_function_macro.rs
@@ -37,7 +37,7 @@ fn main() -> rune::support::Result<()> {
     let output = vm.call(["main"], (1u32,))?;
     let output: i64 = rune::from_value(output)?;
 
-    println!("{}", output);
+    println!("{output}");
     Ok(())
 }
 

--- a/examples/examples/simple_external.rs
+++ b/examples/examples/simple_external.rs
@@ -47,7 +47,7 @@ fn main() -> rune::support::Result<()> {
 
     let output = vm.call(["main"], (External { value: 42 },))?;
     let output: External = rune::from_value(output)?;
-    println!("{:?}", output);
+    println!("{output:?}");
     assert_eq!(output.value, 42);
     Ok(())
 }

--- a/examples/examples/tuple.rs
+++ b/examples/examples/tuple.rs
@@ -33,6 +33,6 @@ fn main() -> rune::support::Result<()> {
     let output = vm.call(["calc"], ((1u32, 2u32),))?;
     let output: (i32, i32) = rune::from_value(output)?;
 
-    println!("{:?}", output);
+    println!("{output:?}");
     Ok(())
 }

--- a/examples/examples/vec_args.rs
+++ b/examples/examples/vec_args.rs
@@ -42,7 +42,7 @@ fn main() -> rune::support::Result<()> {
     let output = vm.call(["main"], ())?;
     let output: u32 = rune::from_value(output)?;
 
-    println!("{}", output);
+    println!("{output}");
     Ok(())
 }
 

--- a/examples/examples/vec_tuple.rs
+++ b/examples/examples/vec_tuple.rs
@@ -37,6 +37,6 @@ fn main() -> rune::support::Result<()> {
     let output = vm.call(["calc"], (input,))?;
     let VecTuple((a, b)): VecTuple<(u32, String)> = rune::from_value(output)?;
 
-    println!("({:?}, {:?})", a, b);
+    println!("({a:?}, {b:?})");
     Ok(())
 }

--- a/examples/examples/vector.rs
+++ b/examples/examples/vector.rs
@@ -40,6 +40,6 @@ fn main() -> rune::support::Result<()> {
     let output = vm.call(["calc"], (input,))?;
     let output: Vec<i64> = rune::from_value(output)?;
 
-    println!("{:?}", output);
+    println!("{output:?}");
     Ok(())
 }

--- a/tools/builder/src/main.rs
+++ b/tools/builder/src/main.rs
@@ -270,8 +270,8 @@ impl Build {
 impl fmt::Display for Build {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Channel(channel) => write!(f, "{}", channel)?,
-            Self::Version(version) => write!(f, "{}", version)?,
+            Self::Channel(channel) => write!(f, "{channel}")?,
+            Self::Version(version) => write!(f, "{version}")?,
         }
 
         Ok(())

--- a/tools/site/src/main.rs
+++ b/tools/site/src/main.rs
@@ -18,7 +18,7 @@ fn main() -> Result<()> {
     let bin = target.join("zola");
 
     if !bin.is_file() {
-        println!("Downloading: {}", url);
+        println!("Downloading: {url}");
         let bytes = reqwest::blocking::get(&url)?.bytes()?;
         let decoder = GzDecoder::new(io::Cursor::new(bytes.as_ref()));
         let mut archive = Archive::new(decoder);


### PR DESCRIPTION
The latest set of clippy diagnostics includes `uninlined_format_args`, which hits a lot of places in the codebase 😅

I also added `clippy::unnecessary_operation` to the `#[allow(clippy::no_effect)]` in `crates/rune-alloc/src/hashbrown/map.rs` and added an `#[expect(clippy::mut_from_ref)]` in `crates/rune/src/hir/arena.rs` (which seems to be the intended behavior).