### PR TITLE
Implement support for passing custom indentation to the formatter

### DIFF
--- a/crates/rune/src/compile/mod.rs
+++ b/crates/rune/src/compile/mod.rs
@@ -47,7 +47,7 @@ pub(crate) mod v1;
 
 mod options;
 #[cfg(any(feature = "fmt", feature = "languageserver"))]
-pub(crate) use self::options::FmtOptions;
+pub(crate) use self::options::{FmtOptions, IndentStyle};
 pub use self::options::{Options, ParseOptionError};
 
 mod location;

--- a/crates/rune/src/compile/options.rs
+++ b/crates/rune/src/compile/options.rs
@@ -25,6 +25,16 @@ impl fmt::Display for ParseOptionError {
 
 impl core::error::Error for ParseOptionError {}
 
+/// The indentation to use when formatting.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum IndentStyle {
+    /// Indent using the given number of spaces.
+    #[cfg_attr(not(feature = "fmt"), allow(dead_code))]
+    Spaces(usize),
+    /// Indent using tabs.
+    Tabs,
+}
+
 /// Options specific to formatting.
 #[derive(Debug, Clone)]
 pub(crate) struct FmtOptions {
@@ -32,6 +42,8 @@ pub(crate) struct FmtOptions {
     pub(crate) error_recovery: bool,
     /// Force newline at end of document.
     pub(crate) force_newline: bool,
+    /// The indentation to use.
+    pub(crate) indent: IndentStyle,
 }
 
 impl FmtOptions {
@@ -39,6 +51,7 @@ impl FmtOptions {
     pub(crate) const DEFAULT: Self = Self {
         error_recovery: false,
         force_newline: true,
+        indent: IndentStyle::Spaces(4),
     };
 
     /// Parse an option with the extra diagnostics metadata.
@@ -59,6 +72,26 @@ impl FmtOptions {
             }
             "force-newline" => {
                 self.force_newline = tail.is_none_or(|s| s == "true");
+            }
+            "indent" => {
+                self.indent = match tail {
+                    Some("tab") => IndentStyle::Tabs,
+                    Some(n) => match n.parse() {
+                        Ok(n) => IndentStyle::Spaces(n),
+                        Err(..) => {
+                            return Err(ParseOptionError {
+                                env,
+                                option: option.into(),
+                            });
+                        }
+                    },
+                    None => {
+                        return Err(ParseOptionError {
+                            env,
+                            option: option.into(),
+                        });
+                    }
+                };
             }
             _ => {
                 return Err(ParseOptionError {
@@ -304,6 +337,16 @@ impl Options {
                 },
                 default: "true",
                 options: BOOL,
+            },
+            OptionMeta {
+                key: "fmt.indent",
+                unstable: true,
+                doc: &docstring! {
+                    /// Number of spaces to indent with, or `tab` to indent
+                    /// using tabs.
+                },
+                default: "4",
+                options: "<number>, tab",
             },
         ];
 

--- a/crates/rune/src/fmt/mod.rs
+++ b/crates/rune/src/fmt/mod.rs
@@ -21,7 +21,7 @@ pub(crate) use self::output::Formatter;
 const WS: &str = " ";
 const NL: &str = "\n";
 const NL_CHAR: char = '\n';
-const INDENT: &str = "    ";
+const TAB: &str = "\t";
 
 #[derive(Debug)]
 enum FormatErrorKind {

--- a/crates/rune/src/fmt/output.rs
+++ b/crates/rune/src/fmt/output.rs
@@ -3,11 +3,11 @@ use core::mem::take;
 use crate::alloc::prelude::*;
 use crate::alloc::{self, VecDeque};
 use crate::ast::{Kind, Span};
-use crate::compile::{Error, ErrorKind, FmtOptions, Result, WithSpan};
+use crate::compile::{Error, ErrorKind, FmtOptions, IndentStyle, Result, WithSpan};
 use crate::grammar::{Ignore, Node, Tree};
 use crate::{Diagnostics, SourceId};
 
-use super::{INDENT, NL, NL_CHAR, WS};
+use super::{NL, NL_CHAR, TAB, WS};
 
 /// Hint for how comments may be laid out.
 pub(super) enum Comments {
@@ -89,7 +89,7 @@ impl Buffer {
         self.0.try_push_str(s)
     }
 
-    fn lines(&mut self, indent: usize, lines: usize) -> alloc::Result<()> {
+    fn lines(&mut self, style: IndentStyle, indent: usize, lines: usize) -> alloc::Result<()> {
         if lines == 0 {
             return Ok(());
         }
@@ -99,7 +99,16 @@ impl Buffer {
         }
 
         for _ in 0..indent {
-            self.0.try_push_str(INDENT)?;
+            match style {
+                IndentStyle::Spaces(n) => {
+                    for _ in 0..n {
+                        self.0.try_push_str(WS)?;
+                    }
+                }
+                IndentStyle::Tabs => {
+                    self.0.try_push_str(TAB)?;
+                }
+            }
         }
 
         Ok(())
@@ -269,7 +278,7 @@ impl<'a> Formatter<'a> {
                     self.o.str(WS).with_span(c.span)?;
                 } else {
                     self.o
-                        .lines(self.indent, c.before.min(2))
+                        .lines(self.options.indent, self.indent, c.before.min(2))
                         .with_span(c.span)?;
                 }
             }
@@ -381,7 +390,8 @@ impl<'a> Formatter<'a> {
 
     pub(crate) fn flush_whitespace(&mut self, preserve: bool) -> Result<()> {
         if self.use_lines && self.lines > 0 {
-            self.o.lines(self.indent, self.lines.min(2))?;
+            self.o
+                .lines(self.options.indent, self.indent, self.lines.min(2))?;
             self.ws = false;
             self.use_lines = false;
             self.lines = 0;

--- a/crates/rune/src/fmt/tests/mod.rs
+++ b/crates/rune/src/fmt/tests/mod.rs
@@ -1357,3 +1357,43 @@ fn test_expanded_chain() {
         "#
     );
 }
+
+#[test]
+fn fmt_indent_spaces() {
+    assert_format_with!(
+        { "fmt.indent=2" },
+        r#"
+        fn main() {
+            if true {
+                1
+            } else {
+                2
+            }
+        }
+        "#,
+        r#"
+        fn main() {
+          if true {
+            1
+          } else {
+            2
+          }
+        }
+        "#
+    );
+}
+
+#[test]
+fn fmt_indent_tabs() {
+    assert_format_with!(
+        { "fmt.indent=tab" },
+        r#"
+        fn main() {
+            if true {
+                1
+            }
+        }
+        "#,
+        "fn main() {\n\tif true {\n\t\t1\n\t}\n}",
+    );
+}

--- a/crates/rune/src/languageserver/mod.rs
+++ b/crates/rune/src/languageserver/mod.rs
@@ -425,7 +425,7 @@ fn formatting(
     params: lsp::DocumentFormattingParams,
 ) -> Result<Option<rust_alloc::vec::Vec<lsp::TextEdit>>> {
     state
-        .format(&params.text_document.uri)
+        .format(&params.text_document.uri, &params.options)
         .map(|option| option.map(|formatted| vec![formatted]))
 }
 
@@ -435,7 +435,7 @@ fn range_formatting(
     params: lsp::DocumentRangeFormattingParams,
 ) -> Result<Option<rust_alloc::vec::Vec<lsp::TextEdit>>> {
     state
-        .range_format(&params.text_document.uri, &params.range)
+        .range_format(&params.text_document.uri, &params.range, &params.options)
         .map(|option| option.map(|formatted| vec![formatted]))
 }
 

--- a/crates/rune/src/languageserver/state.rs
+++ b/crates/rune/src/languageserver/state.rs
@@ -13,7 +13,8 @@ use crate::alloc::{self, HashMap, String, Vec};
 use crate::ast::{Span, Spanned};
 use crate::compile::meta;
 use crate::compile::{
-    self, CompileVisitor, LinkerError, Located, Location, MetaError, MetaRef, SourceMeta, WithSpan,
+    self, CompileVisitor, IndentStyle, LinkerError, Located, Location, MetaError, MetaRef,
+    SourceMeta, WithSpan,
 };
 use crate::diagnostics::{Diagnostic, FatalDiagnosticKind};
 use crate::doc::VisitorData;
@@ -330,7 +331,11 @@ impl<'a> State<'a> {
         Ok(Some(results))
     }
 
-    pub(super) fn format(&mut self, uri: &Url) -> Result<Option<lsp::TextEdit>> {
+    pub(super) fn format(
+        &mut self,
+        uri: &Url,
+        format: &lsp::FormattingOptions,
+    ) -> Result<Option<lsp::TextEdit>> {
         let sources = &mut self.workspace.sources;
         tracing::trace!(uri = ?uri.try_to_string()?, uri_exists = sources.get(uri).is_some());
 
@@ -340,14 +345,14 @@ impl<'a> State<'a> {
 
         let source = s.content.try_to_string()?;
 
+        let mut options = self.options.clone();
+        options.fmt.indent = indent_style(format);
+
         let mut diagnostics = Diagnostics::new();
 
-        let Ok(formatted) = crate::fmt::layout_source_with(
-            &source,
-            SourceId::EMPTY,
-            &self.options,
-            &mut diagnostics,
-        ) else {
+        let Ok(formatted) =
+            crate::fmt::layout_source_with(&source, SourceId::EMPTY, &options, &mut diagnostics)
+        else {
             return Ok(None);
         };
 
@@ -372,6 +377,7 @@ impl<'a> State<'a> {
         &mut self,
         uri: &Url,
         range: &lsp::Range,
+        format: &lsp::FormattingOptions,
     ) -> Result<Option<lsp::TextEdit>> {
         let sources = &mut self.workspace.sources;
         tracing::trace!(uri = ?uri.try_to_string()?, uri_exists = sources.get(uri).is_some());
@@ -391,6 +397,7 @@ impl<'a> State<'a> {
 
         let mut options = self.options.clone();
         options.fmt.force_newline = false;
+        options.fmt.indent = indent_style(format);
 
         let mut diagnostics = Diagnostics::new();
 
@@ -938,6 +945,17 @@ impl ServerSource {
 impl fmt::Display for ServerSource {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.content)
+    }
+}
+
+/// Convert formatting options from a client request into an indentation style.
+fn indent_style(options: &lsp::FormattingOptions) -> IndentStyle {
+    if options.insert_spaces {
+        // NB: Explicitly saturate to usize::MAX.
+        let spaces = usize::try_from(options.tab_size).unwrap_or(usize::MAX);
+        IndentStyle::Spaces(spaces)
+    } else {
+        IndentStyle::Tabs
     }
 }
 


### PR DESCRIPTION
Currently, the formatter always indents with hard-coded 4 spaces. This PR adds a `fmt.indent` option (`-O fmt.indent=<number>` or `-O fmt.indent=tab`, default `4`) and makes the language server use the `tabSize` / `insertSpaces` values clients send with `textDocument/formatting` and `textDocument/rangeFormatting`, which were previously ignored.

Needs #1025 to be merged first, without it option values never reach the fmt parser.