### PR TITLE
rune: Make languageserver reading re-entrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /flamegraph.svg
 /perf.data
 /perf.data.*
+/*.log

--- a/crates/rune/src/languageserver/envelope.rs
+++ b/crates/rune/src/languageserver/envelope.rs
@@ -15,11 +15,11 @@ pub(super) enum RequestId {
 }
 
 #[derive(Debug, TryClone, Deserialize)]
-pub(super) struct IncomingMessage {
+pub(super) struct IncomingMessage<'a> {
     #[allow(unused)]
     pub(super) jsonrpc: V2,
     pub(super) id: Option<RequestId>,
-    pub(super) method: String,
+    pub(super) method: &'a str,
     #[serde(default)]
     #[try_clone(with = Clone::clone)]
     pub(super) params: serde_json::Value,

--- a/crates/rune/src/languageserver/state.rs
+++ b/crates/rune/src/languageserver/state.rs
@@ -560,10 +560,6 @@ impl<'a> State<'a> {
         }
 
         for (url, diagnostics) in reporter.by_url {
-            if diagnostics.is_empty() {
-                continue;
-            }
-
             tracing::info!(
                 url = ?url.try_to_string()?,
                 diagnostics = diagnostics.len(),


### PR DESCRIPTION
Under rare circumstances the language server would partially read an input frame. This is due to how frame reading is implemented so that it's not cancellation safe.

This fixes that.