### PR TITLE
Add constant vec example

### DIFF
--- a/crates/rune/src/module/module.rs
+++ b/crates/rune/src/module/module.rs
@@ -319,6 +319,9 @@ impl Module {
     ///         /// A global ten value.
     ///     });
     ///
+    /// module.constant("VEC", [1, 2, 3].as_slice())
+    ///     .build()?;
+    ///
     /// module.constant("TEN", 10)
     ///     .build_associated::<MyType>()?
     ///     .docs(docstring! {


### PR DESCRIPTION
I struggled quite a while trying create a vec constant with v0.14.0 as neither `vec![1, 2, 3]`, `[1, 2, 3]`, `&[1, 2, 3]`, `ConstValue::from(...)` and many more didn't work.