### PR TITLE
feat: add type annotation parsing

### DIFF
--- a/crates/rune/src/ast/fn_arg.rs
+++ b/crates/rune/src/ast/fn_arg.rs
@@ -8,6 +8,14 @@ fn ast_parse() {
     rt::<ast::FnArg>("abc");
 }
 
+#[test]
+#[cfg(not(miri))]
+fn ast_parse_typed() {
+    rt::<ast::FnArg>("a: i64");
+    rt::<ast::FnArg>("a: foo::Bar");
+    rt::<ast::FnArg>("_: i64");
+}
+
 /// A single argument in a closure.
 #[derive(Debug, TryClone, PartialEq, Eq, ToTokens, Spanned)]
 #[non_exhaustive]
@@ -16,13 +24,89 @@ pub enum FnArg {
     SelfValue(T![self]),
     /// Function argument is a pattern binding.
     Pat(ast::Pat),
+    /// Function argument with type annotation (gradual typing).
+    Typed(Box<FnArgTyped>),
+}
+
+/// A function argument with an optional type annotation.
+#[derive(Debug, TryClone, PartialEq, Eq, ToTokens, Spanned)]
+#[non_exhaustive]
+pub struct FnArgTyped {
+    /// The pattern for this argument (typically just an identifier).
+    pub pat: ast::Pat,
+    /// The colon separator.
+    pub colon: T![:],
+    /// The type annotation.
+    pub ty: ast::Type,
+}
+
+impl FnArg {
+    /// Get the type annotation if present (gradual typing feature).
+    pub fn ty(&self) -> Option<&ast::Type> {
+        match self {
+            FnArg::SelfValue(_) => None,
+            FnArg::Pat(_) => None,
+            FnArg::Typed(typed) => Some(&typed.ty),
+        }
+    }
+
+    /// Get the pattern for this argument.
+    ///
+    /// Returns `None` for `self` arguments, and `Some` for pattern-based
+    /// or typed arguments.
+    pub fn pat(&self) -> Option<&ast::Pat> {
+        match self {
+            FnArg::SelfValue(_) => None,
+            FnArg::Pat(pat) => Some(pat),
+            FnArg::Typed(typed) => Some(&typed.pat),
+        }
+    }
 }
 
 impl Parse for FnArg {
     fn parse(p: &mut Parser<'_>) -> Result<Self> {
         Ok(match p.nth(0)? {
             K![self] => Self::SelfValue(p.parse()?),
-            _ => Self::Pat(p.parse()?),
+            _ => {
+                {
+                    // Check if this is a typed argument: `name: Type` or `_: Type`
+                    // We need to look ahead to distinguish from object patterns
+                    // Pattern: identifier/underscore followed by `:` and then a type
+                    match (p.nth(0)?, p.nth(1)?) {
+                        (K![ident], K![:]) => {
+                            // Parse identifier as a path pattern
+                            let ident = p.parse::<ast::Ident>()?;
+                            let path = ast::Path {
+                                global: None,
+                                first: ast::PathSegment::Ident(ident),
+                                rest: Vec::new(),
+                                trailing: None,
+                                id: Default::default(),
+                            };
+                            let pat = ast::Pat::Path(ast::PatPath {
+                                attributes: Vec::new(),
+                                path,
+                            });
+                            let colon = p.parse::<T![:]>()?;
+                            let ty = p.parse::<ast::Type>()?;
+                            return Ok(Self::Typed(Box::try_new(FnArgTyped { pat, colon, ty })?));
+                        }
+                        (K![_], K![:]) => {
+                            // Parse underscore as ignore pattern
+                            let underscore = p.parse::<T![_]>()?;
+                            let pat = ast::Pat::Ignore(ast::PatIgnore {
+                                attributes: Vec::new(),
+                                underscore,
+                            });
+                            let colon = p.parse::<T![:]>()?;
+                            let ty = p.parse::<ast::Type>()?;
+                            return Ok(Self::Typed(Box::try_new(FnArgTyped { pat, colon, ty })?));
+                        }
+                        _ => {}
+                    }
+                }
+                Self::Pat(p.parse()?)
+            }
         })
     }
 }

--- a/crates/rune/src/hir/lowering.rs
+++ b/crates/rune/src/hir/lowering.rs
@@ -1138,6 +1138,12 @@ fn fn_arg<'hir>(
             hir::FnArg::SelfValue(ast.span(), id)
         }
         ast::FnArg::Pat(ast) => hir::FnArg::Pat(alloc!(pat_binding(cx, ast)?)),
+        ast::FnArg::Typed(_) => {
+            return Err(compile::Error::msg(
+                ast,
+                "Type annotations are not yet fully supported",
+            ));
+        }
     })
 }
 

--- a/crates/rune/src/indexing/index.rs
+++ b/crates/rune/src/indexing/index.rs
@@ -242,8 +242,15 @@ pub(crate) fn item_fn(idx: &mut Indexer<'_, '_>, mut ast: ast::ItemFn) -> compil
     let idx_item = idx.item.replace(item_meta.item);
 
     for (arg, _) in &mut ast.args {
-        if let ast::FnArg::Pat(p) = arg {
-            pat(idx, p)?;
+        match arg {
+            ast::FnArg::Pat(p) => pat(idx, p)?,
+            ast::FnArg::Typed(_) => {
+                return Err(compile::Error::msg(
+                    arg,
+                    "Type annotations are not yet fully supported",
+                ));
+            }
+            _ => {}
         }
     }
 
@@ -1252,6 +1259,12 @@ fn expr_closure(idx: &mut Indexer<'_, '_>, ast: &mut ast::ExprClosure) -> compil
             }
             ast::FnArg::Pat(p) => {
                 pat(idx, p)?;
+            }
+            ast::FnArg::Typed(_) => {
+                return Err(compile::Error::msg(
+                    arg,
+                    "Type annotations are not yet fully supported",
+                ));
             }
         }
     }


### PR DESCRIPTION
Add parsing support for function parameter type annotations WITHOUT feature flags. Type annotations can be parsed but are explicitly rejected during indexing and lowering with a clear error message.

Per maintainer feedback, type annotation support should not be behind a feature flag to avoid feature unification issues. Instead, the parsing is always available but returns a helpful error until full implementation.

Changes:
- Added FnArg::Typed variant for typed function parameters (unconditional)
- Implemented parsing logic for `name: Type` syntax
- Added rejection in indexing and lowering phases
- Included tests for parsing typed arguments

This is a preparatory PR that will be merged first, followed by the full type checking implementation.