### PR TITLE
Add support for scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ If you want to help out, please have a look at [Open Issues].
 
 ## Highlights of Rune
 
+* Run simple [Scripts 📖][support-scripts].
 * Runs a compact representation of the language on top of an efficient
   [stack-based virtual machine][support-virtual-machine].
 * Clean [Rust integration 💻][support-rust-integration].
@@ -117,6 +118,7 @@ println!("{}", output);
 [support-patterns]: https://rune-rs.github.io/book/pattern_matching.html
 [support-reference-counted]: https://rune-rs.github.io/book/variables.html
 [support-rust-integration]: https://github.com/rune-rs/rune/tree/main/crates/rune-modules
+[support-scripts]: https://rune-rs.github.io/book/scripts.html
 [support-serde]: https://github.com/rune-rs/rune/blob/main/crates/rune-modules/src/json.rs
 [support-stack-isolation]: https://rune-rs.github.io/book/call_frames.html
 [support-structs]: https://rune-rs.github.io/book/structs.html

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -4,6 +4,7 @@
 - [Introduction](./introduction.md)
 - [Getting Started](./getting_started.md)
 - [Concepts](./concepts.md)
+  - [Scripts](./scripts.md)
   - [Items and imports](./items_imports.md)
   - [Functions](./functions.md)
   - [Control flow](./control_flow.md)

--- a/book/src/scripts.md
+++ b/book/src/scripts.md
@@ -1,0 +1,21 @@
+Rune can be run in a special mode called a "script" mode. This is the simplest
+way of using Rune.
+
+This is intended to support what looks like inline execution of code, and is
+implemented to allow for evaluating expressions like `value + 40`.
+
+In order to run a program in script mode [`Options::script`] has to be set,
+any implicit arguments passed into the script must then be specified through
+[`Prepare::with_args`].
+
+```rust,noplaypen
+{{#include ../../examples/examples/scripts.rs}}
+```
+
+Behind the scenes script mode defines an unnamed function which can be addressed
+as `Hash::EMPTY`. The arguments that has to be passed into this function is
+defined through [`Prepare::with_args`]. These variables are *not* global
+variables. They are not addressible from other functions.
+
+[`Options::script`]: https://docs.rs/rune/latest/rune/struct.Options.html#method.script
+[`Prepare::with_args`]: https://docs.rs/rune/latest/rune/struct.Build.html#method.with_args

--- a/crates/rune-wasm/src/lib.rs
+++ b/crates/rune-wasm/src/lib.rs
@@ -34,7 +34,7 @@ use anyhow::{Context as _, Result};
 use gloo_utils::format::JsValueSerdeExt;
 use rune::ast::Spanned;
 use rune::compile::LinkerError;
-use rune::diagnostics::{Diagnostic, FatalDiagnosticKind};
+use rune::diagnostics::Diagnostic;
 use rune::modules::capture_io::CaptureIo;
 use rune::runtime::budget;
 use rune::sync::Arc;
@@ -196,24 +196,26 @@ async fn inner_compile(
         match diagnostic {
             Diagnostic::Fatal(error) => {
                 if let Some(source) = sources.get(error.source_id()) {
-                    match error.kind() {
-                        FatalDiagnosticKind::CompileError(error) => {
-                            let span = error.span();
+                    if let Some(error) = error.as_compile_error() {
+                        let span = error.span();
 
-                            let start = WasmPosition::from(
-                                source.find_line_column(span.start.into_usize()),
-                            );
-                            let end =
-                                WasmPosition::from(source.find_line_column(span.end.into_usize()));
+                        let start =
+                            WasmPosition::from(source.find_line_column(span.start.into_usize()));
+                        let end =
+                            WasmPosition::from(source.find_line_column(span.end.into_usize()));
 
-                            diagnostics.push(WasmDiagnostic {
-                                kind: WasmDiagnosticKind::Error,
-                                start,
-                                end,
-                                message: error.to_string(),
-                            });
-                        }
-                        FatalDiagnosticKind::LinkError(error) => match error {
+                        diagnostics.push(WasmDiagnostic {
+                            kind: WasmDiagnosticKind::Error,
+                            start,
+                            end,
+                            message: error.to_string(),
+                        });
+
+                        continue;
+                    }
+
+                    if let Some(error) = error.as_link_error() {
+                        match error {
                             LinkerError::MissingFunction { hash, spans } => {
                                 for (span, _) in spans {
                                     let start = WasmPosition::from(
@@ -232,8 +234,7 @@ async fn inner_compile(
                                 }
                             }
                             _ => {}
-                        },
-                        _ => {}
+                        }
                     }
                 }
             }

--- a/crates/rune/README.md
+++ b/crates/rune/README.md
@@ -26,6 +26,7 @@ If you want to help out, please have a look at [Open Issues].
 
 ## Highlights of Rune
 
+* Run simple [Scripts 📖][support-scripts].
 * Runs a compact representation of the language on top of an efficient
   [stack-based virtual machine][support-virtual-machine].
 * Clean [Rust integration 💻][support-rust-integration].
@@ -117,6 +118,7 @@ println!("{}", output);
 [support-patterns]: https://rune-rs.github.io/book/pattern_matching.html
 [support-reference-counted]: https://rune-rs.github.io/book/variables.html
 [support-rust-integration]: https://github.com/rune-rs/rune/tree/main/crates/rune-modules
+[support-scripts]: https://rune-rs.github.io/book/scripts.html
 [support-serde]: https://github.com/rune-rs/rune/blob/main/crates/rune-modules/src/json.rs
 [support-stack-isolation]: https://rune-rs.github.io/book/call_frames.html
 [support-structs]: https://rune-rs.github.io/book/structs.html

--- a/crates/rune/src/diagnostics/emit.rs
+++ b/crates/rune/src/diagnostics/emit.rs
@@ -15,8 +15,8 @@ use crate::alloc::{self, String};
 use crate::ast::{Span, Spanned};
 use crate::compile::{ErrorKind, LinkerError, Location};
 use crate::diagnostics::{
-    Diagnostic, FatalDiagnostic, FatalDiagnosticKind, RuntimeWarningDiagnostic,
-    RuntimeWarningDiagnosticKind, WarningDiagnostic, WarningDiagnosticKind,
+    Diagnostic, FatalDiagnostic, FatalDiagnosticKind, RuntimeDiagnostic, RuntimeDiagnosticKind,
+    WarningDiagnostic, WarningDiagnosticKind,
 };
 use crate::hash::Hash;
 use crate::runtime::DebugInfo;
@@ -103,7 +103,7 @@ impl Diagnostics {
                 Diagnostic::Warning(w) => {
                     warning_diagnostics_emit(w, out, sources, &config)?;
                 }
-                Diagnostic::RuntimeWarning(w) => {
+                Diagnostic::Runtime(w) => {
                     runtime_warning_diagnostics_emit(w, out, sources, &config, None, None)?;
                 }
             }
@@ -142,7 +142,7 @@ impl Diagnostics {
                 Diagnostic::Warning(w) => {
                     warning_diagnostics_emit(w, out, sources, &config)?;
                 }
-                Diagnostic::RuntimeWarning(w) => {
+                Diagnostic::Runtime(w) => {
                     runtime_warning_diagnostics_emit(
                         w,
                         out,
@@ -343,7 +343,7 @@ impl WarningDiagnostic {
     }
 }
 
-impl RuntimeWarningDiagnostic {
+impl RuntimeDiagnostic {
     /// Generate formatted diagnostics capable of referencing source lines and
     /// hints.
     ///
@@ -478,7 +478,7 @@ where
 
 /// Helper to emit diagnostics for a runtime warning.
 fn runtime_warning_diagnostics_emit<O>(
-    this: &RuntimeWarningDiagnostic,
+    this: &RuntimeDiagnostic,
     out: &mut O,
     sources: &Sources,
     config: &term::Config,
@@ -493,7 +493,7 @@ where
     let mut message = String::new();
 
     match this.kind {
-        RuntimeWarningDiagnosticKind::UsedDeprecated { hash } => {
+        RuntimeDiagnosticKind::UsedDeprecated { hash } => {
             // try to get the function name - this needs to be improved
             let name = match context
                 .map(|c| c.lookup_meta_by_hash(hash))
@@ -554,8 +554,8 @@ where
     }
 
     match this.kind() {
-        FatalDiagnosticKind::Internal(message) => {
-            writeln!(out, "internal error: {message}")?;
+        FatalDiagnosticKind::Custom(message) => {
+            writeln!(out, "{message}")?;
             return Ok(());
         }
         FatalDiagnosticKind::LinkError(error) => {

--- a/crates/rune/src/diagnostics/runtime.rs
+++ b/crates/rune/src/diagnostics/runtime.rs
@@ -5,14 +5,14 @@ use crate::Hash;
 /// Runtime Warning diagnostic emitted during the execution of the VM. Warning diagnostics indicates
 /// an recoverable issues.
 #[derive(Debug)]
-pub struct RuntimeWarningDiagnostic {
+pub struct RuntimeDiagnostic {
     /// The instruction pointer of the vm where the warning happened.
     pub(crate) ip: usize,
     /// The kind of the warning.
-    pub(crate) kind: RuntimeWarningDiagnosticKind,
+    pub(crate) kind: RuntimeDiagnosticKind,
 }
 
-impl RuntimeWarningDiagnostic {
+impl RuntimeDiagnostic {
     /// The instruction pointer of the vm where the warning happened.
     pub fn ip(&self) -> usize {
         self.ip
@@ -21,31 +21,31 @@ impl RuntimeWarningDiagnostic {
     /// The kind of the warning.
     #[cfg(feature = "emit")]
     #[allow(unused)]
-    pub(crate) fn kind(&self) -> &RuntimeWarningDiagnosticKind {
+    pub(crate) fn kind(&self) -> &RuntimeDiagnosticKind {
         &self.kind
     }
 
     #[cfg(test)]
     #[allow(unused)]
-    pub(crate) fn into_kind(self) -> RuntimeWarningDiagnosticKind {
+    pub(crate) fn into_kind(self) -> RuntimeDiagnosticKind {
         self.kind
     }
 }
 
-impl fmt::Display for RuntimeWarningDiagnostic {
+impl fmt::Display for RuntimeDiagnostic {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.kind, f)
     }
 }
 
-impl core::error::Error for RuntimeWarningDiagnostic {}
+impl core::error::Error for RuntimeDiagnostic {}
 
 /// The kind of a [RuntimeWarningDiagnostic].
 #[derive(Debug)]
 #[allow(missing_docs)]
 #[non_exhaustive]
-pub(crate) enum RuntimeWarningDiagnosticKind {
+pub(crate) enum RuntimeDiagnosticKind {
     UsedDeprecated {
         /// The hash which produced the deprecation
         #[cfg_attr(not(feature = "emit"), allow(dead_code))]
@@ -53,10 +53,11 @@ pub(crate) enum RuntimeWarningDiagnosticKind {
     },
 }
 
-impl fmt::Display for RuntimeWarningDiagnosticKind {
+impl fmt::Display for RuntimeDiagnosticKind {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            RuntimeWarningDiagnosticKind::UsedDeprecated { .. } => {
+            RuntimeDiagnosticKind::UsedDeprecated { .. } => {
                 write!(f, "Used deprecated function")
             }
         }

--- a/crates/rune/src/languageserver/state.rs
+++ b/crates/rune/src/languageserver/state.rs
@@ -752,14 +752,14 @@ impl<'a> State<'a> {
                             }
                         }
                     },
-                    FatalDiagnosticKind::Internal(e) => {
+                    FatalDiagnosticKind::Custom(e) => {
                         report_without_span(build, reporter, f.source_id(), e, to_error)?;
                     }
                 },
                 Diagnostic::Warning(e) => {
                     self.report(build, reporter, e.source_id(), e, to_warning)?;
                 }
-                Diagnostic::RuntimeWarning(_) => {}
+                Diagnostic::Runtime(_) => {}
             }
         }
 

--- a/crates/rune/src/lib.rs
+++ b/crates/rune/src/lib.rs
@@ -26,6 +26,7 @@
 //!
 //! ## Highlights of Rune
 //!
+//! * Run simple [Scripts 📖][support-scripts].
 //! * Runs a compact representation of the language on top of an efficient
 //!   [stack-based virtual machine][support-virtual-machine].
 //! * Clean [Rust integration 💻][support-rust-integration].
@@ -118,6 +119,7 @@
 //! [support-patterns]: https://rune-rs.github.io/book/pattern_matching.html
 //! [support-reference-counted]: https://rune-rs.github.io/book/variables.html
 //! [support-rust-integration]: https://github.com/rune-rs/rune/tree/main/crates/rune-modules
+//! [support-scripts]: https://rune-rs.github.io/book/scripts.html
 //! [support-serde]: https://github.com/rune-rs/rune/blob/main/crates/rune-modules/src/json.rs
 //! [support-stack-isolation]: https://rune-rs.github.io/book/call_frames.html
 //! [support-structs]: https://rune-rs.github.io/book/structs.html

--- a/crates/rune/src/macros/macro_context.rs
+++ b/crates/rune/src/macros/macro_context.rs
@@ -72,6 +72,7 @@ where
         &mut diagnostics,
         &mut source_loader,
         &options,
+        &[],
         &gen,
         &context,
         &mut inner,

--- a/crates/rune/src/parse/mod.rs
+++ b/crates/rune/src/parse/mod.rs
@@ -9,6 +9,8 @@ mod peek;
 mod resolve;
 mod traits;
 
+use unicode_ident::{is_xid_continue, is_xid_start};
+
 pub use self::expectation::Expectation;
 pub(crate) use self::expectation::IntoExpectation;
 pub(crate) use self::id::NonZeroId;
@@ -36,4 +38,25 @@ where
     let ast = parser.parse::<T>()?;
     parser.eof()?;
     Ok(ast)
+}
+
+/// Test if the given string is a valid identifier.
+pub(crate) fn is_ident(ident: &str) -> bool {
+    let mut chars = ident.chars();
+
+    let Some(c) = chars.next() else {
+        return false;
+    };
+
+    if !(c == '_' || is_xid_start(c)) {
+        return false;
+    }
+
+    for c in chars {
+        if !is_xid_continue(c) {
+            return false;
+        }
+    }
+
+    true
 }

--- a/crates/rune/src/query/query.rs
+++ b/crates/rune/src/query/query.rs
@@ -151,6 +151,8 @@ pub(crate) struct Query<'a, 'arena> {
     pub(crate) source_loader: &'a mut dyn SourceLoader,
     /// Build options.
     pub(crate) options: &'a Options,
+    /// Implicit function arguments when building a script.
+    pub(crate) args: &'a [String],
     /// Shared id generator.
     pub(crate) gen: &'a Gen,
     /// Native context.
@@ -173,6 +175,7 @@ impl<'a, 'arena> Query<'a, 'arena> {
         diagnostics: &'a mut Diagnostics,
         source_loader: &'a mut dyn SourceLoader,
         options: &'a Options,
+        args: &'a [String],
         gen: &'a Gen,
         context: &'a Context,
         inner: &'a mut QueryInner<'arena>,
@@ -189,6 +192,7 @@ impl<'a, 'arena> Query<'a, 'arena> {
             diagnostics,
             source_loader,
             options,
+            args,
             gen,
             context,
             inner,
@@ -209,6 +213,7 @@ impl<'a, 'arena> Query<'a, 'arena> {
             diagnostics: self.diagnostics,
             source_loader: self.source_loader,
             options: self.options,
+            args: self.args,
             gen: self.gen,
             context: self.context,
             inner: self.inner,

--- a/crates/rune/src/tests.rs
+++ b/crates/rune/src/tests.rs
@@ -517,6 +517,8 @@ mod rename_type;
 #[cfg(not(miri))]
 mod result;
 #[cfg(not(miri))]
+mod scripts;
+#[cfg(not(miri))]
 mod static_typing;
 #[cfg(not(miri))]
 mod tuple;

--- a/crates/rune/src/tests/deprecation.rs
+++ b/crates/rune/src/tests/deprecation.rs
@@ -6,7 +6,7 @@ use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
 
 use crate::diagnostics::Diagnostic;
 
-use self::diagnostics::{RuntimeWarningDiagnosticKind, WarningDiagnosticKind};
+use self::diagnostics::{RuntimeDiagnosticKind, WarningDiagnosticKind};
 
 fn create_context() -> Result<Context> {
     #[derive(Debug, rune::Any)]
@@ -63,8 +63,8 @@ fn check_diagnostic(context: &Context, diagnostic: &Diagnostic, msg: &str) {
             }
             kind => panic!("Unexpected warning: {kind:?}"),
         },
-        Diagnostic::RuntimeWarning(w) => match w.kind() {
-            RuntimeWarningDiagnosticKind::UsedDeprecated { hash, .. } => {
+        Diagnostic::Runtime(w) => match w.kind() {
+            RuntimeDiagnosticKind::UsedDeprecated { hash, .. } => {
                 let message = context.lookup_deprecation(*hash);
                 assert_eq!(message, Some(msg));
             }

--- a/crates/rune/src/tests/scripts.rs
+++ b/crates/rune/src/tests/scripts.rs
@@ -1,0 +1,62 @@
+use crate as rune;
+use crate::support::Result;
+use crate::sync::Arc;
+use crate::termcolor::{ColorChoice, StandardStream};
+use crate::{Context, ContextError, Diagnostics, Hash, Module, Options, Source, Sources, Unit, Vm};
+
+#[rune::function]
+fn calculate(value: i64) -> i64 {
+    value + 10
+}
+
+pub fn module() -> Result<Module, ContextError> {
+    let mut module = Module::new();
+    module.function_meta(calculate)?;
+    Ok(module)
+}
+
+#[test]
+fn simple_script() -> Result<()> {
+    let context = context()?;
+    let runtime = Arc::try_new(context.runtime()?)?;
+
+    let unit = compile(&context, "calculate(value) / 2")?;
+    let mut vm = Vm::new(runtime, unit);
+
+    let output = vm.call(Hash::EMPTY, (5,))?;
+    let output: i64 = crate::from_value(output)?;
+    assert_eq!(output, 7);
+    Ok(())
+}
+
+fn context() -> Result<Arc<Context>, ContextError> {
+    let m = module()?;
+    let mut context = Context::with_default_modules()?;
+    context.install(m)?;
+    Ok(Arc::try_new(context)?)
+}
+
+fn compile(context: &Context, script: &str) -> Result<Arc<Unit>> {
+    let mut sources = Sources::new();
+    sources.insert(Source::memory(script)?)?;
+
+    let mut diagnostics = Diagnostics::new();
+    let mut options = Options::from_default_env()?;
+    options.script(true);
+
+    let result = crate::prepare(&mut sources)
+        .with_args(["value"])?
+        .with_options(&options)
+        .with_context(context)
+        .with_diagnostics(&mut diagnostics)
+        .build();
+
+    if !diagnostics.is_empty() {
+        let mut writer = StandardStream::stderr(ColorChoice::Always);
+        diagnostics.emit(&mut writer, &sources)?;
+    }
+
+    let unit = result?;
+    let unit = Arc::try_new(unit)?;
+    Ok(unit)
+}

--- a/crates/rune/src/worker/task.rs
+++ b/crates/rune/src/worker/task.rs
@@ -25,9 +25,16 @@ pub(crate) enum Task {
 /// The kind of the loaded module.
 #[derive(Debug)]
 pub(crate) enum LoadFileKind {
-    /// A root file, which determined a URL root.
-    Root,
+    /// An original source file.
+    Original,
     /// A loaded module, which inherits its root from the file it was loaded
     /// from.
     Module { root: Option<SourceId> },
+}
+
+impl LoadFileKind {
+    /// Returns true if the loaded file is a module.
+    pub(crate) fn is_module(&self) -> bool {
+        matches!(self, LoadFileKind::Module { .. })
+    }
 }

--- a/examples/examples/scripts.rs
+++ b/examples/examples/scripts.rs
@@ -1,0 +1,61 @@
+use rune::support::Result;
+use rune::sync::Arc;
+use rune::termcolor::{ColorChoice, StandardStream};
+use rune::{Context, ContextError, Diagnostics, Hash, Module, Options, Source, Sources, Unit, Vm};
+
+#[rune::function]
+fn calculate(value: i64) -> i64 {
+    value + 10
+}
+
+pub fn module() -> Result<Module, ContextError> {
+    let mut module = Module::new();
+    module.function_meta(calculate)?;
+    Ok(module)
+}
+
+fn main() -> Result<()> {
+    let context = context()?;
+    let runtime = Arc::try_new(context.runtime()?)?;
+
+    let unit = compile(&context, "calculate(value) / 2")?;
+    let mut vm = Vm::new(runtime, unit);
+
+    let output = vm.call(Hash::EMPTY, (5,))?;
+    let output: i64 = rune::from_value(output)?;
+    println!("{output:?}");
+    assert_eq!(output, 7);
+    Ok(())
+}
+
+fn context() -> Result<Arc<Context>, ContextError> {
+    let m = module()?;
+    let mut context = rune_modules::default_context()?;
+    context.install(m)?;
+    Ok(Arc::try_new(context)?)
+}
+
+fn compile(context: &Context, script: &str) -> Result<Arc<Unit>> {
+    let mut sources = Sources::new();
+    sources.insert(Source::memory(script)?)?;
+
+    let mut diagnostics = Diagnostics::new();
+    let mut options = Options::from_default_env()?;
+    options.script(true);
+
+    let result = rune::prepare(&mut sources)
+        .with_args(["value"])?
+        .with_options(&options)
+        .with_context(context)
+        .with_diagnostics(&mut diagnostics)
+        .build();
+
+    if !diagnostics.is_empty() {
+        let mut writer = StandardStream::stderr(ColorChoice::Always);
+        diagnostics.emit(&mut writer, &sources)?;
+    }
+
+    let unit = result?;
+    let unit = Arc::try_new(unit)?;
+    Ok(unit)
+}


### PR DESCRIPTION
This adds support for setting the argument to scripts.

This can be used to provide access to implicit variables in inline scripts. But it is worth noting that they are implemented as arguments to the empty function, not global variables.

What that means is that something like this is now supported:

```rust
let script = compile(&context, "value / 10");
let mut vm = Vm::new(runtime, script);

let output = vm.call(Hash::EMPTY, (50,))?;
assert_eq!(rune::from_value(output)?, 5);
```

See the included [`scripts`] example.

[`scripts`]: https://github.com/rune-rs/rune/pull/994/changes#diff-20f04756dcfb34d2615abbc122bbf66773adae0595a95b92842727af2743ebe4