### PR TITLE
fix(compile): propagate divergence from expr_match when all arms diverge

### DIFF
--- a/crates/rune/src/compile/v1/assemble.rs
+++ b/crates/rune/src/compile/v1/assemble.rs
@@ -2646,6 +2646,7 @@ fn expr_match<'a, 'hir>(
         cx.asm.jump(&end_label, span)?;
     }
 
+    let mut all_diverge = is_irrefutable;
     let mut it = hir.branches.iter().zip(branches).peekable();
 
     while let Some((branch, (label, scope))) = it.next() {
@@ -2654,8 +2655,11 @@ fn expr_match<'a, 'hir>(
         cx.asm.label(&label)?;
         let scope = cx.scopes.restore(scope);
 
-        if expr(cx, &branch.body, needs)?.converging() && it.peek().is_some() {
-            cx.asm.jump(&end_label, span)?;
+        if expr(cx, &branch.body, needs)?.converging() {
+            all_diverge = false;
+            if it.peek().is_some() {
+                cx.asm.jump(&end_label, span)?;
+            }
         }
 
         cx.scopes.pop(span, scope)?;
@@ -2665,7 +2669,12 @@ fn expr_match<'a, 'hir>(
 
     value.free()?;
     linear.free()?;
-    Ok(Asm::new(span, ()))
+
+    if all_diverge {
+        Ok(Asm::diverge(span))
+    } else {
+        Ok(Asm::new(span, ()))
+    }
 }
 
 /// Compile a literal object.

--- a/crates/rune/tests/diverging.rn
+++ b/crates/rune/tests/diverging.rn
@@ -67,3 +67,82 @@ fn divering_if_else() {
     assert_eq!(inner(2), 3);
     assert_eq!(inner(3), 3);
 }
+
+#[test]
+fn diverging_match_all_arms_return() {
+    fn inner(value) {
+        match value {
+            1 => return "one",
+            2 => return "two",
+            _ => return "other",
+        }
+    }
+
+    assert_eq!(inner(1), "one");
+    assert_eq!(inner(2), "two");
+    assert_eq!(inner(99), "other");
+}
+
+#[test]
+fn diverging_match_with_trailing_code() {
+    fn inner(value) {
+        let result = match value {
+            1 => return "early",
+            _ => "normal",
+        };
+
+        result
+    }
+
+    assert_eq!(inner(1), "early");
+    assert_eq!(inner(2), "normal");
+}
+
+#[test]
+fn diverging_match_nested_in_function() {
+    fn classify(value) {
+        let category = match value {
+            0 => return "zero",
+            n if n > 0 => "positive",
+            _ => "negative",
+        };
+
+        category
+    }
+
+    assert_eq!(classify(0), "zero");
+    assert_eq!(classify(5), "positive");
+    assert_eq!(classify(-3), "negative");
+}
+
+#[test]
+async fn diverging_match_all_arms_return_in_async() {
+    async fn inner(value) {
+        match value {
+            1 => return "one",
+            2 => return "two",
+            _ => return "other",
+        }
+    }
+
+    assert_eq!(inner(1).await, "one");
+    assert_eq!(inner(2).await, "two");
+    assert_eq!(inner(99).await, "other");
+}
+
+#[test]
+async fn diverging_if_all_branches_return_in_async() {
+    async fn inner(cond) {
+        if cond == 0 {
+            return 1;
+        } else if cond == 1 {
+            return 2;
+        } else {
+            return 3;
+        }
+    }
+
+    assert_eq!(inner(0).await, 1);
+    assert_eq!(inner(1).await, 2);
+    assert_eq!(inner(2).await, 3);
+}


### PR DESCRIPTION
When all match arms diverge (every arm contains a `return` statement), the `expr_match` now returns `Asm::diverge` instead of always reporting convergence.

Previously, the parent `return_` function would attempt to read the address of a Defer needs that was never allocated, producing the following error:

    "No address for need defer(0:0 (return value))"

This mirrors the existing divergence tracking already present in `expr_if`.

Fixes: #1016