### PR TITLE
Implement bitwise operations

### DIFF
--- a/crates/rune/src/compile/ir.rs
+++ b/crates/rune/src/compile/ir.rs
@@ -8,7 +8,9 @@ mod eval;
 mod interpreter;
 pub(crate) mod scopes;
 
-use core::ops::{AddAssign, MulAssign, ShlAssign, ShrAssign, SubAssign};
+use core::ops::{
+    AddAssign, BitAndAssign, BitOrAssign, BitXorAssign, MulAssign, ShlAssign, ShrAssign, SubAssign,
+};
 
 use crate as rune;
 use crate::alloc::prelude::*;
@@ -503,6 +505,12 @@ pub(crate) enum IrBinaryOp {
     Gt,
     /// `>=`,
     Gte,
+    /// `&`.
+    BitAnd,
+    /// `^`.
+    BitXor,
+    /// `|`.
+    BitOr,
 }
 
 /// An assign operation.
@@ -521,6 +529,12 @@ pub(crate) enum IrAssignOp {
     Shl,
     /// `>>=`.
     Shr,
+    /// `&=`.
+    BitAnd,
+    /// `^=`.
+    BitXor,
+    /// `|=`.
+    BitOr,
 }
 
 impl IrAssignOp {
@@ -577,6 +591,15 @@ impl IrAssignOp {
                     .with_span(spanned)?;
 
                 target.shr_assign(operand);
+            }
+            IrAssignOp::BitAnd => {
+                target.bitand_assign(operand);
+            }
+            IrAssignOp::BitXor => {
+                target.bitxor_assign(operand);
+            }
+            IrAssignOp::BitOr => {
+                target.bitor_assign(operand);
             }
         }
 

--- a/crates/rune/src/compile/ir/compiler.rs
+++ b/crates/rune/src/compile/ir/compiler.rs
@@ -156,6 +156,9 @@ fn expr_binary(
             ast::BinOp::DivAssign(..) => ir::IrAssignOp::Div,
             ast::BinOp::ShlAssign(..) => ir::IrAssignOp::Shl,
             ast::BinOp::ShrAssign(..) => ir::IrAssignOp::Shr,
+            ast::BinOp::BitAndAssign(..) => ir::IrAssignOp::BitAnd,
+            ast::BinOp::BitXorAssign(..) => ir::IrAssignOp::BitXor,
+            ast::BinOp::BitOrAssign(..) => ir::IrAssignOp::BitOr,
             _ => return Err(compile::Error::msg(hir.op, "op not supported yet")),
         };
 
@@ -187,6 +190,9 @@ fn expr_binary(
         ast::BinOp::Eq(..) => ir::IrBinaryOp::Eq,
         ast::BinOp::Gt(..) => ir::IrBinaryOp::Gt,
         ast::BinOp::Gte(..) => ir::IrBinaryOp::Gte,
+        ast::BinOp::BitAnd(..) => ir::IrBinaryOp::BitAnd,
+        ast::BinOp::BitXor(..) => ir::IrBinaryOp::BitXor,
+        ast::BinOp::BitOr(..) => ir::IrBinaryOp::BitOr,
         _ => return Err(compile::Error::msg(hir.op, "op not supported yet")),
     };
 

--- a/crates/rune/src/compile/ir/eval.rs
+++ b/crates/rune/src/compile/ir/eval.rs
@@ -1,4 +1,4 @@
-use core::ops::{Add, Mul, Shl, Shr, Sub};
+use core::ops::{Add, BitAnd, BitOr, BitXor, Mul, Shl, Shr, Sub};
 
 use crate::alloc::fmt::TryWrite;
 use crate::alloc::prelude::*;
@@ -116,6 +116,15 @@ fn eval_ir_binary(
                         ir::IrBinaryOp::Eq => break 'out Inline::Bool(a == b),
                         ir::IrBinaryOp::Gt => break 'out Inline::Bool(a > b),
                         ir::IrBinaryOp::Gte => break 'out Inline::Bool(a >= b),
+                        ir::IrBinaryOp::BitAnd => {
+                            break 'out Inline::Signed(a.bitand(b));
+                        }
+                        ir::IrBinaryOp::BitXor => {
+                            break 'out Inline::Signed(a.bitxor(b));
+                        }
+                        ir::IrBinaryOp::BitOr => {
+                            break 'out Inline::Signed(a.bitor(b));
+                        }
                     },
                     (Inline::Float(a), Inline::Float(b)) => {
                         #[allow(clippy::float_cmp)]

--- a/crates/rune/tests/bitwise_ops.rn
+++ b/crates/rune/tests/bitwise_ops.rn
@@ -1,0 +1,17 @@
+#[test]
+fn bitwise_ops() {
+    assert_eq!(0b1100 & 0b1010, 0b1000);
+    let anded = 0b0101;
+    anded &= 0b0011;
+    assert_eq!(anded, 0b0001);
+
+    assert_eq!(0b1100 ^ 0b1010, 0b0110);
+    let xored = 0b0101;
+    xored ^= 0b0011;
+    assert_eq!(xored, 0b0110);
+
+    assert_eq!(0b1100 | 0b1010, 0b1110);
+    let ored = 0b0101;
+    ored |= 0b0011;
+    assert_eq!(ored, 0b0111);
+}


### PR DESCRIPTION
I ran into the "op not supported yet" error while trying to use numbers as bitflags in Rune. I noticed that adding support for those operations seemed to be pretty straightforward, hence this PR.