### PR TITLE
Change mod's Ident to Path for more advanced module resolution.

### DIFF
--- a/crates/rune/src/ast/item_mod.rs
+++ b/crates/rune/src/ast/item_mod.rs
@@ -27,7 +27,7 @@ pub struct ItemMod {
     /// The `mod` keyword.
     pub mod_token: T![mod],
     /// The name of the mod.
-    pub name: ast::Ident,
+    pub name: ast::Path,
     /// The optional body of the module declaration.
     pub body: ItemModBody,
     /// The id of the module item.

--- a/crates/rune/src/indexing/indexer.rs
+++ b/crates/rune/src/indexing/indexer.rs
@@ -446,7 +446,13 @@ impl Indexer<'_, '_> {
         ast: &mut ast::ItemMod,
         docs: &[Doc],
     ) -> compile::Result<()> {
-        let name = ast.name.resolve(resolve_context!(self.q))?;
+        let original_name = ast
+            .name
+            .resolve(resolve_context!(self.q))?
+            .try_to_string()
+            .unwrap();
+        let name = Box::try_new(original_name.split("::").last().unwrap())?;
+
         let visibility = ast_to_visibility(&ast.visibility)?;
         let guard = self.items.push_name(name.as_ref())?;
 
@@ -469,12 +475,14 @@ impl Indexer<'_, '_> {
             ));
         };
 
-        let source = self.q.source_loader.load(
-            self.q.sources,
-            root,
-            self.q.pool.module_item(mod_item),
-            &*ast,
-        )?;
+        let item = self.q.pool.module_item(mod_item);
+        let buff =
+            rune_core::item::ItemBuf::with_item([original_name.try_clone().unwrap()]).unwrap();
+        let item = unsafe { rune_core::item::Item::from_bytes(buff.as_bytes()) };
+        let source = self
+            .q
+            .source_loader
+            .load(self.q.sources, root, item, &*ast)?;
 
         if let Some(loaded) = self.loaded.as_mut() {
             if let Some(_existing) = loaded.try_insert(mod_item, (self.source_id, ast.span()))? {


### PR DESCRIPTION
The goal of this change is to allow more advanced path traversal for file resolvers, specifically allowing the following:
``mod ::VoxelEras::DestinyHailstorm::settings;``
Where ``::VoxelEras::DestinyHailstorm`` refers to an absolute path of a given mod, or alternatively:
``mod crate::settings``
Which refers to an absolute path within the context of the given mod.

This still allows modules to be resolved "locally" like so:
``mod settings;``
Where the file path can be used to determine the module's location.

In Rhai (with my custom file resolver), this is:
``import "/VoxelEras:DestinyHailstorm/settings" as settings;``
Or locally:
``import "./settings" as settings;``

I'm not sure if this would have any side effects, but it does seem to compile and work fine in my project so far.