### PR TITLE
Improve the error when a format argument isn't a constant

### DIFF
--- a/crates/rune/src/compile/error.rs
+++ b/crates/rune/src/compile/error.rs
@@ -61,7 +61,6 @@ impl Error {
     }
 
     /// Get the kind of the error.
-    #[cfg(feature = "emit")]
     pub(crate) fn kind(&self) -> &ErrorKind {
         &self.kind
     }

--- a/crates/rune/src/macros/format_args.rs
+++ b/crates/rune/src/macros/format_args.rs
@@ -4,7 +4,7 @@ use crate as rune;
 use crate::alloc::prelude::*;
 use crate::alloc::{self, BTreeMap, BTreeSet, Box, HashMap, String, Vec};
 use crate::ast::{self, Span, Spanned};
-use crate::compile::{self, WithSpan};
+use crate::compile::{self, ErrorKind, WithSpan};
 use crate::macros::{quote, MacroContext, Quote, ToTokens, TokenStream};
 use crate::parse::{Parse, Parser, Peek, Peeker};
 use crate::runtime::format;
@@ -24,7 +24,26 @@ pub struct FormatArgs {
 impl FormatArgs {
     /// Expand the format specification.
     pub fn expand(&self, cx: &mut MacroContext<'_, '_, '_>) -> compile::Result<Quote<'_>> {
-        let format = cx.eval(&self.format)?;
+        let format = match cx.eval(&self.format) {
+            Ok(format) => format,
+            Err(error) => {
+                // A missing local means a runtime value was passed where the
+                // format argument, which is evaluated at compile time, has to
+                // be a constant. The raw error points inside the expression
+                // ("no local variable `s`") without saying that, so replace it
+                // with a clearer message. Anything else (such as a depth limit
+                // hit while evaluating a constant) is left untouched.
+                if let ErrorKind::MissingLocal { .. } = error.kind() {
+                    return Err(compile::Error::msg(
+                        self.format.span(),
+                        "the format argument must be a string literal or constant expression, \
+                         use a \"{}\" placeholder to format a runtime value",
+                    ));
+                }
+
+                return Err(error);
+            }
+        };
 
         let mut pos = Vec::new();
         let mut named = HashMap::<Box<str>, _>::new();

--- a/crates/rune/src/tests/core_macros.rs
+++ b/crates/rune/src/tests/core_macros.rs
@@ -19,6 +19,25 @@ fn test_asserts() {
 }
 
 #[test]
+fn non_constant_format_argument() {
+    use ErrorKind::*;
+
+    // Passing a runtime value where the format string is expected used to
+    // surface an inner const-eval error like "no local variable `s`". Make
+    // sure it now explains what the macro actually wants.
+    assert_errors! {
+        r#"pub fn main() { let s = ""; format!(s) }"#,
+        span!(36, 37), Custom { error } => {
+            assert_eq!(
+                error.to_string(),
+                "the format argument must be a string literal or constant expression, \
+                 use a \"{}\" placeholder to format a runtime value"
+            );
+        }
+    }
+}
+
+#[test]
 fn test_stringify() {
     let out: String = rune!(stringify!(assert_eq!(1 + 1, 2)));
     assert_eq!("assert_eq ! ( 1 + 1 , 2 )", out);


### PR DESCRIPTION
When a runtime value is passed where a formatting macro wants the format string, like `panic!(s)` or `println!("x is " + x.to_string())`, the error came straight from constant evaluation and just said something like `no local variable `s``. That points inside the expression and doesn't really say what the macro wants.

`FormatArgs::expand` now catches that case and reports it against the whole format argument instead, saying it has to be a string literal or constant expression and that a `"{}"` placeholder is the way to format a runtime value. Only the missing local case is rewritten, so other failures (like a depth limit hit while evaluating a genuinely constant format string) are left as they were. Constant format strings, including consts and compile-time concatenation, are unaffected.

Fixes #730
