### PR TITLE
Add hegel property tests as a soft CI dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,3 +243,13 @@ jobs:
     - run: cargo run --release --bin rune -- test --all-targets -O test-std=true
       env:
         RUNEFLAGS: v2=true
+
+  hegel_tests:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+    - uses: Swatinem/rust-cache@v2
+    - run: cargo test
+      working-directory: hegel_tests

--- a/hegel_tests/.gitignore
+++ b/hegel_tests/.gitignore
@@ -1,0 +1,3 @@
+/target
+/.hegel
+/Cargo.lock

--- a/hegel_tests/Cargo.toml
+++ b/hegel_tests/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rune-hegel-tests"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[workspace]
+
+[dependencies]
+rune = { path = "../crates/rune" }
+hegeltest = "0.28.2"

--- a/hegel_tests/src/lib.rs
+++ b/hegel_tests/src/lib.rs
@@ -1,0 +1,209 @@
+use rune::runtime::FromValue;
+use rune::sync::Arc;
+use rune::{Context, Diagnostics, Hash, Options, Source, Sources, Vm};
+
+/// Outcome of evaluating a source that isn't a plain success.
+#[derive(Debug)]
+pub enum EvalError {
+    Compile,
+    Vm,
+    Convert,
+}
+
+/// Compile `source` as a script and run it, returning the top-level value.
+pub fn eval_result<T>(context: &Context, source: &str) -> Result<T, EvalError>
+where
+    T: FromValue,
+{
+    let mut sources = Sources::new();
+    sources
+        .insert(Source::memory(source).map_err(|_| EvalError::Compile)?)
+        .map_err(|_| EvalError::Compile)?;
+
+    let mut diagnostics = Diagnostics::new();
+    let mut options = Options::default();
+    options.script(true);
+
+    let unit = rune::prepare(&mut sources)
+        .with_context(context)
+        .with_diagnostics(&mut diagnostics)
+        .with_options(&options)
+        .build()
+        .map_err(|_| EvalError::Compile)?;
+    let unit = Arc::try_new(unit).map_err(|_| EvalError::Compile)?;
+
+    let runtime = Arc::try_new(context.runtime().map_err(|_| EvalError::Compile)?)
+        .map_err(|_| EvalError::Compile)?;
+    let mut vm = Vm::new(runtime, unit);
+
+    let value = vm.call(Hash::EMPTY, ()).map_err(|_| EvalError::Vm)?;
+    rune::runtime::from_value::<T>(value).map_err(|_| EvalError::Convert)
+}
+
+/// Compile `source`, discarding the result: the property is that compilation
+/// returns instead of panicking, whatever the input.
+pub fn try_compile(context: &Context, source: &str, script: bool) {
+    let Ok(source) = Source::new("main", source) else {
+        return;
+    };
+
+    let mut sources = Sources::new();
+    sources.insert(source).expect("insert source");
+
+    let mut diagnostics = Diagnostics::new();
+    let mut options = Options::default();
+    if script {
+        options.script(true);
+    }
+
+    drop(
+        rune::prepare(&mut sources)
+            .with_context(context)
+            .with_diagnostics(&mut diagnostics)
+            .with_options(&options)
+            .build(),
+    );
+}
+
+use hegel::generators;
+
+#[derive(Debug, Clone, Copy)]
+pub enum ArithOp {
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Rem,
+}
+
+impl ArithOp {
+    fn symbol(self) -> &'static str {
+        match self {
+            ArithOp::Add => "+",
+            ArithOp::Sub => "-",
+            ArithOp::Mul => "*",
+            ArithOp::Div => "/",
+            ArithOp::Rem => "%",
+        }
+    }
+
+    fn apply(self, a: i64, b: i64) -> Option<i64> {
+        match self {
+            ArithOp::Add => a.checked_add(b),
+            ArithOp::Sub => a.checked_sub(b),
+            ArithOp::Mul => a.checked_mul(b),
+            ArithOp::Div => a.checked_div(b),
+            ArithOp::Rem => a.checked_rem(b),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum Expr {
+    Lit(i64),
+    Neg(Box<Expr>),
+    Bin(ArithOp, Box<Expr>, Box<Expr>),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum RefError {
+    Arith(ArithOp),
+    NegOverflow,
+}
+
+pub const ALL_OPS: [ArithOp; 5] = [
+    ArithOp::Add,
+    ArithOp::Sub,
+    ArithOp::Mul,
+    ArithOp::Div,
+    ArithOp::Rem,
+];
+
+pub fn literal_gen() -> hegel::generators::BoxedGenerator<'static, i64> {
+    use hegel::generators::Generator;
+    hegel::one_of!(
+        generators::integers::<i64>().min_value(-8).max_value(8),
+        generators::integers::<i64>(),
+        generators::sampled_from(vec![
+            i64::MIN,
+            i64::MIN + 1,
+            -1,
+            0,
+            1,
+            2,
+            i64::MAX - 1,
+            i64::MAX
+        ]),
+    )
+    .boxed()
+}
+
+// Callers keep `depth` small: rune aborts the process on deeply nested input
+// (#1040), below hegel's own depth cap, so generated expressions must stay shallow.
+pub fn expr(
+    depth: u32,
+    allow_neg: bool,
+    ops: Vec<ArithOp>,
+) -> hegel::generators::BoxedGenerator<'static, Expr> {
+    use hegel::generators::Generator;
+
+    let leaf = literal_gen().map(Expr::Lit).boxed();
+    if depth == 0 {
+        return leaf;
+    }
+
+    let bin = hegel::tuples!(
+        generators::sampled_from(ops.clone()),
+        expr(depth - 1, allow_neg, ops.clone()),
+        expr(depth - 1, allow_neg, ops.clone())
+    )
+    .map(|(op, lhs, rhs)| Expr::Bin(op, Box::new(lhs), Box::new(rhs)))
+    .boxed();
+
+    if allow_neg {
+        let neg = expr(depth - 1, allow_neg, ops.clone())
+            .map(|e| Expr::Neg(Box::new(e)))
+            .boxed();
+        hegel::one_of!(leaf, neg, bin).boxed()
+    } else {
+        hegel::one_of!(leaf, bin).boxed()
+    }
+}
+
+pub fn eval_reference(expr: &Expr) -> Result<i64, RefError> {
+    match expr {
+        Expr::Lit(n) => Ok(*n),
+        Expr::Neg(inner) => eval_reference(inner)?
+            .checked_neg()
+            .ok_or(RefError::NegOverflow),
+        Expr::Bin(op, lhs, rhs) => {
+            let lhs = eval_reference(lhs)?;
+            let rhs = eval_reference(rhs)?;
+            op.apply(lhs, rhs).ok_or(RefError::Arith(*op))
+        }
+    }
+}
+
+pub fn render(expr: &Expr, out: &mut String) {
+    match expr {
+        Expr::Lit(n) => {
+            out.push('(');
+            out.push_str(&n.to_string());
+            out.push(')');
+        }
+        Expr::Neg(inner) => {
+            out.push_str("(-");
+            render(inner, out);
+            out.push(')');
+        }
+        Expr::Bin(op, lhs, rhs) => {
+            out.push('(');
+            render(lhs, out);
+            out.push(' ');
+            out.push_str(op.symbol());
+            out.push(' ');
+            render(rhs, out);
+            out.push(')');
+        }
+    }
+}

--- a/hegel_tests/tests/arithmetic.rs
+++ b/hegel_tests/tests/arithmetic.rs
@@ -1,0 +1,90 @@
+// The VM implements integer arithmetic with checked operations
+// (`runtime/vm/ops.rs`): `+`/`*` raise `VmErrorKind::Overflow`, `-` raises
+// `Underflow`, and `/`/`%` raise `DivideByZero` when the checked operation
+// fails. These properties compare generated expressions against a Rust-side
+// checked `i64` reference implementation.
+//
+// `VmErrorKind` is not part of rune's public API, so the specific error kind
+// can't be matched from outside the crate; these tests assert that overflow
+// surfaces as a VM error rather than a value or panic.
+
+use hegel::generators;
+use rune::Context;
+use rune_hegel_tests::{
+    eval_reference, eval_result, expr, literal_gen, render, EvalError, RefError, ALL_OPS,
+};
+
+#[test]
+fn arithmetic_matches_checked_i64_reference() {
+    let context = Context::with_default_modules().expect("failed to build context");
+
+    hegel::Hegel::new(|tc| {
+        let depth = tc.draw(generators::integers::<u32>().max_value(4));
+        let e = tc.draw(expr(depth, true, ALL_OPS.to_vec()));
+
+        let mut src = String::new();
+        render(&e, &mut src);
+
+        let reference = match eval_reference(&e) {
+            Err(RefError::NegOverflow) => {
+                // Negating `i64::MIN` is unchecked in `Vm::op_neg`: panics in
+                // debug, wraps in release (rune-rs/rune#1030). Excluded here so
+                // the rest of the arithmetic surface stays covered.
+                tc.reject()
+            }
+            other => other,
+        };
+
+        let result = eval_result::<i64>(&context, &src);
+
+        match (reference, result) {
+            (Ok(expected), Ok(actual)) => assert_eq!(actual, expected, "source: {src}"),
+            (Ok(expected), Err(error)) => {
+                panic!("expected {expected}, got error: {error:?}\nsource: {src}")
+            }
+            (Err(RefError::Arith(_)), Err(EvalError::Vm)) => {}
+            (Err(reference), result) => {
+                panic!("expected VM error for {reference:?}, got {result:?}\nsource: {src}")
+            }
+        }
+    })
+    .run();
+}
+
+#[test]
+fn shift_ops_match_checked_reference() {
+    let context = Context::with_default_modules().expect("failed to build context");
+
+    hegel::Hegel::new(|tc| {
+        let value = tc.draw(literal_gen());
+        let shift: i64 = tc.draw(hegel::one_of!(
+            generators::integers::<i64>().min_value(0).max_value(70),
+            generators::integers::<i64>(),
+            generators::sampled_from(vec![-1, 63, 64, (u32::MAX as i64) + 1]),
+        ));
+        let shl = tc.draw(generators::booleans());
+
+        let symbol = if shl { "<<" } else { ">>" };
+        let src = format!("({value}) {symbol} ({shift})");
+
+        let expected = u32::try_from(shift).ok().and_then(|shift| {
+            if shl {
+                value.checked_shl(shift)
+            } else {
+                value.checked_shr(shift)
+            }
+        });
+
+        let result = eval_result::<i64>(&context, &src);
+
+        match (expected, result) {
+            (Some(expected), Ok(actual)) => assert_eq!(actual, expected, "source: {src}"),
+            (Some(expected), Err(error)) => {
+                panic!("expected {expected}, got error: {error:?}\nsource: {src}")
+            }
+            (None, Err(EvalError::Vm)) => {}
+            (None, result) => panic!("expected VM error, got {result:?}\nsource: {src}"),
+        }
+    })
+    .run();
+}

--- a/hegel_tests/tests/compiler.rs
+++ b/hegel_tests/tests/compiler.rs
@@ -1,0 +1,114 @@
+use hegel::generators::{self, Generator};
+use rune::Context;
+use rune_hegel_tests::try_compile;
+
+/// Property: the lexer, parser and compiler never panic on arbitrary unicode
+/// input, in either script or module mode.
+#[test]
+fn compile_never_panics_on_arbitrary_text() {
+    let context = Context::with_default_modules().expect("failed to build context");
+
+    hegel::Hegel::new(|tc| {
+        let source: String = tc.draw(hegel::one_of!(
+            generators::text().boxed(),
+            // Strings built from raw codepoints, hitting control characters and
+            // supplementary planes more often than `text()` does.
+            generators::vecs(
+                generators::integers::<u32>()
+                    .max_value(0x10_FFFF)
+                    .map(|n| char::from_u32(n).unwrap_or('\u{FFFD}'))
+            )
+            .map(|v| v.into_iter().collect())
+            .boxed(),
+        ));
+        let script = tc.draw(generators::booleans());
+
+        try_compile(&context, &source, script);
+    })
+    .run();
+}
+
+fn token_vocabulary() -> Vec<&'static str> {
+    vec![
+        "fn", "let", "if", "else", "while", "for", "in", "loop", "match", "enum", "struct", "impl",
+        "pub", "use", "mod", "const", "break", "continue", "return", "async", "await", "yield",
+        "select", "true", "false", "self", "is", "not", "crate", "super", "default", "{", "}", "(",
+        ")", "[", "]", ",", ";", ":", "::", ".", "..", "..=", "=>", "->", "#", "#{", "=", "==",
+        "!=", "<", ">", "<=", ">=", "+", "-", "*", "/", "%", "&&", "||", "!", "&", "|", "^", "<<",
+        ">>", "+=", "-=", "*=", "/=", "?", "@", "$", "'label", "_", "x", "foo", "Bar", "テスト",
+        "0", "1", "42", "9223372036854775807", "0xff", "0o77", "0b1010", "1.5", "1e300",
+        "\"string\"", "'c'", "`template ${x}`", "b\"bytes\"", "b'b'", "#[test]", "//! doc",
+        "// comment", "/* block */",
+    ]
+}
+
+/// Property: the parser and compiler never panic on "script-shaped" input —
+/// random sequences of valid Rune tokens.
+#[test]
+fn compile_never_panics_on_token_soup() {
+    let context = Context::with_default_modules().expect("failed to build context");
+    let vocabulary = token_vocabulary();
+
+    hegel::Hegel::new(|tc| {
+        let count = tc.draw(generators::integers::<usize>().max_value(60));
+        let mut source = String::new();
+
+        for _ in 0..count {
+            let token = tc.draw(generators::sampled_from(vocabulary.clone()));
+            source.push_str(token);
+            let newline = tc.draw(generators::booleans());
+            source.push(if newline { '\n' } else { ' ' });
+        }
+
+        let script = tc.draw(generators::booleans());
+        try_compile(&context, &source, script);
+    })
+    .run();
+}
+
+fn nested_source(shape: &str, depth: usize) -> String {
+    let (open, close) = match shape {
+        "paren" => ("(", ")"),
+        "array" => ("[", "]"),
+        "block" => ("{", "}"),
+        "neg" => ("-(", ")"),
+        "object" => ("#{a: ", "}"),
+        "call" => ("f(", ")"),
+        _ => unreachable!(),
+    };
+
+    let mut source = String::with_capacity(depth * (open.len() + close.len()) + 16);
+
+    if shape == "call" {
+        source.push_str("fn f(v) { v } ");
+    }
+
+    for _ in 0..depth {
+        source.push_str(open);
+    }
+    source.push('0');
+    for _ in 0..depth {
+        source.push_str(close);
+    }
+
+    source
+}
+
+/// Property: moderately deep expression nesting compiles (or errors) without
+/// crashing the process. Depth is capped at 20: deeper nesting aborts the
+/// process with a stack overflow in the recursive parser (rune-rs/rune#1040).
+#[test]
+fn nested_expressions_compile_without_crashing() {
+    let context = Context::with_default_modules().expect("failed to build context");
+
+    hegel::Hegel::new(|tc| {
+        let depth = tc.draw(generators::integers::<usize>().min_value(1).max_value(20));
+        let shape = tc.draw(generators::sampled_from(vec![
+            "paren", "array", "block", "neg", "object", "call",
+        ]));
+
+        let source = nested_source(shape, depth);
+        try_compile(&context, &source, true);
+    })
+    .run();
+}

--- a/hegel_tests/tests/const_exprs.rs
+++ b/hegel_tests/tests/const_exprs.rs
@@ -1,0 +1,46 @@
+// Const expressions are evaluated at compile time by the IR interpreter
+// (`compile/ir/eval.rs`), while the same expression written without `const`
+// runs through the VM (`runtime/vm/ops.rs`). The two evaluators must agree.
+
+use hegel::generators;
+use rune::Context;
+use rune_hegel_tests::{eval_reference, eval_result, expr, render, ArithOp};
+
+/// Property: a `const` expression evaluated by the compile-time IR interpreter
+/// yields the same value as the identical expression evaluated by the VM at
+/// runtime.
+#[test]
+fn const_eval_matches_runtime_eval() {
+    let context = Context::with_default_modules().expect("failed to build context");
+
+    hegel::Hegel::new(|tc| {
+        let depth = tc.draw(generators::integers::<u32>().max_value(3));
+
+        // `allow_neg = false`: unary expressions are not supported in const
+        // contexts, so `-expr` would be a compile error rather than a
+        // disagreement. `%` is likewise excluded: const evaluation reports 'op
+        // not supported yet' for it.
+        let ops = vec![ArithOp::Add, ArithOp::Sub, ArithOp::Mul, ArithOp::Div];
+        let e = tc.draw(expr(depth, false, ops));
+
+        // Overflowing const expressions panic the compiler in debug builds
+        // (rune-rs/rune#1039); excluded here.
+        tc.assume(eval_reference(&e).is_ok());
+
+        let mut src = String::new();
+        render(&e, &mut src);
+
+        let runtime = eval_result::<i64>(&context, &src);
+        let constant = eval_result::<i64>(&context, &format!("const VALUE = {src}; VALUE"));
+
+        match (runtime, constant) {
+            (Ok(runtime), Ok(constant)) => {
+                assert_eq!(runtime, constant, "runtime and const evaluation disagree\nsource: {src}")
+            }
+            (runtime, constant) => panic!(
+                "expected both evaluations to succeed\nruntime: {runtime:?}\nconst: {constant:?}\nsource: {src}"
+            ),
+        }
+    })
+    .run();
+}

--- a/hegel_tests/tests/general.rs
+++ b/hegel_tests/tests/general.rs
@@ -1,0 +1,78 @@
+use hegel::generators;
+use rune::runtime::budget;
+use rune::sync::Arc;
+use rune::{Context, Diagnostics, Hash, Options, Source, Sources, Vm};
+use rune_hegel_tests::eval_result;
+
+/// Property: formatting any `i64` through a template string agrees with Rust's
+/// integer formatting (the runtime formats integers through `itoa`).
+#[test]
+fn template_int_formatting_matches_rust() {
+    let context = Context::with_default_modules().expect("failed to build context");
+
+    hegel::Hegel::new(|tc| {
+        let n: i64 = tc.draw(hegel::one_of!(
+            generators::integers::<i64>(),
+            generators::sampled_from(vec![i64::MIN, -1, 0, 1, i64::MAX]),
+        ));
+
+        let src = format!("`${{{n}}}`");
+
+        match eval_result::<String>(&context, &src) {
+            Ok(out) => assert_eq!(out, n.to_string(), "source: {src}"),
+            Err(error) => panic!("failed to evaluate template {src}: {error:?}"),
+        }
+    })
+    .run();
+}
+
+/// Property: a VM running a script that never terminates on its own is always
+/// halted by an instruction budget — `budget::with` returns an error rather
+/// than hanging or panicking, for any budget and any of the loop shapes below.
+#[test]
+fn budget_halts_infinite_loops() {
+    let context = Context::with_default_modules().expect("failed to build context");
+    let runtime = Arc::try_new(context.runtime().expect("runtime")).expect("runtime arc");
+
+    hegel::Hegel::new(|tc| {
+        let budget_size = tc.draw(hegel::one_of!(
+            generators::integers::<usize>().min_value(1).max_value(100),
+            generators::integers::<usize>().min_value(1).max_value(100_000),
+        ));
+
+        // All templates loop forever without erroring: the modulus keeps the
+        // counter small so checked arithmetic can never overflow.
+        let modulus = tc.draw(generators::integers::<i64>().min_value(1).max_value(1_000));
+        let program = tc.draw(generators::sampled_from(vec![
+            format!("let i = 0; while true {{ i = (i + 1) % {modulus}; }} i"),
+            "loop { }".to_string(),
+            format!("fn f(m) {{ let i = 0; while true {{ i = (i + 1) % m; }} }} f({modulus})"),
+            "while true { while true { } }".to_string(),
+        ]));
+
+        let mut sources = Sources::new();
+        sources.insert(Source::memory(&program).expect("source")).expect("insert");
+
+        let mut diagnostics = Diagnostics::default();
+        let mut options = Options::default();
+        options.script(true);
+
+        let unit = rune::prepare(&mut sources)
+            .with_context(&context)
+            .with_diagnostics(&mut diagnostics)
+            .with_options(&options)
+            .build()
+            .expect("infinite loop programs must compile");
+
+        let unit = Arc::try_new(unit).expect("unit arc");
+        let mut vm = Vm::new(runtime.clone(), unit);
+
+        let result = budget::with(budget_size, || vm.call(Hash::EMPTY, ())).call();
+
+        assert!(
+            result.is_err(),
+            "an infinite loop terminated successfully under budget {budget_size}: {result:?}\nprogram: {program}"
+        );
+    })
+    .run();
+}

--- a/hegel_tests/tests/literals.rs
+++ b/hegel_tests/tests/literals.rs
@@ -1,0 +1,155 @@
+use hegel::generators::{self, Generator};
+use rune::Context;
+use rune_hegel_tests::eval_result;
+
+/// Property: rendering any `i64` as a decimal, hex, octal or binary literal
+/// (optionally with `_` digit separators and an optional `i64` suffix) and
+/// evaluating it yields the value back. Exercises the lexer's number handling
+/// and the negative-literal special case in HIR lowering, including `i64::MIN`.
+#[test]
+fn integer_literal_roundtrip_all_bases() {
+    let context = Context::with_default_modules().expect("failed to build context");
+
+    hegel::Hegel::new(|tc| {
+        let n: i64 = tc.draw(hegel::one_of!(
+            generators::integers::<i64>(),
+            generators::sampled_from(vec![i64::MIN, i64::MIN + 1, -1, 0, 1, i64::MAX]),
+        ));
+        let base: u8 = tc.draw(generators::integers::<u8>().max_value(3));
+        let separators = tc.draw(generators::booleans());
+        let suffix = tc.draw(generators::booleans());
+
+        let magnitude = n.unsigned_abs();
+
+        let mut digits = match base {
+            0 => format!("{magnitude}"),
+            1 => format!("{magnitude:x}"),
+            2 => format!("{magnitude:o}"),
+            _ => format!("{magnitude:b}"),
+        };
+
+        if separators {
+            let joined: Vec<String> = digits.chars().map(|c| c.to_string()).collect();
+            digits = joined.join("_");
+        }
+
+        let prefix = match base {
+            0 => "",
+            1 => "0x",
+            2 => "0o",
+            _ => "0b",
+        };
+
+        let sign = if n < 0 { "-" } else { "" };
+        let suffix = if suffix { "i64" } else { "" };
+        let src = format!("{sign}{prefix}{digits}{suffix}");
+
+        match eval_result::<i64>(&context, &src) {
+            Ok(out) => assert_eq!(out, n, "source: {src}"),
+            Err(error) => panic!("failed to evaluate literal {src}: {error:?}"),
+        }
+    })
+    .run();
+}
+
+/// Property: rendering any finite `f64` with Rust's shortest round-trip
+/// formatting and evaluating it as a Rune float literal yields the exact same
+/// bits back.
+#[test]
+fn float_literal_roundtrip() {
+    let context = Context::with_default_modules().expect("failed to build context");
+
+    hegel::Hegel::new(|tc| {
+        let f: f64 = tc.draw(
+            generators::floats::<f64>()
+                .allow_nan(false)
+                .allow_infinity(false),
+        );
+
+        let src = format!("{f:?}");
+
+        match eval_result::<f64>(&context, &src) {
+            Ok(out) => assert_eq!(out.to_bits(), f.to_bits(), "expected {f:?}, got {out:?}\nsource: {src}"),
+            Err(error) => panic!("failed to evaluate float literal {src}: {error:?}"),
+        }
+    })
+    .run();
+}
+
+/// Escape a string so it can be embedded in a double-quoted Rune string
+/// literal. When `force_unicode_escapes` is set every character is written as a
+/// `\u{..}` escape to exercise the escape parser; otherwise only characters
+/// that must be escaped are.
+fn escape_rune_string(s: &str, force_unicode_escapes: bool) -> String {
+    let mut out = String::new();
+
+    for c in s.chars() {
+        if force_unicode_escapes {
+            out.push_str(&format!("\\u{{{:x}}}", c as u32));
+            continue;
+        }
+
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{{{:x}}}", c as u32)),
+            c => out.push(c),
+        }
+    }
+
+    out
+}
+
+/// Property: any string, escaped and embedded as a Rune string literal,
+/// evaluates back to the original string.
+#[test]
+fn string_literal_roundtrip() {
+    let context = Context::with_default_modules().expect("failed to build context");
+
+    hegel::Hegel::new(|tc| {
+        let s: String = tc.draw(generators::text());
+        let force_unicode_escapes = tc.draw(generators::booleans());
+
+        let src = format!("\"{}\"", escape_rune_string(&s, force_unicode_escapes));
+
+        match eval_result::<String>(&context, &src) {
+            Ok(out) => assert_eq!(out, s, "source: {src}"),
+            Err(error) => panic!("failed to evaluate string literal {src}: {error:?}"),
+        }
+    })
+    .run();
+}
+
+/// Property: any char, escaped and embedded as a Rune char literal, evaluates
+/// back to the original char.
+#[test]
+fn char_literal_roundtrip() {
+    let context = Context::with_default_modules().expect("failed to build context");
+
+    hegel::Hegel::new(|tc| {
+        let c: char = tc.draw(
+            hegel::one_of!(
+                generators::integers::<u32>().max_value(0x7F),
+                generators::integers::<u32>().max_value(0x10_FFFF),
+            )
+            .map(|n| char::from_u32(n).unwrap_or('\u{FFFD}')),
+        );
+
+        // The lexer rejects raw control characters (including DEL and the C1
+        // range) inside char literals, so those must use escapes.
+        let escaped = match c {
+            '\'' => "\\'".to_string(),
+            '\\' => "\\\\".to_string(),
+            c if c.is_control() => format!("\\u{{{:x}}}", c as u32),
+            c => c.to_string(),
+        };
+
+        let src = format!("'{escaped}'");
+
+        match eval_result::<char>(&context, &src) {
+            Ok(out) => assert_eq!(out, c, "source: {src}"),
+            Err(error) => panic!("failed to evaluate char literal {src}: {error:?}"),
+        }
+    })
+    .run();
+}

--- a/hegel_tests/tests/value_roundtrip.rs
+++ b/hegel_tests/tests/value_roundtrip.rs
@@ -1,0 +1,67 @@
+use std::collections::HashMap;
+
+use hegel::generators::{self, Generator};
+use rune::runtime::{from_value, to_value};
+
+/// Property: converting a primitive Rust value into a Rune `Value` and back
+/// yields the original value, over the full domain of each type.
+#[hegel::test]
+fn value_roundtrip_preserves_primitives(tc: hegel::TestCase) {
+    let n: i64 = tc.draw(generators::integers::<i64>());
+    let out: i64 = from_value(to_value(n).expect("to_value")).expect("from_value");
+    assert_eq!(out, n);
+
+    let n: u64 = tc.draw(generators::integers::<u64>());
+    let out: u64 = from_value(to_value(n).expect("to_value")).expect("from_value");
+    assert_eq!(out, n);
+
+    let f: f64 = tc.draw(generators::floats::<f64>());
+    let out: f64 = from_value(to_value(f).expect("to_value")).expect("from_value");
+    assert_eq!(out.to_bits(), f.to_bits(), "value: {f:?}");
+
+    let b: bool = tc.draw(generators::booleans());
+    let out: bool = from_value(to_value(b).expect("to_value")).expect("from_value");
+    assert_eq!(out, b);
+
+    let c: char = tc.draw(
+        generators::integers::<u32>()
+            .max_value(0x10_FFFF)
+            .map(|n| char::from_u32(n).unwrap_or('\u{FFFD}')),
+    );
+    let out: char = from_value(to_value(c).expect("to_value")).expect("from_value");
+    assert_eq!(out, c);
+}
+
+/// Property: converting compound Rust values (strings, vectors, maps, options,
+/// tuples) into a Rune `Value` and back yields the original.
+#[hegel::test]
+fn value_roundtrip_preserves_compound_values(tc: hegel::TestCase) {
+    let s: String = tc.draw(generators::text());
+    let out: String = from_value(to_value(s.clone()).expect("to_value")).expect("from_value");
+    assert_eq!(out, s);
+
+    let v: Vec<i64> = tc.draw(generators::vecs(generators::integers::<i64>()));
+    let out: Vec<i64> = from_value(to_value(v.clone()).expect("to_value")).expect("from_value");
+    assert_eq!(out, v);
+
+    let m: HashMap<String, i64> = tc.draw(generators::hashmaps(
+        generators::text().max_size(16),
+        generators::integers::<i64>(),
+    ));
+    let out: HashMap<String, i64> =
+        from_value(to_value(m.clone()).expect("to_value")).expect("from_value");
+    assert_eq!(out, m);
+
+    let o: Option<i64> = tc.draw(generators::optional(generators::integers::<i64>()));
+    let out: Option<i64> = from_value(to_value(o).expect("to_value")).expect("from_value");
+    assert_eq!(out, o);
+
+    let t: (i64, String, bool) = tc.draw(generators::tuples!(
+        generators::integers::<i64>(),
+        generators::text().max_size(16),
+        generators::booleans(),
+    ));
+    let out: (i64, String, bool) =
+        from_value(to_value(t.clone()).expect("to_value")).expect("from_value");
+    assert_eq!(out, t);
+}


### PR DESCRIPTION
Follow up to #1030 which adds the Hegel tests that found that bug.

This includes a bunch of tests that I think are good tests but do not currently seem to find bugs in rune. Totally happy to ditch those if you prefer.

I've added this as a separate non-blocking job in CI, via a separate hegel_tests crate. I'm not particularly attached to this approach (it was Claude's suggestion for your requirements) so let me know if you want me to back some or all of the CI integration out.

NB this currently has workarounds to avoid hitting #1039 and #1040 