### PR TITLE
Fix statements such as `if cond { } (..)` being treated as call expressions

### DIFF
--- a/crates/rune/src/ast/expr.rs
+++ b/crates/rune/src/ast/expr.rs
@@ -105,7 +105,9 @@ pub(crate) struct Callable(bool);
 pub(crate) const CALLABLE: Callable = Callable(true);
 
 /// Indicates that an expression should be treated as if it's *not* callable.
-/// This is used to solve otherwise parsing ambiguities.
+/// This is used to solve otherwise parsing ambiguities, such as when a
+/// block-like expression in statement position is followed by parenthesis like
+/// `if true { } (1, 2, 3);`. It is treated as two statements rather than call.
 pub(crate) const NOT_CALLABLE: Callable = Callable(false);
 
 impl ops::Deref for Callable {
@@ -244,6 +246,7 @@ impl Expr {
             Self::If(_) => callable,
             Self::Match(_) => callable,
             Self::Select(_) => callable,
+            Self::Block(_) => callable,
             _ => true,
         }
     }

--- a/crates/rune/src/ast/stmt.rs
+++ b/crates/rune/src/ast/stmt.rs
@@ -8,6 +8,36 @@ fn ast_parse() {
     rt::<ast::Stmt>("let x = 1;");
     rt::<ast::Stmt>("#[attr] let a = f();");
     rt::<ast::Stmt>("line!().bar()");
+
+    // A block-like expression in statement position followed by parenthesis is
+    // treated as two statements rather than a call.
+    let block = rt::<ast::Block>("{ if true { } (1, 2, 3); }");
+    assert_eq!(block.statements.len(), 2);
+    assert!(matches!(
+        block.statements[0],
+        ast::Stmt::Expr(ast::Expr::If(..))
+    ));
+
+    let block = rt::<ast::Block>("{ match x { _ => () } (1, 2, 3); }");
+    assert_eq!(block.statements.len(), 2);
+    assert!(matches!(
+        block.statements[0],
+        ast::Stmt::Expr(ast::Expr::Match(..))
+    ));
+
+    let block = rt::<ast::Block>("{ { } (1, 2, 3); }");
+    assert_eq!(block.statements.len(), 2);
+    assert!(matches!(
+        block.statements[0],
+        ast::Stmt::Expr(ast::Expr::Block(..))
+    ));
+
+    let block = rt::<ast::Block>("{ if true { } [1, 2, 3]; }");
+    assert_eq!(block.statements.len(), 2);
+
+    // In expression position the same construct is a call.
+    let expr = rt::<ast::Expr>("if true { a } else { b }(1, 2, 3)");
+    assert!(matches!(expr, ast::Expr::Call(..)));
 }
 
 /// A statement within a block.
@@ -59,7 +89,7 @@ impl Parse for Stmt {
             let local = Box::try_new(ast::Local::parse_with_meta(p, take(&mut attributes))?)?;
             Self::Local(local)
         } else {
-            let expr = ast::Expr::parse_with_meta(p, &mut attributes, ast::expr::CALLABLE)?;
+            let expr = ast::Expr::parse_with_meta(p, &mut attributes, ast::expr::NOT_CALLABLE)?;
 
             // Parsed an expression which can be treated directly as an item.
             match p.parse()? {
@@ -120,7 +150,7 @@ impl Parse for ItemOrExpr {
             return Err(compile::Error::unsupported(span, "visibility modifier"));
         }
 
-        let expr = ast::Expr::parse_with_meta(p, &mut attributes, ast::expr::CALLABLE)?;
+        let expr = ast::Expr::parse_with_meta(p, &mut attributes, ast::expr::NOT_CALLABLE)?;
 
         if let Some(span) = attributes.option_span() {
             return Err(compile::Error::unsupported(span, "attributes"));

--- a/crates/rune/src/grammar/grammar.rs
+++ b/crates/rune/src/grammar/grammar.rs
@@ -43,6 +43,12 @@ enum Range {
     No,
 }
 
+#[derive(Debug, Clone, Copy)]
+enum Callable {
+    Yes,
+    No,
+}
+
 macro_rules! __ws {
     () => {
         $crate::ast::Kind::Whitespace
@@ -207,7 +213,7 @@ fn stmt(p: &mut Parser<'_>) -> Result<()> {
             labels(p)?;
 
             if matches!(
-                outer_expr_with(p, Brace::Yes, Range::Yes, Binary::Yes, &cx)?,
+                outer_expr_with(p, Brace::Yes, Range::Yes, Binary::Yes, Callable::No, &cx)?,
                 Error
             ) {
                 Error
@@ -666,7 +672,7 @@ fn expr(p: &mut Parser<'_>) -> Result<()> {
     modifiers(p)?;
     labels(p)?;
     let cx = ErrorCx;
-    outer_expr_with(p, Brace::Yes, Range::Yes, Binary::Yes, &cx)?;
+    outer_expr_with(p, Brace::Yes, Range::Yes, Binary::Yes, Callable::Yes, &cx)?;
     p.close_at(&c, Expr)?;
     Ok(())
 }
@@ -683,7 +689,7 @@ fn expr_with(
     attributes(p)?;
     modifiers(p)?;
     labels(p)?;
-    outer_expr_with(p, brace, range, binary, cx)?;
+    outer_expr_with(p, brace, range, binary, Callable::Yes, cx)?;
     p.close_at(&c, Expr)?;
     Ok(())
 }
@@ -705,6 +711,7 @@ fn outer_expr_with(
     brace: Brace,
     range: Range,
     binary: Binary,
+    callable: Callable,
     cx: &dyn ExprCx,
 ) -> Result<Kind> {
     let c = p.checkpoint()?;
@@ -714,7 +721,7 @@ fn outer_expr_with(
         return Ok(kind);
     }
 
-    kind = expr_chain(p, &c, kind)?;
+    kind = expr_chain(p, &c, kind, callable)?;
 
     if p.peek()? == K![=] {
         p.close_at(&c, Expr)?;
@@ -820,7 +827,7 @@ fn expr_primary(p: &mut Parser<'_>, brace: Brace, range: Range, cx: &dyn ExprCx)
         }
         K![!] | K![-] | K![&] | K![*] => {
             p.bump()?;
-            outer_expr_with(p, brace, range, Binary::No, cx)?;
+            outer_expr_with(p, brace, range, Binary::No, Callable::Yes, cx)?;
             ExprUnary
         }
         K![if] => {
@@ -889,7 +896,7 @@ fn expr_primary(p: &mut Parser<'_>, brace: Brace, range: Range, cx: &dyn ExprCx)
 
             if is_expr_with(p, brace, Range::No)? {
                 let cx = ErrorCx;
-                outer_expr_with(p, brace, Range::No, Binary::Yes, &cx)?;
+                outer_expr_with(p, brace, Range::No, Binary::Yes, Callable::Yes, &cx)?;
                 ExprRangeTo
             } else {
                 ExprRangeFull
@@ -898,7 +905,7 @@ fn expr_primary(p: &mut Parser<'_>, brace: Brace, range: Range, cx: &dyn ExprCx)
         K![..=] if matches!(range, Range::Yes) => {
             p.bump()?;
             let cx = ErrorCx;
-            outer_expr_with(p, brace, Range::No, Binary::Yes, &cx)?;
+            outer_expr_with(p, brace, Range::No, Binary::Yes, Callable::Yes, &cx)?;
             ExprRangeToInclusive
         }
         K![#] if matches!(p.glued(1)?, K!['{']) => {
@@ -918,25 +925,31 @@ fn expr_primary(p: &mut Parser<'_>, brace: Brace, range: Range, cx: &dyn ExprCx)
     Ok(kind)
 }
 
-fn kind_is_callable(kind: Kind) -> bool {
+fn kind_is_callable(kind: Kind, callable: Callable) -> bool {
     match kind {
         ExprWhile => false,
-        ExprLoop => true,
+        ExprLoop => matches!(callable, Callable::Yes),
         ExprFor => false,
-        ExprIf => true,
-        ExprMatch => true,
-        ExprSelect => true,
+        ExprIf => matches!(callable, Callable::Yes),
+        ExprMatch => matches!(callable, Callable::Yes),
+        ExprSelect => matches!(callable, Callable::Yes),
+        Block => matches!(callable, Callable::Yes),
         _ => true,
     }
 }
 
 #[tracing::instrument(skip_all)]
-fn expr_chain(p: &mut Parser<'_>, c: &Checkpoint, mut kind: Kind) -> Result<Kind> {
+fn expr_chain(
+    p: &mut Parser<'_>,
+    c: &Checkpoint,
+    mut kind: Kind,
+    callable: Callable,
+) -> Result<Kind> {
     let mut before = p.checkpoint()?;
     let mut has_chain = false;
 
     while !p.is_eof()? {
-        let is_callable = kind_is_callable(kind);
+        let is_callable = kind_is_callable(kind, callable);
 
         let k = match p.peek()? {
             K!['['] if is_callable => {
@@ -1272,7 +1285,7 @@ fn expr_binary(
         let range = if op.is_assoc() { Range::No } else { Range::Yes };
 
         let c = p.checkpoint()?;
-        outer_expr_with(p, brace, range, Binary::No, cx)?;
+        outer_expr_with(p, brace, range, Binary::No, Callable::Yes, cx)?;
 
         has_any = true;
 
@@ -1312,7 +1325,7 @@ fn expr_range(p: &mut Parser<'_>, c: &Checkpoint, kind: Kind, brace: Brace) -> R
 
             if is_expr_with(p, brace, Range::No)? {
                 let cx = ErrorCx;
-                outer_expr_with(p, brace, Range::No, Binary::Yes, &cx)?;
+                outer_expr_with(p, brace, Range::No, Binary::Yes, Callable::Yes, &cx)?;
                 ExprRange
             } else {
                 ExprRangeFrom
@@ -1323,7 +1336,7 @@ fn expr_range(p: &mut Parser<'_>, c: &Checkpoint, kind: Kind, brace: Brace) -> R
 
             if is_expr_with(p, brace, Range::No)? {
                 let cx = ErrorCx;
-                outer_expr_with(p, brace, Range::No, Binary::Yes, &cx)?;
+                outer_expr_with(p, brace, Range::No, Binary::Yes, Callable::Yes, &cx)?;
                 ExprRangeInclusive
             } else {
                 Error

--- a/crates/rune/src/tests.rs
+++ b/crates/rune/src/tests.rs
@@ -424,6 +424,8 @@ mod attribute;
 #[cfg(not(miri))]
 mod binary;
 #[cfg(not(miri))]
+mod bug_1021;
+#[cfg(not(miri))]
 mod bug_326;
 #[cfg(not(miri))]
 mod bug_344;

--- a/crates/rune/src/tests/bug_1021.rs
+++ b/crates/rune/src/tests/bug_1021.rs
@@ -1,0 +1,35 @@
+prelude!();
+
+/// A block-like expression in statement position followed by a parenthesized
+/// expression was treated as a call, so `if true { } (1, 2, 3);` called the
+/// unit value of the `if` instead of being parsed as two statements.
+///
+/// See https://github.com/rune-rs/rune/issues/1021
+#[test]
+fn test_bug_1021() {
+    let _: () = rune! {
+        pub fn main() {
+            if true { }
+            (1, 2, 3);
+        }
+
+        main()
+    };
+
+    let _: () = rune! {
+        pub fn main() {
+            if true { 1 } else { 0 }
+            (1, 2, 3);
+        }
+
+        main()
+    };
+
+    // In expression position a block-like expression can still be called.
+    let out: i64 = rune! {
+        let f = if true { || 1 } else { || 2 }();
+        f
+    };
+
+    assert_eq!(out, 1);
+}


### PR DESCRIPTION
Statements beginning with a block-like expression (if, match, select, loop, or a plain block) now end at their closing brace, matching Rust: a following `(..)` or `[..]` starts a new statement instead of becoming a call or index on the block. Expression position is unchanged.

`let x = if c { f } else { g }();` still calls -- as are `.field`, `.await`, `?` and binary operators.

Implemented in both parsers. The AST parser now parses statements with `NOT_CALLABLE`, and the grammar parser gets an equivalent Callable flag.

Fixes #1021 