### PR TITLE
Fix bogus Cycle in import for single-component context modules

### DIFF
--- a/crates/rune/src/query/query.rs
+++ b/crates/rune/src/query/query.rs
@@ -1487,6 +1487,18 @@ impl<'a, 'arena> Query<'a, 'arena> {
                     continue;
                 };
 
+                // NB: a self-referential import, where the import target is
+                // the item itself (e.g. `use http;` at the crate root, which
+                // refers to a context-installed module of the same name),
+                // does not rewrite the item being resolved. Treat it as
+                // resolving to itself and stop here, so that resolution can
+                // fall through to other sources of meta (like the context)
+                // instead of looping and reporting a bogus import cycle.
+                if import.target == cur {
+                    any_matched = true;
+                    break 'outer;
+                }
+
                 // Imports are *always* used once they pass this step.
                 if let Used::Used = import_used {
                     self.set_used(&item_meta)?;
@@ -1598,6 +1610,15 @@ impl<'a, 'arena> Query<'a, 'arena> {
                 return Ok(None);
             }
         };
+
+        // NB: A self-referential import (e.g. `use http;` at the crate root,
+        // where the imported item equals its target) is treated as *not
+        // found*, so that resolution falls through to other sources of meta
+        // (such as a context-installed module of the same name) instead of
+        // looping on itself and producing a bogus `Cycle in import` error.
+        if import.target == item {
+            return Ok(None);
+        }
 
         let meta = meta::Meta {
             context: false,

--- a/crates/rune/src/tests/compiler_use.rs
+++ b/crates/rune/src/tests/compiler_use.rs
@@ -2,6 +2,66 @@ prelude!();
 
 use ErrorKind::*;
 
+/// Regression test: importing a context-installed module whose item path is a
+/// single root component (e.g. `::http`) with `use http;` must not produce a
+/// bogus `Cycle in import` error once the imported name is used.
+#[test]
+fn test_use_single_component_context_module() {
+    let mut module = Module::with_crate("http").expect("failed to build module");
+    module
+        .function("meaning", || 42i64)
+        .build()
+        .expect("failed to register function");
+
+    let mut context = Context::with_default_modules().expect("failed to build context");
+    context.install(&module).expect("failed to install module");
+
+    let out: i64 = run(
+        &context,
+        r#"
+        use http;
+
+        pub fn main() {
+            http::meaning()
+        }
+        "#,
+        (),
+        false,
+    )
+    .expect("program failed to run");
+
+    assert_eq!(out, 42);
+}
+
+/// Same as above, but the import is never used. This must still compile.
+#[test]
+fn test_use_single_component_context_module_unused() {
+    let mut module = Module::with_crate("http").expect("failed to build module");
+    module
+        .function("meaning", || 42i64)
+        .build()
+        .expect("failed to register function");
+
+    let mut context = Context::with_default_modules().expect("failed to build context");
+    context.install(&module).expect("failed to install module");
+
+    let out: i64 = run(
+        &context,
+        r#"
+        use http;
+
+        pub fn main() {
+            42
+        }
+        "#,
+        (),
+        false,
+    )
+    .expect("program failed to run");
+
+    assert_eq!(out, 42);
+}
+
 #[test]
 fn test_import_cycle() {
     assert_errors! {


### PR DESCRIPTION
Fixes #1047

## Problem

`use http;` for a context-installed module rooted at a single component
(e.g. `::http` from `rune-modules`) fails with a bogus `Cycle in import`,
whether or not the import is ever used. Fully-qualified paths and
multi-component imports are unaffected. See the linked issue for a minimal
reproduction.

## Root cause

The indexed import entry for `use http;` at the crate root is
self-referential: `insert_import` registers it at item `::http` with target
`::http`. The bogus cycle is then produced through *two* distinct paths:

1. When the name is **used**, `import_step` picks up the self-referential
   entry via `remove_indexed`, inserts a `Kind::Import` meta pointing at
   itself, and `import()` loops on it.
2. When the import is **unused**, `import_indexed` eagerly inserts the same
   self-referential `Kind::Import` meta while processing `Build::Query` and
   queues `Build::Import`; the access-check in `Build::Import` then hits
   that meta in `import_step`'s first branch and loops the same way.

In both cases `visited.try_insert` fails on the second iteration, producing
`ErrorKind::ImportCycle`.

## Fix

Two small changes in `crates/rune/src/query/query.rs`:

* `import_step()`: a self-referential import entry (`import.target == item`)
  is treated as *not found*, so no self-referential meta is inserted and
  resolution falls through to other sources of meta (such as a
  context-installed module of the same name).
* `import()`: a self-referential import step (`import.target == cur`)
  resolves the item to itself and stops, instead of looping. This covers the
  self-referential meta that `import_indexed` inserts for unused imports.

Semantics are unchanged for everything else: genuine import cycles (e.g. the
cases in `test_import_cycle`) still error, and multi-component / aliased
imports are unaffected since their entries are never self-referential.

## Tests

* Two new regression tests in `compiler_use.rs` install a single-component
  context module (`Module::with_crate("http")`) and cover both the used and
  the unused import case. Both fail without this fix and pass with it.
* Full `cargo test -p rune --lib --features workspace,fmt` passes
  (566 passed, 0 failed).